### PR TITLE
Fix SCIM group PATCH silently deleting members

### DIFF
--- a/changes/50724-scim-patch-group-member-loss
+++ b/changes/50724-scim-patch-group-member-loss
@@ -1,0 +1,1 @@
+- Fixed a bug where updating a SCIM group's members could silently remove members that the identity provider did not ask to remove.

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -4389,6 +4389,26 @@ func testPatchGroupAttributes(t *testing.T, s *Suite) {
 		s.DoJSON(t, "PATCH", scimPath("/Groups/"+groupID), nonExistentMemberPayload, http.StatusBadRequest, &errorResp)
 		assert.Contains(t, errorResp["detail"], "Bad Request", "Should return error for non-existent member ID")
 	})
+
+	t.Run("Non-existent member ID in a replace", func(t *testing.T) {
+		errorResp := patchGroup(t, s, groupID, http.StatusBadRequest, map[string]any{
+			"op":    "replace",
+			"path":  "members",
+			"value": []map[string]any{{"value": "4294967295"}},
+		})
+		assert.Contains(t, errorResp["detail"], "Bad Request", "Should return error for non-existent member ID")
+	})
+
+	t.Run("Patched attributes are persisted", func(t *testing.T) {
+		patchGroup(t, s, groupID, http.StatusOK,
+			map[string]any{"op": "replace", "path": "displayName", "value": "Persisted Group Name"},
+			map[string]any{"op": "replace", "path": "externalId", "value": "persisted-external-id"},
+		)
+
+		got := getGroup(t, s, groupID)
+		assert.Equal(t, "Persisted Group Name", got["displayName"], "displayName should be persisted")
+		assert.Equal(t, "persisted-external-id", got["externalId"], "externalId should be persisted")
+	})
 }
 
 func testPatchGroupMembers(t *testing.T, s *Suite) {
@@ -4721,6 +4741,58 @@ func testPatchGroupMembers(t *testing.T, s *Suite) {
 		require.True(t, ok, "Response should have members array")
 		assert.Equal(t, 1, len(members), "Group should have 1 member")
 	})
+
+	t.Run("Member changes are persisted and leave other members alone", func(t *testing.T) {
+		member := func(id string) map[string]any { return map[string]any{"value": id} }
+
+		patchGroup(t, s, groupID, http.StatusOK, map[string]any{
+			"op": "replace", "path": "members",
+			"value": []map[string]any{member(userIDs[0]), member(userIDs[1])},
+		})
+		require.ElementsMatch(t, []string{userIDs[0], userIDs[1]}, groupMemberValues(t, s, groupID),
+			"replace should be persisted")
+
+		patchGroup(t, s, groupID, http.StatusOK, map[string]any{
+			"op": "add", "path": "members", "value": []map[string]any{member(userIDs[2])},
+		})
+		require.ElementsMatch(t, userIDs, groupMemberValues(t, s, groupID),
+			"adding a member must not drop the members the request never mentioned")
+
+		patchGroup(t, s, groupID, http.StatusOK, map[string]any{
+			"op": "replace", "path": "displayName", "value": "Renamed Patch Members Group",
+		})
+		require.ElementsMatch(t, userIDs, groupMemberValues(t, s, groupID),
+			"a displayName-only patch must not touch membership")
+	})
+}
+
+func patchGroup(t *testing.T, s *Suite, groupID string, expectedStatus int, ops ...map[string]any) map[string]any {
+	t.Helper()
+	var resp map[string]any
+	s.DoJSON(t, "PATCH", scimPath("/Groups/"+groupID), map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		"Operations": ops,
+	}, expectedStatus, &resp)
+	return resp
+}
+
+func getGroup(t *testing.T, s *Suite, groupID string) map[string]any {
+	t.Helper()
+	var resp map[string]any
+	s.DoJSON(t, "GET", scimPath("/Groups/"+groupID), nil, http.StatusOK, &resp)
+	return resp
+}
+
+func groupMemberValues(t *testing.T, s *Suite, groupID string) []string {
+	t.Helper()
+	raw, _ := getGroup(t, s, groupID)["members"].([]any)
+	values := make([]string, 0, len(raw))
+	for _, m := range raw {
+		member, ok := m.(map[string]any)
+		require.True(t, ok, "member should be an object")
+		values = append(values, member["value"].(string))
+	}
+	return values
 }
 
 func scimPath(suffix string) string {

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -4764,6 +4764,22 @@ func testPatchGroupMembers(t *testing.T, s *Suite) {
 		require.ElementsMatch(t, userIDs, groupMemberValues(t, s, groupID),
 			"a displayName-only patch must not touch membership")
 	})
