### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/antigravity/darwin.json
+++ b/ee/maintained-apps/outputs/antigravity/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.10.0",
+      "version": "2.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.10.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.11.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.google.antigravity');"
       },
-      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.10.0-4996573600546816/darwin-arm/Antigravity.dmg",
+      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/darwin-arm/Antigravity.dmg",
       "install_script_ref": "b60a046d",
       "uninstall_script_ref": "5e1a08b9",
-      "sha256": "220e759763989b8f86c5a06454678b4b0a0ea528a7fb8960f8d45f7c7ac8909b",
+      "sha256": "713225e2da4d9f50a196e68937d862c12e98b1dd18b7bfab0d0a0c127e67e8dc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "151.1.93.136",
+      "version": "151.1.93.137",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '151.1.93.136') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '151.1.93.137') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'brave.exe');"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.93.136/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.93.137/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "8256a29857d1b2ab6698c46fed68aa32ea46d260b806e9a6040923fc1c9f9ee7",
+      "sha256": "387c89e13884f25135d78139a2201c32bb1f05b1faec6700abac08a2fd880543",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/creative-force-kelvin/windows.json
+++ b/ee/maintained-apps/outputs/creative-force-kelvin/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.8.1",
+      "version": "6.9.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Kelvin' AND publisher = 'Creative Force';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kelvin' AND publisher = 'Creative Force' AND version_compare(version, '6.8.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kelvin' AND publisher = 'Creative Force' AND version_compare(version, '6.9.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'creative force kelvin.exe');"
       },
-      "installer_url": "https://download.creativeforce.io/released-files.042024/prod/kelvin/win/Kelvin-6.8.1-win.msi",
+      "installer_url": "https://download.creativeforce.io/released-files.042024/prod/kelvin/win/Kelvin-6.9.0-win.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "afce06ed",
-      "sha256": "6b8a2b15b9f970563544e460d90d32c7e3dea5805f77a6029a08507db65e62aa",
+      "sha256": "ab7bdcf7a72b767a0c21fcc9e11fe4cb1d38876cca0d1fc9016a4a1d879d5b84",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/datagrip/windows.json
+++ b/ee/maintained-apps/outputs/datagrip/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.2.3",
+      "version": "2026.2.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.9437.163') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.10315.24') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) IN ('datagrip.exe','datagrip64.exe'));"
       },
-      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.2.3.exe",
+      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.2.4.exe",
       "install_script_ref": "0897461e",
       "uninstall_script_ref": "020465dd",
-      "sha256": "6c9f8722a98be09df1610256f699af7d1a70628f2e5d58d35fa83e20f8f6e505",
+      "sha256": "d08d92cebec9081f95e5bf8c5b9153dacf86915e113327d395f11a8f9ad28eac",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Antigravity for macOS to version 2.11.0.
  * Updated Brave Browser for Windows to version 151.1.93.137.
  * Updated Kelvin for Windows to version 6.9.0.
  * Updated DataGrip for Windows to version 2026.2.4.
  * Installer links, version detection, and checksums now reflect the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->