### PR TITLE
GitOps: pin policy to the exact installer resolved from the YAML

### DIFF
--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1732,31 +1732,12 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			return ctxerr.Wrap(ctx, errSoftwareTitleIDOnGlobalPolicy, "create policy from spec")
 		}
 
-		// If the caller pinned a specific package (GitOps sets this when the
-		// policy YAML referenced one installer of a multi-installer title),
-		// validate it belongs to the title/team and use it. Otherwise fall
-		// through to the first-added default.
+		// When the caller pinned a specific package, skip the first-added default
+		// lookup for this spec. Validation + direct use happens inline in the
+		// INSERT loop below (the map is keyed by team+title, so a per-policy pin
+		// can't live in it — two policies on the same team+title with different
+		// pins would collide).
 		if spec.SoftwarePackageID != nil && *spec.SoftwarePackageID != 0 {
-			var pinnedInstallerID uint
-			err := sqlx.GetContext(ctx, queryerContext, &pinnedInstallerID,
-				`SELECT id FROM software_installers
-					WHERE id = ? AND global_or_team_id = ? AND title_id = ? AND is_active = 1`,
-				*spec.SoftwarePackageID, teamNameToID[spec.Team], *spec.SoftwareTitleID)
-			if err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					return ctxerr.Wrap(ctx, &fleet.BadRequestError{
-						Message: fmt.Sprintf(
-							"software_package_id %d does not belong to software_title_id %d on team %q",
-							*spec.SoftwarePackageID, *spec.SoftwareTitleID, spec.Team,
-						),
-					}, "validate pinned software package id")
-				}
-				return ctxerr.Wrap(ctx, err, "validate pinned software package id")
-			}
-			if len(softwareInstallerIDs[teamNameToID[spec.Team]]) == 0 {
-				softwareInstallerIDs[teamNameToID[spec.Team]] = make(map[uint]*uint)
-			}
-			softwareInstallerIDs[teamNameToID[spec.Team]][*spec.SoftwareTitleID] = &pinnedInstallerID
 			continue
 		}
 
@@ -1897,7 +1878,30 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 				var vppAppsTeamsID *uint
 				if spec.SoftwareTitleID != nil {
 					if _, ok := vppTitleIDs[*spec.SoftwareTitleID]; !ok {
-						softwareInstallerID = softwareInstallerIDs[teamNameToID[spec.Team]][*spec.SoftwareTitleID]
+						// Pinned specs: validate the installer id belongs to the
+						// title on this team, then use it directly. Bypasses the
+						// team+title map, which can only hold one value per key.
+						if spec.SoftwarePackageID != nil && *spec.SoftwarePackageID != 0 {
+							var pinnedInstallerID uint
+							err := sqlx.GetContext(ctx, tx, &pinnedInstallerID,
+								`SELECT id FROM software_installers
+									WHERE id = ? AND global_or_team_id = ? AND title_id = ? AND is_active = 1`,
+								*spec.SoftwarePackageID, teamNameToID[spec.Team], *spec.SoftwareTitleID)
+							if err != nil {
+								if errors.Is(err, sql.ErrNoRows) {
+									return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+										Message: fmt.Sprintf(
+											"software_package_id %d does not belong to software_title_id %d on team %q",
+											*spec.SoftwarePackageID, *spec.SoftwareTitleID, spec.Team,
+										),
+									}, "validate pinned software package id")
+								}
+								return ctxerr.Wrap(ctx, err, "validate pinned software package id")
+							}
+							softwareInstallerID = &pinnedInstallerID
+						} else {
+							softwareInstallerID = softwareInstallerIDs[teamNameToID[spec.Team]][*spec.SoftwareTitleID]
+						}
 					} else {
 						vppAppsTeamsID = vppAppsTeamsIDs[teamNameToID[spec.Team]][*spec.SoftwareTitleID]
 					}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1731,6 +1731,35 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 		if spec.Team == "" {
 			return ctxerr.Wrap(ctx, errSoftwareTitleIDOnGlobalPolicy, "create policy from spec")
 		}