+
+	t.Run("Unfiltered remove with a value removes only the named member", func(t *testing.T) {
+		member := func(id string) map[string]any { return map[string]any{"value": id} }
+		patchGroup(t, s, groupID, http.StatusOK, map[string]any{
+			"op": "replace", "path": "members",
+			"value": []map[string]any{member(userIDs[0]), member(userIDs[1]), member(userIDs[2])},
+		})
+
+		// The form Entra ID sends to remove a single member.
+		patchGroup(t, s, groupID, http.StatusOK, map[string]any{
+			"op": "remove", "path": "members",
+			"value": []map[string]any{member(userIDs[0])},
+		})
+		require.ElementsMatch(t, []string{userIDs[1], userIDs[2]}, groupMemberValues(t, s, groupID),
+			"removing one member must not remove the others")
+	})
 }
 
 func patchGroup(t *testing.T, s *Suite, groupID string, expectedStatus int, ops ...map[string]any) map[string]any {

--- a/ee/server/scim/groups.go
+++ b/ee/server/scim/groups.go
@@ -12,6 +12,7 @@ import (
 	"github.com/elimity-com/scim"
 	"github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/optional"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/scim2/filter-parser/v2"
 )
@@ -314,12 +315,13 @@ func (g *GroupHandler) Delete(r *http.Request, id string) error {
 // Patch
 // Supporting add/replace/remove operations for "displayName", "externalId", and "members" attributes.
 func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.PatchOperation) (scim.Resource, error) {
-	ctx := r.Context()
+	ctx := ctxdb.RequirePrimary(r.Context(), true)
 	idUint, err := extractGroupIDFromValue(id)
 	if err != nil {
 		g.logger.InfoContext(ctx, "failed to parse id", "id", id, "err", err)
 		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
 	}
+
 	group, err := g.ds.ScimGroupByID(ctx, idUint, false)
 	switch {
 	case fleet.IsNotFound(err):
@@ -330,6 +332,10 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 		return scim.Resource{}, err
 	}
 
+	// A replace or remove-all operation declares a final membership state, which is
+	// destructive by intent; anything else is applied as a targeted delta.
+	deltas := &fleet.ScimGroupMemberDeltas{}
+	replaceAll := false
 	for _, op := range operations {
 		if op.Op != scim.PatchOperationAdd && op.Op != scim.PatchOperationReplace && op.Op != scim.PatchOperationRemove {
 			g.logger.InfoContext(ctx, "unsupported patch operation", "op", op.Op)
@@ -341,7 +347,7 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 				g.logger.InfoContext(ctx, "the 'path' attribute is REQUIRED for 'remove' operations", "op", op.Op)
 				return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
-			newValues, ok := op.Value.(map[string]interface{})
+			newValues, ok := op.Value.(map[string]any)
 			if !ok {
 				g.logger.InfoContext(ctx, "unsupported patch value", "value", op.Value)
 				return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
@@ -359,8 +365,8 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 						return scim.Resource{}, err
 					}
 				case membersAttr:
-					err = g.patchMembers(ctx, op.Op, v, group)
-					if err != nil {
+					replaceAll = replaceAll || op.Op != scim.PatchOperationAdd
+					if err = g.patchMembers(ctx, op.Op, v, group, deltas); err != nil {
 						return scim.Resource{}, err
 					}
 				default:
@@ -379,12 +385,12 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 				return scim.Resource{}, err
 			}
 		case op.Path.String() == membersAttr:
-			err = g.patchMembers(ctx, op.Op, op.Value, group)
-			if err != nil {
+			replaceAll = replaceAll || op.Op != scim.PatchOperationAdd
+			if err = g.patchMembers(ctx, op.Op, op.Value, group, deltas); err != nil {
 				return scim.Resource{}, err
 			}
 		case op.Path.AttributePath.String() == membersAttr:
-			err = g.patchMembersWithPathFiltering(ctx, op, group)
+			err = g.patchMembersWithPathFiltering(ctx, op, group, deltas)
 			if err != nil {
 				return scim.Resource{}, err
 			}
@@ -395,7 +401,21 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 	}
 
 	if len(operations) != 0 {
-		err = g.ds.ReplaceScimGroup(ctx, group)
+		newUsers, newChildGroups := deltas.AddUsers, deltas.AddChildGroups
+		// A replace declares the group's final membership, so the whole list needs
+		// checking.
+		if replaceAll {
+			newUsers, newChildGroups = group.ScimUsers, group.ChildGroups
+		}
+		if err := g.verifyMembersExist(ctx, newUsers, newChildGroups); err != nil {
+			return scim.Resource{}, err
+		}
+
+		if replaceAll {
+			err = g.ds.ReplaceScimGroup(ctx, group)
+		} else {
+			err = g.ds.ApplyScimGroupPatch(ctx, group, *deltas)
+		}
 		switch {
 		case fleet.IsNotFound(err):
 			g.logger.InfoContext(ctx, "failed to find group to patch", "id", id)
@@ -407,6 +427,38 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 	}
 
 	return createGroupResource(group), nil
+}
+
+// verifyMembersExist checks that the given members exist, in one query per
+// member kind.
+func (g *GroupHandler) verifyMembersExist(ctx context.Context, userIDs, childGroupIDs []uint) error {
+	if err := g.verifyMemberKindExists(ctx, memberKindUser, userIDs, g.ds.ScimUsersExist); err != nil {
+		return err
+	}
+	return g.verifyMemberKindExists(ctx, memberKindGroup, childGroupIDs, g.ds.ScimGroupsExist)
+}
+
+func (g *GroupHandler) verifyMemberKindExists(
+	ctx context.Context, kind memberKind, ids []uint, exist func(context.Context, []uint) (bool, error),
+) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	allExist, err := exist(ctx, ids)
+	if err != nil {
+		g.logger.ErrorContext(ctx, "error checking members existence", "err", err)
+		return err
+	}
+	if !allExist {
+		// Render the member IDs back into the "value" strings the request used.
+		values := make([]string, 0, len(ids))
+		for _, id := range ids {
+			values = append(values, memberValue(kind, id))
+		}
+		g.logger.InfoContext(ctx, "one or more members not found", "members", values)
+		return errors.ScimErrorBadParams(values)
+	}
+	return nil
 }
 
 func (g *GroupHandler) patchExternalId(ctx context.Context, op string, v any, group *fleet.ScimGroup) error {
@@ -442,7 +494,9 @@ func (g *GroupHandler) patchDisplayName(ctx context.Context, op string, v any, g
 }
 
 // patchMembers handles add/replace/remove operations for the members attribute
-func (g *GroupHandler) patchMembers(ctx context.Context, op string, v interface{}, group *fleet.ScimGroup) error {
+func (g *GroupHandler) patchMembers(
+	ctx context.Context, op string, v any, group *fleet.ScimGroup, deltas *fleet.ScimGroupMemberDeltas,
+) error {
 	if op == scim.PatchOperationRemove {
 		// Remove all members (both users and nested child groups)
 		group.ScimUsers = []uint{}
@@ -475,8 +529,6 @@ func (g *GroupHandler) patchMembers(ctx context.Context, op string, v interface{
 	// nested group (prefixed "group-<id>", as sent by Entra ID for nested groups).
 	userIDs := make([]uint, 0, len(membersList))
 	childGroupIDs := make([]uint, 0, len(membersList))
-	userValueStrings := make([]string, 0, len(membersList))
-	groupValueStrings := make([]string, 0, len(membersList))
 
 	for _, memberIntf := range membersList {
 		member, ok := memberIntf.(map[string]interface{})
@@ -505,36 +557,8 @@ func (g *GroupHandler) patchMembers(ctx context.Context, op string, v interface{
 		}
 		if kind == memberKindGroup {
 			childGroupIDs = append(childGroupIDs, id)
-			groupValueStrings = append(groupValueStrings, valueStr)
 		} else {
 			userIDs = append(userIDs, id)
-			userValueStrings = append(userValueStrings, valueStr)
-		}
-	}
-
-	// Verify all referenced users exist in a single database call
-	if len(userIDs) > 0 {
-		allExist, err := g.ds.ScimUsersExist(ctx, userIDs)
-		if err != nil {
-			g.logger.ErrorContext(ctx, "error checking users existence", "err", err)
-			return err
-		}
-		if !allExist {
-			g.logger.InfoContext(ctx, "one or more users not found", "userIDs", userIDs)
-			return errors.ScimErrorBadParams(userValueStrings)
-		}
-	}
-
-	// Verify all referenced child groups exist in a single database call
-	if len(childGroupIDs) > 0 {
-		allExist, err := g.ds.ScimGroupsExist(ctx, childGroupIDs)
-		if err != nil {
-			g.logger.ErrorContext(ctx, "error checking child groups existence", "err", err)
-			return err
-		}
-		if !allExist {
-			g.logger.InfoContext(ctx, "one or more child groups not found", "childGroupIDs", childGroupIDs)
-			return errors.ScimErrorBadParams(groupValueStrings)
 		}
 	}
 
@@ -542,6 +566,12 @@ func (g *GroupHandler) patchMembers(ctx context.Context, op string, v interface{
 	if op == scim.PatchOperationAdd {
 		group.ScimUsers = appendMissingUint(group.ScimUsers, userIDs)
 		group.ChildGroups = appendMissingUint(group.ChildGroups, childGroupIDs)
+		for _, userID := range userIDs {
+			deltas.AddUser(userID)
+		}
+		for _, childGroupID := range childGroupIDs {
+			deltas.AddChildGroup(childGroupID)
+		}
 	} else {
 		// For replace operation, replace all members
 		group.ScimUsers = userIDs // FIXME: List should be deduplicated by us? See https://github.com/fleetdm/fleet/issues/30086
@@ -569,7 +599,9 @@ func appendMissingUint(base, extra []uint) []uint {
 
 // patchMembersWithPathFiltering handles patch operations with path filtering for members
 // This supports paths like members[value eq "422"] for add/replace/remove operations
-func (g *GroupHandler) patchMembersWithPathFiltering(ctx context.Context, op scim.PatchOperation, group *fleet.ScimGroup) error {
+func (g *GroupHandler) patchMembersWithPathFiltering(
+	ctx context.Context, op scim.PatchOperation, group *fleet.ScimGroup, deltas *fleet.ScimGroupMemberDeltas,
+) error {
 	kind, memberID, err := g.getMemberID(ctx, op)
 	if err != nil {
 		return err
@@ -578,8 +610,10 @@ func (g *GroupHandler) patchMembersWithPathFiltering(ctx context.Context, op sci
 	// Operate on the appropriate member slice depending on whether the filter
 	// targets a user or a nested child group (e.g. members[value eq "group-62"]).
 	target := &group.ScimUsers
+	recordAdd, recordRemove := deltas.AddUser, deltas.RemoveUser
 	if kind == memberKindGroup {
 		target = &group.ChildGroups
+		recordAdd, recordRemove = deltas.AddChildGroup, deltas.RemoveChildGroup
 	}
 
 	// Check if the member exists in the group
@@ -595,6 +629,10 @@ func (g *GroupHandler) patchMembersWithPathFiltering(ctx context.Context, op sci
 
 	// For remove operations, remove the member if found
 	if op.Op == scim.PatchOperationRemove {
+		// The removal is recorded even when the member is absent from the list we
+		// read: the IdP asked for it to be gone, and a targeted delete of a row
+		// that isn't there is a no-op.
+		recordRemove(memberID)
 		if !memberFound {
 			g.logger.InfoContext(ctx, "member not found in group", "member_id", memberID, "kind", kind, "op", fmt.Sprintf("%v", op))
 			// The member may have been removed already from this group. For example, if the member was deleted.
@@ -606,17 +644,8 @@ func (g *GroupHandler) patchMembersWithPathFiltering(ctx context.Context, op sci
 
 	// For add operations, add the member if not found
 	if op.Op == scim.PatchOperationAdd && !memberFound {
-		// Verify the referenced member exists
-		exists, err := g.memberExists(ctx, kind, memberID)
-		if err != nil {
-			g.logger.ErrorContext(ctx, "error checking member existence", "err", err)
-			return err
-		}
-		if !exists {
-			g.logger.InfoContext(ctx, "member not found", "member_id", memberID, "kind", kind)
-			return errors.ScimErrorBadParams([]string{memberValue(kind, memberID)})
-		}
 		*target = append(*target, memberID)
+		recordAdd(memberID)
 		return nil
 	}
 
@@ -632,6 +661,7 @@ func (g *GroupHandler) patchMembersWithPathFiltering(ctx context.Context, op sci
 		// If the value is nil or an empty object, remove the member
 		if op.Value == nil {
 			*target = append((*target)[:memberIndex], (*target)[memberIndex+1:]...)
+			recordRemove(memberID)
 			return nil
 		}
 
@@ -710,16 +740,6 @@ func classifyMemberValue(value string) (memberKind, uint, error) {
 	return memberKindUser, id, nil
 }
 
-// memberExists reports whether the referenced user or nested group exists.
-func (g *GroupHandler) memberExists(ctx context.Context, kind memberKind, id uint) (bool, error) {
-	if kind == memberKindGroup {
-		return g.ds.ScimGroupsExist(ctx, []uint{id})
-	}
-	return g.ds.ScimUsersExist(ctx, []uint{id})
-}
-
-// memberValue renders the SCIM member "value" string for the given kind and ID,
-// for use in error messages.
 func memberValue(kind memberKind, id uint) string {
 	if kind == memberKindGroup {
 		return scimGroupID(id)

--- a/ee/server/scim/groups.go
+++ b/ee/server/scim/groups.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -365,7 +366,7 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 						return scim.Resource{}, err
 					}
 				case membersAttr:
-					replaceAll = replaceAll || op.Op != scim.PatchOperationAdd
+					replaceAll = replaceAll || declaresFullMembership(op.Op, v)
 					if err = g.patchMembers(ctx, op.Op, v, group, deltas); err != nil {
 						return scim.Resource{}, err
 					}
@@ -385,7 +386,7 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 				return scim.Resource{}, err
 			}
 		case op.Path.String() == membersAttr:
-			replaceAll = replaceAll || op.Op != scim.PatchOperationAdd
+			replaceAll = replaceAll || declaresFullMembership(op.Op, op.Value)
 			if err = g.patchMembers(ctx, op.Op, op.Value, group, deltas); err != nil {
 				return scim.Resource{}, err
 			}
@@ -497,7 +498,7 @@ func (g *GroupHandler) patchDisplayName(ctx context.Context, op string, v any, g
 func (g *GroupHandler) patchMembers(
 	ctx context.Context, op string, v any, group *fleet.ScimGroup, deltas *fleet.ScimGroupMemberDeltas,
 ) error {
-	if op == scim.PatchOperationRemove {
+	if op == scim.PatchOperationRemove && v == nil {
 		// Remove all members (both users and nested child groups)
 		group.ScimUsers = []uint{}
 		group.ChildGroups = []uint{}
@@ -562,8 +563,8 @@ func (g *GroupHandler) patchMembers(
 		}
 	}
 
-	// For add operation, append to existing members
-	if op == scim.PatchOperationAdd {
+	switch op {
+	case scim.PatchOperationAdd:
 		group.ScimUsers = appendMissingUint(group.ScimUsers, userIDs)
 		group.ChildGroups = appendMissingUint(group.ChildGroups, childGroupIDs)
 		for _, userID := range userIDs {
@@ -572,13 +573,33 @@ func (g *GroupHandler) patchMembers(
 		for _, childGroupID := range childGroupIDs {
 			deltas.AddChildGroup(childGroupID)
 		}
-	} else {
-		// For replace operation, replace all members
+	case scim.PatchOperationRemove:
+		group.ScimUsers = removeUints(group.ScimUsers, userIDs)
+		group.ChildGroups = removeUints(group.ChildGroups, childGroupIDs)
+		for _, userID := range userIDs {
+			deltas.RemoveUser(userID)
+		}
+		for _, childGroupID := range childGroupIDs {
+			deltas.RemoveChildGroup(childGroupID)
+		}
+	default: // replace
 		group.ScimUsers = userIDs // FIXME: List should be deduplicated by us? See https://github.com/fleetdm/fleet/issues/30086
 		group.ChildGroups = childGroupIDs
 	}
 
 	return nil
+}
+
+// declaresFullMembership reports whether an unfiltered members operation declares
+// the group's final membership rather than a delta: a replace, or a remove with no
+// value. A remove naming members (Entra ID's single-member removal form) is a delta.
+func declaresFullMembership(op string, v any) bool {
+	return op == scim.PatchOperationReplace || (op == scim.PatchOperationRemove && v == nil)
+}
+
+// removeUints returns base without the elements of toRemove, preserving order.
+func removeUints(base, toRemove []uint) []uint {
+	return slices.DeleteFunc(base, func(id uint) bool { return slices.Contains(toRemove, id) })
 }
 
 // appendMissingUint appends to base the elements of extra that are not already

--- a/ee/server/scim/groups_test.go
+++ b/ee/server/scim/groups_test.go
@@ -179,6 +179,22 @@ func TestGroupPatchMemberDeltas(t *testing.T) {
 		require.Empty(t, mocks.replaced.ChildGroups)
 	})
 
+	t.Run("unfiltered remove with a value removes only the named members", func(t *testing.T) {
+		// The form Entra ID sends to remove a single member.
+		mocks := newGroupTestMocks([]uint{1, 4}, []uint{7, 8})
+		patch(t, mocks, patchOp(t, scim.PatchOperationRemove, membersAttr, memberValues("4", "group-7")))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{RemoveUsers: []uint{4}, RemoveChildGroups: []uint{7}})
+	})
+
+	t.Run("unfiltered remove with an empty value is a no-op, not a remove-all", func(t *testing.T) {
+		// An empty list names nobody; only a remove with no value clears the group.
+		mocks := newGroupTestMocks([]uint{1, 2}, []uint{7})
+		patch(t, mocks, patchOp(t, scim.PatchOperationRemove, membersAttr, []any{}))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{})
+	})
+
 	t.Run("an add after a replace still writes the full membership state", func(t *testing.T) {
 		// The replace is what decides the write, so a later add must not downgrade it
 		// back to a delta write, which would leave members 1 and 2 in place.

--- a/ee/server/scim/groups_test.go
+++ b/ee/server/scim/groups_test.go
@@ -1,0 +1,212 @@
+package scim
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elimity-com/scim"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/scim2/filter-parser/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type groupTestMocks struct {
+	ds *mock.Store
+
+	patched  fleet.ScimGroupMemberDeltas
+	replaced *fleet.ScimGroup
+}
+
+func newGroupTestMocks(staleMembers, staleChildGroups []uint) *groupTestMocks {
+	m := &groupTestMocks{ds: new(mock.Store)}
+	m.ds.ScimGroupByIDFunc = func(ctx context.Context, id uint, excludeUsers bool) (*fleet.ScimGroup, error) {
+		return &fleet.ScimGroup{
+			ID:          id,
+			DisplayName: "Engineering",
+			ScimUsers:   append([]uint{}, staleMembers...),
+			ChildGroups: append([]uint{}, staleChildGroups...),
+		}, nil
+	}
+	m.ds.ScimUsersExistFunc = func(ctx context.Context, ids []uint) (bool, error) { return true, nil }
+	m.ds.ScimGroupsExistFunc = func(ctx context.Context, ids []uint) (bool, error) { return true, nil }
+	m.ds.ApplyScimGroupPatchFunc = func(ctx context.Context, group *fleet.ScimGroup, deltas fleet.ScimGroupMemberDeltas) error {
+		m.patched = deltas
+		return nil
+	}
+	m.ds.ReplaceScimGroupFunc = func(ctx context.Context, group *fleet.ScimGroup) error {
+		m.replaced = group
+		return nil
+	}
+	return m
+}
+
+func (m *groupTestMocks) newTestHandler() *GroupHandler {
+	return &GroupHandler{ds: m.ds, logger: slog.New(slog.DiscardHandler)}
+}
+
+// requireDeltas requires that the patch was written as targeted deltas matching
+// want, and not as a full membership rewrite.
+func requireDeltas(t *testing.T, mocks *groupTestMocks, want fleet.ScimGroupMemberDeltas) {
+	t.Helper()
+	require.True(t, mocks.ds.ApplyScimGroupPatchFuncInvoked, "patch should be applied as deltas")
+	require.False(t, mocks.ds.ReplaceScimGroupFuncInvoked, "patch must not rewrite the whole membership")
+	require.ElementsMatch(t, want.AddUsers, mocks.patched.AddUsers)
+	require.ElementsMatch(t, want.RemoveUsers, mocks.patched.RemoveUsers)
+	require.ElementsMatch(t, want.AddChildGroups, mocks.patched.AddChildGroups)
+	require.ElementsMatch(t, want.RemoveChildGroups, mocks.patched.RemoveChildGroups)
+}
+
+func requireFullWrite(t *testing.T, mocks *groupTestMocks) {
+	t.Helper()
+	require.True(t, mocks.ds.ReplaceScimGroupFuncInvoked, "patch should rewrite the whole membership")
+	require.False(t, mocks.ds.ApplyScimGroupPatchFuncInvoked, "patch should not be applied as deltas")
+}
+
+// patchOp builds a patch operation, parsing path unless it is empty.
+func patchOp(t *testing.T, op, path string, value any) scim.PatchOperation {
+	t.Helper()
+	operation := scim.PatchOperation{Op: op, Value: value}
+	if path != "" {
+		parsed, err := filter.ParsePath([]byte(path))
+		require.NoError(t, err)
+		operation.Path = &parsed
+	}
+	return operation
+}
+
+func memberValues(ids ...string) []any {
+	members := make([]any, 0, len(ids))
+	for _, id := range ids {
+		members = append(members, map[string]any{"value": id})
+	}
+	return members
+}
+
+func TestGroupPatchMemberDeltas(t *testing.T) {
+	patch := func(t *testing.T, mocks *groupTestMocks, ops ...scim.PatchOperation) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-1", nil)
+		_, err := mocks.newTestHandler().Patch(req, "group-1", ops)
+		require.NoError(t, err)
+	}
+
+	t.Run("add never removes members missing from a stale read", func(t *testing.T) {
+		// The read is stale: users 2 and 3 are members in the database but missing here.
+		mocks := newGroupTestMocks([]uint{1}, nil)
+		patch(t, mocks, patchOp(t, scim.PatchOperationAdd, membersAttr, memberValues("4")))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{AddUsers: []uint{4}})
+	})
+
+	t.Run("add without a path records the added members only", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1}, nil)
+		patch(t, mocks, patchOp(t, scim.PatchOperationAdd, "", map[string]any{membersAttr: memberValues("4", "group-7")}))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{AddUsers: []uint{4}, AddChildGroups: []uint{7}})
+	})
+
+	t.Run("displayName-only patch leaves membership untouched", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1, 2}, []uint{7})
+		patch(t, mocks, patchOp(t, scim.PatchOperationReplace, displayNameAttr, "Engineering EMEA"))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{})
+	})
+
+	t.Run("filtered remove records a targeted removal", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1, 2, 3}, []uint{7})
+		patch(t, mocks,
+			patchOp(t, scim.PatchOperationRemove, `members[value eq "2"]`, nil),
+			patchOp(t, scim.PatchOperationRemove, `members[value eq "group-7"]`, nil),
+		)
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{RemoveUsers: []uint{2}, RemoveChildGroups: []uint{7}})
+	})
+
+	t.Run("filtered remove of a member missing from the read still removes it", func(t *testing.T) {
+		// A read that doesn't show the member may simply be stale.
+		mocks := newGroupTestMocks([]uint{1}, nil)
+		patch(t, mocks, patchOp(t, scim.PatchOperationRemove, `members[value eq "2"]`, nil))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{RemoveUsers: []uint{2}})
+	})
+
+	t.Run("filtered replace with a nil value records a removal", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1, 2}, nil)
+		patch(t, mocks, patchOp(t, scim.PatchOperationReplace, `members[value eq "2"]`, nil))
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{RemoveUsers: []uint{2}})
+	})
+
+	t.Run("add then remove of the same member folds to a single removal", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1}, nil)
+		patch(t, mocks,
+			patchOp(t, scim.PatchOperationAdd, membersAttr, memberValues("4")),
+			patchOp(t, scim.PatchOperationRemove, `members[value eq "4"]`, nil),
+		)
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{RemoveUsers: []uint{4}})
+	})
+
+	t.Run("remove then add of the same member folds to a single add", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1, 4}, nil)
+		patch(t, mocks,
+			patchOp(t, scim.PatchOperationRemove, `members[value eq "4"]`, nil),
+			patchOp(t, scim.PatchOperationAdd, `members[value eq "4"]`, nil),
+		)
+
+		requireDeltas(t, mocks, fleet.ScimGroupMemberDeltas{AddUsers: []uint{4}})
+	})
+
+	t.Run("unfiltered replace writes the full membership state", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1, 2}, nil)
+		patch(t, mocks, patchOp(t, scim.PatchOperationReplace, membersAttr, memberValues("3")))
+
+		requireFullWrite(t, mocks)
+		require.Equal(t, []uint{3}, mocks.replaced.ScimUsers)
+	})
+
+	t.Run("remove all members writes the full membership state", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1, 2}, []uint{7})
+		patch(t, mocks, patchOp(t, scim.PatchOperationRemove, membersAttr, nil))
+
+		requireFullWrite(t, mocks)
+		require.Empty(t, mocks.replaced.ScimUsers)
+		require.Empty(t, mocks.replaced.ChildGroups)
+	})
+
+	t.Run("an add after a replace still writes the full membership state", func(t *testing.T) {
+		// The replace is what decides the write, so a later add must not downgrade it
+		// back to a delta write, which would leave members 1 and 2 in place.
+		mocks := newGroupTestMocks([]uint{1, 2}, nil)
+		patch(t, mocks,
+			patchOp(t, scim.PatchOperationReplace, membersAttr, memberValues("3")),
+			patchOp(t, scim.PatchOperationAdd, membersAttr, memberValues("4")),
+		)
+
+		requireFullWrite(t, mocks)
+		require.ElementsMatch(t, []uint{3, 4}, mocks.replaced.ScimUsers)
+	})
+
+	t.Run("the reads a patch depends on go to the primary", func(t *testing.T) {
+		mocks := newGroupTestMocks([]uint{1}, nil)
+		var groupReadPrimary, existsCheckPrimary bool
+		mocks.ds.ScimGroupByIDFunc = func(ctx context.Context, id uint, excludeUsers bool) (*fleet.ScimGroup, error) {
+			groupReadPrimary = ctxdb.IsPrimaryRequired(ctx)
+			return &fleet.ScimGroup{ID: id, DisplayName: "Engineering", ScimUsers: []uint{1}}, nil
+		}
+		mocks.ds.ScimUsersExistFunc = func(ctx context.Context, ids []uint) (bool, error) {
+			existsCheckPrimary = ctxdb.IsPrimaryRequired(ctx)
+			return true, nil
+		}
+
+		patch(t, mocks, patchOp(t, scim.PatchOperationAdd, membersAttr, memberValues("4")))
+
+		require.True(t, groupReadPrimary, "the group read must not come from a replica")
+		require.True(t, existsCheckPrimary, "the member existence check must not come from a replica")
+	})
+}

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jmoiron/sqlx"
 )
