### PR TITLE
Resend Android managed app config on custom host vital value change

### DIFF
--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -487,13 +487,21 @@ func resendMDMProfilesForCustomHostVital(ctx context.Context, tx sqlx.ExtContext
 // It queues the host-scoped batch task, not the team-wide make_android_app_available, since a vital is set per host,
 // so a team-wide re-push would hit every host in the fleet on every value change.
 func resendAndroidAppConfigsForCustomHostVital(ctx context.Context, tx sqlx.ExtContext, hostID, vitalID uint) error {
+	var enterpriseID string
+	if err := sqlx.GetContext(ctx, tx, &enterpriseID,
+		`SELECT enterprise_id FROM android_enterprises WHERE enterprise_id != '' LIMIT 1`); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "get android enterprise id for app config resend")
+	}
+
 	var host struct {
 		UUID           string `db:"uuid"`
 		GlobalOrTeamID uint   `db:"global_or_team_id"`
 	}
-	err := sqlx.GetContext(ctx, tx, &host,
-		`SELECT uuid, COALESCE(team_id, 0) AS global_or_team_id FROM hosts WHERE id = ? AND platform = 'android'`, hostID)
-	if err != nil {
+	if err := sqlx.GetContext(ctx, tx, &host,
+		`SELECT uuid, COALESCE(team_id, 0) AS global_or_team_id FROM hosts WHERE id = ? AND platform = 'android'`, hostID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// Not an Android host, so it has no managed app config.
 			return nil
@@ -517,7 +525,7 @@ func resendAndroidAppConfigsForCustomHostVital(ctx context.Context, tx sqlx.ExtC
 		AppTeamID     uint   `db:"app_team_id"`
 	}
 	if err := sqlx.SelectContext(ctx, tx, &candidates, selectStmt,
-		host.GlobalOrTeamID, fleet.CustomHostVitalPrefix); err != nil {
+		host.GlobalOrTeamID, varName); err != nil {
 		return ctxerr.Wrap(ctx, err, "select android app configs referencing custom host vital")
 	}
 
@@ -541,22 +549,12 @@ func resendAndroidAppConfigsForCustomHostVital(ctx context.Context, tx sqlx.ExtC
 	// An app scoped away from this host by labels isn't available on it, so it
 	// must not be pushed. The worker's batch task takes the hosts it is given
 	// without re-checking scope, hence the check here.
-	policyIDByAppTeam, err := androidHostPolicyIDsForApps(ctx, tx, hostID, appTeamIDs)
+	policyIDByAppTeam, err := androidHostPolicyIDsForApps(ctx, tx, hostID, host.GlobalOrTeamID, appTeamIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get android policy ids for app config resend")
 	}
 	if len(policyIDByAppTeam) == 0 {
 		return nil
-	}
-
-	var enterpriseID string
-	if err := sqlx.GetContext(ctx, tx, &enterpriseID,
-		`SELECT enterprise_id FROM android_enterprises WHERE enterprise_id != '' LIMIT 1`); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// No enterprise configured — nothing can be delivered.
-			return nil
-		}
-		return ctxerr.Wrap(ctx, err, "get android enterprise id for app config resend")
 	}
 
 	const insertJob = `INSERT INTO jobs (name, args, state, error) VALUES (?, ?, 'queued', '')`
@@ -590,7 +588,7 @@ func resendAndroidAppConfigsForCustomHostVital(ctx context.Context, tx sqlx.ExtC
 // getIncludedHostUUIDMapForSoftware, which answers the same question for every
 // host in one app's fleet; here the scope filter correlates to the outer
 // vat.id so every app resolves in one query rather than one query each.
-func androidHostPolicyIDsForApps(ctx context.Context, tx sqlx.ExtContext, hostID uint, appTeamIDs []uint) (map[uint]string, error) {
+func androidHostPolicyIDsForApps(ctx context.Context, tx sqlx.ExtContext, hostID, globalOrTeamID uint, appTeamIDs []uint) (map[uint]string, error) {
 	if len(appTeamIDs) == 0 {
 		return nil, nil
 	}
@@ -598,11 +596,11 @@ func androidHostPolicyIDsForApps(ctx context.Context, tx sqlx.ExtContext, hostID
 	stmt := fmt.Sprintf(`SELECT vat.id AS app_team_id, COALESCE(ad.applied_policy_id, '') AS policy_id
 		FROM hosts h
 		JOIN android_devices ad ON ad.enterprise_specific_id = h.uuid
-		JOIN vpp_apps_teams vat ON vat.team_id <=> h.team_id AND vat.id IN (?)
+		JOIN vpp_apps_teams vat ON vat.global_or_team_id = ? AND vat.id IN (?)
 		WHERE h.id = ? AND h.platform = 'android' AND EXISTS (%s)`,
 		fmt.Sprintf(labelScopedFilter, softwareTypeVPP, "vat.id"))
 
-	stmt, args, err := sqlx.In(stmt, appTeamIDs, hostID)
+	stmt, args, err := sqlx.In(stmt, globalOrTeamID, appTeamIDs, hostID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -208,6 +209,18 @@ func (ds *Datastore) customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtConte
 				FROM mdm_android_configuration_profiles p
 				LEFT JOIN teams t ON t.id = p.team_id;`,
 		},
+		// An Android app's managed configuration is delivered by the software
+		// worker rather than the profile reconciler, but it references vitals the
+		// same way a profile does, so it gets the same delete protection.
+		{
+			desc: "get android app configuration contents",
+			stmt: `SELECT 'android_app_config' AS entity,
+				COALESCE(NULLIF(va.name, ''), aac.application_id) AS name,
+				COALESCE(t.name, 'Unassigned') AS team_name, aac.configuration AS contents
+				FROM android_app_configurations aac
+				LEFT JOIN vpp_apps va ON va.adam_id = aac.application_id AND va.platform = 'android'
+				LEFT JOIN teams t ON t.id = aac.team_id;`,
+		},
 		// Software installer and setup-experience scripts exceed secret-variable
 		// delete-protection (which doesn't scan them), so a vital can't be deleted
 		// while a script that runs it would silently start failing on hosts.
@@ -334,6 +347,11 @@ func (ds *Datastore) SetHostCustomHostVitalValue(ctx context.Context, hostID uin
 		if err := resendDeviceNameForCustomHostVital(ctx, tx, hostID, vitalID); err != nil {
 			return ctxerr.Wrap(ctx, err, "resend device name for custom host vital value change")
 		}
+
+		// Queue a re-push of the Android managed app configurations that reference the vital.
+		if err := resendAndroidAppConfigsForCustomHostVital(ctx, tx, hostID, vitalID); err != nil {
+			return ctxerr.Wrap(ctx, err, "resend android app configs for custom host vital value change")
+		}
 		return nil
 	})
 }
@@ -346,12 +364,10 @@ func (ds *Datastore) SetHostCustomHostVitalValue(ctx context.Context, hostID uin
 // tracked in mdm_configuration_profile_variables. Declarations only reset status
 // (the DDM reconciler re-stamps variables_updated_at, cache-busting the token).
 //
-// Unlike the IdP resend, this deliberately omits certificate templates and
-// Android managed app config: a vital can't reach cert templates (they only
-// take fleet_variables), and Android managed app config isn't tracked by
-// content-match resend like profiles are (its delivery is driven by the
-// software worker, not the profile reconciler), so there's nothing on those
-// two surfaces to resend here.
+// Unlike the IdP resend, this deliberately omits certificate templates: a
+// vital can't reach them (they only take fleet_variables). Android managed app
+// config is handled separately by resendAndroidAppConfigsForCustomHostVital,
+// which has no status row to reset.
 func resendMDMProfilesForCustomHostVital(ctx context.Context, tx sqlx.ExtContext, hostID, vitalID uint) error {
 	var hostUUID string
 	if err := sqlx.GetContext(ctx, tx, &hostUUID, `SELECT uuid FROM hosts WHERE id = ?`, hostID); err != nil {
@@ -463,6 +479,147 @@ func resendMDMProfilesForCustomHostVital(ctx context.Context, tx sqlx.ExtContext
 	}
 
 	return nil
+}
+
+// Re-pushes the Android managed app configurations in the host's fleet that reference $FLEET_HOST_VITAL_<vitalID>.
+// App config delivery is driven by the software worker rather than the profile reconciler,
+// so the resend is a queued job instead of a status reset.
+// It queues the host-scoped batch task, not the team-wide make_android_app_available, since a vital is set per host,
+// so a team-wide re-push would hit every host in the fleet on every value change.
+func resendAndroidAppConfigsForCustomHostVital(ctx context.Context, tx sqlx.ExtContext, hostID, vitalID uint) error {
+	var host struct {
+		UUID           string `db:"uuid"`
+		GlobalOrTeamID uint   `db:"global_or_team_id"`
+	}
+	err := sqlx.GetContext(ctx, tx, &host,
+		`SELECT uuid, COALESCE(team_id, 0) AS global_or_team_id FROM hosts WHERE id = ? AND platform = 'android'`, hostID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Not an Android host, so it has no managed app config.
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "get android host for app config resend")
+	}
+
+	varName := fmt.Sprintf("%s%d", fleet.CustomHostVitalPrefix, vitalID)
+
+	const selectStmt = `SELECT aac.application_id, aac.configuration, vat.id AS app_team_id
+		FROM android_app_configurations aac
+		JOIN vpp_apps_teams vat
+			ON vat.adam_id = aac.application_id
+			AND vat.global_or_team_id = aac.global_or_team_id
+			AND vat.platform = 'android'
+		WHERE aac.global_or_team_id = ? AND INSTR(aac.configuration, ?) > 0`
+
+	var candidates []struct {
+		ApplicationID string `db:"application_id"`
+		Configuration string `db:"configuration"`
+		AppTeamID     uint   `db:"app_team_id"`
+	}
+	if err := sqlx.SelectContext(ctx, tx, &candidates, selectStmt,
+		host.GlobalOrTeamID, fleet.CustomHostVitalPrefix); err != nil {
+		return ctxerr.Wrap(ctx, err, "select android app configs referencing custom host vital")
+	}
+
+	type matchedApp struct {
+		applicationID string
+		appTeamID     uint
+	}
+	var matched []matchedApp
+	var appTeamIDs []uint
+	for _, c := range candidates {
+		if !fleet.ContainsVar(c.Configuration, varName) {
+			continue
+		}
+		matched = append(matched, matchedApp{applicationID: c.ApplicationID, appTeamID: c.AppTeamID})
+		appTeamIDs = append(appTeamIDs, c.AppTeamID)
+	}
+	if len(matched) == 0 {
+		return nil
+	}
+
+	// An app scoped away from this host by labels isn't available on it, so it
+	// must not be pushed. The worker's batch task takes the hosts it is given
+	// without re-checking scope, hence the check here.
+	policyIDByAppTeam, err := androidHostPolicyIDsForApps(ctx, tx, hostID, appTeamIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get android policy ids for app config resend")
+	}
+	if len(policyIDByAppTeam) == 0 {
+		return nil
+	}
+
+	var enterpriseID string
+	if err := sqlx.GetContext(ctx, tx, &enterpriseID,
+		`SELECT enterprise_id FROM android_enterprises WHERE enterprise_id != '' LIMIT 1`); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// No enterprise configured — nothing can be delivered.
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "get android enterprise id for app config resend")
+	}
+
+	const insertJob = `INSERT INTO jobs (name, args, state, error) VALUES (?, ?, 'queued', '')`
+	for _, m := range matched {
+		policyID, inScope := policyIDByAppTeam[m.appTeamID]
+		if !inScope {
+			continue
+		}
+		args, err := json.Marshal(map[string]any{
+			"task":                   "make_android_app_available_batch",
+			"application_id":         m.applicationID,
+			"app_team_id":            m.appTeamID,
+			"enterprise_name":        "enterprises/" + enterpriseID,
+			"app_config_changed":     true,
+			"host_uuid_to_policy_id": map[string]string{host.UUID: policyID},
+		})
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "marshal job args for android app config resend")
+		}
+		if _, err := tx.ExecContext(ctx, insertJob, "software_worker", json.RawMessage(args)); err != nil {
+			return ctxerr.Wrap(ctx, err, "insert android app config resend job")
+		}
+	}
+
+	return nil
+}
+
+// androidHostPolicyIDsForApps returns the host's applied Android policy ID for
+// each of the given apps it is in scope for, keyed by vpp_apps_teams row id.
+// Apps the host is out of scope for are absent. Single-host counterpart of
+// getIncludedHostUUIDMapForSoftware, which answers the same question for every
+// host in one app's fleet; here the scope filter correlates to the outer
+// vat.id so every app resolves in one query rather than one query each.
+func androidHostPolicyIDsForApps(ctx context.Context, tx sqlx.ExtContext, hostID uint, appTeamIDs []uint) (map[uint]string, error) {
+	if len(appTeamIDs) == 0 {
+		return nil, nil
+	}
+
+	stmt := fmt.Sprintf(`SELECT vat.id AS app_team_id, COALESCE(ad.applied_policy_id, '') AS policy_id
+		FROM hosts h
+		JOIN android_devices ad ON ad.enterprise_specific_id = h.uuid
+		JOIN vpp_apps_teams vat ON vat.team_id <=> h.team_id AND vat.id IN (?)
+		WHERE h.id = ? AND h.platform = 'android' AND EXISTS (%s)`,
+		fmt.Sprintf(labelScopedFilter, softwareTypeVPP, "vat.id"))
+
+	stmt, args, err := sqlx.In(stmt, appTeamIDs, hostID)
+	if err != nil {
+		return nil, err
+	}
+
+	var rows []struct {
+		AppTeamID uint   `db:"app_team_id"`
+		PolicyID  string `db:"policy_id"`
+	}
+	if err := sqlx.SelectContext(ctx, tx, &rows, stmt, args...); err != nil {
+		return nil, err
+	}
+
+	policyIDs := make(map[uint]string, len(rows))
+	for _, r := range rows {
+		policyIDs[r.AppTeamID] = r.PolicyID
+	}
+	return policyIDs, nil
 }
 
 func (ds *Datastore) GetHostCustomHostVitals(ctx context.Context, hostID uint) ([]fleet.HostCustomHostVital, error) {

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -739,6 +739,19 @@ func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *D
 	token := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, vitalID)
 	otherToken := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, otherVitalID)
 
+	// A different vital whose ID happens to start with vitalID's digits (1 vs 10).
+	// INSTR can't tell $FLEET_HOST_VITAL_1 from $FLEET_HOST_VITAL_10, so an app
+	// referencing only this one is a false-positive candidate in SQL that the Go
+	// ContainsVar pass has to reject. It must resend for its own vital, never for
+	// vitalID.
+	lookalikeVitalID := vitalID * 10
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO custom_host_vitals (id, name) VALUES (?, 'LOOKALIKE')`, lookalikeVitalID)
+		return err
+	})
+	lookalikeToken := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, lookalikeVitalID)
+
 	// vitalApp's config references the vital; otherApp's references a different
 	// vital; otherTeamApp's references the same vital but in another fleet.
 	const (
@@ -746,6 +759,8 @@ func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *D
 		secondVitalAppID = "com.example.secondvitalapp"
 		otherAppID       = "com.example.otherapp"
 		otherTeamAppID   = "com.example.otherteamapp"
+		lookalikeAppID   = "com.example.lookalikeapp"
+		noSigilAppID     = "com.example.nosigilapp"
 	)
 	appTeamIDs := map[string]uint{}
 	addApp := func(appID string, teamID uint) {
@@ -772,6 +787,8 @@ func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *D
 	addApp(vitalAppID, 0)
 	addApp(otherAppID, 0)
 	addApp(otherTeamAppID, otherTeam.ID)
+	addApp(lookalikeAppID, 0)
+	addApp(noSigilAppID, 0)
 
 	configWith := func(tok string) []byte {
 		return []byte(fmt.Sprintf(`{"managedConfiguration":{"assetTag":"%s"}}`, tok))
@@ -779,6 +796,10 @@ func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *D
 	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, vitalAppID, configWith(token)))
 	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, otherAppID, configWith(otherToken)))
 	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), otherTeam.ID, otherTeamAppID, configWith(token)))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, lookalikeAppID, configWith(lookalikeToken)))
