### PR TITLE
Support SVG org logos in generate-gitops

### DIFF
--- a/changes/49444-generate-gitops-svg-org-logo
+++ b/changes/49444-generate-gitops-svg-org-logo
@@ -1,0 +1,1 @@
+* Fixed `fleetctl generate-gitops` failing with an unsupported Content-Type error when the org logo is an SVG.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1211,8 +1211,10 @@ func orgLogoExtFromContentType(contentType string) (string, error) {
 		return ".jpg", nil
 	case "image/webp":
 		return ".webp", nil
+	case "image/svg+xml":
+		return ".svg", nil
 	}
-	return "", fmt.Errorf("unsupported logo Content-Type %q (expected image/png, image/jpeg, or image/webp)", mediaType)
+	return "", fmt.Errorf("unsupported logo Content-Type %q (expected image/png, image/jpeg, image/webp, or image/svg+xml)", mediaType)
 }
 
 func (cmd *GenerateGitopsCommand) generateEULA() (string, error) {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -3276,6 +3276,23 @@ func TestGenerateGitopsExportOrgLogos(t *testing.T) {
 		assert.Equal(t, string(pngBody), cmd.FilesToWrite["lib/org_logo/dark.png"])
 	})
 
+	t.Run("SVG logo is exported with an .svg extension", func(t *testing.T) {
+		svgBody := []byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8"><rect width="8" height="8"/></svg>`)
+		cmd, _ := newOrgLogoCommand(t,
+			&orgLogoStub{MockClient: &MockClient{}, body: svgBody, contentType: "image/svg+xml"},
+			fleet.OrgInfo{
+				OrgName:            "ACME",
+				OrgLogoURLDarkMode: "https://fleet.example.com/api/latest/fleet/logo?mode=dark",
+			},
+		)
+
+		orgInfo, err := cmd.generateOrgInfo()
+		require.NoError(t, err)
+
+		assert.Equal(t, "./lib/org_logo/dark.svg", orgInfo["org_logo_path_dark_mode"])
+		assert.Equal(t, string(svgBody), cmd.FilesToWrite["lib/org_logo/dark.svg"])
+	})
+
 	t.Run("external URLs are exported unchanged (existing customer configs)", func(t *testing.T) {
 		stub := &orgLogoStub{
 			MockClient: &MockClient{},
@@ -3324,6 +3341,36 @@ func TestGenerateGitopsExportOrgLogos(t *testing.T) {
 		assert.Contains(t, errBuf.String(), "warning")
 		assert.Contains(t, errBuf.String(), "dark")
 	})
+}
+
+func TestOrgLogoExtFromContentType(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		contentType string
+		wantExt     string
+		wantErr     bool
+	}{
+		{contentType: "image/png", wantExt: ".png"},
+		{contentType: "image/jpeg", wantExt: ".jpg"},
+		{contentType: "image/webp", wantExt: ".webp"},
+		{contentType: "image/svg+xml", wantExt: ".svg"},
+		// The serving endpoint may append parameters to the header.
+		{contentType: "image/svg+xml; charset=utf-8", wantExt: ".svg"},
+		{contentType: "image/gif", wantErr: true},
+		{contentType: "application/octet-stream", wantErr: true},
+		{contentType: "", wantErr: true},
+	} {
+		t.Run(tc.contentType, func(t *testing.T) {
+			ext, err := orgLogoExtFromContentType(tc.contentType)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantExt, ext)
+		})
+	}
 }
 
 func TestGeneratePoliciesPatchPolicyOrphanedFromFleetMaintainedApp(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49444

SVG became a valid org logo format and the server serves it as `image/svg+xml`, but `orgLogoExtFromContentType` in `generate-gitops` never got the matching case. The whole export aborted with exit 1 and wrote no files at all, not just the logo.

## Steps to reproduce

1. Upload an SVG as the org logo (Settings > Organization settings > Organization info).
2. Run `fleetctl generate-gitops --dir <dir>`.

Before this change:

```
Generating GitOps configuration files...
Error generating org settings: org logo (light): unsupported logo Content-Type "image/svg+xml" (expected image/png, image/jpeg, or image/webp)
Error: Something's gone wrong. Please try again. If this keeps happening please file an issue:
```

Exit code 1, and `<dir>` is empty.

## How I tested

Against a local server with a throwaway database, comparing two `fleetctl` binaries built from the same tree, one with the fix reverted.

1. Uploaded an SVG through the Fleet UI as both the light and dark org logo. Confirmed the server stores it and serves it as `image/svg+xml`.
2. Ran `generate-gitops` with the pre-fix binary: reproduced the error above, exit 1, zero files written.
3. Ran it with the fix: export completes and writes `lib/org_logo/light.svg` and `lib/org_logo/dark.svg`, with `org_logo_path_light_mode` / `org_logo_path_dark_mode` in `default.yml` replacing the URL keys. Both files are byte-identical to the uploaded SVG.
4. Round-tripped it. Deleted both stored logos (`GET` then returns 404), ran `fleetctl gitops` on the generated files, and got `[+] applied org logo (light|dark) from lib/org_logo/*.svg`. Read both back: 200, `image/svg+xml`, byte-identical to the original upload. The apply side needed no change since it validates by content rather than by extension.

Unit tests cover the new content type, a `charset` parameter on the header, and the reject cases.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `fleetctl generate-gitops` failures when organization logos use SVG format.
  * SVG logos are now exported with the correct `.svg` file extension.
  * Improved error messaging for unsupported logo formats.

* **Tests**
  * Added coverage for SVG logo exports and supported image content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->