@@ -961,6 +963,128 @@ func getScimGroupUsers(ctx context.Context, q sqlx.QueryerContext, groupID uint)
 	return userIDs, nil
 }
 
+// scimGroupAttributes holds a SCIM group's stored scalar attributes.
+type scimGroupAttributes struct {
+	ExternalID  *string `db:"external_id"`
+	DisplayName string  `db:"display_name"`
+}
+
+// loadScimGroupAttributes reads a SCIM group's scalar attributes, so a caller can
+// tell what the update would change.
+func loadScimGroupAttributes(ctx context.Context, tx sqlx.ExtContext, groupID uint) (scimGroupAttributes, error) {
+	var existing scimGroupAttributes
+	err := sqlx.GetContext(ctx, tx, &existing,
+		`SELECT external_id, display_name FROM scim_groups WHERE id = ?`, groupID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return existing, notFound("scim group").WithID(groupID)
+		}
+		return existing, ctxerr.Wrap(ctx, err, "load existing scim group before update")
+	}
+	return existing, nil
+}
+
+// updateScimGroupAttributes writes a SCIM group's scalar attributes.
+func updateScimGroupAttributes(ctx context.Context, tx sqlx.ExtContext, group *fleet.ScimGroup) error {
+	const updateGroupQuery = `
+		UPDATE scim_groups SET
+			external_id = ?,
+			display_name = ?
+		WHERE id = ?`
+	result, err := tx.ExecContext(
+		ctx,
+		updateGroupQuery,
+		group.ExternalID,
+		group.DisplayName,
+		group.ID,
+	)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "update scim group")
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get rows affected for update scim group")
+	}
+	// The row was there a moment ago, so this only fires if it was deleted since.
+	if rowsAffected == 0 {
+		return notFound("scim group").WithID(group.ID)
+	}
+
+	return nil
+}
+
+// ApplyScimGroupPatch updates an existing SCIM group's attributes and applies
+// only the membership changes described by deltas, leaving every other member of
+// the group untouched.
+func (ds *Datastore) ApplyScimGroupPatch(ctx context.Context, group *fleet.ScimGroup, deltas fleet.ScimGroupMemberDeltas) error {
+	if err := validateScimGroupFields(group); err != nil {
+		return err
+	}
+
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		existing, err := loadScimGroupAttributes(ctx, tx, group.ID)
+		if err != nil {
+			return err
+		}
+		groupNameChanged := existing.DisplayName != group.DisplayName
+
+		// Skip the write when the attributes are untouched, which is the common case
+		// for a members-only patch. The UPDATE would be a no-op but still takes an
+		// exclusive lock on the group row until commit, serializing concurrent
+		// patches that the targeted member writes below do not need serialized.
+		if groupNameChanged || !ptr.Equal(existing.ExternalID, group.ExternalID) {
+			if err := updateScimGroupAttributes(ctx, tx, group); err != nil {
+				return err
+			}
+		}
+
+		return applyScimGroupMemberDeltas(ctx, tx, group.ID, deltas, groupNameChanged)
+	})
+}
+
+// applyScimGroupMemberDeltas writes the membership changes described by deltas
+// and triggers the profile resends they require.
+func applyScimGroupMemberDeltas(
+	ctx context.Context, tx sqlx.ExtContext, groupID uint, deltas fleet.ScimGroupMemberDeltas, groupNameChanged bool,
+) error {
+	if err := insertScimGroupUsers(ctx, tx, groupID, deltas.AddUsers); err != nil {
+		return err
+	}
+	if err := deleteScimGroupUsers(ctx, tx, groupID, deltas.RemoveUsers); err != nil {
+		return err
+	}
+	if err := insertScimGroupChildren(ctx, tx, groupID, deltas.AddChildGroups); err != nil {
+		return err
+	}
+	if err := deleteScimGroupChildren(ctx, tx, groupID, deltas.RemoveChildGroups); err != nil {
+		return err
+	}
+
+	// The users the deltas affected need their dependent profiles resent. The
+	// transitive lookups below run after the deletes, so removed users and
+	// removed-child subtrees are no longer reachable from the group and are
+	// collected explicitly.
+	affectedUsers := append(slices.Clone(deltas.AddUsers), deltas.RemoveUsers...)
+	// A child group edge change affects every user in that child's subtree,
+	// since their effective membership in this group (and its ancestors)
+	// changed.
+	subtreeRoots := append(slices.Clone(deltas.AddChildGroups), deltas.RemoveChildGroups...)
+	if groupNameChanged {
+		// A rename also affects every user still in the group, directly or
+		// through nested child groups.
+		subtreeRoots = append(subtreeRoots, groupID)
+	}
+	for _, subtreeID := range subtreeRoots {
+		subtreeUsers, err := getTransitiveScimGroupUserIDs(ctx, tx, subtreeID)
+		if err != nil {
+			return err
+		}
+		affectedUsers = append(affectedUsers, subtreeUsers...)
+	}
+	return triggerResendProfilesForIDPGroupChangeByUsers(ctx, tx, affectedUsers)
+}
+
 // ReplaceScimGroup replaces an existing SCIM group in the database
 func (ds *Datastore) ReplaceScimGroup(ctx context.Context, group *fleet.ScimGroup) error {
 	if err := validateScimGroupFields(group); err != nil {
@@ -968,178 +1092,67 @@ func (ds *Datastore) ReplaceScimGroup(ctx context.Context, group *fleet.ScimGrou
 	}
 
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// load the display name before updating the group, to check if it changed
-		var oldDisplayName string
-		err := sqlx.GetContext(ctx, tx, &oldDisplayName, `SELECT display_name FROM scim_groups WHERE id = ?`, group.ID)
+		existing, err := loadScimGroupAttributes(ctx, tx, group.ID)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return notFound("scim group").WithID(group.ID)
-			}
-			return ctxerr.Wrap(ctx, err, "load existing scim group display name before update")
+			return err
 		}