+	// A bare mention with no '$' isn't a variable reference, but INSTR matches it.
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, noSigilAppID,
+		[]byte(fmt.Sprintf(`{"managedConfiguration":{"note":"see %s%d in the runbook"}}`, fleet.CustomHostVitalPrefix, vitalID))))
 
 	type appConfigResendJob struct {
 		Task             string            `json:"task"`
@@ -822,6 +843,19 @@ func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *D
 	// whose config references it, in the host's fleet only.
 	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, vitalID, "Engineering"))
 	jobs := drainJobs()
+
+	// Both of these match the SQL INSTR filter for vitalID and are ruled out only
+	// by the Go ContainsVar pass. Asserted before the exact count so a regression
+	// names the guard that broke instead of just reporting a bad job count.
+	resentApps := make([]string, 0, len(jobs))
+	for _, j := range jobs {
+		resentApps = append(resentApps, j.ApplicationID)
+	}
+	require.NotContains(t, resentApps, lookalikeAppID,
+		"an app referencing only the lookalike vital ($FLEET_HOST_VITAL_<vitalID*10>) must not resend on vitalID's change")
+	require.NotContains(t, resentApps, noSigilAppID,
+		"a bare mention with no '$' isn't a variable reference and must not resend")
+
 	require.Len(t, jobs, 1)
 	require.Equal(t, "make_android_app_available_batch", jobs[0].Task)
 	require.Equal(t, vitalAppID, jobs[0].ApplicationID)
