### PR TITLE
Fix software inventory rows saved without a software title

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -604,9 +604,27 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 			return nil, ctxerr.Wrap(ctx, err, "update software titles upgrade code")
 		}
 		// Pre-insert software and titles in small batches
-		err = ds.preInsertSoftwareInventory(ctx, existingSoftwareSummaries, incomingSoftwareByChecksum, incomingChecksumsToExistingTitles)
+		missing, err := ds.preInsertSoftwareInventory(ctx, existingSoftwareSummaries, incomingSoftwareByChecksum, incomingChecksumsToExistingTitles, false)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "pre-insert software inventory")
+		}
+		// A missed title means it is not in the database: a concurrent
+		// CleanupSoftwareTitles deleted it right after the pre-insert (it was briefly
+		// orphaned outside the transaction), or cleanup on another Fleet instance
+		// deleted it and this instance's stale title cache skipped re-inserting it.
+		// The miss evicted those cache entries, so retrying the unresolved software
+		// re-inserts its titles; only rows whose title also misses the retry are
+		// written with a NULL title_id, for the hourly cleanup's repair to re-link.
+		if len(missing) > 0 {
+			retry := make(map[string]fleet.Software, len(missing))
+			for _, checksum := range missing {
+				if sw, ok := incomingSoftwareByChecksum[checksum]; ok {
+					retry[checksum] = sw
+				}
+			}
+			if _, err := ds.preInsertSoftwareInventory(ctx, nil, retry, incomingChecksumsToExistingTitles, true); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "retry pre-insert software inventory")
+			}
 		}
 
 	}
@@ -1126,13 +1144,17 @@ func matchWindowsFMATitle(name string, prefixes []windowsFMAPrefix) (windowsFMAP
 }
 
 // preInsertSoftwareInventory pre-inserts software and software_titles outside the main transaction
