### PR TITLE
Add 4.90.0 baseline and 4.89→4.90 / 4.90→4.91 migration loadtest results

### DIFF
--- a/tools/loadtest/metrics/runs/baseline/490loadtest/490loadtest-2026-07-30-150402Z-6h.json
+++ b/tools/loadtest/metrics/runs/baseline/490loadtest/490loadtest-2026-07-30-150402Z-6h.json
@@ -1,0 +1,670 @@
+{
+  "metadata": {
+    "workspace": "490loadtest",
+    "collected_at": "2026-07-30T15:04:02Z",
+    "region": "us-east-2",
+    "interval": "6h",
+    "time_window": {
+      "start": "2026-07-30T09:04:02Z",
+      "end": "2026-07-30T15:04:02Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 58.96,
+      "Minimum": 56.78,
+      "Maximum": 60.91,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.87,
+      "Minimum": 4.43,
+      "Maximum": 6.43,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.76,
+      "Minimum": 2.68,
+      "Maximum": 2.83,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.39,
+      "Minimum": 2.38,
+      "Maximum": 2.4,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 21.23,
+      "Minimum": 16.43,
+      "Maximum": 34.03,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 182.26,
+      "Minimum": 73,
+      "Maximum": 260,
+      "Unit": "Count",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 2361.02,
+      "Maximum": 3222.54,
+      "Unit": "Count/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 0,
+      "Sum": 0.02,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 18.68,
+        "Minimum": 10.58,
+        "Maximum": 35.22,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 106.63,
+        "Minimum": 59,
+        "Maximum": 156,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 2.02,
+        "Maximum": 187.51,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 18.71,
+        "Minimum": 9.41,
+        "Maximum": 33.94,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 103.63,
+        "Minimum": 67,
+        "Maximum": 137,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 0.73,
+        "Maximum": 53.21,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.71
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.39
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.25
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.21
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.05
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.38
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.31
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.23
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.08
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.38
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.33
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.24
+          },
+          {
+            "rank": 4,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.09
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.07
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 33.91,
+        "Minimum": 33.42,
+        "Maximum": 34.33,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 4.71,
+        "Minimum": 4.71,
+        "Maximum": 4.72,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 4.19,
+        "Minimum": 4.12,
+        "Maximum": 4.25,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.66,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 4.62,
+        "Minimum": 4.55,
+        "Maximum": 4.7,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.66,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 16.44,
+      "Unit": "Seconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Sum": 288602166,
+      "Unit": "Count",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Sum": 312967069984,
+      "Unit": "Bytes",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 29573282156.09,
+      "Minimum": 29003972608,
+      "Unit": "Bytes",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 27401158135.87,
+      "Maximum": 27555299328,
+      "Unit": "Bytes",
+      "data_points": 63,
+      "max_points": 72,
+      "data_coverage": 0.88
+    },
+    "select_latency": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 6.7,
+      "Maximum": 66.67,
+      "Unit": "Milliseconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 3.19,
+      "Maximum": 11.84,
+      "Unit": "Milliseconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 1.23,
+      "Maximum": 4.93,
+      "Unit": "Milliseconds",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.04,
+      "maximum": 3.65,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2361.02,
+      "total_iops_avg": 2361.02,
+      "utilization_pct": 11.81
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 6.73,
+        "Maximum": 29,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 30656147842.84,
+        "Minimum": 30479400960,
+        "Unit": "Bytes",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 100,
+        "Minimum": 99.93,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 0.6,
+        "Maximum": 4.89,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 2.02,
+        "write_iops_avg": 0,
+        "total_iops_avg": 2.02,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 1.49,
+        "maximum": 3.39,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 7.29,
+        "Maximum": 22,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 30646130369.42,
+        "Minimum": 30352171008,
+        "Unit": "Bytes",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 100,
+        "Minimum": 100,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 0.55,
+        "Maximum": 5.47,
+        "Unit": "Milliseconds",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 0.73,
+        "write_iops_avg": 0,
+        "total_iops_avg": 0.73,
+        "utilization_pct": 0
+      },
+      "threads_running": {
+        "average": 1.46,
+        "maximum": 3.28,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 145.24,
+        "Maximum": 168,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 88.91,
+        "Minimum": 88.73,
+        "Unit": "Percent",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 6.01,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Average": 5.41,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-30T04:04:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 72,
+        "max_points": 72,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 1059155.66,
+      "Sum": 9538755844,
+      "Unit": "Bytes/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-07-30T04:04:00-05:00",
+      "Average": 424212.05,
+      "Sum": 3820453726,
+      "Unit": "Bytes/Second",
+      "data_points": 72,
+      "max_points": 72,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/baseline/490loadtest/490loadtest-2026-07-30-150402Z-6h.md
+++ b/tools/loadtest/metrics/runs/baseline/490loadtest/490loadtest-2026-07-30-150402Z-6h.md
@@ -1,0 +1,56 @@
+# Metrics Synopsis: 490loadtest
+
+- **Collected:** 2026-07-30T15:04:02Z
+- **Interval:** 6h
+- **Window:** 2026-07-30T09:04:02Z to 2026-07-30T15:04:02Z
+
+## Summary (6h averages)
+
+```
+Fleet Server:  CPU=58.96%  Mem=4.87%  Containers=25
+Loadtest:      CPU=2.76%  Mem=2.39%  Containers=50
+RDS Writer:    CPU=21.23%  Connections=182.26  Deadlocks=0.02
+RDS reader-1:  CPU=18.68%  Connections=106.63
+RDS reader-2:  CPU=18.71%  Connections=103.63
+Redis:         CPU=33.91%  Mem=4.71%
+
+Top SQL (writer):
+  #1 load=0.71  COMMIT
+  #2 load=0.39  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.25  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #4 load=0.21  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #5 load=0.05  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.38  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.31  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.23  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.08  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+  #5 load=0.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+
+Top SQL (reader-2):
+  #1 load=0.38  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.33  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.24  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.09  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+  #5 load=0.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+ALB:           Latency=0s  5xx=0  Requests=288602166  Traffic=298468.66MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.54GB  CacheHit=100%  Disk=25.52GB  Threads=2.04  IOPS=11.81%
+               SelectLat=6.7ms  InsertLat=3.19ms
+RDS reader-1: FreeMem=28.55GB  CacheHit=100%  ReplicaLag=6.73ms  Threads=1.49  IOPS=0.01%
+               SelectLat=0.6ms
+RDS reader-2: FreeMem=28.54GB  CacheHit=100%  ReplicaLag=7.29ms  Threads=1.46  IOPS=0%
+               SelectLat=0.55ms
+Redis:         Connections=145.24  Evictions=0  CacheHit=88.91%
+Network:       RX=9096.87MB  TX=3643.47MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer Deadlocks = 0.02 (expected 0)
+
+  ⚠ 1 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-160436Z-30m.json
+++ b/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-160436Z-30m.json
@@ -1,0 +1,662 @@
+{
+  "metadata": {
+    "workspace": "490mig2",
+    "collected_at": "2026-08-03T16:04:36Z",
+    "region": "us-east-2",
+    "interval": "30m",
+    "time_window": {
+      "start": "2026-08-03T15:34:36Z",
+      "end": "2026-08-03T16:04:36Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.37,
+      "Minimum": 59.97,
+      "Maximum": 60.84,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.58,
+      "Minimum": 4.48,
+      "Maximum": 4.66,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.74,
+      "Minimum": 2.73,
+      "Maximum": 2.74,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.16,
+      "Minimum": 2.14,
+      "Maximum": 2.17,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 30.58,
+      "Minimum": 24.88,
+      "Maximum": 40.71,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 172.8,
+      "Minimum": 108,
+      "Maximum": 221,
+      "Unit": "Count",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 2442.16,
+      "Maximum": 3213.69,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 15.02,
+        "Minimum": 13.32,
+        "Maximum": 17.13,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 75.37,
+        "Minimum": 63,
+        "Maximum": 90,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 8.99,
+        "Maximum": 85.2,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 22.08,
+        "Minimum": 16.24,
+        "Maximum": 25.81,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 95.67,
+        "Minimum": 88,
+        "Maximum": 101,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 44.92,
+        "Maximum": 399.42,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) /* , ... */ ) ",
+        "load_avg": 0.87
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.86
+      },
+      {
+        "rank": 3,
+        "sql": "COMMIT",
+        "load_avg": 0.82
+      },
+      {
+        "rank": 4,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.27
+      },
+      {
+        "rank": 5,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.19
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.39
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.32
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.24
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id` WHERE `sc` . `cve` IN ( ?, ... ",
+            "load_avg": 0.09
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+            "load_avg": 0.09
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.4
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.33
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.23
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.16
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` INNER JOIN HOSTS `h` ON `hs` . `host_id` = `h` . `id` WHERE `h` . `team_id` IS NOT NULL AND `hs` . `software_id` > ? GROUP BY `st` . `id` , `h` . `team_id`",
+            "load_avg": 0.14
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 34.18,
+        "Minimum": 34.05,
+        "Maximum": 34.4,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 4.72,
+        "Minimum": 4.71,
+        "Maximum": 4.72,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 4.64,
+        "Minimum": 4.57,
+        "Maximum": 4.68,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.66,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 4.42,
+        "Minimum": 4.37,
+        "Maximum": 4.46,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 4.66,
+        "Minimum": 4.66,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 0.85,
+      "Unit": "Seconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Sum": 24051917,
+      "Unit": "Count",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Sum": 26158862304,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 29617041134.93,
+      "Minimum": 28992086016,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 19.69,
+      "Maximum": 51.84,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 3.75,
+      "Maximum": 9.23,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 1.89,
+      "Maximum": 4.27,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 3.31,
+      "maximum": 4.29,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2442.16,
+      "total_iops_avg": 2442.16,
+      "utilization_pct": 12.21
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 6.57,
+        "Maximum": 16,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 30826637312,
+        "Minimum": 30806474752,
+        "Unit": "Bytes",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 100,
+        "Minimum": 99.96,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 0.44,
+        "Maximum": 0.49,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 8.99,
+        "write_iops_avg": 0,
+        "total_iops_avg": 8.99,
+        "utilization_pct": 0.04
+      },
+      "threads_running": {
+        "average": 1.06,
+        "maximum": 1.19,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 6.3,
+        "Maximum": 17,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 30741029819.73,
+        "Minimum": 30620545024,
+        "Unit": "Bytes",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.91,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 0.65,
+        "Maximum": 2.99,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 44.92,
+        "write_iops_avg": 0,
+        "total_iops_avg": 44.92,
+        "utilization_pct": 0.22
+      },
+      "threads_running": {
+        "average": 1.9,
+        "maximum": 2.35,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 153.5,
+        "Maximum": 176,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 88.88,
+        "Minimum": 88.75,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 5.33,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Average": 5.07,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-03T10:34:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 1055956.72,
+      "Sum": 791967542,
+      "Unit": "Bytes/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-03T10:34:00-05:00",
+      "Average": 429510.89,
+      "Sum": 322133165,
+      "Unit": "Bytes/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-160436Z-30m.md
+++ b/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-160436Z-30m.md
@@ -1,0 +1,54 @@
+# Metrics Synopsis: 490mig2
+
+- **Collected:** 2026-08-03T16:04:36Z
+- **Interval:** 30m
+- **Window:** 2026-08-03T15:34:36Z to 2026-08-03T16:04:36Z
+
+## Summary (30m averages)
+
+```
+Fleet Server:  CPU=60.37%  Mem=4.58%  Containers=25
+Loadtest:      CPU=2.74%  Mem=2.16%  Containers=50
+RDS Writer:    CPU=30.58%  Connections=172.8  Deadlocks=0
+RDS reader-1:  CPU=15.02%  Connections=75.37
+RDS reader-2:  CPU=22.08%  Connections=95.67
+Redis:         CPU=34.18%  Mem=4.72%
+
+Top SQL (writer):
+  #1 load=0.87  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #2 load=0.86  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #3 load=0.82  COMMIT
+  #4 load=0.27  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #5 load=0.19  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+
+Top SQL (reader-1):
+  #1 load=0.39  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.32  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.24  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.09  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+  #5 load=0.09  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+
+Top SQL (reader-2):
+  #1 load=0.4  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.33  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.23  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.16  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+  #5 load=0.14  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_s
+ALB:           Latency=0s  5xx=0  Requests=24051917  Traffic=24947.04MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.58GB  CacheHit=100%  Disk=N/A  Threads=3.31  IOPS=12.21%
+               SelectLat=19.69ms  InsertLat=3.75ms
+RDS reader-1: FreeMem=28.71GB  CacheHit=100%  ReplicaLag=6.57ms  Threads=1.06  IOPS=0.04%
+               SelectLat=0.44ms
+RDS reader-2: FreeMem=28.63GB  CacheHit=99.99%  ReplicaLag=6.3ms  Threads=1.9  IOPS=0.22%
+               SelectLat=0.65ms
+Redis:         Connections=153.5  Evictions=0  CacheHit=88.88%
+Network:       RX=755.28MB  TX=307.21MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-203925Z-200m.json
+++ b/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-203925Z-200m.json
@@ -1,0 +1,670 @@
+{
+  "metadata": {
+    "workspace": "490mig2",
+    "collected_at": "2026-08-03T20:39:25Z",
+    "region": "us-east-2",
+    "interval": "200m",
+    "time_window": {
+      "start": "2026-08-03T17:19:25Z",
+      "end": "2026-08-03T20:39:25Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 62.55,
+      "Minimum": 58.7,
+      "Maximum": 67.75,
+      "Unit": "Percent",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 5.28,
+      "Minimum": 4.79,
+      "Maximum": 5.86,
+      "Unit": "Percent",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.75,
+      "Minimum": 2.68,
+      "Maximum": 2.84,
+      "Unit": "Percent",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.37,
+      "Minimum": 2.33,
+      "Maximum": 2.39,
+      "Unit": "Percent",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 19.58,
+      "Minimum": 7.21,
+      "Maximum": 45.44,
+      "Unit": "Percent",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 130.75,
+      "Minimum": 74,
+      "Maximum": 200,
+      "Unit": "Count",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 2167.22,
+      "Maximum": 3600.31,
+      "Unit": "Count/Second",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 18.37,
+        "Minimum": 9.38,
+        "Maximum": 34.19,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 72.1,
+        "Minimum": 52,
+        "Maximum": 109,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 15.32,
+        "Maximum": 437.38,
+        "Unit": "Count/Second",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 16.73,
+        "Minimum": 12.11,
+        "Maximum": 28.68,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 70.32,
+        "Minimum": 46,
+        "Maximum": 132,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 10.39,
+        "Maximum": 528.19,
+        "Unit": "Count/Second",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.89
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.35
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.12
+      },
+      {
+        "rank": 4,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.06
+      },
+      {
+        "rank": 5,
+        "sql": "DELETE FROM `host_software` WHERE `host_id` = ? AND `software_id` IN ( ?, ... ",
+        "load_avg": 0.03
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.36
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.3
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.22
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.12
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id` WHERE `sc` . `cve` IN ( ?, ... ",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.41
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.33
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.25
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.07
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_identifier` , `s` . RELEASE , `s` . `arch` , `s` . `vendor` , `s` . `extension_for` , `s` . `extension_id` , `s` . `title_id` , COALESCE ( `sc` . `cpe` , ? ) AS `generated_cpe` FROM `software` `s` LEFT JOIN `software_cpe` `sc` ON ( `s` . `id` = `sc` . `software_id` ) WHERE `s` . SOURCE NOT IN (...) ",
+            "load_avg": 0.06
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 34.47,
+        "Minimum": 33.6,
+        "Maximum": 37.61,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 4.72,
+        "Minimum": 4.62,
+        "Maximum": 4.78,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 4.63,
+        "Minimum": 4.12,
+        "Maximum": 5.82,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.57,
+        "Maximum": 4.69,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 4.43,
+        "Minimum": 3.87,
+        "Maximum": 5.65,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.55,
+        "Maximum": 4.69,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 16.02,
+      "Unit": "Seconds",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Sum": 160413194,
+      "Unit": "Count",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Sum": 174190231009,
+      "Unit": "Bytes",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 29475553976.32,
+      "Minimum": 29094932480,
+      "Unit": "Bytes",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 25544038038.59,
+      "Maximum": 26031325184,
+      "Unit": "Bytes",
+      "data_points": 34,
+      "max_points": 40,
+      "data_coverage": 0.85
+    },
+    "select_latency": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 3.7,
+      "Maximum": 74.15,
+      "Unit": "Milliseconds",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 10.34,
+      "Maximum": 65.04,
+      "Unit": "Milliseconds",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 5.14,
+      "Maximum": 34.34,
+      "Unit": "Milliseconds",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 1.92,
+      "maximum": 7.58,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2167.22,
+      "total_iops_avg": 2167.22,
+      "utilization_pct": 10.84
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 7.8,
+        "Maximum": 25,
+        "Unit": "Milliseconds",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 30695896637.44,
+        "Minimum": 30381477888,
+        "Unit": "Bytes",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 100,
+        "Minimum": 99.94,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 0.56,
+        "Maximum": 3.27,
+        "Unit": "Milliseconds",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 15.32,
+        "write_iops_avg": 0,
+        "total_iops_avg": 15.32,
+        "utilization_pct": 0.08
+      },
+      "threads_running": {
+        "average": 1.51,
+        "maximum": 3.24,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 6.86,
+        "Maximum": 26,
+        "Unit": "Milliseconds",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 30709975367.68,
+        "Minimum": 30644473856,
+        "Unit": "Bytes",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 100,
+        "Minimum": 99.77,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 0.46,
+        "Maximum": 3.16,
+        "Unit": "Milliseconds",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 10.39,
+        "write_iops_avg": 0,
+        "total_iops_avg": 10.39,
+        "utilization_pct": 0.05
+      },
+      "threads_running": {
+        "average": 1.27,
+        "maximum": 2.92,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 170.09,
+        "Maximum": 1144,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 88.86,
+        "Minimum": 85.88,
+        "Unit": "Percent",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 5.42,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Average": 5.2,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-03T12:19:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 40,
+        "max_points": 40,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 1075113.44,
+      "Sum": 5375567222,
+      "Unit": "Bytes/Second",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-03T12:19:00-05:00",
+      "Average": 427576.49,
+      "Sum": 2137882433,
+      "Unit": "Bytes/Second",
+      "data_points": 40,
+      "max_points": 40,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-203925Z-200m.md
+++ b/tools/loadtest/metrics/runs/migration/489to490mig/490mig2-2026-08-03-203925Z-200m.md
@@ -1,0 +1,54 @@
+# Metrics Synopsis: 490mig2
+
+- **Collected:** 2026-08-03T20:39:25Z
+- **Interval:** 200m
+- **Window:** 2026-08-03T17:19:25Z to 2026-08-03T20:39:25Z
+
+## Summary (200m averages)
+
+```
+Fleet Server:  CPU=62.55%  Mem=5.28%  Containers=25
+Loadtest:      CPU=2.75%  Mem=2.37%  Containers=50
+RDS Writer:    CPU=19.58%  Connections=130.75  Deadlocks=0
+RDS reader-1:  CPU=18.37%  Connections=72.1
+RDS reader-2:  CPU=16.73%  Connections=70.32
+Redis:         CPU=34.47%  Mem=4.72%
+
+Top SQL (writer):
+  #1 load=0.89  COMMIT
+  #2 load=0.35  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.12  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #4 load=0.06  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #5 load=0.03  DELETE FROM `host_software` WHERE `host_id` = ? AND `software_id` IN ( ?, ... 
+
+Top SQL (reader-1):
+  #1 load=0.36  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.3  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.22  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.12  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+  #5 load=0.07  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+
+Top SQL (reader-2):
+  #1 load=0.41  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.33  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.25  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+  #5 load=0.06  SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_
+ALB:           Latency=0s  5xx=0  Requests=160413194  Traffic=166120.75MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.45GB  CacheHit=100%  Disk=23.79GB  Threads=1.92  IOPS=10.84%
+               SelectLat=3.7ms  InsertLat=10.34ms
+RDS reader-1: FreeMem=28.59GB  CacheHit=100%  ReplicaLag=7.8ms  Threads=1.51  IOPS=0.08%
+               SelectLat=0.56ms
+RDS reader-2: FreeMem=28.6GB  CacheHit=100%  ReplicaLag=6.86ms  Threads=1.27  IOPS=0.05%
+               SelectLat=0.46ms
+Redis:         Connections=170.09  Evictions=0  CacheHit=88.86%
+Network:       RX=5126.54MB  TX=2038.84MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-152159Z-3h.json
+++ b/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-152159Z-3h.json
@@ -1,0 +1,994 @@
+{
+  "metadata": {
+    "workspace": "490to491mig3",
+    "collected_at": "2026-08-26T15:21:59Z",
+    "region": "us-east-2",
+    "interval": "3h",
+    "time_window": {
+      "start": "2026-08-26T12:21:59Z",
+      "end": "2026-08-26T15:21:59Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.13,
+      "Minimum": 59.13,
+      "Maximum": 60.94,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.86,
+      "Minimum": 4.61,
+      "Maximum": 5.35,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.75,
+      "Minimum": 2.72,
+      "Maximum": 2.79,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.86,
+      "Minimum": 2.85,
+      "Maximum": 2.86,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 20.0254,
+      "Minimum": 15.4517,
+      "Maximum": 35.9517,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 144.7167,
+      "Minimum": 80,
+      "Maximum": 205,
+      "Unit": "Count",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 0.0032,
+      "Maximum": 0.0333,
+      "Unit": "Count/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 2468.3933,
+      "Maximum": 3488.64,
+      "Unit": "Count/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 0.0001,
+      "Sum": 0.0167,
+      "Maximum": 0.0167,
+      "Unit": "Count/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 17.5811,
+        "Minimum": 9.6433,
+        "Maximum": 34.875,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 120.45,
+        "Minimum": 95,
+        "Maximum": 142,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 3.0775,
+        "Maximum": 239.8873,
+        "Unit": "Count/Second",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 19.1481,
+        "Minimum": 9.5767,
+        "Maximum": 29.1167,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 128.5,
+        "Minimum": 110,
+        "Maximum": 144,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 2.8644,
+        "Maximum": 243.5459,
+        "Unit": "Count/Second",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.73
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.39
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.27
+      },
+      {
+        "rank": 4,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.05
+      },
+      {
+        "rank": 5,
+        "sql": "DELETE FROM `host_software` WHERE `host_id` = ? AND `software_id` IN ( ?, ... ",
+        "load_avg": 0.03
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.32
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.26
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT COUNT ( * ) FROM `host_software`",
+            "load_avg": 0.07
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` INNER JOIN HOSTS `h` ON `hs` . `host_id` = `h` . `id` WHERE `h` . `team_id` IS NOT NULL AND `hs` . `software_id` > ? GROUP BY `st` . `id` , `h` . `team_id`",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.44
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.37
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.28
+          },
+          {
+            "rank": 4,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.13
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id` WHERE `sc` . `cve` IN ( ?, ... ",
+            "load_avg": 0.11
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 34.4478,
+        "Minimum": 33.85,
+        "Maximum": 35.2902,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 4.7167,
+        "Minimum": 4.7106,
+        "Maximum": 4.7239,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 4.4213,
+        "Minimum": 4.35,
+        "Maximum": 4.4841,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 4.6674,
+        "Minimum": 4.6634,
+        "Maximum": 4.6701,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 4.687,
+        "Minimum": 4.6174,
+        "Maximum": 4.8175,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 4.6674,
+        "Minimum": 4.6637,
+        "Maximum": 4.6707,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 0.004,
+      "Minimum": 0.0001,
+      "Maximum": 18.4984,
+      "Unit": "Seconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "target_response_time_percentiles": {
+      "p99": 0.0211,
+      "p95": 0.0114
+    },
+    "http_5xx_count": {
+      "Sum": 0,
+      "Unit": "Count",
+      "no_datapoints": true
+    },
+    "http_elb_5xx_count": {
+      "Sum": 0,
+      "Unit": "Count",
+      "no_datapoints": true
+    },
+    "request_count": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Sum": 144300441,
+      "Unit": "Count",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Sum": 164963753691,
+      "Unit": "Bytes",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 9.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-08-26T15:16:00Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused bootstrap packages: listing bootstrap package in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fbootstrap-packages\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T15:15:56Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused software title icons: listing software title icon in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fsoftware-title-icons\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T15:15:52Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused software installers: listing software installer in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fsoftware-installers\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T14:16:02Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused bootstrap packages: listing bootstrap package in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fbootstrap-packages\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T14:15:57Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused software title icons: listing software title icon in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fsoftware-title-icons\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T14:15:55Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused software installers: listing software installer in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fsoftware-installers\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T13:16:04Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused bootstrap packages: listing bootstrap package in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fbootstrap-packages\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T13:16:00Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused software title icons: listing software title icon in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fsoftware-title-icons\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}",
+      "{\"ts\":\"2026-08-26T13:15:56Z\",\"level\":\"error\",\"msg\":\"running job\",\"cron\":\"cleanups_then_aggregation\",\"schedule\":\"cleanups_then_aggregation\",\"instanceID\":\"<redacted>\",\"err\":\"cleanup unused software installers: listing software installer in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , HostID: , request send failed, Get \\\"http://localhost:9000/<redacted>?list-type=2&prefix=dev-prefix%2Fsoftware-installers\\\": dial tcp 127.0.0.1:9000: connect: connection refused\",\"jobID\":\"<redacted>\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 29416861104.3556,
+      "Minimum": 28665880576,
+      "Unit": "Bytes",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 35257811968,
+      "Maximum": 35332882432,
+      "Unit": "Bytes",
+      "data_points": 32,
+      "max_points": 36,
+      "data_coverage": 0.89
+    },
+    "select_latency": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 3.4605,
+      "Maximum": 58.2333,
+      "Unit": "Milliseconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 4.2678,
+      "Maximum": 16.436,
+      "Unit": "Milliseconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 2.3213,
+      "Maximum": 8.9929,
+      "Unit": "Milliseconds",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 1.78,
+      "maximum": 2.73,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0.0032,
+      "write_iops_avg": 2468.3933,
+      "total_iops_avg": 2468.4,
+      "utilization_pct": 12.34
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 6.6722,
+        "Maximum": 22,
+        "Unit": "Milliseconds",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 30642838823.8222,
+        "Minimum": 30364741632,
+        "Unit": "Bytes",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 99.999,
+        "Minimum": 99.9113,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 1.122,
+        "Maximum": 6.6805,
+        "Unit": "Milliseconds",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 3.0775,
+        "write_iops_avg": 0,
+        "total_iops_avg": 3.08,
+        "utilization_pct": 0.02
+      },
+      "threads_running": {
+        "average": 1.31,
+        "maximum": 3.24,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 6.7556,
+        "Maximum": 30,
+        "Unit": "Milliseconds",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 30682416492.0889,
+        "Minimum": 30635106304,
+        "Unit": "Bytes",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 99.9992,
+        "Minimum": 99.9225,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 0.4527,
+        "Maximum": 3.4436,
+        "Unit": "Milliseconds",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 2.8644,
+        "write_iops_avg": 0,
+        "total_iops_avg": 2.86,
+        "utilization_pct": 0.01
+      },
+      "threads_running": {
+        "average": 1.61,
+        "maximum": 4.11,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 148.6778,
+        "Maximum": 158,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 88.9165,
+        "Minimum": 88.7344,
+        "Unit": "Percent",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Average": 5.3,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-26T05:21:00-07:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 36,
+        "max_points": 36,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 1112224.6449,
+      "Sum": 5005010902,
+      "Unit": "Bytes/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-26T05:21:00-07:00",
+      "Average": 434820.4838,
+      "Sum": 1956692177,
+      "Unit": "Bytes/Second",
+      "data_points": 36,
+      "max_points": 36,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "fleet_abnormal_stops": 0,
+    "running_tasks": 50,
+    "failed_health_checks": 0,
+    "unable_to_place": 0,
+    "service_events": [],
+    "tasks": [
+      {
+        "task_id": "ae788a4d1ed44e3fa599767f388bfbeb",
+        "started_at": "2026-08-25T12:31:38.255000-07:00",
+        "started_epoch": 1787686298,
+        "uptime_min": 1190.35
+      },
+      {
+        "task_id": "4333a499390b4d0fbbac76bb7a32f3aa",
+        "started_at": "2026-08-25T12:33:45.584000-07:00",
+        "started_epoch": 1787686425,
+        "uptime_min": 1188.23
+      },
+      {
+        "task_id": "5c39fe555f13431fa06bf32c2dfadd66",
+        "started_at": "2026-08-25T12:33:45.596000-07:00",
+        "started_epoch": 1787686425,
+        "uptime_min": 1188.23
+      },
+      {
+        "task_id": "e17bbcf97dc84b5bad7dbd4a56f62d7e",
+        "started_at": "2026-08-25T12:33:45.795000-07:00",
+        "started_epoch": 1787686425,
+        "uptime_min": 1188.23
+      },
+      {
+        "task_id": "407bee8d7c8a4ebc9a172136e00b9030",
+        "started_at": "2026-08-25T12:36:34.250000-07:00",
+        "started_epoch": 1787686594,
+        "uptime_min": 1185.42
+      },
+      {
+        "task_id": "6ee0cdbcdd6f422291adb46df69b5853",
+        "started_at": "2026-08-25T12:36:34.333000-07:00",
+        "started_epoch": 1787686594,
+        "uptime_min": 1185.42
+      },
+      {
+        "task_id": "ec02eb325d474e00bf098ed9f913e47a",
+        "started_at": "2026-08-25T12:36:34.584000-07:00",
+        "started_epoch": 1787686594,
+        "uptime_min": 1185.42
+      },
+      {
+        "task_id": "e410f02dccd04f089ab06a72095c877e",
+        "started_at": "2026-08-25T12:36:35.154000-07:00",
+        "started_epoch": 1787686595,
+        "uptime_min": 1185.4
+      },
+      {
+        "task_id": "32805d875d3c46009148c18d82c8c3b7",
+        "started_at": "2026-08-25T12:41:40.210000-07:00",
+        "started_epoch": 1787686900,
+        "uptime_min": 1180.32
+      },
+      {
+        "task_id": "0d332e2f77c9484aa31673f7b6961e87",
+        "started_at": "2026-08-25T12:41:41.648000-07:00",
+        "started_epoch": 1787686901,
+        "uptime_min": 1180.3
+      },
+      {
+        "task_id": "432749748504429e94e1ee3d5c0a106e",
+        "started_at": "2026-08-25T12:41:41.434000-07:00",
+        "started_epoch": 1787686901,
+        "uptime_min": 1180.3
+      },
+      {
+        "task_id": "2c4875e1d01048b2b37855caf15b342c",
+        "started_at": "2026-08-25T12:41:42.483000-07:00",
+        "started_epoch": 1787686902,
+        "uptime_min": 1180.28
+      },
+      {
+        "task_id": "2a22744ca9a44ef9a1f3ccf6d28a6698",
+        "started_at": "2026-08-25T12:46:49.973000-07:00",
+        "started_epoch": 1787687209,
+        "uptime_min": 1175.17
+      },
+      {
+        "task_id": "ea1c11a9885342edba6f95cb70773880",
+        "started_at": "2026-08-25T12:46:50.292000-07:00",
+        "started_epoch": 1787687210,
+        "uptime_min": 1175.15
+      },
+      {
+        "task_id": "27b04cea5dd04428b0b641aa2dbc64a8",
+        "started_at": "2026-08-25T12:46:52.566000-07:00",
+        "started_epoch": 1787687212,
+        "uptime_min": 1175.12
+      },
+      {
+        "task_id": "72fa20081e134bdf89e919365b53e92e",
+        "started_at": "2026-08-25T12:46:53.266000-07:00",
+        "started_epoch": 1787687213,
+        "uptime_min": 1175.1
+      },
+      {
+        "task_id": "9fb7cc6778204902b85ae48473f84116",
+        "started_at": "2026-08-25T12:51:59.282000-07:00",
+        "started_epoch": 1787687519,
+        "uptime_min": 1170
+      },
+      {
+        "task_id": "37341be7959f4bc691d6f4ec2ab951b5",
+        "started_at": "2026-08-25T12:52:00.251000-07:00",
+        "started_epoch": 1787687520,
+        "uptime_min": 1169.98
+      },
+      {
+        "task_id": "39fbd684cce046c3ba163a184304d8c6",
+        "started_at": "2026-08-25T12:52:00.200000-07:00",
+        "started_epoch": 1787687520,
+        "uptime_min": 1169.98
+      },
+      {
+        "task_id": "e862443e64ae42ecb0096d20752354e5",
+        "started_at": "2026-08-25T12:52:01.055000-07:00",
+        "started_epoch": 1787687521,
+        "uptime_min": 1169.97
+      },
+      {
+        "task_id": "a4cf5c704c264bfd8273c13ae29405ee",
+        "started_at": "2026-08-25T12:57:19.768000-07:00",
+        "started_epoch": 1787687839,
+        "uptime_min": 1164.67
+      },
+      {
+        "task_id": "d5736858e8144780aa8ba4f0c44346b1",
+        "started_at": "2026-08-25T12:57:19.557000-07:00",
+        "started_epoch": 1787687839,
+        "uptime_min": 1164.67
+      },
+      {
+        "task_id": "82dea923ccf64a8daca5a5120b711138",
+        "started_at": "2026-08-25T12:57:20.365000-07:00",
+        "started_epoch": 1787687840,
+        "uptime_min": 1164.65
+      },
+      {
+        "task_id": "e4f307c0f6de4677a9e9e0466cd9b263",
+        "started_at": "2026-08-25T12:57:20.974000-07:00",
+        "started_epoch": 1787687840,
+        "uptime_min": 1164.65
+      },
+      {
+        "task_id": "4fbad9ab732d4d40b2a37c31e0239d3e",
+        "started_at": "2026-08-25T13:02:23.423000-07:00",
+        "started_epoch": 1787688143,
+        "uptime_min": 1159.6
+      },
+      {
+        "task_id": "75bec0c718704ff98d0f7070ea1ddc1c",
+        "started_at": "2026-08-25T13:02:23.398000-07:00",
+        "started_epoch": 1787688143,
+        "uptime_min": 1159.6
+      },
+      {
+        "task_id": "b5728ea25e8c4b9596399ba6c67e39b0",
+        "started_at": "2026-08-25T13:02:23.363000-07:00",
+        "started_epoch": 1787688143,
+        "uptime_min": 1159.6
+      },
+      {
+        "task_id": "fdc5ad487d444d8a91ad09c1e44dbdfa",
+        "started_at": "2026-08-25T13:02:25.089000-07:00",
+        "started_epoch": 1787688145,
+        "uptime_min": 1159.57
+      },
+      {
+        "task_id": "9f3b5c7fd80a46daaa023926f9bb5d44",
+        "started_at": "2026-08-25T13:07:39.793000-07:00",
+        "started_epoch": 1787688459,
+        "uptime_min": 1154.33
+      },
+      {
+        "task_id": "2acebb74175e423e8674b32361293fca",
+        "started_at": "2026-08-25T13:07:41.324000-07:00",
+        "started_epoch": 1787688461,
+        "uptime_min": 1154.3
+      },
+      {
+        "task_id": "9844cdded0044c5db9c2416203695bc9",
+        "started_at": "2026-08-25T13:07:49.362000-07:00",
+        "started_epoch": 1787688469,
+        "uptime_min": 1154.17
+      },
+      {
+        "task_id": "51cde32a206841f9aff4031ddd04e041",
+        "started_at": "2026-08-25T13:07:53.063000-07:00",
+        "started_epoch": 1787688473,
+        "uptime_min": 1154.1
+      },
+      {
+        "task_id": "cf548554bd6c4c5ebfd2efe56616d097",
+        "started_at": "2026-08-25T13:12:50.350000-07:00",
+        "started_epoch": 1787688770,
+        "uptime_min": 1149.15
+      },
+      {
+        "task_id": "56cc44bf6671462385f0cc53bd642bb6",
+        "started_at": "2026-08-25T13:12:51.107000-07:00",
+        "started_epoch": 1787688771,
+        "uptime_min": 1149.13
+      },
+      {
+        "task_id": "a118a1d17c5c4929a865e5e9fd2fbb93",
+        "started_at": "2026-08-25T13:12:51.067000-07:00",
+        "started_epoch": 1787688771,
+        "uptime_min": 1149.13
+      },
+      {
+        "task_id": "7606c3cb0e3c44e4944a96e0f364234b",
+        "started_at": "2026-08-25T13:12:52.664000-07:00",
+        "started_epoch": 1787688772,
+        "uptime_min": 1149.12
+      },
+      {
+        "task_id": "5d7207fc9c6a4fff97b698b20dcdc9d6",
+        "started_at": "2026-08-25T13:17:49.925000-07:00",
+        "started_epoch": 1787689069,
+        "uptime_min": 1144.17
+      },
+      {
+        "task_id": "d2fc3d6e8efd422d9943c9d1da7fdfd1",
+        "started_at": "2026-08-25T13:17:50.907000-07:00",
+        "started_epoch": 1787689070,
+        "uptime_min": 1144.15
+      },
+      {
+        "task_id": "d8d7e4cdef714f138b115e7d219d5018",
+        "started_at": "2026-08-25T13:17:50.709000-07:00",
+        "started_epoch": 1787689070,
+        "uptime_min": 1144.15
+      },
+      {
+        "task_id": "a71c285087244918889ed0d006841e12",
+        "started_at": "2026-08-25T13:17:51.644000-07:00",
+        "started_epoch": 1787689071,
+        "uptime_min": 1144.13
+      },
+      {
+        "task_id": "dd6a3b0ff9bf4f4284dc10d09125d854",
+        "started_at": "2026-08-25T13:23:10.693000-07:00",
+        "started_epoch": 1787689390,
+        "uptime_min": 1138.82
+      },
+      {
+        "task_id": "fd1c804bf3ee417fa5a83fd6d58d9462",
+        "started_at": "2026-08-25T13:23:10.745000-07:00",
+        "started_epoch": 1787689390,
+        "uptime_min": 1138.82
+      },
+      {
+        "task_id": "13e20a1cc6194e58bd7741d515924607",
+        "started_at": "2026-08-25T13:23:12.211000-07:00",
+        "started_epoch": 1787689392,
+        "uptime_min": 1138.78
+      },
+      {
+        "task_id": "5122da6e5fad46508e51b3dc246955c2",
+        "started_at": "2026-08-25T13:23:12.151000-07:00",
+        "started_epoch": 1787689392,
+        "uptime_min": 1138.78
+      },
+      {
+        "task_id": "0e8001b76aae4b33ba1612dc3b18c5f6",
+        "started_at": "2026-08-25T13:28:17.445000-07:00",
+        "started_epoch": 1787689697,
+        "uptime_min": 1133.7
+      },
+      {
+        "task_id": "c32ce759d7824a009933b70d358dd7c5",
+        "started_at": "2026-08-25T13:28:18.847000-07:00",
+        "started_epoch": 1787689698,
+        "uptime_min": 1133.68
+      },
+      {
+        "task_id": "d237929873bf4fd1925b8f2fd72534ce",
+        "started_at": "2026-08-25T13:28:18.753000-07:00",
+        "started_epoch": 1787689698,
+        "uptime_min": 1133.68
+      },
+      {
+        "task_id": "bf57201ee49942fb88c32ea0eb5e5bd0",
+        "started_at": "2026-08-25T13:28:19.070000-07:00",
+        "started_epoch": 1787689699,
+        "uptime_min": 1133.67
+      },
+      {
+        "task_id": "31c1e0c0782447c187ed1703d49e9244",
+        "started_at": "2026-08-25T13:33:26.800000-07:00",
+        "started_epoch": 1787690006,
+        "uptime_min": 1128.55
+      },
+      {
+        "task_id": "e788430b782646c994c9c9a4bcfd9159",
+        "started_at": "2026-08-25T13:33:28.858000-07:00",
+        "started_epoch": 1787690008,
+        "uptime_min": 1128.52
+      }
+    ]
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-152159Z-3h.md
+++ b/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-152159Z-3h.md
@@ -1,0 +1,62 @@
+# Metrics Synopsis: 490to491mig3
+
+- **Collected:** 2026-08-26T15:21:59Z
+- **Interval:** 3h
+- **Window:** 2026-08-26T12:21:59Z to 2026-08-26T15:21:59Z
+
+## Summary (3h averages)
+
+```
+Fleet Server:  CPU=60.13%  Mem=4.86%  Containers=25
+Loadtest:      CPU=2.75%  Mem=2.86%  Containers=50
+RDS Writer:    CPU=20.0254%  Connections=144.7167  Deadlocks=0.0167
+RDS reader-1:  CPU=17.5811%  Connections=120.45
+RDS reader-2:  CPU=19.1481%  Connections=128.5
+Redis:         CPU=34.4478%  Mem=4.7167%
+
+Top SQL (writer):
+  #1 load=0.73  COMMIT
+  #2 load=0.39  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.27  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #4 load=0.05  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #5 load=0.03  DELETE FROM `host_software` WHERE `host_id` = ? AND `software_id` IN ( ?, ... 
+
+Top SQL (reader-1):
+  #1 load=0.32  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.26  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.2  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.07  SELECT COUNT ( * ) FROM `host_software`
+  #5 load=0.07  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_s
+
+Top SQL (reader-2):
+  #1 load=0.44  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.37  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.28  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.13  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+  #5 load=0.11  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+ALB:           Latency avg=0.004s p95=0.0114s p99=0.0211s
+               Target5xx=0  ELB5xx=0  Requests=144300441  Traffic=157321.7MB
+Fleet Errors:  Count=9.0
+  · 2026-08-26T15:16:00Z  cleanup unused bootstrap packages: listing bootstrap package in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , …
+  · 2026-08-26T15:15:56Z  cleanup unused software title icons: listing software title icon in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID…
+  · 2026-08-26T15:15:52Z  cleanup unused software installers: listing software installer in S3 store: operation error S3: ListObjectsV2, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: …
+  (9 samples total in the .json)
+RDS Writer:    FreeMem=27.4GB  CacheHit=100%  Disk=32.84GB  Threads=1.78  IOPS=2468 (12.34% of max)
+               SelectLat=3.4605ms  InsertLat=4.2678ms
+RDS reader-1: FreeMem=28.54GB  CacheHit=99.999%  ReplicaLag=6.6722ms  Threads=1.31  IOPS=3 (0.02% of max)
+               SelectLat=1.122ms
+RDS reader-2: FreeMem=28.58GB  CacheHit=99.9992%  ReplicaLag=6.7556ms  Threads=1.61  IOPS=3 (0.01% of max)
+               SelectLat=0.4527ms
+Redis:         Connections=148.6778  Evictions=0  CacheHit=88.9165%
+Network:       RX=4773.15MB  TX=1866.05MB
+Containers:    Running=50  AbnormalStops=0  FleetStops=0  FailedHealthChecks=0  PlacementFailures=0
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer Deadlocks = 0.0167 (expected 0)
+  🔴 ALERT: Fleet Server Errors = 9.0 (expected 0)
+
+  ⚠ 2 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-180834Z-30m.json
+++ b/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-180834Z-30m.json
@@ -1,0 +1,976 @@
+{
+  "metadata": {
+    "workspace": "490to491mig3",
+    "collected_at": "2026-08-26T18:08:34Z",
+    "region": "us-east-2",
+    "interval": "30m",
+    "time_window": {
+      "start": "2026-08-26T17:38:34Z",
+      "end": "2026-08-26T18:08:34Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 62.49,
+      "Minimum": 61.52,
+      "Maximum": 62.93,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 5.59,
+      "Minimum": 5.02,
+      "Maximum": 6.12,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.78,
+      "Minimum": 2.76,
+      "Maximum": 2.79,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.94,
+      "Minimum": 2.93,
+      "Maximum": 2.96,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 18.2868,
+      "Minimum": 13.7,
+      "Maximum": 19.3667,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 172.4,
+      "Minimum": 67,
+      "Maximum": 256,
+      "Unit": "Count",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 2452.3188,
+      "Maximum": 2570.1427,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 22.5338,
+        "Minimum": 13.88,
+        "Maximum": 29.1217,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 152.2333,
+        "Minimum": 63,
+        "Maximum": 215,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 64.4972,
+        "Maximum": 88.947,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 10.6493,
+        "Minimum": 5.235,
+        "Maximum": 18.9367,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 56,
+        "Minimum": 39,
+        "Maximum": 84,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 36.8149,
+        "Maximum": 70.9631,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 4.88
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.25
+      },
+      {
+        "rank": 3,
+        "sql": "DELETE FROM `host_software_installed_paths` WHERE `id` IN (...) ",
+        "load_avg": 0.11
+      },
+      {
+        "rank": 4,
+        "sql": "DELETE FROM `host_software` WHERE `host_id` = ? AND `software_id` IN (...) ",
+        "load_avg": 0.09
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT IGNORE INTO `scheduled_query_stats` ( `scheduled_query_id` , `host_id` , `average_memory` , `denylisted` , `executions` , `schedule_interval` , `last_executed` , `output_size` , `system_time` , `user_time` , `wall_time` ) VALUES ( ( SELECT `sq` . `query_id` FROM `scheduled_queries` `sq` JOIN `packs` `p` ON ( `sq` . `pack_id` = `p` . `id` ) WHERE `p` . `pack_type` IS NULL AND `p` . NAME = ? AND `sq` . NAME = ? ) , ?, ... ) , ( ( SELECT `sq` . `query_id` FROM `scheduled_queries` `sq` JOIN `",
+        "load_avg": 0.09
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) UNION ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `updated_at` FROM `cron_stats` WHERE NAME = ? AND `stats_type` = ? AND ( STATUS = ? OR STATUS = ? OR STATUS = ? ) ORDER BY `created_at` DESC LIMIT ? ) ",
+            "load_avg": 0.51
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.47
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.4
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.31
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` INNER JOIN HOSTS `h` ON `hs` . `host_id` = `h` . `id` WHERE `h` . `team_id` IS NOT NULL AND `hs` . `software_id` > ? GROUP BY `st` . `id` , `h` . `team_id`",
+            "load_avg": 0.2
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.15
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.11
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `extension_for` , `s` . `bundle_identifier` , `s` . RELEASE , `s` . `vendor` , `s` . `arch` , `s` . `extension_id` , `s` . `upgrade_code` , `hs` . `last_opened_at` FROM `software` `s` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` WHERE `hs` . `host_id` = ? ",
+            "load_avg": 0.08
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.08
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `t` . `id` , `t` . `host_id` , `t` . `software_id` , `t` . `installed_path` , `t` . `team_identifier` , `t` . `cdhash_sha256` , `t` . `executable_sha256` , `t` . `executable_path` FROM `host_software_installed_paths` `t` WHERE `t` . `host_id` = ? ",
+            "load_avg": 0.03
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 34.609,
+        "Minimum": 32.9388,
+        "Maximum": 37.8937,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 4.7422,
+        "Minimum": 4.7167,
+        "Maximum": 4.7844,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 4.3776,
+        "Minimum": 3.5333,
+        "Maximum": 5.45,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 4.6704,
+        "Minimum": 4.6678,
+        "Maximum": 4.6844,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 4.6315,
+        "Minimum": 3.8167,
+        "Maximum": 5.8833,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 4.6705,
+        "Minimum": 4.6671,
+        "Maximum": 4.6853,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 0.0043,
+      "Minimum": 0.0001,
+      "Maximum": 3.286,
+      "Unit": "Seconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "target_response_time_percentiles": {
+      "p99": 0.0214,
+      "p95": 0.0115
+    },
+    "http_5xx_count": {
+      "Sum": 0,
+      "Unit": "Count",
+      "no_datapoints": true
+    },
+    "http_elb_5xx_count": {
+      "Sum": 0,
+      "Unit": "Count",
+      "no_datapoints": true
+    },
+    "request_count": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Sum": 24047884,
+      "Unit": "Count",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Sum": 27359584499,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 28628331451.7333,
+      "Minimum": 28420182016,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 1.0761,
+      "Maximum": 1.1765,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 3.7803,
+      "Maximum": 5.7066,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 2.158,
+      "Maximum": 2.9218,
+      "Unit": "Milliseconds",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 1.35,
+      "maximum": 1.43,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2452.3188,
+      "total_iops_avg": 2452.32,
+      "utilization_pct": 12.26
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 6.3333,
+        "Maximum": 13,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 30660388044.8,
+        "Minimum": 30640275456,
+        "Unit": "Bytes",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 99.9826,
+        "Minimum": 99.9791,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 0.4752,
+        "Maximum": 0.4901,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 64.4972,
+        "write_iops_avg": 0,
+        "total_iops_avg": 64.5,
+        "utilization_pct": 0.32
+      },
+      "threads_running": {
+        "average": 2.72,
+        "maximum": 3.71,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 6.3667,
+        "Maximum": 12,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 30881622152.5333,
+        "Minimum": 30824538112,
+        "Unit": "Bytes",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 99.9846,
+        "Minimum": 99.976,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 0.4555,
+        "Maximum": 0.4661,
+        "Unit": "Milliseconds",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 36.8149,
+        "write_iops_avg": 0,
+        "total_iops_avg": 36.81,
+        "utilization_pct": 0.18
+      },
+      "threads_running": {
+        "average": 0.63,
+        "maximum": 1.32,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 470.3,
+        "Maximum": 1138,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 88.922,
+        "Minimum": 86.4481,
+        "Unit": "Percent",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-26T10:38:00-07:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 6,
+        "max_points": 6,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 1080607.1627,
+      "Sum": 810455372,
+      "Unit": "Bytes/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-26T10:38:00-07:00",
+      "Average": 433944.4053,
+      "Sum": 325458304,
+      "Unit": "Bytes/Second",
+      "data_points": 6,
+      "max_points": 6,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "fleet_abnormal_stops": 0,
+    "running_tasks": 50,
+    "failed_health_checks": 0,
+    "unable_to_place": 0,
+    "service_events": [],
+    "tasks": [
+      {
+        "task_id": "ae788a4d1ed44e3fa599767f388bfbeb",
+        "started_at": "2026-08-25T12:31:38.255000-07:00",
+        "started_epoch": 1787686298,
+        "uptime_min": 1356.93
+      },
+      {
+        "task_id": "4333a499390b4d0fbbac76bb7a32f3aa",
+        "started_at": "2026-08-25T12:33:45.584000-07:00",
+        "started_epoch": 1787686425,
+        "uptime_min": 1354.82
+      },
+      {
+        "task_id": "5c39fe555f13431fa06bf32c2dfadd66",
+        "started_at": "2026-08-25T12:33:45.596000-07:00",
+        "started_epoch": 1787686425,
+        "uptime_min": 1354.82
+      },
+      {
+        "task_id": "e17bbcf97dc84b5bad7dbd4a56f62d7e",
+        "started_at": "2026-08-25T12:33:45.795000-07:00",
+        "started_epoch": 1787686425,
+        "uptime_min": 1354.82
+      },
+      {
+        "task_id": "407bee8d7c8a4ebc9a172136e00b9030",
+        "started_at": "2026-08-25T12:36:34.250000-07:00",
+        "started_epoch": 1787686594,
+        "uptime_min": 1352
+      },
+      {
+        "task_id": "6ee0cdbcdd6f422291adb46df69b5853",
+        "started_at": "2026-08-25T12:36:34.333000-07:00",
+        "started_epoch": 1787686594,
+        "uptime_min": 1352
+      },
+      {
+        "task_id": "ec02eb325d474e00bf098ed9f913e47a",
+        "started_at": "2026-08-25T12:36:34.584000-07:00",
+        "started_epoch": 1787686594,
+        "uptime_min": 1352
+      },
+      {
+        "task_id": "e410f02dccd04f089ab06a72095c877e",
+        "started_at": "2026-08-25T12:36:35.154000-07:00",
+        "started_epoch": 1787686595,
+        "uptime_min": 1351.98
+      },
+      {
+        "task_id": "32805d875d3c46009148c18d82c8c3b7",
+        "started_at": "2026-08-25T12:41:40.210000-07:00",
+        "started_epoch": 1787686900,
+        "uptime_min": 1346.9
+      },
+      {
+        "task_id": "0d332e2f77c9484aa31673f7b6961e87",
+        "started_at": "2026-08-25T12:41:41.648000-07:00",
+        "started_epoch": 1787686901,
+        "uptime_min": 1346.88
+      },
+      {
+        "task_id": "432749748504429e94e1ee3d5c0a106e",
+        "started_at": "2026-08-25T12:41:41.434000-07:00",
+        "started_epoch": 1787686901,
+        "uptime_min": 1346.88
+      },
+      {
+        "task_id": "2c4875e1d01048b2b37855caf15b342c",
+        "started_at": "2026-08-25T12:41:42.483000-07:00",
+        "started_epoch": 1787686902,
+        "uptime_min": 1346.87
+      },
+      {
+        "task_id": "2a22744ca9a44ef9a1f3ccf6d28a6698",
+        "started_at": "2026-08-25T12:46:49.973000-07:00",
+        "started_epoch": 1787687209,
+        "uptime_min": 1341.75
+      },
+      {
+        "task_id": "ea1c11a9885342edba6f95cb70773880",
+        "started_at": "2026-08-25T12:46:50.292000-07:00",
+        "started_epoch": 1787687210,
+        "uptime_min": 1341.73
+      },
+      {
+        "task_id": "27b04cea5dd04428b0b641aa2dbc64a8",
+        "started_at": "2026-08-25T12:46:52.566000-07:00",
+        "started_epoch": 1787687212,
+        "uptime_min": 1341.7
+      },
+      {
+        "task_id": "72fa20081e134bdf89e919365b53e92e",
+        "started_at": "2026-08-25T12:46:53.266000-07:00",
+        "started_epoch": 1787687213,
+        "uptime_min": 1341.68
+      },
+      {
+        "task_id": "9fb7cc6778204902b85ae48473f84116",
+        "started_at": "2026-08-25T12:51:59.282000-07:00",
+        "started_epoch": 1787687519,
+        "uptime_min": 1336.58
+      },
+      {
+        "task_id": "37341be7959f4bc691d6f4ec2ab951b5",
+        "started_at": "2026-08-25T12:52:00.251000-07:00",
+        "started_epoch": 1787687520,
+        "uptime_min": 1336.57
+      },
+      {
+        "task_id": "39fbd684cce046c3ba163a184304d8c6",
+        "started_at": "2026-08-25T12:52:00.200000-07:00",
+        "started_epoch": 1787687520,
+        "uptime_min": 1336.57
+      },
+      {
+        "task_id": "e862443e64ae42ecb0096d20752354e5",
+        "started_at": "2026-08-25T12:52:01.055000-07:00",
+        "started_epoch": 1787687521,
+        "uptime_min": 1336.55
+      },
+      {
+        "task_id": "a4cf5c704c264bfd8273c13ae29405ee",
+        "started_at": "2026-08-25T12:57:19.768000-07:00",
+        "started_epoch": 1787687839,
+        "uptime_min": 1331.25
+      },
+      {
+        "task_id": "d5736858e8144780aa8ba4f0c44346b1",
+        "started_at": "2026-08-25T12:57:19.557000-07:00",
+        "started_epoch": 1787687839,
+        "uptime_min": 1331.25
+      },
+      {
+        "task_id": "82dea923ccf64a8daca5a5120b711138",
+        "started_at": "2026-08-25T12:57:20.365000-07:00",
+        "started_epoch": 1787687840,
+        "uptime_min": 1331.23
+      },
+      {
+        "task_id": "e4f307c0f6de4677a9e9e0466cd9b263",
+        "started_at": "2026-08-25T12:57:20.974000-07:00",
+        "started_epoch": 1787687840,
+        "uptime_min": 1331.23
+      },
+      {
+        "task_id": "4fbad9ab732d4d40b2a37c31e0239d3e",
+        "started_at": "2026-08-25T13:02:23.423000-07:00",
+        "started_epoch": 1787688143,
+        "uptime_min": 1326.18
+      },
+      {
+        "task_id": "75bec0c718704ff98d0f7070ea1ddc1c",
+        "started_at": "2026-08-25T13:02:23.398000-07:00",
+        "started_epoch": 1787688143,
+        "uptime_min": 1326.18
+      },
+      {
+        "task_id": "b5728ea25e8c4b9596399ba6c67e39b0",
+        "started_at": "2026-08-25T13:02:23.363000-07:00",
+        "started_epoch": 1787688143,
+        "uptime_min": 1326.18
+      },
+      {
+        "task_id": "fdc5ad487d444d8a91ad09c1e44dbdfa",
+        "started_at": "2026-08-25T13:02:25.089000-07:00",
+        "started_epoch": 1787688145,
+        "uptime_min": 1326.15
+      },
+      {
+        "task_id": "9f3b5c7fd80a46daaa023926f9bb5d44",
+        "started_at": "2026-08-25T13:07:39.793000-07:00",
+        "started_epoch": 1787688459,
+        "uptime_min": 1320.92
+      },
+      {
+        "task_id": "2acebb74175e423e8674b32361293fca",
+        "started_at": "2026-08-25T13:07:41.324000-07:00",
+        "started_epoch": 1787688461,
+        "uptime_min": 1320.88
+      },
+      {
+        "task_id": "9844cdded0044c5db9c2416203695bc9",
+        "started_at": "2026-08-25T13:07:49.362000-07:00",
+        "started_epoch": 1787688469,
+        "uptime_min": 1320.75
+      },
+      {
+        "task_id": "51cde32a206841f9aff4031ddd04e041",
+        "started_at": "2026-08-25T13:07:53.063000-07:00",
+        "started_epoch": 1787688473,
+        "uptime_min": 1320.68
+      },
+      {
+        "task_id": "cf548554bd6c4c5ebfd2efe56616d097",
+        "started_at": "2026-08-25T13:12:50.350000-07:00",
+        "started_epoch": 1787688770,
+        "uptime_min": 1315.73
+      },
+      {
+        "task_id": "56cc44bf6671462385f0cc53bd642bb6",
+        "started_at": "2026-08-25T13:12:51.107000-07:00",
+        "started_epoch": 1787688771,
+        "uptime_min": 1315.72
+      },
+      {
+        "task_id": "a118a1d17c5c4929a865e5e9fd2fbb93",
+        "started_at": "2026-08-25T13:12:51.067000-07:00",
+        "started_epoch": 1787688771,
+        "uptime_min": 1315.72
+      },
+      {
+        "task_id": "7606c3cb0e3c44e4944a96e0f364234b",
+        "started_at": "2026-08-25T13:12:52.664000-07:00",
+        "started_epoch": 1787688772,
+        "uptime_min": 1315.7
+      },
+      {
+        "task_id": "5d7207fc9c6a4fff97b698b20dcdc9d6",
+        "started_at": "2026-08-25T13:17:49.925000-07:00",
+        "started_epoch": 1787689069,
+        "uptime_min": 1310.75
+      },
+      {
+        "task_id": "d2fc3d6e8efd422d9943c9d1da7fdfd1",
+        "started_at": "2026-08-25T13:17:50.907000-07:00",
+        "started_epoch": 1787689070,
+        "uptime_min": 1310.73
+      },
+      {
+        "task_id": "d8d7e4cdef714f138b115e7d219d5018",
+        "started_at": "2026-08-25T13:17:50.709000-07:00",
+        "started_epoch": 1787689070,
+        "uptime_min": 1310.73
+      },
+      {
+        "task_id": "a71c285087244918889ed0d006841e12",
+        "started_at": "2026-08-25T13:17:51.644000-07:00",
+        "started_epoch": 1787689071,
+        "uptime_min": 1310.72
+      },
+      {
+        "task_id": "dd6a3b0ff9bf4f4284dc10d09125d854",
+        "started_at": "2026-08-25T13:23:10.693000-07:00",
+        "started_epoch": 1787689390,
+        "uptime_min": 1305.4
+      },
+      {
+        "task_id": "fd1c804bf3ee417fa5a83fd6d58d9462",
+        "started_at": "2026-08-25T13:23:10.745000-07:00",
+        "started_epoch": 1787689390,
+        "uptime_min": 1305.4
+      },
+      {
+        "task_id": "13e20a1cc6194e58bd7741d515924607",
+        "started_at": "2026-08-25T13:23:12.211000-07:00",
+        "started_epoch": 1787689392,
+        "uptime_min": 1305.37
+      },
+      {
+        "task_id": "5122da6e5fad46508e51b3dc246955c2",
+        "started_at": "2026-08-25T13:23:12.151000-07:00",
+        "started_epoch": 1787689392,
+        "uptime_min": 1305.37
+      },
+      {
+        "task_id": "0e8001b76aae4b33ba1612dc3b18c5f6",
+        "started_at": "2026-08-25T13:28:17.445000-07:00",
+        "started_epoch": 1787689697,
+        "uptime_min": 1300.28
+      },
+      {
+        "task_id": "c32ce759d7824a009933b70d358dd7c5",
+        "started_at": "2026-08-25T13:28:18.847000-07:00",
+        "started_epoch": 1787689698,
+        "uptime_min": 1300.27
+      },
+      {
+        "task_id": "d237929873bf4fd1925b8f2fd72534ce",
+        "started_at": "2026-08-25T13:28:18.753000-07:00",
+        "started_epoch": 1787689698,
+        "uptime_min": 1300.27
+      },
+      {
+        "task_id": "bf57201ee49942fb88c32ea0eb5e5bd0",
+        "started_at": "2026-08-25T13:28:19.070000-07:00",
+        "started_epoch": 1787689699,
+        "uptime_min": 1300.25
+      },
+      {
+        "task_id": "31c1e0c0782447c187ed1703d49e9244",
+        "started_at": "2026-08-25T13:33:26.800000-07:00",
+        "started_epoch": 1787690006,
+        "uptime_min": 1295.13
+      },
+      {
+        "task_id": "e788430b782646c994c9c9a4bcfd9159",
+        "started_at": "2026-08-25T13:33:28.858000-07:00",
+        "started_epoch": 1787690008,
+        "uptime_min": 1295.1
+      }
+    ]
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-180834Z-30m.md
+++ b/tools/loadtest/metrics/runs/migration/490to491mig3/490to491mig3-2026-08-26-180834Z-30m.md
@@ -1,0 +1,55 @@
+# Metrics Synopsis: 490to491mig3
+
+- **Collected:** 2026-08-26T18:08:34Z
+- **Interval:** 30m
+- **Window:** 2026-08-26T17:38:34Z to 2026-08-26T18:08:34Z
+
+## Summary (30m averages)
+
+```
+Fleet Server:  CPU=62.49%  Mem=5.59%  Containers=25
+Loadtest:      CPU=2.78%  Mem=2.94%  Containers=50
+RDS Writer:    CPU=18.2868%  Connections=172.4  Deadlocks=0
+RDS reader-1:  CPU=22.5338%  Connections=152.2333
+RDS reader-2:  CPU=10.6493%  Connections=56
+Redis:         CPU=34.609%  Mem=4.7422%
+
+Top SQL (writer):
+  #1 load=4.88  COMMIT
+  #2 load=0.25  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.11  DELETE FROM `host_software_installed_paths` WHERE `id` IN (...) 
+  #4 load=0.09  DELETE FROM `host_software` WHERE `host_id` = ? AND `software_id` IN (...) 
+  #5 load=0.09  INSERT IGNORE INTO `scheduled_query_stats` ( `scheduled_query_id` , `host_id` , 
+
+Top SQL (reader-1):
+  #1 load=0.51  ( SELECT `id` , NAME , `instance` , `stats_type` , STATUS , `created_at` , `upda
+  #2 load=0.47  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #3 load=0.4  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.31  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.2  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_s
+
+Top SQL (reader-2):
+  #1 load=0.15  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.11  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.08  SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `extensi
+  #4 load=0.08  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.03  SELECT `t` . `id` , `t` . `host_id` , `t` . `software_id` , `t` . `installed_pat
+ALB:           Latency avg=0.0043s p95=0.0115s p99=0.0214s
+               Target5xx=0  ELB5xx=0  Requests=24047884  Traffic=26092.13MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=26.66GB  CacheHit=100%  Disk=N/A  Threads=1.35  IOPS=2452 (12.26% of max)
+               SelectLat=1.0761ms  InsertLat=3.7803ms
+RDS reader-1: FreeMem=28.55GB  CacheHit=99.9826%  ReplicaLag=6.3333ms  Threads=2.72  IOPS=65 (0.32% of max)
+               SelectLat=0.4752ms
+RDS reader-2: FreeMem=28.76GB  CacheHit=99.9846%  ReplicaLag=6.3667ms  Threads=0.63  IOPS=37 (0.18% of max)
+               SelectLat=0.4555ms
+Redis:         Connections=470.3  Evictions=0  CacheHit=88.922%
+Network:       RX=772.91MB  TX=310.38MB
+Containers:    Running=50  AbnormalStops=0  FleetStops=0  FailedHealthChecks=0  PlacementFailures=0
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```


### PR DESCRIPTION
## Summary

Adds the **4.90.0** baseline and the **4.89 → 4.90** / **4.90 → 4.91** migration load test artifacts, following the existing `tools/loadtest/metrics/runs/` conventions.

### Baseline — `runs/baseline/490loadtest/`
6h run on the 4.90 RC instance.
- `490loadtest-2026-07-30-150402Z-6h.{json,md}`

### Migration — `runs/migration/489to490mig/`
4.89 → 4.90 migration, before vs. after. (Collected under Terraform workspace `490mig2`, hence the file prefix.)
- `490mig2-2026-08-03-160436Z-30m.{json,md}` — pre-migration (30m window)
- `490mig2-2026-08-03-203925Z-200m.{json,md}` — post-migration (200m window)

### Migration — `runs/migration/490to491mig3/`
4.90 → 4.91 migration, before vs. after.
- `490to491mig3-2026-08-26-152159Z-3h.{json,md}` — pre-migration (3h window)
- `490to491mig3-2026-08-26-180834Z-30m.{json,md}` — post-migration (30m window)

## Results

| Run | Fleet errors | ALB 5xx | Abnormal stops | Threshold checks |
|-----|:---:|:---:|:---:|---|
| Baseline 4.90 (6h) | 0 | 0 | 0 | RDS Writer Deadlocks avg 0.02 (occasional, retried) |
| 4.89→4.90 pre (30m) | 0 | 0 | 0 | ✅ all within thresholds |
| 4.89→4.90 post (200m) | 0 | 0 | 0 | ✅ all within thresholds |
| 4.90→4.91 pre (3h) | 9 | 0 | 0 | RDS Writer Deadlocks avg 0.0167; Fleet server errors 9 |
| 4.90→4.91 post (30m) | 0 | 0 | 0 | ✅ all within thresholds |

Notes on the two flags:

- **RDS writer deadlocks** — a near-zero average of occasional deadlocks that MySQL retries. Same pattern as the 4.89 runs.
- **9 Fleet server errors in the 4.90→4.91 pre-migration window** — all from the `cleanups_then_aggregation` cron (`cleanup unused bootstrap packages` / `software title icons` / `software installers`) failing to reach the S3 endpoint at `http://localhost:9000` with the `dev-prefix` prefix. That's the instance's S3 config pointing at a dev-mode endpoint, not a server regression: three cleanup jobs × three hourly runs. No errors in the post-migration window.

Everything else is within expected range and holds steady across both migrations.

The 4.90→4.91 runs were collected with the newer `collect-metrics.sh` (ALB p95/p99 latency, IOPS as absolute + % of max, ECS service-event failure detection replacing start-spread), so those `.json`/`.md` files carry a few more fields than the earlier ones.

Data only — no script or code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added baseline load-test results covering a six-hour run.
  * Added migration test reports for 30-minute, 200-minute, and three-hour scenarios.
  * Reports include application, database, cache, networking, request performance, error rates, and container health metrics.
  * Included detailed performance data such as resource utilization, latency, throughput, connections, IOPS, deadlocks, replica lag, and top database queries.
  * Added snapshots to support comparison across migration and workload durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->