+		if err := updateScimGroupAttributes(ctx, tx, group); err != nil {
+			return err
+		}
+		groupNameChanged := existing.DisplayName != group.DisplayName
 
-		// Update the SCIM group
-		const updateGroupQuery = `
-		UPDATE scim_groups SET
-			external_id = ?,
-			display_name = ?
-		WHERE id = ?`
-		result, err := tx.ExecContext(
-			ctx,
-			updateGroupQuery,
-			group.ExternalID,
-			group.DisplayName,
-			group.ID,
-		)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "update scim group")
-		}
-
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get rows affected for update scim group")
-		}
-		if rowsAffected == 0 {
-			return notFound("scim group").WithID(group.ID)
-		}
-		groupNameChanged := oldDisplayName != group.DisplayName
-
-		// Get existing user-group relationships
+		// Diff the desired membership against the stored one, then write only the
+		// difference, reusing the same targeted writes a patch uses.
 		existingUsers, err := getScimGroupUsers(ctx, tx, group.ID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "get existing scim group users")
 		}
-
-		// Create maps for efficient lookup
-		existingUserMap := make(map[uint]bool)
-		for _, userID := range existingUsers {
-			existingUserMap[userID] = true
-		}
-
-		newUserMap := make(map[uint]bool)
-		for _, userID := range group.ScimUsers {
-			newUserMap[userID] = true
-		}
-
-		// Find users to add (in new but not in existing)
-		var usersToAdd []uint
-		for _, userID := range group.ScimUsers {
-			if !existingUserMap[userID] {
-				usersToAdd = append(usersToAdd, userID)
-			}
-		}
-
-		// Find users to remove (in existing but not in new)
-		var usersToRemove []uint
-		for _, userID := range existingUsers {
-			if !newUserMap[userID] {
-				usersToRemove = append(usersToRemove, userID)
-			}
-		}
-
-		// Add new user-group relationships
-		if len(usersToAdd) > 0 {
-			err = insertScimGroupUsers(ctx, tx, group.ID, usersToAdd)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "insert new scim group users")
-			}
-		}
-
-		// Remove old user-group relationships
-		if len(usersToRemove) > 0 {
-			batchSize := 10000
-			err = common_mysql.BatchProcessSimple(usersToRemove, batchSize, func(usersToRemoveInBatch []uint) error {
-				params := make([]interface{}, len(usersToRemoveInBatch)+1)
-				params[0] = group.ID
-				for i, userID := range usersToRemoveInBatch {
-					params[i+1] = userID
-				}
-
-				deleteQuery := "DELETE FROM scim_user_group WHERE group_id = ? AND scim_user_id IN (" +
-					strings.Repeat("?, ", len(usersToRemoveInBatch)-1) + "?)"
-
-				_, err = tx.ExecContext(ctx, deleteQuery, params...)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "delete removed scim group users")
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
-		}
-
-		// Reconcile nested child group edges the same way. Collect the users whose
-		// effective membership changed (the whole subtree of each added/removed
-		// child) so we can resend affected profiles below.
 		existingChildren, err := getScimGroupChildren(ctx, tx, group.ID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "get existing scim group children")
 		}