-// to reduce lock contention. These operations are idempotent due to INSERT IGNORE.
+// to reduce lock contention. These operations are idempotent due to INSERT IGNORE, so the caller
+// retries the returned checksums — the ones whose software title could not be resolved — with a
+// second call. Unless finalAttempt is true, software rows with an unresolved title are left
+// uninserted; on the final attempt they are inserted with a NULL title_id as a last resort.
 func (ds *Datastore) preInsertSoftwareInventory(
 	ctx context.Context,
 	existingSoftwareSummaries []softwareSummary,
 	incomingSoftwareByChecksum map[string]fleet.Software,
 	incomingChecksumsToExistingTitleSummaries map[string]fleet.SoftwareTitleSummary,
-) error {
+	finalAttempt bool,
+) ([]string, error) {
 	type titleKey struct {
 		name         string
 		source       string
@@ -1168,7 +1190,7 @@ func (ds *Datastore) preInsertSoftwareInventory(
 	}
 
 	if len(needsInsert) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	bestTitleNames := make(map[titleKey]string)
@@ -1225,6 +1247,7 @@ func (ds *Datastore) preInsertSoftwareInventory(
 	winFMAPrefixes := windowsFMAPrefixes(winFMANames)
 
 	// Process in smaller batches to reduce lock time
+	var missing []string
 	err := common_mysql.BatchProcessSimple(keys, softwareInventoryInsertBatchSize, func(batchKeys []string) error {
 		batchSoftware := make(map[string]fleet.Software, len(batchKeys))
 		for _, key := range batchKeys {
@@ -1347,7 +1370,8 @@ func (ds *Datastore) preInsertSoftwareInventory(
 		}
 
 		// Each batch in its own transaction (for SELECT title IDs + INSERT software).
-		return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		var batchMissing []string
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 			// Map to store title IDs for all titles (both existing and new)
 			titleIDsByChecksum := make(map[string]uint, len(incomingChecksumsToExistingTitleSummaries))
 
@@ -1529,28 +1553,6 @@ func (ds *Datastore) preInsertSoftwareInventory(
 
 			// Insert software entries
 			const numberOfArgsPerSoftware = 13
-			values := strings.TrimSuffix(
-				strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?,?,?),", len(batchKeys)), ",",
-			)
-			stmt := fmt.Sprintf(
-				`INSERT IGNORE INTO software (
-					name,
-					version,
-					source,
-					`+"`release`"+`,
-					vendor,
-					arch,
-					bundle_identifier,
-					extension_id,
-					extension_for,
-					title_id,
-					checksum,
-					application_id,
-					upgrade_code
-				) VALUES %s`,
-				values,
-			)
-
 			args := make([]any, 0, len(batchKeys)*numberOfArgsPerSoftware)
 			var missingChecksums []string
 			for _, checksum := range batchKeys {
@@ -1560,9 +1562,12 @@ func (ds *Datastore) preInsertSoftwareInventory(
 				if id, ok := titleIDsByChecksum[checksum]; ok {
 					titleID = &id
 				} else {
-					// Track software missing title IDs; titles inserted outside the
-					// transaction may have been deleted by a concurrent CleanupSoftwareTitles.
+					// The title this software needs is not in the database; leave the row
+					// uninserted (except on the final attempt) so the caller can retry it.
 					missingChecksums = append(missingChecksums, checksum)
+					if !finalAttempt {
+						continue
+					}
 				}
 
 				// Use FMA canonical name if available, otherwise use osquery-reported name.
@@ -1596,19 +1601,13 @@ func (ds *Datastore) preInsertSoftwareInventory(
 				)
 			}
 
-			// When title IDs are missing, a concurrent CleanupSoftwareTitles likely
-			// deleted the titles we just inserted (they were orphaned briefly outside the
-			// transaction). Clear those cache entries so they are re-inserted on the next
-			// agent check-in. The software row proceeds with NULL title_id; the next
-			// ingestion cycle will re-create the title and link it.
+			// A missing title was deleted between its pre-insert above and this lookup —
+			// by a concurrent CleanupSoftwareTitles, or by one on another Fleet instance
+			// that left this instance's title cache stale, which skipped the pre-insert
+			// entirely. Evict those cache entries so the caller's retry re-creates the
+			// titles instead of skipping them again.
 			if len(missingChecksums) > 0 {
-				var examples []string
 				for _, checksum := range missingChecksums {
-					sw := batchSoftware[checksum]
-					if len(examples) < 3 {
-						examples = append(examples, fmt.Sprintf("%s %s %s", sw.Name, sw.Version, sw.Source))
-					}
-					// Evict from the in-process cache so the next ingestion cycle re-inserts the title.
 					if title, ok := newTitlesNeeded[checksum]; ok {
 						bundleID := ""
 						if title.BundleIdentifier != nil {
@@ -1618,27 +1617,64 @@ func (ds *Datastore) preInsertSoftwareInventory(
 						ds.deleteKnownSoftwareTitleKey(cacheKey)
 					}
 				}
-				// Log rather than return a hard error: the title INSERT is outside the
-				// transaction, so withRetryTxx cannot re-insert the title on retry.
-				// The software row proceeds with NULL title_id and the evicted cache
-				// entry ensures the title is re-created on the next ingestion cycle.
-				if ds.logger != nil {
+				// Last resort, when the caller's retry also missed: the rows are inserted
+				// with a NULL title_id rather than dropping the inventory. Such rows are
+				// invisible to every query that joins software to software_titles until
+				// the hourly cleanup's repairUnlinkedSoftware re-links them.
+				if finalAttempt && ds.logger != nil {
+					var examples []string
+					for _, checksum := range missingChecksums {
+						if len(examples) >= 3 {
+							break
+						}
+						sw := batchSoftware[checksum]
+						examples = append(examples, fmt.Sprintf("%s %s %s", sw.Name, sw.Version, sw.Source))
+					}
 					ds.logger.ErrorContext(ctx, "inserting software without title_id",
 						"count", len(missingChecksums),
 						"examples", strings.Join(examples, "; "),
 					)
 				}
 			}
+			batchMissing = missingChecksums
 
-			if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
-				return ctxerr.Wrap(ctx, err, "pre-insert software")
+			if len(args) > 0 {
+				values := strings.TrimSuffix(
+					strings.Repeat("(?,?,?,?,?,?,?,?,?,?,?,?,?),", len(args)/numberOfArgsPerSoftware), ",",
+				)
+				stmt := fmt.Sprintf(
+					`INSERT IGNORE INTO software (
+						name,
+						version,
+						source,
+						`+"`release`"+`,
+						vendor,
+						arch,
+						bundle_identifier,
+						extension_id,
+						extension_for,
+						title_id,
+						checksum,
+						application_id,
+						upgrade_code
+					) VALUES %s`,
+					values,
+				)
+				if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+					return ctxerr.Wrap(ctx, err, "pre-insert software")
+				}
 			}
 
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
+
+		missing = append(missing, batchMissing...)
+		return nil
 	})
 
-	return err
+	return missing, err
 }
 
 // linkSoftwareToHost links pre-inserted software to a host.
@@ -3310,12 +3346,21 @@ func (ds *Datastore) cleanupUnusedSoftware(ctx context.Context) error {
 
 func (ds *Datastore) CleanupSoftwareTitles(ctx context.Context) error {
 	var n int64
+	var repaired int
 	defer func(start time.Time) {
 		ds.logger.DebugContext(ctx, "cleanup orphaned software titles",
 			"rows_affected", n,
+			"software_relinked", repaired,
 			"took", time.Since(start),
 		)
 	}(time.Now())
+
+	// Re-link broken software rows before deleting orphaned titles, so that a title this
+	// repair just created or matched is not considered orphaned in the same run.
+	repaired, err := ds.repairUnlinkedSoftware(ctx)
+	if err != nil {
+		return err
+	}
 
 	const (
 		findOrphanedSoftwareTitlesStmt = `
@@ -3341,6 +3386,7 @@ func (ds *Datastore) CleanupSoftwareTitles(ctx context.Context) error {
 	)
 
 	var lastID uint
+	var deletedTitleIDs []uint
 	for range cleanupMaxIterations {
 		var ids []uint
 		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &ids, findOrphanedSoftwareTitlesStmt, lastID, cleanupBatchSize); err != nil {
@@ -3361,6 +3407,28 @@ func (ds *Datastore) CleanupSoftwareTitles(ctx context.Context) error {
 		}
 		ra, _ := res.RowsAffected()
 		n += ra
+
+		// A concurrent ingestion can link a row to one of these titles between the
+		// DELETE's reference re-check and its commit, leaving it pointing at a title that
+		// no longer exists — as invisible as a NULL title_id. NULL those links while the
+		// deleted ids are known; finding them later would cost a full pass over software's
+		// title_id index. Per batch, so earlier batches stay covered if a later one fails.
+		if ra > 0 {
+			if err := ds.nullDanglingTitleLinks(ctx, ids); err != nil {
+				return err
+			}
+			deletedTitleIDs = append(deletedTitleIDs, ids...)
+		}
+	}
+
+	// Recheck every title deleted this run: an ingestion that committed its link after its
+	// batch's nulling above is caught here, widening the window from milliseconds to the
+	// whole run. Usually a fast no-op over already-clean ids.
+	for start := 0; start < len(deletedTitleIDs); start += cleanupBatchSize {
+		end := min(start+cleanupBatchSize, len(deletedTitleIDs))
+		if err := ds.nullDanglingTitleLinks(ctx, deletedTitleIDs[start:end]); err != nil {
+			return err
+		}
 	}
 
 	// If any titles were deleted, clear the in-process title cache so that future

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1630,7 +1630,7 @@ func (ds *Datastore) preInsertSoftwareInventory(
 						sw := batchSoftware[checksum]
 						examples = append(examples, fmt.Sprintf("%s %s %s", sw.Name, sw.Version, sw.Source))
 					}
-					ds.logger.ErrorContext(ctx, "inserting software without title_id",
+					ds.logger.WarnContext(ctx, "inserting software without title_id",
 						"count", len(missingChecksums),
 						"examples", strings.Join(examples, "; "),
 					)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -143,6 +143,8 @@ func TestSoftware(t *testing.T) {
 		{"BatchNewSoftwareCategoriesIdempotent", testBatchNewSoftwareCategoriesIdempotent},
 		{"CreateIntermediateInstallFailureRecordAfterDeletion", testCreateIntermediateInstallFailureRecordAfterDeletion},
 		{"ListHostSoftwareSortByDisplayName", testListHostSoftwareSortByDisplayName},
+		{"CleanupSoftwareTitlesRepairsUnlinkedSoftware", testCleanupSoftwareTitlesRepairsUnlinkedSoftware},
+		{"NullDanglingTitleLinks", testNullDanglingTitleLinks},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -10703,7 +10705,7 @@ func testPreInsertSoftwareInventory(t *testing.T, ds *Datastore) {
 	}
 
 	// Pre-insert once
-	err := ds.preInsertSoftwareInventory(ctx, nil, softwareChecksums, nil)
+	_, err := ds.preInsertSoftwareInventory(ctx, nil, softwareChecksums, nil, false)
 	require.NoError(t, err)
 
 	// Count inserted software
@@ -10714,7 +10716,7 @@ func testPreInsertSoftwareInventory(t *testing.T, ds *Datastore) {
 	require.Equal(t, 10, count)
 
 	// Pre-insert again (should be idempotent)
-	err = ds.preInsertSoftwareInventory(ctx, nil, softwareChecksums, nil)
+	_, err = ds.preInsertSoftwareInventory(ctx, nil, softwareChecksums, nil, false)
 	require.NoError(t, err)
 
 	// Count should remain the same

--- a/server/datastore/mysql/software_title_repair.go
+++ b/server/datastore/mysql/software_title_repair.go
@@ -1,0 +1,238 @@
+// Repair for software rows whose software_titles link is broken: preInsertSoftwareInventory
+// writes a NULL title_id as a last resort, and CleanupSoftwareTitles nulls links to titles it
+// deleted out from under a concurrent ingestion. Such a row is invisible to every query that
+// joins software to software_titles, and ingestion never revisits it because its checksum
+// already exists, so CleanupSoftwareTitles re-links it here at the start of each hourly run.
+
+package mysql
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/jmoiron/sqlx"
+)
+
+// softwareRepairCandidate is a software row whose software_titles link is broken, with
+// the columns needed to match or (re)create its title.
+type softwareRepairCandidate struct {
+	ID               uint    `db:"id"`
+	Name             string  `db:"name"`
+	Source           string  `db:"source"`
+	ExtensionFor     string  `db:"extension_for"`
+	BundleIdentifier *string `db:"bundle_identifier"`
+	ApplicationID    *string `db:"application_id"`
+	UpgradeCode      *string `db:"upgrade_code"`
+}
+
+// linuxPackageSources are the sources whose software names can denote a Linux kernel
+// package. Ingestion gates the same check on the host's platform, which a software row
+// does not carry.
+var linuxPackageSources = map[string]struct{}{
+	"deb_packages":    {},
+	"rpm_packages":    {},
+	"pacman_packages": {},
+}
+
+// softwareTitleLinkStmts re-link a batch of broken software rows, mirroring ingestion's
+// match semantics (see preInsertSoftwareInventory) and precedence: bundle identifier,
+// upgrade code, name, then Android application ID — last so batches without Android rows
+// can skip it, and with it a full scan of software_titles, which has no index on
+// application_id. Each only touches rows that are still unlinked, so a row keeps the first
+// match it gets. Name matching is left to MySQL's utf8mb4_unicode_ci collation, which is
+// what enforces title uniqueness in the first place.
+var softwareTitleLinkStmts = []string{
+	`
+	UPDATE software s
+	JOIN software_titles st
+		ON st.bundle_identifier = s.bundle_identifier
+		AND st.source = s.source
+		AND st.extension_for = s.extension_for
+	SET s.title_id = st.id
+	WHERE s.id IN (?) AND s.title_id IS NULL AND s.bundle_identifier IS NOT NULL AND s.bundle_identifier != ''`,
+	`
+	UPDATE software s
+	JOIN software_titles st
+		ON st.source = 'programs'
+		AND st.unique_identifier = s.upgrade_code
+	SET s.title_id = st.id
+	WHERE s.id IN (?) AND s.title_id IS NULL AND s.source = 'programs'
+		AND s.upgrade_code IS NOT NULL AND s.upgrade_code != ''`,
+	`
+	UPDATE software s
+	JOIN software_titles st
+		ON st.name = s.name
+		AND st.source = s.source
+		AND st.extension_for = s.extension_for
+		AND st.bundle_identifier IS NULL
+	SET s.title_id = st.id
+	WHERE s.id IN (?) AND s.title_id IS NULL AND (s.bundle_identifier IS NULL OR s.bundle_identifier = '')`,
+	`
+	UPDATE software s
+	JOIN software_titles st
+		ON st.application_id = s.application_id
+		AND st.source = s.source
+	SET s.title_id = st.id
+	WHERE s.id IN (?) AND s.title_id IS NULL AND s.source = 'android_apps'
+		AND s.application_id IS NOT NULL AND s.application_id != ''`,
+}
+
+// repairUnlinkedSoftware re-links software rows with a NULL title_id, creating the titles
+// that no longer exist. It heals them whether or not any host reports the software again,
+// and returns the number of rows re-linked.
+func (ds *Datastore) repairUnlinkedSoftware(ctx context.Context) (int, error) {
+	// FORCE INDEX because the optimizer otherwise picks an index merge with the primary
+	// key and sorts the result; the title_id index alone answers both the IS NULL filter
+	// and the ordering (id is its implicit suffix), so this reads only the broken rows
+	// instead of scanning the (large) software table.
+	const findNullTitleSoftwareStmt = `
+		SELECT id, name, source, extension_for, bundle_identifier, application_id, upgrade_code
+		FROM software FORCE INDEX (title_id)
+		WHERE title_id IS NULL AND id > ?
+		ORDER BY id
+		LIMIT ?`
+
+	var repaired int
+
+	// Read from the replica, as the other cleanups do: every repair statement re-checks on
+	// the writer that the row is still unlinked, so a stale read is at worst wasted work.
+	var lastID uint
+	for range cleanupMaxIterations {
+		var candidates []softwareRepairCandidate
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &candidates, findNullTitleSoftwareStmt, lastID, cleanupBatchSize); err != nil {
+			return repaired, ctxerr.Wrap(ctx, err, "find software with no title for repair")
+		}
+		if len(candidates) == 0 {
+			break
+		}
+		lastID = candidates[len(candidates)-1].ID
+
+		n, err := ds.repairSoftwareTitleLinks(ctx, candidates)
+		if err != nil {
+			return repaired, err
+		}
+		repaired += n
+	}
+
+	return repaired, nil
+}
+
+// repairSoftwareTitleLinks links a batch of broken software rows to their titles,
+// creating the titles that do not exist yet. It returns the number of rows linked.
+func (ds *Datastore) repairSoftwareTitleLinks(ctx context.Context, candidates []softwareRepairCandidate) (int, error) {
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	if err := ds.insertMissingSoftwareTitles(ctx, candidates); err != nil {
+		return 0, err
+	}
+
+	ids := make([]uint, 0, len(candidates))
+	hasAndroid := false
+	for _, c := range candidates {
+		ids = append(ids, c.ID)
+		hasAndroid = hasAndroid || c.Source == "android_apps"
+	}
+
+	linkStmts := softwareTitleLinkStmts
+	if !hasAndroid {
+		linkStmts = linkStmts[:len(linkStmts)-1]
+	}
+	for _, linkStmt := range linkStmts {
+		stmt, args, err := sqlx.In(linkStmt, ids)
+		if err != nil {
+			return 0, ctxerr.Wrap(ctx, err, "build link software to title query")
+		}
+		if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+			return 0, ctxerr.Wrap(ctx, err, "link software to title")
+		}
+	}
+
+	stmt, args, err := sqlx.In(`SELECT COUNT(*) FROM software WHERE id IN (?) AND title_id IS NULL`, ids)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "build count unlinked software query")
+	}
+	var remaining int
+	if err := sqlx.GetContext(ctx, ds.writer(ctx), &remaining, stmt, args...); err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "count unlinked software")
+	}
+	if remaining > 0 && ds.logger != nil {
+		ds.logger.WarnContext(ctx, "could not link software to a software title",
+			"count", remaining,
+		)
+	}
+	return len(ids) - remaining, nil
+}
+
+// insertMissingSoftwareTitles creates the titles the given software rows need, built from
+// the rows themselves. Creating unconditionally is safe: when a matching title already
+// exists, the INSERT IGNORE collides with it on software_titles' unique indexes — whose
+// unique_identifier coalesces the same identities the link statements match on — so linking
+// afterwards cannot pick up a duplicate.
+func (ds *Datastore) insertMissingSoftwareTitles(ctx context.Context, candidates []softwareRepairCandidate) error {
+	var (
+		values []string
+		args   []any
+	)
+	seen := make(map[string]struct{}, len(candidates))
+	for _, c := range candidates {
+		var bundleID *string
+		if ptr.ValOrZero(c.BundleIdentifier) != "" {
+			bundleID = c.BundleIdentifier
+		}
+		// An empty application_id has to become NULL: unique_identifier coalesces to it
+		// ahead of the name, so empty strings would all collide. An empty upgrade_code is
+		// passed through, as ingestion does, because unique_identifier NULLIFs it.
+		var applicationID *string
+		if ptr.ValOrZero(c.ApplicationID) != "" {
+			applicationID = c.ApplicationID
+		}
+		var isKernel bool
+		if _, ok := linuxPackageSources[c.Source]; ok {
+			isKernel = fleet.IsKernelSoftwareName(c.Name)
+		}
+
+		key := UniqueSoftwareTitleStr(c.Name, c.Source, c.ExtensionFor, ptr.ValOrZero(bundleID),
+			strconv.FormatBool(isKernel))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		values = append(values, "(?,?,?,?,?,?,?)")
+		args = append(args, c.Name, c.Source, c.ExtensionFor, bundleID, isKernel, applicationID, c.UpgradeCode)
+	}
+	if len(values) == 0 {
+		return nil
+	}
+
+	stmt := `INSERT IGNORE INTO software_titles (name, source, extension_for, bundle_identifier, is_kernel, application_id, upgrade_code) VALUES ` +
+		strings.Join(values, ",")
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "insert missing software titles")
+	}
+	return nil
+}
+
+// nullDanglingTitleLinks clears software.title_id for rows pointing at any of the given
+// titles that no longer exist. The join guards titles that survived the orphan re-check.
+func (ds *Datastore) nullDanglingTitleLinks(ctx context.Context, titleIDs []uint) error {
+	const nullDanglingStmt = `
+		UPDATE software s
+		LEFT JOIN software_titles st ON st.id = s.title_id
+		SET s.title_id = NULL
+		WHERE s.title_id IN (?) AND st.id IS NULL`
+	stmt, args, err := sqlx.In(nullDanglingStmt, titleIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build null dangling software title links query")
+	}
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "null dangling software title links")
+	}
+	return nil
+}

--- a/server/datastore/mysql/software_title_repair_test.go
+++ b/server/datastore/mysql/software_title_repair_test.go
@@ -1,0 +1,189 @@
+package mysql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/platform/mysql/testing_utils"
+	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+func insertUnlinkedSoftware(t *testing.T, ctx context.Context, ds *Datastore, hostID uint,
+	name, version, source, bundleID string, upgradeCode, applicationID *string, titleID *uint,
+) int64 {
+	t.Helper()
+	res, err := ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO software (name, version, source, bundle_identifier, upgrade_code, application_id, title_id, checksum)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, UNHEX(MD5(?)))`,
+		name, version, source, bundleID, upgradeCode, applicationID, titleID, name+version+source)
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO host_software (host_id, software_id) VALUES (?, ?)`, hostID, id)
+	require.NoError(t, err)
+	return id
+}
+
+func softwareTitleID(t *testing.T, ctx context.Context, ds *Datastore, query string, arg any) *uint {
+	t.Helper()
+	var rows []struct {
+		TitleID *uint `db:"title_id"`
+	}
+	require.NoError(t, sqlx.SelectContext(ctx, ds.writer(ctx), &rows, query, arg))
+	require.Len(t, rows, 1)
+	return rows[0].TitleID
+}
+
+func titleIDByBundle(t *testing.T, ctx context.Context, ds *Datastore, bundleID string) uint {
+	t.Helper()
+	var id uint
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &id,
+		`SELECT id FROM software_titles WHERE bundle_identifier = ?`, bundleID))
+	return id
+}
+
+func TestSoftwareIngestionAfterRemoteTitleCleanup(t *testing.T) {
+	const dbName = "software_remote_title_gc"
+
+	ds := CreateNamedMySQLDS(t, dbName)
+	ds2 := connectMySQL(t, dbName, new(testing_utils.DatastoreTestOptions))
+	t.Cleanup(func() { ds2.Close() })
+
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "host1", "10.0.0.1", "hostkey1", "hostuuid1", time.Now())
+
+	uniqueSW := fleet.Software{Name: "UniqueApp", Version: "1.0.0", Source: "apps", BundleIdentifier: "com.example.uniqueapp"}
+	otherSW := fleet.Software{Name: "OtherApp", Version: "2.0.0", Source: "apps", BundleIdentifier: "com.example.otherapp"}
+
+	uniqueAppTitleID := func() *uint {
+		return softwareTitleID(t, ctx, ds,
+			`SELECT title_id FROM software WHERE bundle_identifier = ?`, uniqueSW.BundleIdentifier)
+	}
+
+	_, err := ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{uniqueSW, otherSW})
+	require.NoError(t, err)
+	require.NotNil(t, uniqueAppTitleID())
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{otherSW})
+	require.NoError(t, err)
+
+	require.NoError(t, ds2.SyncHostsSoftware(ctx, time.Now()))
+	require.NoError(t, ds2.CleanupSoftwareTitles(ctx))
+
+	var titleCount int
+	err = sqlx.GetContext(ctx, ds.writer(ctx), &titleCount,
+		`SELECT COUNT(*) FROM software_titles WHERE bundle_identifier = ?`, uniqueSW.BundleIdentifier)
+	require.NoError(t, err)
+	require.Zero(t, titleCount, "the orphaned title should have been garbage-collected")
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{uniqueSW, otherSW})
+	require.NoError(t, err)
+	require.NotNil(t, uniqueAppTitleID(), "software row was inserted with a NULL title_id")
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{uniqueSW})
+	require.NoError(t, err)
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{uniqueSW, otherSW})
+	require.NoError(t, err)
+	require.NotNil(t, uniqueAppTitleID(), "software row with NULL title_id was never repaired")
+}
+
+func testCleanupSoftwareTitlesRepairsUnlinkedSoftware(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "repairhost", "10.0.0.2", "repairkey", "repairuuid", time.Now())
+
+	keeper := fleet.Software{Name: "KeeperApp", Version: "1.0.0", Source: "apps", BundleIdentifier: "com.example.keeper"}
+	_, err := ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{keeper})
+	require.NoError(t, err)
+	keeperTitleID := titleIDByBundle(t, ctx, ds, keeper.BundleIdentifier)
+
+	upgradeCode := "{2A1B3C4D-0000-0000-0000-000000000001}"
+	applicationID := "com.example.androidapp"
+
+	res, err := ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO software_titles (name, source, extension_for, application_id) VALUES (?, ?, '', ?)`,
+		"Android App", "android_apps", applicationID)
+	require.NoError(t, err)
+	androidTitleID, err := res.LastInsertId()
+	require.NoError(t, err)
+
+	newBundleSW := insertUnlinkedSoftware(t, ctx, ds, host.ID, "OrphanApp", "1.0.0", "apps", "com.example.orphan", nil, nil, nil)
+	existingBundleSW := insertUnlinkedSoftware(t, ctx, ds, host.ID, "KeeperApp Beta", "2.0.0", "apps", keeper.BundleIdentifier, nil, nil, nil)
+	programSW := insertUnlinkedSoftware(t, ctx, ds, host.ID, "SomeProgram", "3.0.0", "programs", "", &upgradeCode, nil, nil)
+	kernelSW := insertUnlinkedSoftware(t, ctx, ds, host.ID, "linux-image-6.8.0-45-generic", "6.8.0", "deb_packages", "", nil, nil, nil)
+	androidSW := insertUnlinkedSoftware(t, ctx, ds, host.ID, "Android App (renamed)", "4.0.0", "android_apps", "", nil, &applicationID, nil)
+
+	require.NoError(t, ds.CleanupSoftwareTitles(ctx))
+
+	titleOf := func(softwareID int64) fleet.SoftwareTitle {
+		var titles []fleet.SoftwareTitle
+		require.NoError(t, sqlx.SelectContext(ctx, ds.writer(ctx), &titles,
+			`SELECT st.id, st.name, st.source, st.bundle_identifier, st.is_kernel, st.upgrade_code
+			 FROM software s JOIN software_titles st ON st.id = s.title_id WHERE s.id = ?`, softwareID))
+		require.Len(t, titles, 1, "software row %d is not linked to an existing title", softwareID)
+		return titles[0]
+	}
+
+	newTitle := titleOf(newBundleSW)
+	require.Equal(t, "OrphanApp", newTitle.Name)
+	require.Equal(t, "apps", newTitle.Source)
+	require.NotNil(t, newTitle.BundleIdentifier)
+	require.Equal(t, "com.example.orphan", *newTitle.BundleIdentifier)
+
+	require.Equal(t, keeperTitleID, titleOf(existingBundleSW).ID, "repair created a duplicate title instead of reusing the existing one")
+	var keeperTitleCount int
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &keeperTitleCount,
+		`SELECT COUNT(*) FROM software_titles WHERE bundle_identifier = ?`, keeper.BundleIdentifier))
+	require.Equal(t, 1, keeperTitleCount)
+
+	programTitle := titleOf(programSW)
+	require.Equal(t, "programs", programTitle.Source)
+	require.NotNil(t, programTitle.UpgradeCode)
+	require.Equal(t, upgradeCode, *programTitle.UpgradeCode)
+
+	require.True(t, titleOf(kernelSW).IsKernel, "repaired Linux kernel title should be marked as a kernel")
+
+	require.EqualValues(t, androidTitleID, titleOf(androidSW).ID)
+
+	require.NoError(t, ds.CleanupSoftwareTitles(ctx))
+	require.Equal(t, newTitle.ID, titleOf(newBundleSW).ID)
+	require.Equal(t, keeperTitleID, titleOf(existingBundleSW).ID)
+}
+
+func testNullDanglingTitleLinks(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "danglinghost", "10.0.0.3", "danglingkey", "danglinguuid", time.Now())
+
+	linked := fleet.Software{Name: "LinkedApp", Version: "1.0.0", Source: "apps", BundleIdentifier: "com.example.linked"}
+	_, err := ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{linked})
+	require.NoError(t, err)
+	linkedTitleID := titleIDByBundle(t, ctx, ds, linked.BundleIdentifier)
+
+	deletedTitleID := uint(999999)
+	ghostID := insertUnlinkedSoftware(t, ctx, ds, host.ID, "GhostApp", "1.0.0", "apps", "com.example.ghost", nil, nil, &deletedTitleID)
+
+	require.NoError(t, ds.nullDanglingTitleLinks(ctx, []uint{deletedTitleID, linkedTitleID}))
+
+	ghostTitleID := func() *uint {
+		return softwareTitleID(t, ctx, ds, `SELECT title_id FROM software WHERE id = ?`, ghostID)
+	}
+
+	require.Nil(t, ghostTitleID(), "link to the deleted title should have been cleared")
+
+	var linkedCount int
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &linkedCount,
+		`SELECT COUNT(*) FROM software WHERE title_id = ?`, linkedTitleID))
+	require.Equal(t, 1, linkedCount, "link to a live title must not be cleared")
+
+	require.NoError(t, ds.CleanupSoftwareTitles(ctx))
+	repairedTitleID := ghostTitleID()
+	require.NotNil(t, repairedTitleID)
+	var ghostTitleBundle string
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &ghostTitleBundle,
+		`SELECT bundle_identifier FROM software_titles WHERE id = ?`, *repairedTitleID))
+	require.Equal(t, "com.example.ghost", ghostTitleBundle)
+}

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -229,6 +229,22 @@ func (s Software) ToUniqueStr() string {
 	return strings.Join(ss, SoftwareFieldSeparator)
 }
 
