### PR TITLE
Fix race and CI failures

### DIFF
--- a/pkg/nettest/nettest.go
+++ b/pkg/nettest/nettest.go
@@ -74,6 +74,11 @@ func Retryable(err error) bool {
 	return false
 }
 
+// maxNetRetryAttempts bounds retries so a persistently broken remote (e.g. a feed release missing
+// an asset, which reads as a retryable HTTP error) fails the test in minutes, not at the package's
+// 1h timeout with no useful output.
+const maxNetRetryAttempts = 30
+
 // RunWithNetRetry runs the given function and retries in case of network errors (see Retryable).
 func RunWithNetRetry(t *testing.T, fn func() error) error {
 	var err error
@@ -85,6 +90,6 @@ func RunWithNetRetry(t *testing.T, fn func() error) error {
 			return err
 		}
 		return nil
-	}, retry.WithInterval(5*time.Second))
+	}, retry.WithInterval(5*time.Second), retry.WithMaxAttempts(maxNetRetryAttempts))
 	return err
 }

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -2705,12 +2705,18 @@ func testReapStuckActivatedMDMInstalls(t *testing.T, ds *Datastore) {
 		"an install younger than a sub-second timeout must survive it")
 	require.Nil(t, vppVerifyState(subSecondExec).VerificationFailedAt)
 
-	// the same timeout does reap it once it is genuinely older
+	// the same timeout does reap it once it is genuinely older. Only this install is checked: the
+	// hosts answered "just now" above are by now also older than a sub-second timeout, and none of
+	// them is used again.
 	setActivatedAgo(subSecondExec, 5_000_000)
 	reaped, err = ds.ReapStuckActivatedMDMInstalls(ctx, subSecondTimeout, 10)
 	require.NoError(t, err)
-	require.Len(t, reaped, 1)
-	require.Equal(t, subSecondExec, reaped[0].CommandUUID)
+	reapedUUIDs = reapedUUIDs[:0]
+	for _, r := range reaped {
+		reapedUUIDs = append(reapedUUIDs, r.CommandUUID)
+	}
+	require.Contains(t, reapedUUIDs, subSecondExec)
+	require.NotNil(t, vppVerifyState(subSecondExec).VerificationFailedAt)
 
 	// maxHosts bounds hosts, not rows: two stuck hosts, one run each
 	hLimitA, hLimitB := newMDMHost(), newMDMHost()

--- a/server/pubsub/agent_notifications.go
+++ b/server/pubsub/agent_notifications.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -121,16 +122,25 @@ func (n *RedisAgentNotifier) subscribeOnce(ctx context.Context, deliver func(Age
 	if err := psc.Subscribe(agentNotificationsChannel); err != nil {
 		return ctxerr.Wrap(ctx, err, "subscribe to agent notifications channel")
 	}
-	defer psc.Unsubscribe(agentNotificationsChannel) //nolint:errcheck
 	onSubscribed()
 
-	// Close the connection when ctx is done to unblock ReceiveWithTimeout.
 	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	// the conn must not be closed (deferred above) while the unsubscribe may still be writing
+	defer wg.Wait()
 	defer close(done)
 	go func() {
+		defer wg.Done()
 		select {
 		case <-ctx.Done():
-			_ = conn.Close()
+			// Unsubscribe when ctx is done to unblock ReceiveWithTimeout: redigo allows one
+			// concurrent sender and one receiver on a conn, but closing a pooled conn while
+			// another goroutine receives on it races. Closing is the fallback if the
+			// unsubscribe itself cannot be sent, as the conn is already broken then.
+			if err := psc.Unsubscribe(agentNotificationsChannel); err != nil {
+				_ = conn.Close()
+			}
 		case <-done:
 		}
 	}()
@@ -147,7 +157,10 @@ func (n *RedisAgentNotifier) subscribeOnce(ctx context.Context, deliver func(Age
 		case error:
 			return ctxerr.Wrap(ctx, msg, "receive agent notification")
 		case redigo.Subscription:
-			// Subscribe/unsubscribe confirmations; nothing to do.
+			// Count reaches 0 once the ctx-done unsubscribe is confirmed.
+			if msg.Count == 0 {
+				return nil
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a race introduced in https://github.com/fleetdm/fleet/issues/50639.

Fixes https://github.com/fleetdm/fleet/actions/runs/33044301712.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Network operations that repeatedly fail now stop after 30 attempts instead of retrying indefinitely, while retaining the existing five-second retry interval.
  - Agent notification subscriptions now shut down more gracefully, reducing the risk of dropped connections and ensuring pending unsubscribe operations complete cleanly.
- **Reliability**
  - Improved handling of timed-out datastore operations and subscription cleanup for more predictable service behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->