@@ -830,6 +864,13 @@ func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *D
 	require.True(t, jobs[0].AppConfigChanged)
 	require.Equal(t, map[string]string{androidHost.Host.UUID: "1"}, jobs[0].HostUUIDToPolicy,
 		"resend must target only the host whose value changed, at its applied policy")
+
+	// The lookalike app resends for its own vital, so its absence above is the id
+	// boundary working rather than a misconfigured fixture.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, lookalikeVitalID, "LOOKALIKE-VALUE"))
+	jobs = drainJobs()
+	require.Len(t, jobs, 1)
+	require.Equal(t, lookalikeAppID, jobs[0].ApplicationID)
 
 	// Re-setting the same vital queues again: the value changed, so the device
 	// needs the new one even though nothing else moved.

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,7 @@ func TestCustomHostVitals(t *testing.T) {
 		{"DeleteCustomHostVital", testDeleteCustomHostVital},
 		{"DeleteUsedCustomHostVital", testDeleteUsedCustomHostVital},
 		{"SetHostValueResendsReferencingProfiles", testSetHostCustomHostVitalValueResendsProfiles},
+		{"SetHostValueResendsReferencingAndroidAppConfigs", testSetHostCustomHostVitalValueResendsAndroidAppConfigs},
 		{"SetHostValueResendsReferencingDeviceName", testSetHostCustomHostVitalValueResendsDeviceName},
 		{"ReconcileSnapshotMarksVitalDeclarations", testReconcileSnapshotMarksVitalDeclarations},
 		{"ValidateReferencedCustomHostVitalsRejectsMalformed", testValidateReferencedCustomHostVitalsRejectsMalformed},
@@ -432,6 +434,34 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.NoError(t, ds.DeleteMDMAndroidConfigProfile(ctx, androidProfile.ProfileUUID))
 	})
 