+const (
+	linuxImageKernelPattern = `^linux-image-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-[[:digit:]]+-[[:alnum:]]+`
+	rpmKernelName           = "kernel"
+	archKernelPattern       = `^linux(?:-(?:lts|zen|hardened))?$`
+)
+
+var (
+	linuxImageKernelRegex = regexp.MustCompile(linuxImageKernelPattern)
+	archKernelRegex       = regexp.MustCompile(archKernelPattern)
+)
+
+// IsKernelSoftwareName reports whether name is the name of a Linux kernel package.
+func IsKernelSoftwareName(name string) bool {
+	return linuxImageKernelRegex.MatchString(name) || name == rpmKernelName || archKernelRegex.MatchString(name)
+}
+
 // ComputeRawChecksum computes the checksum for a software entry.
 //
 // This is the SOLE source of truth for the software checksum. The checksum is

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2297,16 +2297,7 @@ func directIngestScheduledQueryStats(ctx context.Context, logger *slog.Logger, h
 	return nil
 }
 
-const (
-	linuxImageRegex = `^linux-image-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-[[:digit:]]+-[[:alnum:]]+`
-	rpmKernelName   = "kernel"
-	archKernelName  = `^linux(?:-(?:lts|zen|hardened))?$`
-)
-
-var (
-	kernelRegex     = regexp.MustCompile(linuxImageRegex)
-	archKernelRegex = regexp.MustCompile(archKernelName)
-)
+const rpmKernelName = "kernel"
 
 func directIngestSoftware(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var software []fleet.Software
@@ -2342,7 +2333,7 @@ func directIngestSoftware(ctx context.Context, logger *slog.Logger, host *fleet.
 			continue
 		}
 
-		if fleet.IsLinux(host.Platform) && (kernelRegex.MatchString(s.Name) || s.Name == rpmKernelName || archKernelRegex.MatchString(s.Name)) {
+		if fleet.IsLinux(host.Platform) && fleet.IsKernelSoftwareName(s.Name) {
 			s.IsKernel = true
 		}
 


### PR DESCRIPTION
Resolves #51913

Software rows could be written with title_id = NULL, making the software invisible to every UI and API query, since they all join software to software_titles. Two paths led there: the per-instance title cache has no TTL and no cross-instance invalidation, so after a title is garbage-collected by the cleanup cron on another instance every other instance still skips re-creating it; and a title inserted outside the main transaction can be deleted by a concurrent CleanupSoftwareTitles before the transaction resolves it. Once written, such a row was permanent — its checksum already exists, so ingestion never revisits its title.

Ingestion now retries title resolution once, evicting the stale cache entries and re-inserting the titles before falling back to a NULL title_id. The hourly cleanup re-links rows with a NULL title_id, creating the missing titles from the software rows themselves; when it deletes an orphaned title out from under a concurrent ingestion, it clears that dangling link at delete time so the next run re-links the row. The kernel-name check moves to fleet.IsKernelSoftwareName so the repair can derive is_kernel without importing the service layer.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved software inventory reliability when titles are removed during concurrent cleanup.
  * Automatically repairs missing or broken software title links.
  * Preserves software associations by matching bundle identifiers, upgrade codes, names, and Android application IDs.
  * Improved detection and classification of Linux kernel software across supported package formats.

* **Tests**
  * Added coverage for title-link repair, cleanup scenarios, and post-cleanup software ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->