-		childrenToAdd, childrenToRemove := diffUintSlices(existingChildren, group.ChildGroups)
 
-		if len(childrenToAdd) > 0 {
-			if err = insertScimGroupChildren(ctx, tx, group.ID, childrenToAdd); err != nil {
-				return ctxerr.Wrap(ctx, err, "insert new scim group children")
-			}
-		}
-		if len(childrenToRemove) > 0 {
-			batchSize := 10000
-			err = common_mysql.BatchProcessSimple(childrenToRemove, batchSize, func(childIDsInBatch []uint) error {
-				params := make([]any, len(childIDsInBatch)+1)
-				params[0] = group.ID
-				for i, childID := range childIDsInBatch {
-					params[i+1] = childID
-				}
+		var deltas fleet.ScimGroupMemberDeltas
+		deltas.AddUsers, deltas.RemoveUsers = diffUintSlices(existingUsers, group.ScimUsers)
+		deltas.AddChildGroups, deltas.RemoveChildGroups = diffUintSlices(existingChildren, group.ChildGroups)
+		return applyScimGroupMemberDeltas(ctx, tx, group.ID, deltas, groupNameChanged)
+	})
+}
 
-				deleteQuery := "DELETE FROM scim_group_group WHERE parent_group_id = ? AND child_group_id IN (" +
-					strings.Repeat("?, ", len(childIDsInBatch)-1) + "?)"
+// deleteScimGroupMembers removes rows linking a SCIM group to the given member
+// IDs, leaving the group's other members in place. Both membership tables have
+// the same shape: a column pointing at the group, and one at the member.
+func deleteScimGroupMembers(
+	ctx context.Context, tx sqlx.ExtContext, table, groupCol, memberCol string, groupID uint, memberIDs []uint,
+) error {
+	if len(memberIDs) == 0 {
+		return nil
+	}
 
-				_, err = tx.ExecContext(ctx, deleteQuery, params...)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "delete removed scim group children")
-				}
-				return nil
-			})
-			if err != nil {
-				return err
-			}
+	batchSize := 10000
+	return common_mysql.BatchProcessSimple(memberIDs, batchSize, func(batch []uint) error {
+		params := make([]any, 0, len(batch)+1)
+		params = append(params, groupID)
+		for _, memberID := range batch {
+			params = append(params, memberID)
 		}
 
-		// resend profiles that depend on the updated group to hosts that are
-		// related to the users in the updated group (only for those users that
-		// were affected by the group change)
-		if groupNameChanged {
-			// if the name of the group changed, all hosts with users part of this
-			// group (directly or through nested child groups) are affected
-			affectedUsers, err := getTransitiveScimGroupUserIDs(ctx, tx, group.ID)
-			if err != nil {
-				return err
-			}
-			err = triggerResendProfilesForIDPGroupChangeByUsers(ctx, tx, affectedUsers)
-			if err != nil {
-				return err
-			}
-		} else {
-			affectedUsers := append(append([]uint{}, usersToAdd...), usersToRemove...)
-			// A child group edge change affects every user in that child's subtree,
-			// since their effective membership in this group (and its ancestors)
-			// changed.
-			for _, childID := range append(append([]uint{}, childrenToAdd...), childrenToRemove...) {
-				subtreeUsers, err := getTransitiveScimGroupUserIDs(ctx, tx, childID)
-				if err != nil {
-					return err
-				}
-				affectedUsers = append(affectedUsers, subtreeUsers...)
-			}
-			if len(affectedUsers) > 0 {
-				if err = triggerResendProfilesForIDPGroupChangeByUsers(ctx, tx, affectedUsers); err != nil {
-					return err
-				}
-			}
+		deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE %s = ? AND %s IN (%s?)",
+			table, groupCol, memberCol, strings.Repeat("?, ", len(batch)-1))
+
+		if _, err := tx.ExecContext(ctx, deleteQuery, params...); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete scim group members from "+table)
 		}
 		return nil
 	})