+	t.Run("android app configurations", func(t *testing.T) {
+		const appID = "org.mozilla.firefox"
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO vpp_apps (adam_id, platform, name) VALUES (?, 'android', 'Firefox')`, appID); err != nil {
+				return err
+			}
+			_, err := q.ExecContext(ctx,
+				`INSERT INTO vpp_apps_teams (adam_id, platform, team_id, global_or_team_id) VALUES (?, 'android', ?, ?)`,
+				appID, foobarTeam.ID, foobarTeam.ID)
+			return err
+		})
+		require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), foobarTeam.ID, appID,
+			[]byte(fmt.Sprintf(`{"managedConfiguration":{"assetTag":"%s"}}`, token))))
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, fleet.CustomHostVitalEntityAndroidAppConfig, useErr.Entity.Type)
+		require.Equal(t, "Firefox", useErr.Entity.Name)
+		require.Equal(t, "Foobar", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteAndroidAppConfiguration(ctx, appID, foobarTeam.ID))
+	})
+
 	t.Run("scripts", func(t *testing.T) {
 		script, err := ds.NewScript(ctx, &fleet.Script{
 			Name:           "collect.sh",
@@ -680,6 +710,156 @@ func testSetHostCustomHostVitalValueResendsProfiles(t *testing.T, ds *Datastore)
 			host.UUID, declVital.DeclarationUUID)
 	})
 	require.Nil(t, declStatus, "declaration should be reset (NULL status) so the DDM reconciler re-delivers it")
+}
+
+// Setting a host's value for a vital must queue a resend of the Android
+// managed app configurations delivered to that host that reference the vital.
+// Unlike profiles, app configs have no per-host status row to reset: delivery
+// is driven by the software worker, so the resend is a queued job scoped to
+// the one affected host, not the whole fleet.
+func testSetHostCustomHostVitalValueResendsAndroidAppConfigs(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// The enterprise name is resolved from the DB when queueing the job.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `INSERT INTO android_enterprises (signup_name, enterprise_id) VALUES ('test', 'LC0vital123')`)
+		return err
+	})
+
+	androidHost, err := ds.NewAndroidHost(ctx, createAndroidHost("chv-appcfg-host"), false)
+	require.NoError(t, err)
+	macHost := test.NewHost(t, ds, "chv-appcfg-mac", "9", "chv-appcfg-mackey", "chv-appcfg-macuuid", time.Now())
+
+	otherTeam, err := ds.NewTeam(ctx, &fleet.Team{Name: "chv-appcfg-other-team"})
+	require.NoError(t, err)
+
+	vitalID := createCustomHostVital(t, ds, "FUNCTION")
+	otherVitalID := createCustomHostVital(t, ds, "OTHER")
+	unusedVitalID := createCustomHostVital(t, ds, "UNUSED")
+	token := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, vitalID)
+	otherToken := fmt.Sprintf("$%s%d", fleet.CustomHostVitalPrefix, otherVitalID)
+
+	// vitalApp's config references the vital; otherApp's references a different
+	// vital; otherTeamApp's references the same vital but in another fleet.
+	const (
+		vitalAppID       = "com.example.vitalapp"
+		secondVitalAppID = "com.example.secondvitalapp"
+		otherAppID       = "com.example.otherapp"
+		otherTeamAppID   = "com.example.otherteamapp"
+	)
+	appTeamIDs := map[string]uint{}
+	addApp := func(appID string, teamID uint) {
+		t.Helper()
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO vpp_apps (adam_id, platform, name) VALUES (?, 'android', ?)`, appID, appID); err != nil {
+				return err
+			}
+			res, err := q.ExecContext(ctx,
+				`INSERT INTO vpp_apps_teams (adam_id, platform, team_id, global_or_team_id) VALUES (?, 'android', ?, ?)`,
+				appID, ptr.UintOrNilIfZero(teamID), teamID)
+			if err != nil {
+				return err
+			}
+			id, err := res.LastInsertId()
+			if err != nil {
+				return err
+			}
+			appTeamIDs[appID] = uint(id) //nolint:gosec // test-only insert id
+			return nil
+		})
+	}
+	addApp(vitalAppID, 0)
+	addApp(otherAppID, 0)
+	addApp(otherTeamAppID, otherTeam.ID)
+
+	configWith := func(tok string) []byte {
+		return []byte(fmt.Sprintf(`{"managedConfiguration":{"assetTag":"%s"}}`, tok))
+	}
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, vitalAppID, configWith(token)))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, otherAppID, configWith(otherToken)))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), otherTeam.ID, otherTeamAppID, configWith(token)))
+
+	type appConfigResendJob struct {
+		Task             string            `json:"task"`
+		ApplicationID    string            `json:"application_id"`
+		AppTeamID        uint              `json:"app_team_id"` //nolint:apiparamcheck // mirrors the worker job args
+		EnterpriseName   string            `json:"enterprise_name"`
+		AppConfigChanged bool              `json:"app_config_changed"`
+		HostUUIDToPolicy map[string]string `json:"host_uuid_to_policy_id"`
+	}
+	// Reads and clears the queue, so each assertion sees only its own jobs.
+	drainJobs := func() []appConfigResendJob {
+		t.Helper()
+		var raw []json.RawMessage
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &raw,
+				`SELECT args FROM jobs WHERE name = 'software_worker' AND state = 'queued'`)
+		})
+		jobs := make([]appConfigResendJob, 0, len(raw))
+		for _, r := range raw {
+			var j appConfigResendJob
+			require.NoError(t, json.Unmarshal(r, &j))
+			jobs = append(jobs, j)
+		}
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `DELETE FROM jobs`)
+			return err
+		})
+		return jobs
+	}
+	drainJobs()
+
+	// A vital no app config references queues nothing.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, unusedVitalID, "ignored"))
+	require.Empty(t, drainJobs())
+
+	// A non-Android host queues nothing, even for a referenced vital.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, macHost.ID, vitalID, "Engineering"))
+	require.Empty(t, drainJobs())
+
+	// The referenced vital queues exactly one host-scoped resend, for the app
+	// whose config references it, in the host's fleet only.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, vitalID, "Engineering"))
+	jobs := drainJobs()
+	require.Len(t, jobs, 1)
+	require.Equal(t, "make_android_app_available_batch", jobs[0].Task)
+	require.Equal(t, vitalAppID, jobs[0].ApplicationID)
+	require.Equal(t, appTeamIDs[vitalAppID], jobs[0].AppTeamID)
+	require.Equal(t, "enterprises/LC0vital123", jobs[0].EnterpriseName)
+	require.True(t, jobs[0].AppConfigChanged)
+	require.Equal(t, map[string]string{androidHost.Host.UUID: "1"}, jobs[0].HostUUIDToPolicy,
+		"resend must target only the host whose value changed, at its applied policy")
+
+	// Re-setting the same vital queues again: the value changed, so the device
+	// needs the new one even though nothing else moved.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, vitalID, "Support"))
+	require.Len(t, drainJobs(), 1)
+
+	// A second app referencing the same vital gets its own resend, so both
+	// apps' policies are re-pushed off one value change.
+	addApp(secondVitalAppID, 0)
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(ctx, ds.writer(ctx), 0, secondVitalAppID, configWith(token)))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, vitalID, "Sales"))
+	jobs = drainJobs()
+	require.Len(t, jobs, 2)
+	resentAppIDs := []string{jobs[0].ApplicationID, jobs[1].ApplicationID}
+	require.ElementsMatch(t, []string{vitalAppID, secondVitalAppID}, resentAppIDs)
+
+	// Scoping one app to a label the host isn't a member of puts the host out of
+	// that app's scope: it drops out of the resend while the other stays.
+	label, err := ds.NewLabel(ctx, &fleet.Label{Name: "chv-appcfg-scope", Query: "SELECT 1"})
+	require.NoError(t, err)
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO vpp_app_team_labels (vpp_app_team_id, label_id, exclude) VALUES (?, ?, 0)`,
+			appTeamIDs[vitalAppID], label.ID)
+		return err
+	})
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, androidHost.Host.ID, vitalID, "OutOfScope"))
+	jobs = drainJobs()
+	require.Len(t, jobs, 1, "the out-of-scope app must not be resent")
+	require.Equal(t, secondVitalAppID, jobs[0].ApplicationID)
 }
 
 // testSetHostCustomHostVitalValueResendsDeviceName covers the device-name side

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4293,7 +4293,7 @@ FROM (
 			0 AS count_installer_labels,
 			0 AS count_host_labels,
 			0 AS count_host_updated_after_labels
-		WHERE NOT EXISTS ( SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = ?)
+		WHERE NOT EXISTS ( SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = %[2]s)
 
 		UNION
 
@@ -4307,7 +4307,7 @@ FROM (
 		LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
 		AND lm.host_id = h.id
 		WHERE
-			sil.%[1]s_id = ?
+			sil.%[1]s_id = %[2]s
 			AND sil.exclude = 0
 		HAVING
 			count_installer_labels > 0
@@ -4331,7 +4331,7 @@ FROM (
 		LEFT OUTER JOIN labels lbl ON lbl.id = sil.label_id
 		LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = h.id
 WHERE
-	sil.%[1]s_id = ?
+	sil.%[1]s_id = %[2]s
 	AND sil.exclude = 1
 HAVING
 	count_installer_labels > 0
@@ -4343,7 +4343,7 @@ func (ds *Datastore) GetIncludedHostIDMapForSoftwareInstaller(ctx context.Contex
 }
 
 func (ds *Datastore) getIncludedHostIDMapForSoftware(ctx context.Context, tx sqlx.ExtContext, softwareID uint, swType softwareType) (map[uint]struct{}, error) {
-	filter := fmt.Sprintf(labelScopedFilter, swType)
+	filter := fmt.Sprintf(labelScopedFilter, swType, "?")
 	stmt := fmt.Sprintf(`SELECT
 	h.id
 FROM