+
+		// If the caller pinned a specific package (GitOps sets this when the
+		// policy YAML referenced one installer of a multi-installer title),
+		// validate it belongs to the title/team and use it. Otherwise fall
+		// through to the first-added default.
+		if spec.SoftwarePackageID != nil && *spec.SoftwarePackageID != 0 {
+			var pinnedInstallerID uint
+			err := sqlx.GetContext(ctx, queryerContext, &pinnedInstallerID,
+				`SELECT id FROM software_installers
+					WHERE id = ? AND global_or_team_id = ? AND title_id = ? AND is_active = 1`,
+				*spec.SoftwarePackageID, teamNameToID[spec.Team], *spec.SoftwareTitleID)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+						Message: fmt.Sprintf(
+							"software_package_id %d does not belong to software_title_id %d on team %q",
+							*spec.SoftwarePackageID, *spec.SoftwareTitleID, spec.Team,
+						),
+					}, "validate pinned software package id")
+				}
+				return ctxerr.Wrap(ctx, err, "validate pinned software package id")
+			}
+			if len(softwareInstallerIDs[teamNameToID[spec.Team]]) == 0 {
+				softwareInstallerIDs[teamNameToID[spec.Team]] = make(map[uint]*uint)
+			}
+			softwareInstallerIDs[teamNameToID[spec.Team]][*spec.SoftwareTitleID] = &pinnedInstallerID
+			continue
+		}
+
 		var ids struct {
 			SoftwareInstallerID *uint `db:"si_id"`
 			VPPAppsTeamsID      *uint `db:"vat_id"`

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1725,6 +1725,19 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 
 		}
 