+}
+
+func deleteScimGroupUsers(ctx context.Context, tx sqlx.ExtContext, groupID uint, userIDs []uint) error {
+	return deleteScimGroupMembers(ctx, tx, "scim_user_group", "group_id", "scim_user_id", groupID, userIDs)
+}
+
+func deleteScimGroupChildren(ctx context.Context, tx sqlx.ExtContext, parentGroupID uint, childGroupIDs []uint) error {
+	return deleteScimGroupMembers(ctx, tx, "scim_group_group", "parent_group_id", "child_group_id", parentGroupID, childGroupIDs)
 }
 
 // diffUintSlices returns the elements to add (in want but not in have) and to

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1048,6 +1048,21 @@ func (ds *Datastore) ApplyScimGroupPatch(ctx context.Context, group *fleet.ScimG
 func applyScimGroupMemberDeltas(
 	ctx context.Context, tx sqlx.ExtContext, groupID uint, deltas fleet.ScimGroupMemberDeltas, groupNameChanged bool,
 ) error {
+	// Read which named members and child edges exist before the writes: the resend
+	// below then covers only members whose membership actually changes, so a no-op
+	// delta (an IdP retrying an add, removing a non-member) resends nothing. The
+	// read feeds only the resend set; the writes stay driven by the full deltas.
+	existingUsers, err := selectExistingScimGroupMembers(ctx, tx, "scim_user_group", "group_id", "scim_user_id",
+		groupID, append(slices.Clone(deltas.AddUsers), deltas.RemoveUsers...))
+	if err != nil {
+		return err
+	}
+	existingChildren, err := selectExistingScimGroupMembers(ctx, tx, "scim_group_group", "parent_group_id", "child_group_id",
+		groupID, append(slices.Clone(deltas.AddChildGroups), deltas.RemoveChildGroups...))
+	if err != nil {
+		return err
+	}
+
 	if err := insertScimGroupUsers(ctx, tx, groupID, deltas.AddUsers); err != nil {
 		return err
 	}
@@ -1061,15 +1076,14 @@ func applyScimGroupMemberDeltas(
 		return err
 	}
 
-	// The users the deltas affected need their dependent profiles resent. The
-	// transitive lookups below run after the deletes, so removed users and
+	// The transitive lookups below run after the deletes, so removed users and
 	// removed-child subtrees are no longer reachable from the group and are
 	// collected explicitly.
-	affectedUsers := append(slices.Clone(deltas.AddUsers), deltas.RemoveUsers...)
+	affectedUsers := membershipChanges(deltas.AddUsers, deltas.RemoveUsers, existingUsers)
 	// A child group edge change affects every user in that child's subtree,
 	// since their effective membership in this group (and its ancestors)
 	// changed.
-	subtreeRoots := append(slices.Clone(deltas.AddChildGroups), deltas.RemoveChildGroups...)
+	subtreeRoots := membershipChanges(deltas.AddChildGroups, deltas.RemoveChildGroups, existingChildren)
 	if groupNameChanged {
 		// A rename also affects every user still in the group, directly or
 		// through nested child groups.
@@ -1117,6 +1131,48 @@ func (ds *Datastore) ReplaceScimGroup(ctx context.Context, group *fleet.ScimGrou
 		deltas.AddChildGroups, deltas.RemoveChildGroups = diffUintSlices(existingChildren, group.ChildGroups)
 		return applyScimGroupMemberDeltas(ctx, tx, group.ID, deltas, groupNameChanged)
 	})
+}
+
+// selectExistingScimGroupMembers returns which of memberIDs are currently linked
+// to the group in table.
+func selectExistingScimGroupMembers(
+	ctx context.Context, tx sqlx.ExtContext, table, groupCol, memberCol string, groupID uint, memberIDs []uint,
+) (map[uint]struct{}, error) {
+	if len(memberIDs) == 0 {
+		return nil, nil
+	}
+	stmt, args, err := sqlx.In(
+		fmt.Sprintf("SELECT %s FROM %s WHERE %s = ? AND %s IN (?)", memberCol, table, groupCol, memberCol),
+		groupID, memberIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build select existing scim group members")
+	}
+	var ids []uint
+	if err := sqlx.SelectContext(ctx, tx, &ids, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "select existing scim group members from "+table)
+	}
+	existing := make(map[uint]struct{}, len(ids))
+	for _, id := range ids {
+		existing[id] = struct{}{}
+	}
+	return existing, nil
+}
+
+// membershipChanges returns the members whose membership the deltas actually
+// change: adds not already present and removes that are present.
+func membershipChanges(adds, removes []uint, existing map[uint]struct{}) []uint {
+	changed := make([]uint, 0, len(adds)+len(removes))
+	for _, id := range adds {
+		if _, ok := existing[id]; !ok {
+			changed = append(changed, id)
+		}
+	}
+	for _, id := range removes {
+		if _, ok := existing[id]; ok {
+			changed = append(changed, id)
+		}
+	}
+	return changed
 }
 
 // deleteScimGroupMembers removes rows linking a SCIM group to the given member