@@ -4370,7 +4370,7 @@ func (ds *Datastore) GetIncludedHostUUIDMapForAppStoreApp(ctx context.Context, v
 }
 
 func (ds *Datastore) getIncludedHostUUIDMapForSoftware(ctx context.Context, tx sqlx.ExtContext, softwareID uint, swType softwareType) (map[string]string, error) {
-	filter := fmt.Sprintf(labelScopedFilter, swType)
+	filter := fmt.Sprintf(labelScopedFilter, swType, "?")
 	stmt := fmt.Sprintf(`SELECT
 		h.uuid AS uuid,
 		ad.applied_policy_id AS applied_policy_id
@@ -4405,7 +4405,7 @@ func (ds *Datastore) GetExcludedHostIDMapForSoftwareInstaller(ctx context.Contex
 }
 
 func (ds *Datastore) getExcludedHostIDMapForSoftware(ctx context.Context, softwareID uint, swType softwareType) (map[uint]struct{}, error) {
-	filter := fmt.Sprintf(labelScopedFilter, swType)
+	filter := fmt.Sprintf(labelScopedFilter, swType, "?")
 	stmt := fmt.Sprintf(`SELECT
 	h.id
 FROM

--- a/server/fleet/custom_host_vitals.go
+++ b/server/fleet/custom_host_vitals.go
@@ -124,6 +124,7 @@ const (
 	CustomHostVitalEntityAppleDeclaration      CustomHostVitalEntity = "apple_declaration"
 	CustomHostVitalEntityWindowsProfile        CustomHostVitalEntity = "windows_profile"
 	CustomHostVitalEntityAndroidProfile        CustomHostVitalEntity = "android_profile"
+	CustomHostVitalEntityAndroidAppConfig      CustomHostVitalEntity = "android_app_config"
 	CustomHostVitalEntitySoftwareInstaller     CustomHostVitalEntity = "software_installer"
 	CustomHostVitalEntitySetupExperienceScript CustomHostVitalEntity = "setup_experience_script"
 	CustomHostVitalEntityLabel                 CustomHostVitalEntity = "label"
@@ -166,6 +167,8 @@ func (i CustomHostVitalUsedInfo) Message() string {
 		noun, action = "setup experience script", "Please edit or delete the setup experience script and try again."
 	case CustomHostVitalEntityLabel:
 		noun, action = "label", "Please edit or delete the label and try again."
+	case CustomHostVitalEntityAndroidAppConfig:
+		noun, action = "software", "Please edit or clear the software's configuration and try again."
 	}
 	return fmt.Sprintf(
 		"Custom host vital %q (used as $%s%d) is used by the %q %s in the %q fleet. %s",

--- a/server/worker/software_worker.go
+++ b/server/worker/software_worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -214,6 +215,15 @@ func (v *SoftwareWorker) makeAndroidAppAvailableBatch(ctx context.Context, appli
 			}
 			substituted, err := v.substituteFleetVarsInConfigs(ctx, configByAppID, subHost)
 			if err != nil {
+				// One host that can't supply a referenced value must not block the
+				// rest of the batch, nor burn the job's retries on something no
+				// retry can fix. Whichever value is missing has its own resend
+				// trigger for when it lands.
+				if isUnresolvableAndroidAppConfigForHost(err) {
+					v.Log.WarnContext(ctx, "skipping android app config for host that can't supply a referenced value",
+						"host_uuid", hostUUID, "application_id", applicationID, "err", err)
+					continue
+				}
 				return ctxerr.Wrapf(ctx, err, "substitute fleet vars for host %s", hostUUID)
 			}
 
@@ -567,6 +577,20 @@ func (v *SoftwareWorker) substituteFleetVarsInConfigs(
 		result[appID] = substituted
 	}
 	return result, nil
+}
+
+// isUnresolvableAndroidAppConfigForHost separates "this host can't supply a
+// referenced value" — a custom host vital with no value set for this host, or
+// an unresolvable $FLEET_VAR_* — from a real failure. The former is host state
+// no retry can fix, so it's a per-host skip rather than a batch failure.
+func isUnresolvableAndroidAppConfigForHost(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := errors.AsType[*fleet.MissingCustomHostVitalValueError](err); ok {
+		return true
+	}
+	return errors.Is(err, profiles.ErrUnresolvableAndroidAppConfigVar)
 }
 
 func androidHostToSubstitutionHost(h *fleet.AndroidHost) profiles.AndroidAppConfigSubstitutionHost {

--- a/server/worker/software_worker_test.go
+++ b/server/worker/software_worker_test.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/mdm/profiles"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/assert"
@@ -370,6 +373,81 @@ func TestMakeAndroidAppAvailableBatchWithVars(t *testing.T) {
 	require.NotContains(t, capturedConfigByHost["uuid-aaa"], "$FLEET_VAR_HOST_UUID")
 	require.Contains(t, capturedConfigByHost["uuid-bbb"], "uuid-bbb", "host uuid-bbb should appear in its config")
 	require.NotContains(t, capturedConfigByHost["uuid-bbb"], "$FLEET_VAR_HOST_UUID")
+}
+
+// A host that can't supply a referenced value must not take the rest of its
+// batch down with it: the other hosts still get their app config, and the job
+// succeeds rather than burning its retries.
+func TestMakeAndroidAppAvailableBatchSkipsHostMissingVitalValue(t *testing.T) {
+	pushedConfigByHost := map[string]string{}
+
+	androidModule := &mockAndroidModule{
+		addAppsToAndroidPolicyFunc: func(ctx context.Context, enterpriseName string, appPolicies []*androidmanagement.ApplicationPolicy, hostUUIDs map[string]string) (map[string]*android.MDMAndroidPolicyRequest, error) {
+			require.Len(t, hostUUIDs, 1)
+			result := make(map[string]*android.MDMAndroidPolicyRequest)
+			for uuid := range hostUUIDs {
+				pushedConfigByHost[uuid] = string(appPolicies[0].ManagedConfiguration)
+				result[uuid] = &android.MDMAndroidPolicyRequest{PolicyVersion: sql.Null[int64]{V: 1, Valid: true}}
+			}
+			return result, nil
+		},
+	}
+
+	hostIDByUUID := map[string]uint{"uuid-has-value": 1, "uuid-no-value": 2}
+
+	ds := new(mock.Store)
+	ds.GetAndroidAppConfigurationByAppTeamIDFunc = func(ctx context.Context, appTeamID uint) ([]byte, error) {
+		return []byte(`{"managedConfiguration":{"assetTag":"$FLEET_HOST_VITAL_7"}}`), nil
+	}
+	ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+		var hosts []*fleet.Host
+		for _, uuid := range uuids {
+			hosts = append(hosts, &fleet.Host{ID: hostIDByUUID[uuid], UUID: uuid, Platform: "android"})
+		}
+		return hosts, nil
+	}
+	ds.ExpandCustomHostVitalsFunc = func(ctx context.Context, hostID uint, document string) (string, error) {
+		if hostID == hostIDByUUID["uuid-no-value"] {
+			return "", &fleet.MissingCustomHostVitalValueError{MissingIDs: []uint{7}, MissingNames: []string{"Asset tag"}}
+		}
+		return strings.ReplaceAll(document, "$FLEET_HOST_VITAL_7", "ASSET-1"), nil
+	}
+	var pendingApplyHosts []string
+	ds.SetAndroidAppInstallPendingApplyConfigFunc = func(ctx context.Context, hostUUID, applicationID string, policyVersion int64) error {
+		pendingApplyHosts = append(pendingApplyHosts, hostUUID)
+		return nil
+	}
+
+	w := &SoftwareWorker{Datastore: ds, AndroidModule: androidModule, Log: slog.New(slog.DiscardHandler)}
+
+	hosts := map[string]string{"uuid-has-value": "pol-1", "uuid-no-value": "pol-2"}
+	err := w.makeAndroidAppAvailableBatch(t.Context(), "com.example.app", 1, hosts, "enterprises/test", true)
+	require.NoError(t, err, "a host with no value for the vital must not fail the whole batch")
+
+	require.Contains(t, pushedConfigByHost, "uuid-has-value")
+	require.Contains(t, pushedConfigByHost["uuid-has-value"], "ASSET-1")
+	require.NotContains(t, pushedConfigByHost, "uuid-no-value", "host with no value for the vital should be skipped")
+	require.Equal(t, []string{"uuid-has-value"}, pendingApplyHosts)
+}
+
+func TestIsUnresolvableAndroidAppConfigForHost(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"missing vital value", &fleet.MissingCustomHostVitalValueError{MissingIDs: []uint{1}}, true},
+		{"wrapped missing vital value", fmt.Errorf("substitute: %w", &fleet.MissingCustomHostVitalValueError{MissingIDs: []uint{1}}), true},
+		{"unresolvable fleet var", &profiles.UnresolvableAndroidAppConfigVarError{FleetVar: "HOST_END_USER_IDP_USERNAME"}, true},
+		{"wrapped unresolvable fleet var", fmt.Errorf("substitute: %w", &profiles.UnresolvableAndroidAppConfigVarError{FleetVar: "HOST_END_USER_IDP_USERNAME"}), true},
+		{"unrelated error", errors.New("db is down"), false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, isUnresolvableAndroidAppConfigForHost(c.err))
+		})
+	}
 }
 
 func TestQueueBulkSetAndroidAppsAvailableForHostsChunking(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49421

Custom host vitals shipped for Android managed app configuration in #49696, but a change to a host's value never reached the device: app config delivery is driven by the software worker's job queue rather than the profile reconciler, so there is no per-host status row to reset and nothing re-queued the push. A device kept whatever value it was first given, and a host with no value set yet never recovered once one was set.

Will need to be cherry-picked to the 4.91 RC branch.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

- Enrolled Android Phone
- Added Google Chrome app
- Set this configuration:

<img width="1433" height="621" alt="Screenshot 2026-08-26 at 2 41 03 PM" src="https://github.com/user-attachments/assets/d3fdf9fe-c49c-4928-9925-9694df289d4c" />

Verified that the vital value is reflected on the phone, and that it's changed when the vital's value changes

<img width="1471" height="519" alt="Screenshot 2026-08-26 at 2 42 57 PM" src="https://github.com/user-attachments/assets/d520f05c-7efc-4d92-a14d-f373d7eb22c0" />


<img width="960" height="1280" alt="WhatsApp Image 2026-08-26 at 2 42 21 PM" src="https://github.com/user-attachments/assets/38bbde95-87fe-4b84-8689-4dea8a712052" />



Delete protection:

<img width="1499" height="1264" alt="Screenshot 2026-08-26 at 2 27 21 PM" src="https://github.com/user-attachments/assets/fc52f77c-ef74-4b2b-8860-b0be5aee981c" />

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Android app configurations are now included when checking whether host vitals can be safely deleted.
  * Updating a host vital automatically queues eligible Android app configuration resends.
  * Deletion warnings now identify software configurations that reference a host vital.

* **Bug Fixes**
  * Android configuration jobs now skip hosts with missing or unresolved values without blocking processing for other hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->