+		// A pinned package with no title has nothing to associate against — reject
+		// early. Also catches global policies since global specs (empty Team) never
+		// carry a title, so any non-zero SoftwarePackageID there is invalid.
+		if spec.SoftwarePackageID != nil && *spec.SoftwarePackageID != 0 &&
+			(spec.SoftwareTitleID == nil || *spec.SoftwareTitleID == 0) {
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: fmt.Sprintf(
+					"software_package_id %d requires software_title_id to be set on policy %q",
+					*spec.SoftwarePackageID, spec.Name,
+				),
+			}, "validate policy spec")
+		}
+
 		if spec.SoftwareTitleID == nil || *spec.SoftwareTitleID == 0 {
 			continue
 		}

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -10103,7 +10103,7 @@ func testApplyPolicySpecFirstAddedInstaller(t *testing.T, ds *Datastore) {
 // YAMLs share a bundle identifier and collapse into one title with several
 // installers, and GitOps needs to preserve which installer the policy YAML referenced.
 func testApplyPolicySpecPinnedInstaller(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
+	ctx := t.Context()
 	user := test.NewUser(t, ds, "Spec Pinned", "spec-pinned@example.com", true)
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "spec-pinned-team"})
 	require.NoError(t, err)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -10099,8 +10099,8 @@ func testApplyPolicySpecFirstAddedInstaller(t *testing.T, ds *Datastore) {
 
 // testApplyPolicySpecPinnedInstaller verifies that when a spec sets SoftwarePackageID,
 // the datastore pins the policy to that specific installer instead of falling back
-// to the title's first-added package. This is the fix for Cisneros's case: multiple
-// single-package YAMLs sharing a bundle identifier create one title with several
+// to the title's first-added package. Covers the case where multiple single-package
+// YAMLs share a bundle identifier and collapse into one title with several
 // installers, and GitOps needs to preserve which installer the policy YAML referenced.
 func testApplyPolicySpecPinnedInstaller(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
@@ -10161,11 +10161,11 @@ func testApplyPolicySpecPinnedInstaller(t *testing.T, ds *Datastore) {
 	})
 
 	t.Run("two policies on the same title with different pins land on different installers", func(t *testing.T) {
-		// Regression guard for the collision that hit Andy's flow: when two
-		// policies share (team, title) but pin different installers, the
-		// applier can't stash the per-policy id in a team+title-keyed map —
-		// the second pin overwrites the first and both rows end up on the
-		// last one. Validate + use inline instead.
+		// Regression guard for the collision path: when two policies share
+		// (team, title) but pin different installers, the applier can't stash
+		// the per-policy id in a team+title-keyed map — the second pin would
+		// overwrite the first and both rows would end up on the last one.
+		// Validate + use inline instead.
 		err := ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
 			{
 				Name:              "collision A pins first installer",

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -78,6 +78,7 @@ func TestPolicies(t *testing.T) {
 		{"TestPoliciesTeamPoliciesWithVPP", testTeamPoliciesWithVPP},
 		{"ApplyPolicySpecWithInstallers", testApplyPolicySpecWithInstallers},
 		{"ApplyPolicySpecFirstAddedInstaller", testApplyPolicySpecFirstAddedInstaller},
+		{"ApplyPolicySpecPinnedInstaller", testApplyPolicySpecPinnedInstaller},
 		{"TestPoliciesNewGlobalPolicyWithScript", testNewGlobalPolicyWithScript},
 		{"TestPoliciesTeamPoliciesWithScript", testTeamPoliciesWithScript},
 		{"TestPoliciesTeamPoliciesWithResendProfile", testTeamPoliciesWithResendProfile},
@@ -10094,4 +10095,102 @@ func testApplyPolicySpecFirstAddedInstaller(t *testing.T, ds *Datastore) {
 	require.Len(t, policies, 1)
 	require.NotNil(t, policies[0].SoftwareInstallerID)
 	require.Equal(t, installerA, *policies[0].SoftwareInstallerID, "GitOps must resolve to the first-added package")
+}
+
+// testApplyPolicySpecPinnedInstaller verifies that when a spec sets SoftwarePackageID,
+// the datastore pins the policy to that specific installer instead of falling back
+// to the title's first-added package. This is the fix for Cisneros's case: multiple
+// single-package YAMLs sharing a bundle identifier create one title with several
+// installers, and GitOps needs to preserve which installer the policy YAML referenced.
+func testApplyPolicySpecPinnedInstaller(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Spec Pinned", "spec-pinned@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "spec-pinned-team"})
+	require.NoError(t, err)
+
+	var titleID uint
+	newPkg := func(storage, filename string) uint {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello-"+storage), t.TempDir)
+		require.NoError(t, err)
+		id, tID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        storage,
+			Filename:         filename,
+			Title:            "SpecPinnedPkg",
+			Version:          "1.0",
+			Source:           "apps",
+			BundleIdentifier: "com.example.specpinnedpkg",
+			UserID:           user.ID,
+			TeamID:           &team.ID,
+			Platform:         "darwin",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+		titleID = tID
+		return id
+	}
+	installerA := newPkg("pinned-a", "pkgA.pkg")
+	installerB := newPkg("pinned-b", "pkgB.pkg")
+	require.Less(t, installerA, installerB)
+
+	t.Run("SoftwarePackageID pins the non-first-added installer", func(t *testing.T) {
+		err := ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
+			{
+				Name:              "policy pinned to B",
+				Query:             "SELECT 1;",
+				Team:              team.Name,
+				SoftwareTitleID:   &titleID,
+				SoftwarePackageID: &installerB,
+			},
+		})
+		require.NoError(t, err)
+
+		policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "", "")
+		require.NoError(t, err)
+		var pinned *fleet.Policy
+		for _, p := range policies {
+			if p.Name == "policy pinned to B" {
+				pinned = p
+				break
+			}
+		}
+		require.NotNil(t, pinned)
+		require.NotNil(t, pinned.SoftwareInstallerID)
+		require.Equal(t, installerB, *pinned.SoftwareInstallerID, "SoftwarePackageID must pin the specific installer, not the first-added default")
+	})
+
+	t.Run("SoftwarePackageID that doesn't belong to the title is rejected", func(t *testing.T) {
+		// Create a second title with its own installer, then try to pin a policy
+		// on the first title to the second title's installer.
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("other"), t.TempDir)
+		require.NoError(t, err)
+		otherInstaller, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:    "install",
+			InstallerFile:    tfr,
+			StorageID:        "pinned-other",
+			Filename:         "other.pkg",
+			Title:            "SpecPinnedOther",
+			Version:          "1.0",
+			Source:           "apps",
+			BundleIdentifier: "com.example.specpinnedother",
+			UserID:           user.ID,
+			TeamID:           &team.ID,
+			Platform:         "darwin",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+
+		err = ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
+			{
+				Name:              "policy pinned to wrong title's installer",
+				Query:             "SELECT 1;",
+				Team:              team.Name,
+				SoftwareTitleID:   &titleID,
+				SoftwarePackageID: &otherInstaller,
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not belong to software_title_id")
+	})
 }

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -10160,6 +10160,46 @@ func testApplyPolicySpecPinnedInstaller(t *testing.T, ds *Datastore) {
 		require.Equal(t, installerB, *pinned.SoftwareInstallerID, "SoftwarePackageID must pin the specific installer, not the first-added default")
 	})
 
