### PR TITLE
Adding changes for Fleet v4.90.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 - Added a release budget for Fleet-initiated activities (policy-automation software installs and scripts, and iOS/iPadOS scheduled app updates): they are now queued immediately but released to hosts at a configurable rate (`FLEET_ACTIVITY_FLEET_INITIATED_RELEASE_PER_MINUTE`, default 1000 hosts/minute, 0 = unlimited), spreading out the install-execution and result-ingestion load when an automation fires for many hosts at once. User-initiated activities (self-service installs, admin-run scripts, lock/unlock/wipe, setup experience) are unaffected and now take precedence over queued Fleet-initiated activities on the same host.
+- Fixed editing a policy on a large fleet stalling policy and software install result ingestion fleet-wide. The `policy_membership` wipe now runs after the policy update commits instead of inside its transaction, so its row locks are no longer held for the whole wipe. An interrupted wipe is completed by the policy membership cron.
 
 ## Fleet 4.90.1 (Aug 14, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,18 @@
 - Fixed missing `resolved_in_version` for CVE-2025-63389 on Ollama (resolved in v0.12.4), which was absent because the NVD record only provides a `versionEndIncluding` constraint.
 - Fixed vulnerability detection for Python packages on Ubuntu/Debian devices by stripping the "python3-" name prefix during CPE matching.
 
+## Fleet 4.89.2 (Jul 24, 2026)
+
+### Bug fixes
+
+- Fixed a bug where a failed software install was reported as successfully installed when the install script exited with an error but a post-install script exited successfully.
+- Fixed Windows Autopilot enrollments intermittently hanging on the Enrollment Status Page at "Account setup".
+- Fixed an issue where devices given a mandatory update during ADE enrollment might display a failure or fail to display the update
+- Fixed a bug where adding Windows software via GitOps could create a duplicate software title when a host had already reported the same program.
+- Fixed a bug where Apple MDM devices re-enrolling manually with a pending SCEP renewal would not be treated as a new renewal and might skip apps, profiles, etc
+- Fixed a bug where a Fleet-maintained app install could run a stale, previously-cached version after the app was auto-updated; installs (including automatic retries) now target the version Fleet currently displays.
+- Fixed a bug where pinning a Fleet-maintained app to a different version didn't update the patch policy for it.
+
 ## Fleet 4.89.1 (Jul 16, 2026)
 
 ### Bug fixes
@@ -284,7 +296,7 @@
 - Fixed an issue where the macOS "Update new hosts to latest" OS update setting could stay enabled in GitOps after `minimum_version` and `deadline` were cleared; when `update_new_hosts` isn't explicitly set, it now defaults to enabled only while a minimum version and deadline are configured.
 - Fixed an issue where more than 8 entries for OS versions would not be paginated.
 
-## Fleet 4.88.1 (Jul 10, 2026)
+## Fleet 4.88.1 (Jul 09, 2026)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Fleet 4.90.2 (Aug 27, 2026)
+## Fleet 4.90.2 (Sep 01, 2026)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Fleet 4.90.2 (Aug 27, 2026)
+
+### Bug fixes
+
+- Added a release budget for Fleet-initiated activities (policy-automation software installs and scripts, and iOS/iPadOS scheduled app updates): they are now queued immediately but released to hosts at a configurable rate (`FLEET_ACTIVITY_FLEET_INITIATED_RELEASE_PER_MINUTE`, default 1000 hosts/minute, 0 = unlimited), spreading out the install-execution and result-ingestion load when an automation fires for many hosts at once. User-initiated activities (self-service installs, admin-run scripts, lock/unlock/wipe, setup experience) are unaffected and now take precedence over queued Fleet-initiated activities on the same host.
+
 ## Fleet 4.90.1 (Aug 14, 2026)
 
 ### Bug fixes
@@ -154,18 +160,6 @@
 - Fixed missing `resolved_in_version` for CVE-2025-63389 on Ollama (resolved in v0.12.4), which was absent because the NVD record only provides a `versionEndIncluding` constraint.
 - Fixed vulnerability detection for Python packages on Ubuntu/Debian devices by stripping the "python3-" name prefix during CPE matching.
 
-## Fleet 4.89.2 (Jul 24, 2026)
-
-### Bug fixes
-
-- Fixed a bug where a failed software install was reported as successfully installed when the install script exited with an error but a post-install script exited successfully.
-- Fixed Windows Autopilot enrollments intermittently hanging on the Enrollment Status Page at "Account setup".
-- Fixed an issue where devices given a mandatory update during ADE enrollment might display a failure or fail to display the update
-- Fixed a bug where adding Windows software via GitOps could create a duplicate software title when a host had already reported the same program.
-- Fixed a bug where Apple MDM devices re-enrolling manually with a pending SCEP renewal would not be treated as a new renewal and might skip apps, profiles, etc
-- Fixed a bug where a Fleet-maintained app install could run a stale, previously-cached version after the app was auto-updated; installs (including automatic retries) now target the version Fleet currently displays.
-- Fixed a bug where pinning a Fleet-maintained app to a different version didn't update the patch policy for it.
-
 ## Fleet 4.89.1 (Jul 16, 2026)
 
 ### Bug fixes
@@ -289,7 +283,7 @@
 - Fixed an issue where the macOS "Update new hosts to latest" OS update setting could stay enabled in GitOps after `minimum_version` and `deadline` were cleared; when `update_new_hosts` isn't explicitly set, it now defaults to enabled only while a minimum version and deadline are configured.
 - Fixed an issue where more than 8 entries for OS versions would not be paginated.
 
-## Fleet 4.88.1 (Jul 09, 2026)
+## Fleet 4.88.1 (Jul 10, 2026)
 
 ### Bug fixes
 

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.16
+version: v7.0.17
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.90.1
+appVersion: v4.90.2
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.90.1 # Version of Fleet to deploy
+imageTag: v4.90.2 # Version of Fleet to deploy
 # imagePullPolicy is optional. If unset, Kubernetes defaults to IfNotPresent
 # for tagged images and Always for the :latest tag. Valid values: Always,
 # IfNotPresent, Never.

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.90.1"
+  default     = "fleetdm/fleet:v4.90.2"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.90.1"
+  default = "fleetdm/fleet:v4.90.2"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.90.1",
+  "version": "v4.90.2",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/migration-cleanup/sql_test.go
+++ b/tools/migration-cleanup/sql_test.go
@@ -31,7 +31,7 @@ func requireVersionOrder(t *testing.T, rows []tableRow, wantVersions []int64) {
 }
 
 // Down-move renumber where the moved rows sit mid-table and at the tail, the
-// shape of the 4.90.1 -> 4.91.0 re-timestamping applied to a database that
+// shape of the 4.90.2 -> 4.91.0 re-timestamping applied to a database that
 // tracked main (rows applied between and after the moved migrations).
 func TestSimulateDownMoveAtTail(t *testing.T) {
 	rows := []tableRow{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated Fleet and Fleetctl to version 4.90.2.
  * Updated deployment configurations to use the Fleet 4.90.2 image.
  * Updated the Fleet Helm chart version to 7.0.17.
* **Documentation**
  * Updated release-version references for migration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->