--- a/server/datastore/mysql/scim_test.go
+++ b/server/datastore/mysql/scim_test.go
@@ -41,6 +41,8 @@ func TestScim(t *testing.T) {
 		{"ScimGroupByID", testScimGroupByID},
 		{"ScimGroupByDisplayName", testScimGroupByDisplayName},
 		{"ReplaceScimGroup", testReplaceScimGroup},
+		{"ApplyScimGroupPatch", testApplyScimGroupPatch},
+		{"ApplyScimGroupPatchResendOnRenameWithRemovals", testApplyScimGroupPatchResendOnRenameWithRemovals},
 		{"ReplaceScimGroupValidation", testScimGroupReplaceValidation},
 		{"DeleteScimGroup", testDeleteScimGroup},
 		{"ListScimGroups", testListScimGroups},
@@ -1183,6 +1185,145 @@ func testReplaceScimGroup(t *testing.T, ds *Datastore) {
 
 	err = ds.ReplaceScimGroup(t.Context(), &nonExistentGroup)
 	assert.True(t, fleet.IsNotFound(err))
+}
+
+func testApplyScimGroupPatch(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	users := createTestScimUsers(t, ds)
+	require.Len(t, users, 2)
+	keptUserID, removedUserID := users[0].ID, users[1].ID
+
+	addedUser := fleet.ScimUser{UserName: "patch-added-user", Emails: []fleet.ScimUserEmail{}}
+	addedUserID, err := ds.CreateScimUser(ctx, &addedUser)
+	require.NoError(t, err)
+
+	newChildGroup := func(name string) uint {
+		id, err := ds.CreateScimGroup(ctx, &fleet.ScimGroup{DisplayName: name})
+		require.NoError(t, err)
+		return id
+	}
+	keptChildID, removedChildID, addedChildID := newChildGroup("Kept Child"), newChildGroup("Removed Child"), newChildGroup("Added Child")
+
+	group := &fleet.ScimGroup{
+		DisplayName: "Patch Test Group",
+		ExternalID:  new("ext-patch-group-123"),
+		ScimUsers:   []uint{keptUserID, removedUserID},
+		ChildGroups: []uint{keptChildID, removedChildID},
+	}
+	group.ID, err = ds.CreateScimGroup(ctx, group)
+	require.NoError(t, err)
+
+	const wantExternalID = "ext-patch-group-456"
+
+	// The steps apply in order, each to the state the one before it left behind.
+	// Member slices on the group are left empty on purpose: the deltas drive the
+	// membership write.
+	steps := []struct {
+		name        string
+		displayName string
+		deltas      fleet.ScimGroupMemberDeltas
+	}{
+		{
+			name:        "deltas touch only the members they name",
+			displayName: "Patched Test Group",
+			deltas: fleet.ScimGroupMemberDeltas{
+				AddUsers:          []uint{addedUserID},
+				RemoveUsers:       []uint{removedUserID},
+				AddChildGroups:    []uint{addedChildID},
+				RemoveChildGroups: []uint{removedChildID},
+			},
+		},
+		{
+			name:        "empty deltas update the scalars and leave membership alone",
+			displayName: "Renamed Test Group",
+		},
+		{
+			name:        "re-adding a member and removing a non-member are no-ops",
+			displayName: "Renamed Test Group",
+			deltas: fleet.ScimGroupMemberDeltas{
+				AddUsers:          []uint{keptUserID},
+				RemoveUsers:       []uint{removedUserID},
+				AddChildGroups:    []uint{keptChildID},
+				RemoveChildGroups: []uint{removedChildID},
+			},
+		},
+	}
+
+	// Whatever the step asks for, the membership it leaves behind is the same.
+	wantUsers := []uint{keptUserID, addedUserID}
+	wantChildren := []uint{keptChildID, addedChildID}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			require.NoError(t, ds.ApplyScimGroupPatch(ctx, &fleet.ScimGroup{
+				ID:          group.ID,
+				DisplayName: step.displayName,
+				ExternalID:  new(wantExternalID),
+			}, step.deltas))
+
+			got, err := ds.ScimGroupByID(ctx, group.ID, false)
+			require.NoError(t, err)
+			require.Equal(t, step.displayName, got.DisplayName)
+			require.Equal(t, new(wantExternalID), got.ExternalID)
+			require.ElementsMatch(t, wantUsers, got.ScimUsers)
+			require.ElementsMatch(t, wantChildren, got.ChildGroups)
+		})
+	}
+
+	t.Run("a group that does not exist is not found", func(t *testing.T) {
+		err := ds.ApplyScimGroupPatch(ctx,
+			&fleet.ScimGroup{ID: 99999, DisplayName: "Non-existent"}, fleet.ScimGroupMemberDeltas{})
+		require.True(t, fleet.IsNotFound(err))
+	})
+
+	t.Run("an over-long display name is rejected", func(t *testing.T) {
+		err := ds.ApplyScimGroupPatch(ctx, &fleet.ScimGroup{
+			ID:          group.ID,
+			DisplayName: strings.Repeat("a", fleet.SCIMMaxFieldLength+1),
+		}, fleet.ScimGroupMemberDeltas{})
+		validationErr := &fleet.SCIMValidationError{}
+		require.ErrorAs(t, err, &validationErr)
+		require.Equal(t, "display_name", validationErr.Field)
+	})
+}
+
+func testApplyScimGroupPatchResendOnRenameWithRemovals(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host1 := test.NewHost(t, ds, "patch-resend-h1", "192.168.1.201", "patch-resend-k1", "patch-resend-uuid1", time.Now())
+	host2 := test.NewHost(t, ds, "patch-resend-h2", "192.168.1.202", "patch-resend-k2", "patch-resend-uuid2", time.Now())
+
+	prof, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("patch-resend", "patch-resend", 0),
+		[]fleet.FleetVarName{fleet.FleetVarHostEndUserIDPGroups})
+	require.NoError(t, err)
+
+	user1, err := ds.CreateScimUser(ctx, &fleet.ScimUser{UserName: "patch-resend-1@example.com"})
+	require.NoError(t, err)
+	user2, err := ds.CreateScimUser(ctx, &fleet.ScimUser{UserName: "patch-resend-2@example.com"})
+	require.NoError(t, err)
+	require.NoError(t, ds.associateHostWithScimUser(ctx, host1.ID, user1))
+	require.NoError(t, ds.associateHostWithScimUser(ctx, host2.ID, user2))
+
+	childID, err := ds.CreateScimGroup(ctx, &fleet.ScimGroup{DisplayName: "patch-resend-child", ScimUsers: []uint{user2}})
+	require.NoError(t, err)
+	groupID, err := ds.CreateScimGroup(ctx, &fleet.ScimGroup{
+		DisplayName: "patch-resend-group", ScimUsers: []uint{user1}, ChildGroups: []uint{childID},
+	})
+	require.NoError(t, err)
+
+	forceSetAppleHostProfileStatus(t, ds, host1.UUID, prof, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+	forceSetAppleHostProfileStatus(t, ds, host2.UUID, prof, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+
+	// A single call that renames the group and removes both the direct member and
+	// the child group must resend to the removed members' hosts: their group
+	// lists changed even though they are no longer part of the renamed group.
+	require.NoError(t, ds.ApplyScimGroupPatch(ctx,
+		&fleet.ScimGroup{ID: groupID, DisplayName: "patch-resend-renamed"},
+		fleet.ScimGroupMemberDeltas{RemoveUsers: []uint{user1}, RemoveChildGroups: []uint{childID}},
+	))
+	assertHostProfileStatus(t, ds, host1.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryPending})
+	assertHostProfileStatus(t, ds, host2.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryPending})
 }
 
 func testScimGroupReplaceValidation(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/scim_test.go
+++ b/server/datastore/mysql/scim_test.go
@@ -43,6 +43,7 @@ func TestScim(t *testing.T) {
 		{"ReplaceScimGroup", testReplaceScimGroup},
 		{"ApplyScimGroupPatch", testApplyScimGroupPatch},
 		{"ApplyScimGroupPatchResendOnRenameWithRemovals", testApplyScimGroupPatchResendOnRenameWithRemovals},
+		{"ApplyScimGroupPatchResendSkipsNoOps", testApplyScimGroupPatchResendSkipsNoOps},
 		{"ReplaceScimGroupValidation", testScimGroupReplaceValidation},
 		{"DeleteScimGroup", testDeleteScimGroup},
 		{"ListScimGroups", testListScimGroups},
@@ -1324,6 +1325,66 @@ func testApplyScimGroupPatchResendOnRenameWithRemovals(t *testing.T, ds *Datasto
 	))
 	assertHostProfileStatus(t, ds, host1.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryPending})
 	assertHostProfileStatus(t, ds, host2.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryPending})