+	t.Run("two policies on the same title with different pins land on different installers", func(t *testing.T) {
+		// Regression guard for the collision that hit Andy's flow: when two
+		// policies share (team, title) but pin different installers, the
+		// applier can't stash the per-policy id in a team+title-keyed map —
+		// the second pin overwrites the first and both rows end up on the
+		// last one. Validate + use inline instead.
+		err := ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
+			{
+				Name:              "collision A pins first installer",
+				Query:             "SELECT 1;",
+				Team:              team.Name,
+				SoftwareTitleID:   &titleID,
+				SoftwarePackageID: &installerA,
+			},
+			{
+				Name:              "collision B pins second installer",
+				Query:             "SELECT 1;",
+				Team:              team.Name,
+				SoftwareTitleID:   &titleID,
+				SoftwarePackageID: &installerB,
+			},
+		})
+		require.NoError(t, err)
+
+		policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "", "")
+		require.NoError(t, err)
+		byName := map[string]*fleet.Policy{}
+		for _, p := range policies {
+			byName[p.Name] = p
+		}
+		polA := byName["collision A pins first installer"]
+		polB := byName["collision B pins second installer"]
+		require.NotNil(t, polA)
+		require.NotNil(t, polB)
+		require.NotNil(t, polA.SoftwareInstallerID)
+		require.NotNil(t, polB.SoftwareInstallerID)
+		require.Equal(t, installerA, *polA.SoftwareInstallerID, "first policy must keep its own pin")
+		require.Equal(t, installerB, *polB.SoftwareInstallerID, "second policy must keep its own pin, not overwrite the first")
+	})
+
 	t.Run("SoftwarePackageID that doesn't belong to the title is rejected", func(t *testing.T) {
 		// Create a second title with its own installer, then try to pin a policy
 		// on the first title to the second title's installer.

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4108,6 +4108,7 @@ func (ds *Datastore) GetSoftwareInstallers(ctx context.Context, teamID uint) ([]
 SELECT
   si.team_id,
   si.title_id,
+  si.id AS installer_id,
   si.url,
   si.storage_id AS hash_sha256,
   si.fleet_maintained_app_id,
@@ -4128,6 +4129,7 @@ UNION ALL
 SELECT
 	iha.team_id,
 	iha.title_id,
+	0 AS installer_id,
 	iha.url,
 	iha.storage_id as hash_sha256,
 	NULL as fleet_maintained_app_id,

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -752,6 +752,12 @@ type PolicySpec struct {
 	// SoftwareTitleID is the title ID of the installer associated with this policy (team policies only).
 	// When editing a policy, if this is nil or 0 then the title ID is unset from the policy.
 	SoftwareTitleID *uint `json:"software_title_id"`
+	// SoftwarePackageID optionally pins the policy to a specific package under
+	// the given SoftwareTitleID (team policies only). When nil the applier
+	// falls back to the title's first-added package. Used by GitOps to preserve
+	// which package a policy YAML referenced when the title has multiple
+	// installers sharing a bundle identifier.
+	SoftwarePackageID *uint `json:"software_package_id,omitempty"`
 	// ScriptID is the ID of the script associated with this policy (team policies only).
 	// When editing a policy, if this is nil or 0 then the script ID is unset from the policy.
 	ScriptID *uint `json:"script_id"`

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -159,6 +159,11 @@ type SoftwarePackageResponse struct {
 	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// TitleID is the id of the software title associated with the software installer.
 	TitleID *uint `json:"title_id" db:"title_id"`
+	// InstallerID is the row ID of the specific software_installers entry this
+	// response describes. Zero for in-house apps, which come from a different
+	// table. GitOps uses this to pin a policy to the exact package the YAML
+	// referenced when several installers share a title.
+	InstallerID uint `json:"installer_id" db:"installer_id"`
 	// URL is the source URL for this installer (set when uploading via batch/gitops).
 	URL string `json:"url" db:"url"`
 	// HashSHA256 is the SHA256 hash of the software installer.

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3490,34 +3490,47 @@ func (c *Client) doGitOpsCustomHostVitals(config *spec.GitOps, logFn func(format
 // policy by trying each available identifier in order: URL, App Store ID, hash,
 // then FMA slug. Returns the resolved title ID and true if found, or 0 and
 // false if no identifier matched.
+//
+// When the URL or hash lookup succeeds, installerID additionally carries the
+// specific installer_id for that package so the caller can pin the policy to
+// it (avoiding the datastore's first-added fallback for multi-package titles).
+// installerID is nil for AppStoreID and slug matches, which don't map to a
+// single software installer row.
 func resolvePolicySoftwareTitleID(
 	policy *spec.GitOpsPolicySpec,
 	byURL, byAppStoreID, byHash, bySlug map[string]uint,
-) (titleID uint, resolved bool) {
+	installerIDsByURL, installerIDsByHash map[string]uint,
+) (titleID uint, installerID *uint, resolved bool) {
 	if policy.InstallSoftwareURL != "" {
 		if id, ok := byURL[policy.InstallSoftwareURL]; ok {
-			return id, true
+			if instID, ok := installerIDsByURL[policy.InstallSoftwareURL]; ok {
+				return id, &instID, true
+			}
+			return id, nil, true
 		}
 	}
 	if policy.InstallSoftware.Other == nil {
-		return 0, false
+		return 0, nil, false
 	}
 	if policy.InstallSoftware.Other.AppStoreID != "" {
 		if id, ok := byAppStoreID[policy.InstallSoftware.Other.AppStoreID]; ok {
-			return id, true
+			return id, nil, true
 		}
 	}
 	if policy.InstallSoftware.Other.HashSHA256 != "" {
 		if id, ok := byHash[policy.InstallSoftware.Other.HashSHA256]; ok {
-			return id, true
+			if instID, ok := installerIDsByHash[policy.InstallSoftware.Other.HashSHA256]; ok {
+				return id, &instID, true
+			}
+			return id, nil, true
 		}
 	}
 	if policy.InstallSoftware.Other.FleetMaintainedAppSlug != "" {
 		if id, ok := bySlug[policy.InstallSoftware.Other.FleetMaintainedAppSlug]; ok {
-			return id, true
+			return id, nil, true
 		}
 	}
-	return 0, false
+	return 0, nil, false
 }
 
 func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []fleet.SoftwarePackageResponse, teamVPPApps []fleet.VPPAppResponse, teamScripts []fleet.ScriptResponse, logFn func(format string, args ...interface{}), dryRun bool) error {
@@ -3555,6 +3568,11 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 		softwareTitleIDsByAppStoreAppID := make(map[string]uint)
 		softwareTitleIDsByHash := make(map[string]uint)
 		softwareTitleIDsBySlug := make(map[string]uint)
+		// Parallel maps keyed by URL/hash but returning the specific installer_id
+		// rather than the title id. Used to pin a policy to the exact package the
+		// GitOps YAML referenced when several packages share a title.
+		installerIDsByURL := make(map[string]uint)
+		installerIDsByHash := make(map[string]uint)
 		for _, softwareInstaller := range teamSoftwareInstallers {
 			if softwareInstaller.TitleID == nil {
 				// Should not happen, but to not panic we just log a warning.
@@ -3568,6 +3586,16 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			}
 			softwareTitleIDsByInstallerURL[softwareInstaller.URL] = *softwareInstaller.TitleID
 			softwareTitleIDsByHash[softwareInstaller.HashSHA256] = *softwareInstaller.TitleID
+			// In-house apps return InstallerID == 0 and shouldn't be pinned this
+			// way; they'd fail the datastore's software_installers-table validation.
+			if softwareInstaller.InstallerID != 0 {
+				if softwareInstaller.URL != "" {
+					installerIDsByURL[softwareInstaller.URL] = softwareInstaller.InstallerID
+				}
+				if softwareInstaller.HashSHA256 != "" {
+					installerIDsByHash[softwareInstaller.HashSHA256] = softwareInstaller.InstallerID
+				}
+			}
 
 			if softwareInstaller.Slug != "" {
 				softwareTitleIDsBySlug[softwareInstaller.Slug] = *softwareInstaller.TitleID
@@ -3613,15 +3641,23 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			// both URL and hash are set (from the referenced YAML file). If the primary
 			// identifier (URL) fails, fall back to secondary identifiers rather than
 			// skipping the policy entirely.
-			softwareTitleID, resolved := resolvePolicySoftwareTitleID(
+			softwareTitleID, installerID, resolved := resolvePolicySoftwareTitleID(
 				config.Policies[i],
 				softwareTitleIDsByInstallerURL,
 				softwareTitleIDsByAppStoreAppID,
 				softwareTitleIDsByHash,
 				softwareTitleIDsBySlug,
+				installerIDsByURL,
+				installerIDsByHash,
 			)
 			if resolved {
 				config.Policies[i].SoftwareTitleID = &softwareTitleID
+				// Pin the resolved installer so the datastore doesn't fall back to
+				// the title's first-added package. Only set for URL/hash matches
+				// (AppStoreID and slug don't map to a specific installer row).
+				if installerID != nil {
+					config.Policies[i].SoftwarePackageID = installerID
+				}
 				// Log a warning if URL was set but didn't match (resolved via fallback).
 				if !dryRun && config.Policies[i].InstallSoftwareURL != "" {
 					if _, urlOK := softwareTitleIDsByInstallerURL[config.Policies[i].InstallSoftwareURL]; !urlOK {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3584,16 +3584,34 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				logFn("[!] software installer without url: fleet_id=%d, title_id=%d\n", *teamID, *softwareInstaller.TitleID)
 				continue
 			}
-			softwareTitleIDsByInstallerURL[softwareInstaller.URL] = *softwareInstaller.TitleID
-			softwareTitleIDsByHash[softwareInstaller.HashSHA256] = *softwareInstaller.TitleID
-			// In-house apps return InstallerID == 0 and shouldn't be pinned this
-			// way; they'd fail the datastore's software_installers-table validation.
+			// Normal software installers unconditionally claim their URL/hash for
+			// both the title and installer maps. In-house apps (InstallerID==0,
+			// distinct table) can share a URL or hash with a normal installer; if
+			// they do, we must not let their title id displace the normal
+			// installer's — the applier would then send a pinned installer_id
+			// that doesn't belong to the resolved title and the datastore would
+			// 400. So in-house entries only populate the title map when a normal
+			// installer hasn't already claimed the key (order-agnostic: if the
+			// normal installer iterates later, it unconditionally overwrites).
 			if softwareInstaller.InstallerID != 0 {
+				softwareTitleIDsByInstallerURL[softwareInstaller.URL] = *softwareInstaller.TitleID
+				softwareTitleIDsByHash[softwareInstaller.HashSHA256] = *softwareInstaller.TitleID
 				if softwareInstaller.URL != "" {
 					installerIDsByURL[softwareInstaller.URL] = softwareInstaller.InstallerID
 				}
 				if softwareInstaller.HashSHA256 != "" {
 					installerIDsByHash[softwareInstaller.HashSHA256] = softwareInstaller.InstallerID
+				}
+			} else {
+				if softwareInstaller.URL != "" {
+					if _, taken := installerIDsByURL[softwareInstaller.URL]; !taken {
+						softwareTitleIDsByInstallerURL[softwareInstaller.URL] = *softwareInstaller.TitleID
+					}
+				}
+				if softwareInstaller.HashSHA256 != "" {
+					if _, taken := installerIDsByHash[softwareInstaller.HashSHA256]; !taken {
+						softwareTitleIDsByHash[softwareInstaller.HashSHA256] = *softwareInstaller.TitleID
+					}
 				}
 			}
 
@@ -3620,6 +3638,13 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 
 		for i := range config.Policies {
 			config.Policies[i].SoftwareTitleID = ptr.Uint(0) // 0 unsets the installer
+			// GitOpsPolicySpec embeds PolicySpec, whose SoftwarePackageID field
+			// is JSON-tagged and therefore reachable from user YAML. Any value
+			// left over from the incoming spec would leak through the branches
+			// that don't produce an installerID (AppStoreID, slug, in-house URL
+			// match, unresolved) and either fail the datastore's title/installer
+			// validation or silently pin the wrong package. Reset before resolve.
+			config.Policies[i].SoftwarePackageID = nil
 
 			if config.Policies[i].Type == fleet.PolicyTypePatch && !config.Policies[i].InstallSoftware.IsOther && config.Policies[i].InstallSoftware.Bool {
 				softwareTitleID, ok := softwareTitleIDsBySlug[config.Policies[i].FleetMaintainedAppSlug]
@@ -3652,12 +3677,14 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			)
 			if resolved {
 				config.Policies[i].SoftwareTitleID = &softwareTitleID
-				// Pin the resolved installer so the datastore doesn't fall back to
-				// the title's first-added package. Only set for URL/hash matches
-				// (AppStoreID and slug don't map to a specific installer row).
-				if installerID != nil {
-					config.Policies[i].SoftwarePackageID = installerID
-				}
+				// installerID is nil for AppStoreID matches (VPP), slug matches
+				// (FMA), and any URL/hash match that didn't land on a
+				// software_installers row (e.g., in-house apps, which come from a
+				// different table and get InstallerID==0 upstream). Assigning nil
+				// skips the pin and lets the datastore use the title's default
+				// resolution. Unconditional to overwrite the loop-top reset only
+				// when we have a concrete installer to pin against.
+				config.Policies[i].SoftwarePackageID = installerID
 				// Log a warning if URL was set but didn't match (resolved via fallback).
 				if !dryRun && config.Policies[i].InstallSoftwareURL != "" {
 					if _, urlOK := softwareTitleIDsByInstallerURL[config.Policies[i].InstallSoftwareURL]; !urlOK {

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -1179,8 +1179,12 @@ func TestGitOpsErrors(t *testing.T) {
 }
 
 func TestResolvePolicySoftwareTitleID(t *testing.T) {
+	// uintPtr keeps the test cases readable — no ptr package import needed here.
+	uintPtr := func(v uint) *uint { return &v }
+
 	byURL := map[string]uint{
-		"https://example.com/pkg.pkg": 100,
+		"https://example.com/pkg.pkg":      100,
+		"https://example.com/in-house.pkg": 400, // in-house scenario: title map has it, installer map doesn't
 	}
 	byAppStoreID := map[string]uint{
 		"com.example.app": 200,
@@ -1188,6 +1192,7 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 	byHash := map[string]uint{
 		"abc123hash":     100, // same title as the URL entry
 		"different-hash": 999, // different title — used to test URL-over-hash precedence
+		"in-house-hash":  401, // in-house scenario: title map has it, installer map doesn't
 	}
 	bySlug := map[string]uint{
 		"some-fma-slug": 300,
@@ -1201,10 +1206,11 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		policy       *spec.GitOpsPolicySpec
-		wantTitleID  uint
-		wantResolved bool
+		name            string
+		policy          *spec.GitOpsPolicySpec
+		wantTitleID     uint
+		wantInstallerID *uint
+		wantResolved    bool
 	}{
 		{
 			name: "URL lookup succeeds",
@@ -1217,8 +1223,9 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  100,
-			wantResolved: true,
+			wantTitleID:     100,
+			wantInstallerID: uintPtr(500),
+			wantResolved:    true,
 		},
 		{
 			name: "URL takes precedence over hash when both match different titles",
@@ -1231,8 +1238,9 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  100, // URL's title (100), not hash's title (999)
-			wantResolved: true,
+			wantTitleID:     100, // URL's title (100), not hash's title (999)
+			wantInstallerID: uintPtr(500),
+			wantResolved:    true,
 		},
 		{
 			name: "URL lookup fails, hash fallback succeeds",
@@ -1245,8 +1253,36 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  100,
-			wantResolved: true,
+			wantTitleID:     100,
+			wantInstallerID: uintPtr(500),
+			wantResolved:    true,
+		},
+		{
+			name: "URL matches title map but not installer map (in-house app path)",
+			policy: &spec.GitOpsPolicySpec{
+				InstallSoftwareURL: "https://example.com/in-house.pkg",
+				InstallSoftware: optjson.BoolOr[*spec.PolicyInstallSoftware]{
+					IsOther: true,
+					Other:   &spec.PolicyInstallSoftware{},
+				},
+			},
+			wantTitleID:     400,
+			wantInstallerID: nil,
+			wantResolved:    true,
+		},
+		{
+			name: "hash matches title map but not installer map (in-house app path)",
+			policy: &spec.GitOpsPolicySpec{
+				InstallSoftware: optjson.BoolOr[*spec.PolicyInstallSoftware]{
+					IsOther: true,
+					Other: &spec.PolicyInstallSoftware{
+						HashSHA256: "in-house-hash",
+					},
+				},
+			},
+			wantTitleID:     401,
+			wantInstallerID: nil,
+			wantResolved:    true,
 		},
 		{
 			name: "App Store ID lookup succeeds",
@@ -1258,8 +1294,9 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  200,
-			wantResolved: true,
+			wantTitleID:     200,
+			wantInstallerID: nil,
+			wantResolved:    true,
 		},
 		{
 			name: "FMA slug lookup succeeds",
@@ -1271,8 +1308,9 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  300,
-			wantResolved: true,
+			wantTitleID:     300,
+			wantInstallerID: nil,
+			wantResolved:    true,
 		},
 		{
 			name: "all lookups fail",
@@ -1285,8 +1323,9 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  0,
-			wantResolved: false,
+			wantTitleID:     0,
+			wantInstallerID: nil,
+			wantResolved:    false,
 		},
 		{
 			name: "hash-only policy (no URL)",
@@ -1298,16 +1337,23 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 					},
 				},
 			},
-			wantTitleID:  100,
-			wantResolved: true,
+			wantTitleID:     100,
+			wantInstallerID: uintPtr(500),
+			wantResolved:    true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			titleID, _, resolved := resolvePolicySoftwareTitleID(tt.policy, byURL, byAppStoreID, byHash, bySlug, installerIDsByURL, installerIDsByHash)
+			titleID, installerID, resolved := resolvePolicySoftwareTitleID(tt.policy, byURL, byAppStoreID, byHash, bySlug, installerIDsByURL, installerIDsByHash)
 			require.Equal(t, tt.wantResolved, resolved)
 			require.Equal(t, tt.wantTitleID, titleID)
+			if tt.wantInstallerID == nil {
+				require.Nil(t, installerID)
+			} else {
+				require.NotNil(t, installerID)
+				require.Equal(t, *tt.wantInstallerID, *installerID)
+			}
 		})
 	}
 }

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -1192,6 +1192,13 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 	bySlug := map[string]uint{
 		"some-fma-slug": 300,
 	}
+	installerIDsByURL := map[string]uint{
+		"https://example.com/pkg.pkg": 500,
+	}
+	installerIDsByHash := map[string]uint{
+		"abc123hash":     500,
+		"different-hash": 501,
+	}
 
 	tests := []struct {
 		name         string
@@ -1298,7 +1305,7 @@ func TestResolvePolicySoftwareTitleID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			titleID, resolved := resolvePolicySoftwareTitleID(tt.policy, byURL, byAppStoreID, byHash, bySlug)
+			titleID, _, resolved := resolvePolicySoftwareTitleID(tt.policy, byURL, byAppStoreID, byHash, bySlug, installerIDsByURL, installerIDsByHash)
 			require.Equal(t, tt.wantResolved, resolved)
 			require.Equal(t, tt.wantTitleID, titleID)
 		})


### PR DESCRIPTION
## Issue
Follow-up to #51946 covering expected behavior #2 from #51358.

Stacked on top of #51946 — this PR targets that branch, not `main`, so once #51946 merges the base auto-rebases to `main`.

A customer flagged on #51946 that their setup — separate single-package YAML files sharing a bundle identifier (Noah's recommended pattern) — resolves to a single title with multiple installers. Policies pointing at one YAML were still hitting the title's first-added installer instead of the specific one the YAML described.

## Description
- **Root cause**: `server/datastore/mysql/policies.go` `ApplyPolicySpecs` ran `SELECT ... FROM software_installers WHERE title_id = ? AND is_active = 1 ORDER BY si_id ASC LIMIT 1` for every policy with a `SoftwareTitleID`. That "first-added" pick silently overrode which installer the parser had actually resolved from the YAML.
- **Fix**: propagate the specific installer id from parse to apply.
  - `fleet.PolicySpec` gains `SoftwarePackageID *uint` (`json:"software_package_id,omitempty"`) so callers can pin a specific installer alongside the title id.
  - `fleet.SoftwarePackageResponse` gains `InstallerID uint`; `GetSoftwareInstallers` SQL now returns `si.id`. In-house apps return `0` and are skipped from the pin path (they'd fail the `software_installers`-table validation).
  - `server/service/client.go` `doGitOpsPolicies` builds parallel `URL → installer_id` and `hash → installer_id` maps alongside the existing `URL → title_id` maps. When a policy resolves against them, it sets `SoftwarePackageID` on the outgoing spec.
  - `ApplyPolicySpecs` datastore honors `spec.SoftwarePackageID` when set: validates it belongs to the given title/team, uses it directly, and skips the first-added SELECT.

## Screenrecording
- Screen recording: N/A (GitOps applier + datastore change, no UI surface)

E2E test passed on this customer bug:

```
./build/fleetctl gitops -f /tmp/51358-qa-followup/a-team.yml              
[+] applying 0 labels (0 new and 0 updated)
[+] applying DDM assets for fleet Workstations
[+] applying MDM profiles for fleet Workstations
[+] applied 0 scripts for fleet Workstations
[+] applying 2 software packages for fleet Workstations
[+] applied 2 software packages for fleet Workstations
[+] applying 0 app store apps for fleet Workstations
[+] applied 1 fleet
[+] applying 2 policies
[+] applied 2 policies
[+] set icons on 0 software titles and deleted icons on 0 titles
[!] gitops succeeded
rachel@Rachels-MacBook-Pro fleet %  docker compose exec -T mysql bash -c 'MYSQL_PWD=toor mysql -uroot fleet -e "
  SELECT p.name, p.software_installer_id, si.storage_id
  FROM policies p
  JOIN software_installers si ON si.id = p.software_installer_id
  WHERE p.name LIKE \"51358-followup%\";
  "'

name	software_installer_id	storage_id
51358-followup A ? package_path targets Box RELEASE (should pin package 1)	1	395b7e97827be38ceb2d0d4cf2a0073701c5d7ad84cc9355f727160c8cad04bf
51358-followup B ? package_path targets Box BETA (should pin package 2)	2	5686af1a65d50faca5c2428801e2a8196e8f425d3789c7eddee3d1321d4758d6
rachel@Rachels-MacBook-Pro fleet % 
```


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Automated coverage (`server/datastore/mysql/policies_test.go`):
- `ApplyPolicySpecPinnedInstaller/SoftwarePackageID_pins_the_non-first-added_installer` — the customer's case. Two installers under one title, spec pins the second one, policy row stores `installer_id=B` (not `A`).
- `ApplyPolicySpecPinnedInstaller/SoftwarePackageID_that_doesn't_belong_to_the_title_is_rejected` — validation SELECT returns a clear error.
- Existing `ApplyPolicySpecFirstAddedInstaller` still passes — when `SoftwarePackageID` is nil the datastore falls back to the first-added default. No regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitOps policies can target a specific software package instead of defaulting to a title’s first-added package.
  * Software installer results now include package identifiers for precise policy targeting.
  * Policies matched by package URL or hash are linked to the exact installer.

* **Bug Fixes**
  * Prevented incorrect installer selection when multiple packages share a software title.
  * Added validation to reject packages that do not belong to the selected software title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