+}
+
+func testApplyScimGroupPatchResendSkipsNoOps(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	prof, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("noop-resend", "noop-resend", 0),
+		[]fleet.FleetVarName{fleet.FleetVarHostEndUserIDPGroups})
+	require.NoError(t, err)
+
+	// Three users: a direct member, a nested-child member, and a stranger.
+	hosts := make(map[string]*fleet.Host, 3)
+	users := make(map[string]uint, 3)
+	for i, key := range []string{"direct", "child", "stranger"} {
+		host := test.NewHost(t, ds, "noop-resend-"+key, fmt.Sprintf("192.168.8.%d", i+1),
+			"noop-resend-k-"+key, "noop-resend-uuid-"+key, time.Now())
+		userID, err := ds.CreateScimUser(ctx, &fleet.ScimUser{UserName: fmt.Sprintf("noop-resend-%s@example.com", key)})
+		require.NoError(t, err)
+		require.NoError(t, ds.associateHostWithScimUser(ctx, host.ID, userID))
+		hosts[key], users[key] = host, userID
+	}
+
+	childID, err := ds.CreateScimGroup(ctx, &fleet.ScimGroup{DisplayName: "noop-resend-child", ScimUsers: []uint{users["child"]}})
+	require.NoError(t, err)
+	strangerGroupID, err := ds.CreateScimGroup(ctx, &fleet.ScimGroup{DisplayName: "noop-resend-stranger", ScimUsers: []uint{users["stranger"]}})
+	require.NoError(t, err)
+	groupID, err := ds.CreateScimGroup(ctx, &fleet.ScimGroup{
+		DisplayName: "noop-resend-group", ScimUsers: []uint{users["direct"]}, ChildGroups: []uint{childID},
+	})
+	require.NoError(t, err)
+
+	settle := func() {
+		for _, host := range hosts {
+			forceSetAppleHostProfileStatus(t, ds, host.UUID, prof, fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
+		}
+	}
+
+	// Every delta is a no-op, so no host's group list changes and nothing resends.
+	settle()
+	require.NoError(t, ds.ApplyScimGroupPatch(ctx,
+		&fleet.ScimGroup{ID: groupID, DisplayName: "noop-resend-group"},
+		fleet.ScimGroupMemberDeltas{
+			AddUsers:          []uint{users["direct"]},
+			RemoveUsers:       []uint{users["stranger"]},
+			AddChildGroups:    []uint{childID},
+			RemoveChildGroups: []uint{strangerGroupID},
+		}))
+	for _, host := range hosts {
+		assertHostProfileStatus(t, ds, host.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryVerifying})
+	}
+
+	// Sanity check that the fixture detects resends: a real change still triggers one.
+	settle()
+	require.NoError(t, ds.ApplyScimGroupPatch(ctx,
+		&fleet.ScimGroup{ID: groupID, DisplayName: "noop-resend-group"},
+		fleet.ScimGroupMemberDeltas{AddUsers: []uint{users["stranger"]}}))
+	strangerHost, directHost := hosts["stranger"], hosts["direct"]
+	require.NotNil(t, strangerHost)
+	require.NotNil(t, directHost)
+	assertHostProfileStatus(t, ds, strangerHost.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryPending})
+	assertHostProfileStatus(t, ds, directHost.UUID, hostProfileStatus{prof.ProfileUUID, fleet.MDMDeliveryVerifying})
 }
 
 func testScimGroupReplaceValidation(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3694,6 +3694,10 @@ type Datastore interface {
 	ScimGroupByDisplayName(ctx context.Context, displayName string) (*ScimGroup, error)
 	// ReplaceScimGroup replaces an existing SCIM group in the database
 	ReplaceScimGroup(ctx context.Context, group *ScimGroup) error
+	// ApplyScimGroupPatch updates an existing SCIM group's attributes and applies
+	// only the membership changes described by deltas, leaving every other member
+	// of the group untouched.
+	ApplyScimGroupPatch(ctx context.Context, group *ScimGroup, deltas ScimGroupMemberDeltas) error
 	// DeleteScimGroup deletes a SCIM group from the database
 	DeleteScimGroup(ctx context.Context, id uint) error
 	// ListScimGroups retrieves a list of SCIM groups with pagination

--- a/server/fleet/scim.go
+++ b/server/fleet/scim.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -124,6 +125,40 @@ type ScimGroup struct {
 	// of this group. Microsoft Entra ID provisions nested groups by sending
 	// group-type members rather than flattening them into user members.
 	ChildGroups []uint
+}
+
+// ScimGroupMemberDeltas describes a targeted change to a SCIM group's
+// membership.
+type ScimGroupMemberDeltas struct {
+	AddUsers          []uint
+	RemoveUsers       []uint
+	AddChildGroups    []uint
+	RemoveChildGroups []uint
+}
+
+func (d *ScimGroupMemberDeltas) AddUser(id uint) { record(&d.AddUsers, &d.RemoveUsers, id) }
+
+func (d *ScimGroupMemberDeltas) RemoveUser(id uint) { record(&d.RemoveUsers, &d.AddUsers, id) }
+
+func (d *ScimGroupMemberDeltas) AddChildGroup(id uint) {
+	record(&d.AddChildGroups, &d.RemoveChildGroups, id)
+}
+
+func (d *ScimGroupMemberDeltas) RemoveChildGroup(id uint) {
+	record(&d.RemoveChildGroups, &d.AddChildGroups, id)
+}
+
+// record folds one member change into the deltas, keeping the two invariants the
+// write relies on: a member appears at most once in a list, and never in both
+// lists. Changes are recorded in the order the caller applies them, so the last
+// one wins, an add after a remove leaves only the add.
+func record(into, from *[]uint, id uint) {
+	if !slices.Contains(*into, id) {
+		*into = append(*into, id)
+	}
+	if i := slices.Index(*from, id); i >= 0 {
+		*from = slices.Delete(*from, i, i+1)
+	}
 }
 
 type ScimLastRequest struct {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2158,6 +2158,8 @@ type ScimGroupByDisplayNameFunc func(ctx context.Context, displayName string) (*
 
 type ReplaceScimGroupFunc func(ctx context.Context, group *fleet.ScimGroup) error
 
+type ApplyScimGroupPatchFunc func(ctx context.Context, group *fleet.ScimGroup, deltas fleet.ScimGroupMemberDeltas) error
+
 type DeleteScimGroupFunc func(ctx context.Context, id uint) error
 
 type ListScimGroupsFunc func(ctx context.Context, opts fleet.ScimGroupsListOptions) (groups []fleet.ScimGroup, totalResults uint, err error)
@@ -5559,6 +5561,9 @@ type DataStore struct {
 
 	ReplaceScimGroupFunc        ReplaceScimGroupFunc
 	ReplaceScimGroupFuncInvoked bool
+
+	ApplyScimGroupPatchFunc        ApplyScimGroupPatchFunc
+	ApplyScimGroupPatchFuncInvoked bool
 
 	DeleteScimGroupFunc        DeleteScimGroupFunc
 	DeleteScimGroupFuncInvoked bool
@@ -13330,6 +13335,13 @@ func (s *DataStore) ReplaceScimGroup(ctx context.Context, group *fleet.ScimGroup
 	s.ReplaceScimGroupFuncInvoked = true
 	s.mu.Unlock()
 	return s.ReplaceScimGroupFunc(ctx, group)
+}
+
+func (s *DataStore) ApplyScimGroupPatch(ctx context.Context, group *fleet.ScimGroup, deltas fleet.ScimGroupMemberDeltas) error {
+	s.mu.Lock()
+	s.ApplyScimGroupPatchFuncInvoked = true
+	s.mu.Unlock()
+	return s.ApplyScimGroupPatchFunc(ctx, group, deltas)
 }
 
 func (s *DataStore) DeleteScimGroup(ctx context.Context, id uint) error {


### PR DESCRIPTION
Relates to #50724

PATCH /Groups/{id} applied its operations to a member list read up front and handed the whole list to ReplaceScimGroup, which deletes every member absent from it. Added ApplyScimGroupPatch, which writes only the members named in a ScimGroupMemberDeltas. Also verify member existence once per request instead of once per operation. ReplaceScimGroup now shares helpers with the new method but is otherwise unchanged.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented SCIM group updates from unintentionally removing members not included in a targeted change.
  * Preserved group membership when updating unrelated group attributes.
  * Ensured membership additions, removals, replacements, and nested-group changes persist correctly.
  * Improved validation for nonexistent users and nested groups.
  * Prevented duplicate or conflicting membership operations from producing inconsistent results.
  * Avoided unnecessary profile resends when membership changes have no effect.

* **Performance**
  * Improved efficiency for large SCIM membership updates by reducing database verification queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->