### PR TITLE
APNS Ping frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist
 # generated artifacts
 assets/bundle*.*
 assets/*@*.svg
-assets/*@*.png
+assets/**/*@*.png
 assets/*@*.gif
 assets/*@*.eot
 assets/*@*.woff

--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -40,6 +40,7 @@ const DEFAULT_HOST_MOCK: IHost = {
   policy_updated_at: "2022-01-02T12:00:00Z",
   last_enrolled_at: "2022-01-02T12:00:00Z",
   last_mdm_enrolled_at: "2022-01-02T12:00:00Z",
+  last_mdm_checked_in_at: "",
   seen_time: "2022-04-06T02:11:41Z",
   refetch_requested: false,
   refetch_critical_queries_until: null,

--- a/frontend/components/buttons/ActionButtons/ActionButtons.tsx
+++ b/frontend/components/buttons/ActionButtons/ActionButtons.tsx
@@ -64,6 +64,7 @@ const ActionButtons = ({ baseClass, actions }: IProps): JSX.Element => {
                       variant={action.buttonVariant}
                       onClick={action.onClick}
                       disabled={disableChildren}
+                      icon={action.iconName}
                     >
                       {action.label}
                     </Button>
@@ -72,7 +73,11 @@ const ActionButtons = ({ baseClass, actions }: IProps): JSX.Element => {
               );
             }
             return (
-              <Button variant={action.buttonVariant} onClick={action.onClick}>
+              <Button
+                variant={action.buttonVariant}
+                onClick={action.onClick}
+                icon={action.iconName}
+              >
                 {action.label}
               </Button>
             );

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -395,7 +395,7 @@ export interface IHost {
   policy_updated_at: string;
   last_enrolled_at: string;
   last_mdm_enrolled_at: string;
-  last_mdm_checked_in_at: string;
+  last_mdm_checked_in_at: string | null;
   seen_time: string;
   refetch_requested: boolean;
   refetch_critical_queries_until: string | null;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -395,6 +395,7 @@ export interface IHost {
   policy_updated_at: string;
   last_enrolled_at: string;
   last_mdm_enrolled_at: string;
+  last_mdm_checked_in_at: string;
   seen_time: string;
   refetch_requested: boolean;
   refetch_critical_queries_until: string | null;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -1,5 +1,6 @@
 import { IConfigServerSettings } from "./config";
-import { HostAndroidCertStatus } from "./host";
+import { HostAndroidCertStatus, IHostDevice, IHostMdmData } from "./host";
+import { isAppleDevice } from "./platform";
 
 export interface IMdmApple {
   common_name: string;
@@ -367,4 +368,25 @@ export const isAndroidBYO = (enrollmentStatus: MdmEnrollmentStatus | null) => {
 /** Android COBO (company-owned, fully managed) enrollment. */
 export const isAndroidCOBO = (enrollmentStatus: MdmEnrollmentStatus | null) => {
   return enrollmentStatus === "On (automatic)";
+};
+
+// canTriggerAPNSPing checks the host state if it's allowed to hit APNS ping, it does not do any permission level checks.
+
+type ICanTriggerAPNSPingHost = Pick<IHostDevice, "platform"> & {
+  mdm: Pick<IHostMdmData, "connected_to_fleet"> &
+    Pick<IHostMdmData, "enrollment_status">;
+};
+
+export const canTriggerAPNSPing = (host: ICanTriggerAPNSPingHost) => {
+  return (
+    isAppleDevice(host.platform) &&
+    host.mdm.connected_to_fleet &&
+    host.mdm.enrollment_status !== null &&
+    ([
+      "On (automatic)",
+      "On (manual)",
+      "On (manual - personal)",
+      "On (company-owned)",
+    ] as MdmEnrollmentStatus[]).includes(host.mdm.enrollment_status)
+  );
 };

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -846,6 +846,7 @@ describe("Device User Page - MDM check-in ping", () => {
       status: "online",
     }) as IHostDevice;
     host.mdm.enrollment_status = enrollmentStatus;
+    host.mdm.connected_to_fleet = true;
 
     mockServer.use(customDeviceHandler({ host }));
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -7,6 +7,7 @@ import mockServer from "test/mock-server";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import createMockLicense from "__mocks__/licenseMock";
 import { notify } from "components/ToastNotification";
+import { HostPlatform } from "interfaces/platform";
 
 import deviceUserAPI, {
   IGetSetupExperienceStatusesResponse,
@@ -817,5 +818,107 @@ describe("Device User Page - Fleet Desktop SSO", () => {
 
     await expectRedirectingToIdP();
     expect(initiateDeviceSSO).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Device User Page - MDM check-in ping", () => {
+  let apnsPingSpy: jest.SpyInstance;
+  let refetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    apnsPingSpy = jest.spyOn(deviceUserAPI, "apnsPing").mockResolvedValue({});
+    refetchSpy = jest.spyOn(deviceUserAPI, "refetch").mockResolvedValue({});
+    mockServer.use(defaultDeviceCertificatesHandler);
+    mockServer.use(emptySetupExperienceHandler);
+  });
+
+  afterEach(() => {
+    apnsPingSpy.mockRestore();
+    refetchSpy.mockRestore();
+  });
+
+  const renderDevicePage = (
+    platform: HostPlatform,
+    enrollmentStatus: IHostDevice["mdm"]["enrollment_status"]
+  ) => {
+    const host = createMockHost({
+      platform,
+      status: "online",
+    }) as IHostDevice;
+    host.mdm.enrollment_status = enrollmentStatus;
+
+    mockServer.use(customDeviceHandler({ host }));
+
+    const render = createCustomRenderer({ withBackendMock: true });
+
+    return render(
+      <DeviceUserPage
+        router={mockRouter}
+        params={{ device_auth_token: "testToken" }}
+        location={mockLocation}
+      />
+    );
+  };
+
+  it("pings APNS alongside the refetch for an MDM-enrolled Apple host", async () => {
+    const { user } = renderDevicePage("darwin", "On (manual)");
+
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+
+    await waitFor(() => {
+      expect(apnsPingSpy).toHaveBeenCalledWith("testToken");
+    });
+    expect(refetchSpy).toHaveBeenCalledWith("testToken");
+  });
+
+  it("does not ping APNS when refetching a non-Apple host", async () => {
+    const { user } = renderDevicePage("ubuntu", "On (manual)");
+
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+
+    // The ping is fired before the refetch, so a completed refetch means the
+    // ping decision has already been made.
+    await waitFor(() => {
+      expect(refetchSpy).toHaveBeenCalledWith("testToken");
+    });
+    expect(apnsPingSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not ping APNS when the host's MDM enrollment is off", async () => {
+    const { user } = renderDevicePage("darwin", "Off");
+
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+
+    await waitFor(() => {
+      expect(refetchSpy).toHaveBeenCalledWith("testToken");
+    });
+    expect(apnsPingSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not ping APNS when the host's MDM enrollment is still pending", async () => {
+    const { user } = renderDevicePage("darwin", "Pending");
+
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+
+    await waitFor(() => {
+      expect(refetchSpy).toHaveBeenCalledWith("testToken");
+    });
+    expect(apnsPingSpy).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error but still refetches when the APNS ping fails", async () => {
+    apnsPingSpy.mockRejectedValue(new Error("ping failed"));
+
+    const { user } = renderDevicePage("darwin", "On (manual)");
+
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+
+    await waitFor(() => {
+      expect(notify.error).toHaveBeenCalledWith(
+        "Failed to send APNS ping",
+        expect.anything()
+      );
+    });
+    expect(refetchSpy).toHaveBeenCalledWith("testToken");
   });
 });

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -2,12 +2,12 @@ import React, { useState, useCallback, useEffect, useMemo } from "react";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import useIsMobileWidth from "hooks/useIsMobileWidth";
 import { AxiosError } from "axios";
 
 import { pick } from "lodash";
 
 import classNames from "classnames";
+import useIsMobileWidth from "hooks/useIsMobileWidth";
 
 import deviceUserAPI, {
   IGetDeviceCertsApiParams,
@@ -55,25 +55,13 @@ import {
 
 import UnsupportedScreenSize from "layouts/UnsupportedScreenSize";
 
+import { canTriggerAPNSPing } from "interfaces/mdm";
 import HostSummaryCard from "../cards/HostSummary";
 import VitalsCard from "../cards/Vitals";
 import SoftwareCard from "../cards/Software";
 import PoliciesCard from "../cards/Policies";
-import InfoModal from "./InfoModal";
-import {
-  getErrorMessage,
-  hasRemainingSetupSteps,
-  isSoftwareScriptSetup,
-  isIPhone,
-  isIPad,
-  isRecentlyEnrolled,
-} from "./helpers";
-import useDeviceSSO from "./useDeviceSSO";
 
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
-import AutoEnrollMdmModal from "./AutoEnrollMdmModal";
-import BitLockerPinModal from "./BitLockerPinModal";
-import CreateLinuxKeyModal from "./CreateLinuxKeyModal";
 import ControlsCard from "../cards/Controls";
 import { shouldShowControlsTab } from "../cards/Controls/helpers";
 import {
@@ -84,13 +72,26 @@ import BootstrapPackageModal from "../HostDetailsPage/modals/BootstrapPackageMod
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 import { parseSelfServiceQueryParams } from "../cards/Software/SelfService/SelfService";
 import SelfService from "../cards/Software/SelfService";
-import DeviceUserBanners from "./components/DeviceUserBanners";
 import CertificateDetailsModal from "../modals/CertificateDetailsModal";
 import CertificatesCard from "../cards/Certificates";
 import UserCard from "../cards/User";
 import HostHeader from "../cards/HostHeader/HostHeader";
 import InventoryVersionsModal from "../modals/InventoryVersionsModal";
 import { REFETCH_HOST_DETAILS_POLLING_INTERVAL } from "../HostDetailsPage/HostDetailsPage";
+import DeviceUserBanners from "./components/DeviceUserBanners";
+import CreateLinuxKeyModal from "./CreateLinuxKeyModal";
+import BitLockerPinModal from "./BitLockerPinModal";
+import AutoEnrollMdmModal from "./AutoEnrollMdmModal";
+import useDeviceSSO from "./useDeviceSSO";
+import {
+  getErrorMessage,
+  hasRemainingSetupSteps,
+  isSoftwareScriptSetup,
+  isIPhone,
+  isIPad,
+  isRecentlyEnrolled,
+} from "./helpers";
+import InfoModal from "./InfoModal";
 
 import SettingUpYourDevice from "./components/SettingUpYourDevice";
 import InfoButton from "./components/InfoButton";
@@ -539,12 +540,7 @@ const DeviceUserPage = ({
     setShowRefetchSpinner(true);
 
     // Trigger APNS ping independently of the main refetch
-    if (
-      isAppleDevice(host.platform) &&
-      host.mdm.connected_to_fleet &&
-      host.mdm.enrollment_status !== "Off" &&
-      host.mdm.enrollment_status !== "Pending"
-    ) {
+    if (canTriggerAPNSPing(host)) {
       deviceUserAPI.apnsPing(deviceAuthToken).catch((error) => {
         notify.error("Failed to send APNS ping", { response: error });
       });

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -541,6 +541,7 @@ const DeviceUserPage = ({
     // Trigger APNS ping independently of the main refetch
     if (
       isAppleDevice(host.platform) &&
+      host.mdm.connected_to_fleet &&
       host.mdm.enrollment_status !== "Off" &&
       host.mdm.enrollment_status !== "Pending"
     ) {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -537,6 +537,18 @@ const DeviceUserPage = ({
   const onRefetchHost = useCallback(async () => {
     if (!host) return;
     setShowRefetchSpinner(true);
+
+    // Trigger APNS ping independently of the main refetch
+    if (
+      isAppleDevice(host.platform) &&
+      host.mdm.enrollment_status !== "Off" &&
+      host.mdm.enrollment_status !== "Pending"
+    ) {
+      deviceUserAPI.apnsPing(deviceAuthToken).catch((error) => {
+        notify.error("Failed to send APNS ping", { response: error });
+      });
+    }
+
     try {
       await deviceUserAPI.refetch(deviceAuthToken);
       setRefetchStartTime(Date.now());

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
@@ -42,6 +42,7 @@ const OBSERVER = createMockUser({ role: "observer", global_role: "observer" });
 const mockAppleHost = (): IHost => {
   const host = createMockHost({ platform: "darwin", status: "online" });
   host.mdm.enrollment_status = "On (manual)";
+  host.mdm.connected_to_fleet = true;
   return host;
 };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+
+import createMockHost from "__mocks__/hostMock";
+import createMockUser from "__mocks__/userMock";
+import createMockConfig from "__mocks__/configMock";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+
+import { IHost } from "interfaces/host";
+import { IUser } from "interfaces/user";
+import hostAPI from "services/entities/hosts";
+import activitiesAPI from "services/entities/activities";
+import teamAPI from "services/entities/teams";
+import commandAPI from "services/entities/command";
+
+import HostDetailsPage from "./HostDetailsPage";
+
+jest.mock("services/entities/hosts");
+jest.mock("services/entities/activities");
+jest.mock("services/entities/teams");
+jest.mock("services/entities/command");
+jest.mock("components/ToastNotification", () => ({
+  notify: {
+    success: jest.fn(),
+    error: jest.fn(),
+    batch: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const mockLocation = {
+  pathname: "/hosts/1",
+  query: {},
+  search: "",
+};
+
+const ADMIN = createMockUser();
+const OBSERVER = createMockUser({ role: "observer", global_role: "observer" });
+
+/** An Apple host that is MDM-enrolled and online -- the only combination that
+ * pings APNS alongside the refetch. */
+const mockAppleHost = (): IHost => {
+  const host = createMockHost({ platform: "darwin", status: "online" });
+  host.mdm.enrollment_status = "On (manual)";
+  return host;
+};
+
+const stubQueries = (host: IHost) => {
+  (hostAPI.loadHostDetails as jest.Mock).mockResolvedValue({ host });
+  (hostAPI.loadHostDetailsExtension as jest.Mock).mockResolvedValue({
+    macadmins: null,
+  });
+  (hostAPI.getHostCertificates as jest.Mock).mockResolvedValue({
+    certificates: [],
+    meta: { has_next_results: false, has_previous_results: false },
+  });
+  (hostAPI.refetch as jest.Mock).mockResolvedValue({});
+  (hostAPI.apnsPing as jest.Mock).mockResolvedValue({});
+  (activitiesAPI.getHostPastActivities as jest.Mock).mockResolvedValue({
+    activities: [],
+    meta: { has_next_results: false, has_previous_results: false },
+  });
+  (activitiesAPI.getHostUpcomingActivities as jest.Mock).mockResolvedValue({
+    activities: [],
+    count: 0,
+    meta: { has_next_results: false, has_previous_results: false },
+  });
+  (teamAPI.loadAll as jest.Mock).mockResolvedValue({ teams: [] });
+  (commandAPI.getCommands as jest.Mock).mockResolvedValue({
+    results: [],
+    count: 0,
+    meta: { has_next_results: false, has_previous_results: false },
+  });
+};
+
+const renderPageAs = (currentUser: IUser, isGlobalAdmin: boolean) => {
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        currentUser,
+        isGlobalAdmin,
+        isPremiumTier: true,
+        config: createMockConfig(),
+      },
+    },
+  });
+
+  return render(
+    <HostDetailsPage
+      router={createMockRouter()}
+      location={mockLocation}
+      params={{ host_id: "1" }}
+    />
+  );
+};
+
+describe("HostDetailsPage - APNS ping on refetch", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("only pings APNS alongside the refetch for a maintainer or higher", async () => {
+    stubQueries(mockAppleHost());
+
+    // Global admin: refetch fires the ping too.
+    const { user, unmount } = renderPageAs(ADMIN, true);
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+    await waitFor(() => {
+      expect(hostAPI.refetch).toHaveBeenCalled();
+    });
+    expect(hostAPI.apnsPing).toHaveBeenCalledWith(1);
+    unmount();
+
+    (hostAPI.refetch as jest.Mock).mockClear();
+    (hostAPI.apnsPing as jest.Mock).mockClear();
+
+    // Global observer: the refetch still goes out, the ping does not.
+    const { user: observer } = renderPageAs(OBSERVER, false);
+    await observer.click(
+      await screen.findByRole("button", { name: /refetch/i })
+    );
+    await waitFor(() => {
+      expect(hostAPI.refetch).toHaveBeenCalled();
+    });
+    expect(hostAPI.apnsPing).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
@@ -101,7 +101,7 @@ describe("HostDetailsPage - APNS ping on refetch", () => {
     jest.resetAllMocks();
   });
 
-  it("only pings APNS alongside the refetch for a maintainer or higher", async () => {
+  it("pings APNS alongside the refetch for observer and above", async () => {
     stubQueries(mockAppleHost());
 
     // Global admin: refetch fires the ping too.
@@ -116,7 +116,7 @@ describe("HostDetailsPage - APNS ping on refetch", () => {
     (hostAPI.refetch as jest.Mock).mockClear();
     (hostAPI.apnsPing as jest.Mock).mockClear();
 
-    // Global observer: the refetch still goes out, the ping does not.
+    // Global observer: fires the ping as well.
     const { user: observer } = renderPageAs(OBSERVER, false);
     await observer.click(
       await screen.findByRole("button", { name: /refetch/i })
@@ -124,6 +124,6 @@ describe("HostDetailsPage - APNS ping on refetch", () => {
     await waitFor(() => {
       expect(hostAPI.refetch).toHaveBeenCalled();
     });
-    expect(hostAPI.apnsPing).not.toHaveBeenCalled();
+    expect(hostAPI.apnsPing).toHaveBeenCalledWith(1);
   });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -2223,13 +2223,14 @@ const HostDetailsPage = ({
         )}
         {showMDMStatusModal && host.mdm.enrollment_status && (
           <MDMStatusModal
-            fleetId={currentTeam?.id}
+            fleetId={host.team_id}
             hostId={host.id}
             depProfileError={host.mdm.dep_profile_error}
             enrollmentStatus={host.mdm.enrollment_status}
             isPremiumTier={isPremiumTier}
             isAppleDevice={isAppleDeviceHost}
             lastMDMCheckIn={host.last_mdm_checked_in_at}
+            connectedToFleet={host.mdm.connected_to_fleet}
             onSuccessfulCheckIn={refetchHostDetails}
             user={currentUser}
             router={router}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -44,7 +44,10 @@ import {
   IHostCertificate,
   CERTIFICATES_DEFAULT_SORT,
 } from "interfaces/certificates";
-import { FLEET_FILEVAULT_PROFILE_DISPLAY_NAME } from "interfaces/mdm";
+import {
+  canTriggerAPNSPing,
+  FLEET_FILEVAULT_PROFILE_DISPLAY_NAME,
+} from "interfaces/mdm";
 import { ICommand } from "interfaces/command";
 
 import {
@@ -778,10 +781,7 @@ const HostDetailsPage = ({
 
       // Trigger APNS ping independently
       if (
-        isAppleDevice(host.platform) &&
-        host.mdm.connected_to_fleet &&
-        host.mdm.enrollment_status !== "Off" &&
-        host.mdm.enrollment_status !== "Pending" &&
+        canTriggerAPNSPing(host) &&
         permissions.isGlobalOrTeamObserverOrAbove(currentUser, host.team_id)
       ) {
         hostAPI.apnsPing(host.id).catch((error) => {
@@ -2228,7 +2228,7 @@ const HostDetailsPage = ({
             depProfileError={host.mdm.dep_profile_error}
             enrollmentStatus={host.mdm.enrollment_status}
             isPremiumTier={isPremiumTier}
-            isAppleDevice={isAppleDeviceHost}
+            platform={host.platform}
             lastMDMCheckIn={host.last_mdm_checked_in_at}
             connectedToFleet={host.mdm.connected_to_fleet}
             onSuccessfulCheckIn={refetchHostDetails}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -779,6 +779,7 @@ const HostDetailsPage = ({
       // Trigger APNS ping independently
       if (
         isAppleDevice(host.platform) &&
+        host.mdm.connected_to_fleet &&
         host.mdm.enrollment_status !== "Off" &&
         host.mdm.enrollment_status !== "Pending" &&
         (permissions.isTeamMaintainerOrTeamAdmin(currentUser, host.team_id) ||

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -782,8 +782,7 @@ const HostDetailsPage = ({
         host.mdm.connected_to_fleet &&
         host.mdm.enrollment_status !== "Off" &&
         host.mdm.enrollment_status !== "Pending" &&
-        (permissions.isTeamMaintainerOrTeamAdmin(currentUser, host.team_id) ||
-          permissions.isGlobalMaintainerOrGlobalAdmin(currentUser))
+        permissions.isGlobalOrTeamObserverOrAbove(currentUser, host.team_id)
       ) {
         hostAPI.apnsPing(host.id).catch((error) => {
           notify.error("Failed to send APNS ping", { response: error });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -775,6 +775,19 @@ const HostDetailsPage = ({
       // unless there is an error. The spinner state is also controlled in the fullyReloadHost
       // method.
       setShowRefetchSpinner(true);
+
+      // Trigger APNS ping independently
+      // TODO: Should be gated by maintainer or higher?
+      if (
+        isAppleDevice(host.platform) &&
+        host.mdm.enrollment_status !== "Off" &&
+        host.mdm.enrollment_status !== "Pending"
+      ) {
+        hostAPI.apnsPing(host.id).catch((error) => {
+          notify.error("Failed to send APNS ping", { response: error });
+        });
+      }
+
       try {
         await hostAPI.refetch(host).then(() => {
           setRefetchStartTime(Date.now());
@@ -2215,6 +2228,8 @@ const HostDetailsPage = ({
             enrollmentStatus={host.mdm.enrollment_status}
             isPremiumTier={isPremiumTier}
             isAppleDevice={isAppleDeviceHost}
+            lastMDMCheckIn={host.last_mdm_checked_in_at}
+            onSuccessfulCheckIn={refetchHostDetails}
             router={router}
             onExit={toggleMDMStatusModal}
           />

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -777,11 +777,12 @@ const HostDetailsPage = ({
       setShowRefetchSpinner(true);
 
       // Trigger APNS ping independently
-      // TODO: Should be gated by maintainer or higher?
       if (
         isAppleDevice(host.platform) &&
         host.mdm.enrollment_status !== "Off" &&
-        host.mdm.enrollment_status !== "Pending"
+        host.mdm.enrollment_status !== "Pending" &&
+        (permissions.isTeamMaintainerOrTeamAdmin(currentUser, host.team_id) ||
+          permissions.isGlobalMaintainerOrGlobalAdmin(currentUser))
       ) {
         hostAPI.apnsPing(host.id).catch((error) => {
           notify.error("Failed to send APNS ping", { response: error });
@@ -2230,6 +2231,7 @@ const HostDetailsPage = ({
             isAppleDevice={isAppleDeviceHost}
             lastMDMCheckIn={host.last_mdm_checked_in_at}
             onSuccessfulCheckIn={refetchHostDetails}
+            user={currentUser}
             router={router}
             onExit={toggleMDMStatusModal}
           />

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -273,7 +273,9 @@ describe("HostHeader", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          internationalTimeFormat(new Date(defaultSummaryData.detail_updated_at))
+          internationalTimeFormat(
+            new Date(defaultSummaryData.detail_updated_at)
+          )
         )
       ).toBeInTheDocument();
     });

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 
 import { renderWithSetup } from "test/test-utils";
+import { internationalTimeFormat } from "utilities/helpers";
+import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import HostHeader from "./HostHeader";
 import { HostMdmDeviceStatusUIState } from "../../helpers";
 
@@ -244,5 +246,76 @@ describe("HostHeader", () => {
       />
     );
     expect(screen.getByText("Clear passcode pending")).toBeInTheDocument();
+  });
+
+  describe("last MDM check-in", () => {
+    const LAST_CHECK_IN = "2024-04-27T11:00:00Z";
+
+    it("shows the last fetched and last MDM check-in times in a tooltip when the host has checked in", async () => {
+      const { user } = renderWithSetup(
+        <HostHeader
+          summaryData={{
+            ...defaultSummaryData,
+            last_mdm_checked_in_at: LAST_CHECK_IN,
+          }}
+          showRefetchSpinner={false}
+          onRefetchHost={jest.fn()}
+          renderActionsDropdown={renderActionDropdown}
+          hostMdmEnrollmentStatus="On (manual)"
+        />
+      );
+
+      await user.hover(screen.getByText(/Last fetched/i));
+
+      expect(await screen.findByText("Last MDM check-in:")).toBeInTheDocument();
+      expect(
+        screen.getByText(internationalTimeFormat(new Date(LAST_CHECK_IN)))
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          internationalTimeFormat(new Date(defaultSummaryData.detail_updated_at))
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("does not show the check-in tooltip when the host has never checked in", async () => {
+      // normalizeEmptyValues turns an empty check-in timestamp into "---"
+      const { user } = renderWithSetup(
+        <HostHeader
+          summaryData={{
+            ...defaultSummaryData,
+            last_mdm_checked_in_at: DEFAULT_EMPTY_CELL_VALUE,
+          }}
+          showRefetchSpinner={false}
+          onRefetchHost={jest.fn()}
+          renderActionsDropdown={renderActionDropdown}
+          hostMdmEnrollmentStatus="On (manual)"
+        />
+      );
+
+      await user.hover(screen.getByText(/Last fetched/i));
+
+      expect(screen.queryByText("Last MDM check-in:")).not.toBeInTheDocument();
+    });
+
+    it("renders last fetched without a check-in tooltip when the platform reports no check-in field at all", async () => {
+      // lodash `pick` drops the key entirely for platforms whose API response
+      // omits it, so the header gets `undefined` rather than "---".
+      const { user } = renderWithSetup(
+        <HostHeader
+          summaryData={defaultSummaryData}
+          showRefetchSpinner={false}
+          onRefetchHost={jest.fn()}
+          renderActionsDropdown={renderActionDropdown}
+          hostMdmEnrollmentStatus={null}
+        />
+      );
+
+      expect(screen.getByText(/Last fetched/i)).toBeInTheDocument();
+
+      await user.hover(screen.getByText(/Last fetched/i));
+
+      expect(screen.queryByText("Last MDM check-in:")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
 import TooltipWrapper from "components/TooltipWrapper";
 import { MdmEnrollmentStatus } from "interfaces/mdm";
+import { humanLastSeen, internationalTimeFormat } from "utilities/helpers";
 
 import { HostMdmDeviceStatusUIState } from "../../helpers";
 import {
@@ -159,10 +160,56 @@ const HostHeader = ({
     );
   };
 
+  // `summaryData` is run through `normalizeEmptyValues`, so a host that has
+  // never checked in reports "---", while platforms whose API response omits
+  // the field altogether leave it undefined.
+  const lastMdmCheckIn = summaryData.last_mdm_checked_in_at;
+  const hasMdmCheckIn =
+    !!lastMdmCheckIn && lastMdmCheckIn !== DEFAULT_EMPTY_CELL_VALUE;
+
+  const withTooltip = (content: React.ReactNode) => {
+    if (!hasMdmCheckIn) {
+      return content;
+    }
+
+    return (
+      <TooltipWrapper
+        tipContent={
+          <>
+            <span>
+              Last fetched:
+              <b>
+                {" "}
+                {internationalTimeFormat(
+                  new Date(summaryData.detail_updated_at)
+                )}
+              </b>
+            </span>
+            <br />
+            <span>
+              Last MDM check-in:
+              <b> {internationalTimeFormat(new Date(lastMdmCheckIn))}</b>
+            </span>
+          </>
+        }
+        position="top"
+        underline={false}
+        showArrow
+      >
+        {content}
+      </TooltipWrapper>
+    );
+  };
+
+  // eslint-disable-next-line no-nested-ternary
   const lastFetched = summaryData.detail_updated_at ? (
-    <HumanTimeDiffWithFleetLaunchCutoff
-      timeString={summaryData.detail_updated_at}
-    />
+    hasMdmCheckIn ? (
+      humanLastSeen(summaryData.detail_updated_at)
+    ) : (
+      <HumanTimeDiffWithFleetLaunchCutoff
+        timeString={summaryData.detail_updated_at}
+      />
+    )
   ) : (
     ": unavailable"
   );
@@ -219,7 +266,11 @@ const HostHeader = ({
           {renderDeviceStatusTag()}
 
           <div className={`${baseClass}__last-fetched`}>
-            {"Last fetched"} {lastFetched}
+            {withTooltip(
+              <>
+                {"Last fetched"} {lastFetched}
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
@@ -677,11 +677,10 @@ describe("MDMStatusModal - MDM check-in", () => {
     expect(router.push).not.toHaveBeenCalled();
   });
 
-  it("only offers 'Check in now' to a maintainer or higher", async () => {
+  it("offers 'Check in now' to observers and above", async () => {
     const CHECK_IN_BUTTON = { name: /check in now/i };
 
-    // Global admin and global maintainer can ping; a global observer sees the
-    // check-in time but gets no button.
+    // observers and above can all ping
     const { unmount } = renderModal(renderAsAdmin);
     expect(
       await screen.findByRole("button", CHECK_IN_BUTTON)
@@ -699,8 +698,8 @@ describe("MDMStatusModal - MDM check-in", () => {
     renderModal(renderAsAdmin, { user: OBSERVER });
     expect(await screen.findByText("Last MDM check-in")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", CHECK_IN_BUTTON)
-    ).not.toBeInTheDocument();
+      await screen.findByRole("button", CHECK_IN_BUTTON)
+    ).toBeInTheDocument();
   });
 
   it("still navigates to filtered hosts when the MDM status row is clicked", async () => {

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
@@ -4,11 +4,22 @@ import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import { AxiosError } from "axios";
 
+import createMockUser from "__mocks__/userMock";
 import hostAPI from "services/entities/hosts";
 import paths from "router/paths";
+import { internationalTimeFormat } from "utilities/helpers";
+import { notify } from "components/ToastNotification";
 import MDMStatusModal from "./MDMStatusModal";
 
 jest.mock("services/entities/hosts");
+jest.mock("components/ToastNotification", () => ({
+  notify: {
+    success: jest.fn(),
+    error: jest.fn(),
+    batch: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
 
 const mockRouter = createMockRouter();
 
@@ -42,9 +53,16 @@ const mockDepAssignmentResponse = {
 };
 
 describe("MDMStatusModal - component", () => {
+  // Rendered as a global admin throughout. The check-in action is expected to
+  // become permission-gated, and these cases should still pass once it is.
   const render = createCustomRenderer({
     withBackendMock: true,
-    context: {},
+    context: {
+      app: {
+        isGlobalAdmin: true,
+        currentUser: createMockUser(),
+      },
+    },
   });
 
   afterEach(() => {
@@ -61,6 +79,8 @@ describe("MDMStatusModal - component", () => {
         hostId={3}
         enrollmentStatus="On (manual)"
         router={mockRouter}
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -81,6 +101,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier={false}
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -94,6 +116,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice={false}
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -112,6 +136,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -138,6 +164,8 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -171,6 +199,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -201,6 +231,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -221,6 +253,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -247,6 +281,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -272,6 +308,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -300,6 +338,8 @@ describe("MDMStatusModal - component", () => {
         isPremiumTier
         isAppleDevice
         depProfileError
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -331,6 +371,8 @@ describe("MDMStatusModal - component", () => {
         isPremiumTier
         isAppleDevice
         depProfileError
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -361,6 +403,8 @@ describe("MDMStatusModal - component", () => {
         hostId={3}
         enrollmentStatus="On (manual)"
         router={router}
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -393,6 +437,8 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
       />
     );
@@ -417,11 +463,208 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        lastMDMCheckIn=""
+        onSuccessfulCheckIn={jest.fn()}
         onExit={onExit}
       />
     );
 
     await user.click(screen.getByRole("button", { name: "Close" }));
     expect(onExit).toHaveBeenCalled();
+  });
+});
+
+describe("MDMStatusModal - MDM check-in", () => {
+  const LAST_CHECK_IN = "2026-02-10T18:30:00Z";
+
+  // Both roles are exercised because the check-in action is expected to become
+  // permission-gated at maintainer-or-higher; observers are deliberately not
+  // covered here, since their behavior isn't decided yet.
+  const renderAsAdmin = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        isGlobalAdmin: true,
+        currentUser: createMockUser(),
+      },
+    },
+  });
+
+  const renderAsMaintainer = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        isGlobalMaintainer: true,
+        currentUser: createMockUser({
+          role: "maintainer",
+          global_role: "maintainer",
+        }),
+      },
+    },
+  });
+
+  const renderModal = (
+    renderer: typeof renderAsAdmin,
+    props: Partial<React.ComponentProps<typeof MDMStatusModal>> = {}
+  ) =>
+    renderer(
+      <MDMStatusModal
+        hostId={3}
+        enrollmentStatus="On (manual)"
+        router={mockRouter}
+        isPremiumTier
+        isAppleDevice
+        lastMDMCheckIn={LAST_CHECK_IN}
+        onSuccessfulCheckIn={jest.fn()}
+        onExit={jest.fn()}
+        {...props}
+      />
+    );
+
+  beforeEach(() => {
+    (hostAPI.getDepAssignment as jest.Mock).mockResolvedValue(
+      mockDepAssignmentResponse
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders the last MDM check-in time for an Apple host", async () => {
+    renderModal(renderAsAdmin);
+
+    expect(await screen.findByText("Last MDM check-in")).toBeInTheDocument();
+    expect(
+      screen.getByText(internationalTimeFormat(new Date(LAST_CHECK_IN)))
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /check in now/i })).toBeEnabled();
+  });
+
+  it("renders 'Never' when the host has not checked in yet", async () => {
+    renderModal(renderAsAdmin, { lastMDMCheckIn: "" });
+
+    expect(await screen.findByText("Last MDM check-in")).toBeInTheDocument();
+    expect(screen.getByText("Never")).toBeInTheDocument();
+  });
+
+  it("does not render the check-in button for a non-Apple host", async () => {
+    renderModal(renderAsAdmin, { isAppleDevice: false });
+
+    // "MDM status" is also the modal title, so settle on the status row's
+    // value instead to know the list rendered.
+    expect(await screen.findByText(/On \(manual\)/i)).toBeInTheDocument();
+    expect(screen.queryByText("Last MDM check-in")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /check in now/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("pings the host and refreshes host details when 'Check in now' is clicked", async () => {
+    (hostAPI.apnsPing as jest.Mock).mockResolvedValue({});
+    const onSuccessfulCheckIn = jest.fn();
+
+    const { user } = renderModal(renderAsAdmin, { onSuccessfulCheckIn });
+
+    await user.click(
+      await screen.findByRole("button", { name: /check in now/i })
+    );
+
+    await waitFor(() => {
+      expect(onSuccessfulCheckIn).toHaveBeenCalled();
+    });
+    expect(hostAPI.apnsPing).toHaveBeenCalledWith(3);
+    expect(notify.error).not.toHaveBeenCalled();
+  });
+
+  it("pings the host when a global maintainer clicks 'Check in now'", async () => {
+    (hostAPI.apnsPing as jest.Mock).mockResolvedValue({});
+    const onSuccessfulCheckIn = jest.fn();
+
+    const { user } = renderModal(renderAsMaintainer, { onSuccessfulCheckIn });
+
+    await user.click(
+      await screen.findByRole("button", { name: /check in now/i })
+    );
+
+    await waitFor(() => {
+      expect(onSuccessfulCheckIn).toHaveBeenCalled();
+    });
+    expect(hostAPI.apnsPing).toHaveBeenCalledWith(3);
+  });
+
+  it("surfaces an error and does not refresh host details when the ping fails", async () => {
+    (hostAPI.apnsPing as jest.Mock).mockRejectedValue(
+      new AxiosError("network error")
+    );
+    const onSuccessfulCheckIn = jest.fn();
+
+    const { user } = renderModal(renderAsAdmin, { onSuccessfulCheckIn });
+
+    await user.click(
+      await screen.findByRole("button", { name: /check in now/i })
+    );
+
+    await waitFor(() => {
+      expect(notify.error).toHaveBeenCalled();
+    });
+    expect(onSuccessfulCheckIn).not.toHaveBeenCalled();
+    // The button has to come back so the admin can retry.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /check in now/i })
+      ).toBeEnabled();
+    });
+  });
+
+  it("disables 'Check in now' while the ping is in flight", async () => {
+    (hostAPI.apnsPing as jest.Mock).mockReturnValue(
+      new Promise(() => {
+        // never resolve
+      })
+    );
+
+    const { user } = renderModal(renderAsAdmin);
+
+    const checkInButton = await screen.findByRole("button", {
+      name: /check in now/i,
+    });
+    await user.click(checkInButton);
+
+    await waitFor(() => {
+      expect(checkInButton).toBeDisabled();
+    });
+  });
+
+  it("does not navigate to the hosts list when 'Check in now' is clicked", async () => {
+    (hostAPI.apnsPing as jest.Mock).mockResolvedValue({});
+    const router = createMockRouter();
+
+    const { user } = renderModal(renderAsAdmin, { router });
+
+    await user.click(
+      await screen.findByRole("button", { name: /check in now/i })
+    );
+
+    await waitFor(() => {
+      expect(hostAPI.apnsPing).toHaveBeenCalled();
+    });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it("still navigates to filtered hosts when the MDM status row is clicked", async () => {
+    const router = createMockRouter();
+
+    const { user } = renderModal(renderAsAdmin, { router });
+
+    await user.click(await screen.findByText(/On \(manual\)/i));
+
+    await waitFor(() => {
+      expect(router.push).toHaveBeenCalled();
+    });
+    expect((router.push as jest.Mock).mock.calls[0][0]).toContain(
+      "mdm_enrollment_status="
+    );
+    expect(hostAPI.apnsPing).not.toHaveBeenCalled();
   });
 });

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
@@ -82,6 +82,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -105,6 +106,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -121,6 +123,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -142,6 +145,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -171,6 +175,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -207,6 +212,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -240,6 +246,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -263,6 +270,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -292,6 +300,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -320,6 +329,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -351,6 +361,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -385,6 +396,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -418,6 +430,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -453,6 +466,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={jest.fn()}
       />
     );
@@ -480,6 +494,7 @@ describe("MDMStatusModal - component", () => {
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
+        fleetId={null}
         onExit={onExit}
       />
     );
@@ -539,6 +554,8 @@ describe("MDMStatusModal - MDM check-in", () => {
         lastMDMCheckIn={LAST_CHECK_IN}
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
+        fleetId={props.fleetId ?? null}
+        connectedToFleet
         {...props}
       />
     );

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
@@ -78,6 +78,7 @@ describe("MDMStatusModal - component", () => {
       <MDMStatusModal
         hostId={3}
         enrollmentStatus="On (manual)"
+        platform="windows"
         router={mockRouter}
         user={createMockUser()}
         lastMDMCheckIn=""
@@ -102,7 +103,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier={false}
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -119,7 +120,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice={false}
+        platform="windows"
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -141,7 +142,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -169,6 +170,7 @@ describe("MDMStatusModal - component", () => {
     render(
       <MDMStatusModal
         hostId={3}
+        platform="windows"
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
@@ -208,7 +210,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -242,7 +244,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -266,7 +268,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -296,7 +298,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -325,7 +327,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -356,7 +358,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         depProfileError
         user={createMockUser()}
         lastMDMCheckIn=""
@@ -391,7 +393,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={router}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         depProfileError
         user={createMockUser()}
         lastMDMCheckIn=""
@@ -425,6 +427,7 @@ describe("MDMStatusModal - component", () => {
     const { user } = render(
       <MDMStatusModal
         hostId={3}
+        platform="windows"
         enrollmentStatus="On (manual)"
         router={router}
         user={createMockUser()}
@@ -462,7 +465,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -490,7 +493,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
@@ -507,7 +510,7 @@ describe("MDMStatusModal - component", () => {
 describe("MDMStatusModal - MDM check-in", () => {
   const LAST_CHECK_IN = "2026-02-10T18:30:00Z";
 
-  // The check-in action is gated at maintainer-or-higher, and the modal reads
+  // The check-in action is gated at observer-or-higher, and the modal reads
   // the role off its `user` prop rather than app context -- so cases that
   // exercise the gate have to set both.
   const MAINTAINER = createMockUser({
@@ -549,7 +552,7 @@ describe("MDMStatusModal - MDM check-in", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
-        isAppleDevice
+        platform={"darwin"}
         user={createMockUser()}
         lastMDMCheckIn={LAST_CHECK_IN}
         onSuccessfulCheckIn={jest.fn()}
@@ -588,7 +591,7 @@ describe("MDMStatusModal - MDM check-in", () => {
   });
 
   it("does not render the check-in button for a non-Apple host", async () => {
-    renderModal(renderAsAdmin, { isAppleDevice: false });
+    renderModal(renderAsAdmin, { platform: "windows" });
 
     // "MDM status" is also the modal title, so settle on the status row's
     // value instead to know the list rendered.

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tests.tsx
@@ -79,6 +79,7 @@ describe("MDMStatusModal - component", () => {
         hostId={3}
         enrollmentStatus="On (manual)"
         router={mockRouter}
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -101,6 +102,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier={false}
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -116,6 +118,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice={false}
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -136,6 +139,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -164,6 +168,7 @@ describe("MDMStatusModal - component", () => {
         enrollmentStatus="On (manual)"
         router={mockRouter}
         isPremiumTier
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -199,6 +204,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -231,6 +237,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -253,6 +260,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -281,6 +289,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -308,6 +317,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -338,6 +348,7 @@ describe("MDMStatusModal - component", () => {
         isPremiumTier
         isAppleDevice
         depProfileError
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -371,6 +382,7 @@ describe("MDMStatusModal - component", () => {
         isPremiumTier
         isAppleDevice
         depProfileError
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -403,6 +415,7 @@ describe("MDMStatusModal - component", () => {
         hostId={3}
         enrollmentStatus="On (manual)"
         router={router}
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -437,6 +450,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -463,6 +477,7 @@ describe("MDMStatusModal - component", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn=""
         onSuccessfulCheckIn={jest.fn()}
         onExit={onExit}
@@ -477,9 +492,18 @@ describe("MDMStatusModal - component", () => {
 describe("MDMStatusModal - MDM check-in", () => {
   const LAST_CHECK_IN = "2026-02-10T18:30:00Z";
 
-  // Both roles are exercised because the check-in action is expected to become
-  // permission-gated at maintainer-or-higher; observers are deliberately not
-  // covered here, since their behavior isn't decided yet.
+  // The check-in action is gated at maintainer-or-higher, and the modal reads
+  // the role off its `user` prop rather than app context -- so cases that
+  // exercise the gate have to set both.
+  const MAINTAINER = createMockUser({
+    role: "maintainer",
+    global_role: "maintainer",
+  });
+  const OBSERVER = createMockUser({
+    role: "observer",
+    global_role: "observer",
+  });
+
   const renderAsAdmin = createCustomRenderer({
     withBackendMock: true,
     context: {
@@ -495,10 +519,7 @@ describe("MDMStatusModal - MDM check-in", () => {
     context: {
       app: {
         isGlobalMaintainer: true,
-        currentUser: createMockUser({
-          role: "maintainer",
-          global_role: "maintainer",
-        }),
+        currentUser: MAINTAINER,
       },
     },
   });
@@ -514,6 +535,7 @@ describe("MDMStatusModal - MDM check-in", () => {
         router={mockRouter}
         isPremiumTier
         isAppleDevice
+        user={createMockUser()}
         lastMDMCheckIn={LAST_CHECK_IN}
         onSuccessfulCheckIn={jest.fn()}
         onExit={jest.fn()}
@@ -581,7 +603,10 @@ describe("MDMStatusModal - MDM check-in", () => {
     (hostAPI.apnsPing as jest.Mock).mockResolvedValue({});
     const onSuccessfulCheckIn = jest.fn();
 
-    const { user } = renderModal(renderAsMaintainer, { onSuccessfulCheckIn });
+    const { user } = renderModal(renderAsMaintainer, {
+      user: MAINTAINER,
+      onSuccessfulCheckIn,
+    });
 
     await user.click(
       await screen.findByRole("button", { name: /check in now/i })
@@ -650,6 +675,32 @@ describe("MDMStatusModal - MDM check-in", () => {
       expect(hostAPI.apnsPing).toHaveBeenCalled();
     });
     expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it("only offers 'Check in now' to a maintainer or higher", async () => {
+    const CHECK_IN_BUTTON = { name: /check in now/i };
+
+    // Global admin and global maintainer can ping; a global observer sees the
+    // check-in time but gets no button.
+    const { unmount } = renderModal(renderAsAdmin);
+    expect(
+      await screen.findByRole("button", CHECK_IN_BUTTON)
+    ).toBeInTheDocument();
+    unmount();
+
+    const { unmount: unmountMaintainer } = renderModal(renderAsMaintainer, {
+      user: MAINTAINER,
+    });
+    expect(
+      await screen.findByRole("button", CHECK_IN_BUTTON)
+    ).toBeInTheDocument();
+    unmountMaintainer();
+
+    renderModal(renderAsAdmin, { user: OBSERVER });
+    expect(await screen.findByText("Last MDM check-in")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", CHECK_IN_BUTTON)
+    ).not.toBeInTheDocument();
   });
 
   it("still navigates to filtered hosts when the MDM status row is clicked", async () => {

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -17,6 +17,7 @@ import paths from "router/paths";
 import {
   MdmEnrollmentStatus,
   MDM_ENROLLMENT_STATUS_UI_MAP,
+  canTriggerAPNSPing,
 } from "interfaces/mdm";
 import hostAPI, {
   DEPDeviceStatus,
@@ -37,17 +38,21 @@ import { IconNames } from "components/icons";
 import { notify } from "components/ToastNotification";
 import { IUser } from "interfaces/user";
 import permissions from "utilities/permissions";
+import {
+  HostPlatform,
+  isAppleDevice as isAppleDevicePlatform,
+} from "interfaces/platform";
 
 const baseClass = "mdm-status-modal";
 
 interface IMDMStatusModal {
   fleetId: number | null;
   hostId: number;
+  platform: HostPlatform;
   enrollmentStatus: MdmEnrollmentStatus;
   depProfileError?: boolean;
   router: InjectedRouter;
   isPremiumTier?: boolean;
-  isAppleDevice?: boolean;
   lastMDMCheckIn: string | null;
   connectedToFleet?: boolean;
   onSuccessfulCheckIn: () => void;
@@ -162,13 +167,14 @@ const MDMStatusModal = ({
   enrollmentStatus,
   depProfileError = false,
   isPremiumTier = false,
-  isAppleDevice = false,
+  platform,
   lastMDMCheckIn,
   connectedToFleet = false,
   onSuccessfulCheckIn,
   router,
   onExit,
 }: IMDMStatusModal) => {
+  const isAppleDevice = isAppleDevicePlatform(platform);
   const {
     data: depAssignmentData,
     isFetching: isLoadingDepAssignment,
@@ -274,12 +280,13 @@ const MDMStatusModal = ({
     const { value: lastCheckIn } = item;
 
     const canSeeButton =
-      isAppleDevice &&
-      !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
-        enrollmentStatus
-      ) &&
-      connectedToFleet &&
-      permissions.isGlobalOrTeamObserverOrAbove(user, fleetId ?? null);
+      canTriggerAPNSPing({
+        platform,
+        mdm: {
+          connected_to_fleet: connectedToFleet,
+          enrollment_status: enrollmentStatus,
+        },
+      }) && permissions.isGlobalOrTeamObserverOrAbove(user, fleetId ?? null);
 
     return (
       <>

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -48,7 +48,7 @@ interface IMDMStatusModal {
   router: InjectedRouter;
   isPremiumTier?: boolean;
   isAppleDevice?: boolean;
-  lastMDMCheckIn: string;
+  lastMDMCheckIn: string | null;
   onSuccessfulCheckIn: () => void;
   user: IUser | null;
   onExit: () => void;
@@ -271,6 +271,14 @@ const MDMStatusModal = ({
   const renderMDMCheckinRow = (item: IStatusRowItem) => {
     const { value: lastCheckIn } = item;
 
+    const canSeeButton =
+      isAppleDevice &&
+      !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
+        enrollmentStatus
+      ) &&
+      (permissions.isTeamMaintainerOrTeamAdmin(user, fleetId ?? null) ||
+        permissions.isGlobalMaintainerOrGlobalAdmin(user));
+
     return (
       <>
         <div className={`${baseClass}__status`}>
@@ -281,22 +289,17 @@ const MDMStatusModal = ({
               : "Never"}
           </div>
         </div>
-        {isAppleDevice &&
-          !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
-            enrollmentStatus
-          ) &&
-          (permissions.isTeamMaintainerOrTeamAdmin(user, fleetId ?? null) ||
-            permissions.isGlobalMaintainerOrGlobalAdmin(user)) && (
-            <Button
-              onClick={handleClickCheckInNow}
-              icon="refresh"
-              variant="subdued"
-              disabled={isCheckingIn}
-              isLoading={isCheckingIn}
-            >
-              Check in now
-            </Button>
-          )}
+        {canSeeButton && (
+          <Button
+            onClick={handleClickCheckInNow}
+            icon="refresh"
+            variant="subdued"
+            disabled={isCheckingIn}
+            isLoading={isCheckingIn}
+          >
+            Check in now
+          </Button>
+        )}
       </>
     );
   };
@@ -352,11 +355,13 @@ const MDMStatusModal = ({
       },
     ];
 
-    data.push({
-      id: "mdm-checkin",
-      value: lastMDMCheckIn,
-      render: renderMDMCheckinRow,
-    });
+    if (lastMDMCheckIn !== null) {
+      data.push({
+        id: "mdm-checkin",
+        value: lastMDMCheckIn,
+        render: renderMDMCheckinRow,
+      });
+    }
 
     return (
       <List<IStatusRowItem>

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -41,7 +41,7 @@ import permissions from "utilities/permissions";
 const baseClass = "mdm-status-modal";
 
 interface IMDMStatusModal {
-  fleetId?: number;
+  fleetId: number | null;
   hostId: number;
   enrollmentStatus: MdmEnrollmentStatus;
   depProfileError?: boolean;
@@ -49,6 +49,7 @@ interface IMDMStatusModal {
   isPremiumTier?: boolean;
   isAppleDevice?: boolean;
   lastMDMCheckIn: string | null;
+  connectedToFleet?: boolean;
   onSuccessfulCheckIn: () => void;
   user: IUser | null;
   onExit: () => void;
@@ -163,6 +164,7 @@ const MDMStatusModal = ({
   isPremiumTier = false,
   isAppleDevice = false,
   lastMDMCheckIn,
+  connectedToFleet = false,
   onSuccessfulCheckIn,
   router,
   onExit,
@@ -276,6 +278,7 @@ const MDMStatusModal = ({
       !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
         enrollmentStatus
       ) &&
+      connectedToFleet &&
       permissions.isGlobalOrTeamObserverOrAbove(user, fleetId ?? null);
 
     return (
@@ -354,10 +357,10 @@ const MDMStatusModal = ({
       },
     ];
 
-    if (lastMDMCheckIn !== null) {
+    if (lastMDMCheckIn !== null || connectedToFleet) {
       data.push({
         id: "mdm-checkin",
-        value: lastMDMCheckIn,
+        value: lastMDMCheckIn ?? "",
         render: renderMDMCheckinRow,
       });
     }

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -276,8 +276,7 @@ const MDMStatusModal = ({
       !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
         enrollmentStatus
       ) &&
-      (permissions.isTeamMaintainerOrTeamAdmin(user, fleetId ?? null) ||
-        permissions.isGlobalMaintainerOrGlobalAdmin(user));
+      permissions.isGlobalOrTeamObserverOrAbove(user, fleetId ?? null);
 
     return (
       <>

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router";
 import { AxiosError } from "axios";
@@ -34,6 +34,7 @@ import List from "components/List";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import TooltipWrapper from "components/TooltipWrapper";
 import { IconNames } from "components/icons";
+import { notify } from "components/ToastNotification";
 
 const baseClass = "mdm-status-modal";
 
@@ -45,6 +46,8 @@ interface IMDMStatusModal {
   router: InjectedRouter;
   isPremiumTier?: boolean;
   isAppleDevice?: boolean;
+  lastMDMCheckIn: string;
+  onSuccessfulCheckIn: () => void;
   onExit: () => void;
 }
 
@@ -135,8 +138,8 @@ export const getThrottleCopy = (responseUpdatedAt?: string | null) => {
 
 interface IStatusRowItem {
   id: string;
-  name: string;
-  status: MdmEnrollmentStatus;
+  value: string;
+  render: (item: IStatusRowItem) => JSX.Element;
 }
 
 interface IProfileRowItem {
@@ -155,6 +158,8 @@ const MDMStatusModal = ({
   depProfileError = false,
   isPremiumTier = false,
   isAppleDevice = false,
+  lastMDMCheckIn,
+  onSuccessfulCheckIn,
   router,
   onExit,
 }: IMDMStatusModal) => {
@@ -171,6 +176,7 @@ const MDMStatusModal = ({
       retry: false,
     }
   );
+  const [isCheckingIn, setIsCheckingIn] = useState(false);
 
   const enrollmentFilterValue =
     MDM_ENROLLMENT_STATUS_UI_MAP[enrollmentStatus].filterValue;
@@ -181,6 +187,19 @@ const MDMStatusModal = ({
       fleet_id: fleetId,
     });
     router.push(path);
+  };
+
+  const handleClickCheckInNow = async () => {
+    setIsCheckingIn(true);
+
+    try {
+      await hostAPI.apnsPing(hostId);
+      onSuccessfulCheckIn();
+    } catch (error) {
+      notify.error("Failed to send an APNS ping.", { response: error });
+    } finally {
+      setIsCheckingIn(false);
+    }
   };
 
   const handleClickProfileRow = (item: IProfileRowItem) => {
@@ -217,20 +236,22 @@ const MDMStatusModal = ({
     router.push(path);
   };
 
-  const renderStatusRow = (item: IStatusRowItem) => {
-    const statusTooltip = MDM_STATUS_TOOLTIP[item.status];
+  const renderMDMStatusRow = (item: IStatusRowItem) => {
+    const { value } = item;
+    const status = value as MdmEnrollmentStatus;
+    const statusTooltip = MDM_STATUS_TOOLTIP[status];
 
     return (
       <>
         <div className={`${baseClass}__status`}>
-          <div className={`${baseClass}__status-title`}>{item.name}</div>
+          <div className={`${baseClass}__status-title`}>MDM status</div>
           <div className={`${baseClass}__status-value`}>
             {statusTooltip ? (
-              <TooltipWrapper tipContent={MDM_STATUS_TOOLTIP[item.status]}>
-                {MDM_ENROLLMENT_STATUS_UI_MAP[item.status].displayName}
+              <TooltipWrapper tipContent={MDM_STATUS_TOOLTIP[status]}>
+                {MDM_ENROLLMENT_STATUS_UI_MAP[status].displayName}
               </TooltipWrapper>
             ) : (
-              MDM_ENROLLMENT_STATUS_UI_MAP[item.status].displayName
+              MDM_ENROLLMENT_STATUS_UI_MAP[status].displayName
             )}
           </div>
         </div>
@@ -239,6 +260,37 @@ const MDMStatusModal = ({
           rowHover
           noLink
         />
+      </>
+    );
+  };
+
+  const renderMDMCheckinRow = (item: IStatusRowItem) => {
+    const { value: lastCheckIn } = item;
+
+    return (
+      <>
+        <div className={`${baseClass}__status`}>
+          <div className={`${baseClass}__status-title`}>Last MDM check-in</div>
+          <div className={`${baseClass}__status-value`}>
+            {lastCheckIn
+              ? internationalTimeFormat(new Date(lastCheckIn))
+              : "Never"}
+          </div>
+        </div>
+        {isAppleDevice &&
+          !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
+            enrollmentStatus
+          ) && (
+            <Button
+              onClick={handleClickCheckInNow}
+              icon="refresh"
+              variant="subdued"
+              disabled={isCheckingIn}
+              isLoading={isCheckingIn}
+            >
+              Check in now
+            </Button>
+          )}
       </>
     );
   };
@@ -289,16 +341,26 @@ const MDMStatusModal = ({
     const data: IStatusRowItem[] = [
       {
         id: "mdm-status",
-        name: "MDM status",
-        status: enrollmentStatus,
+        value: enrollmentStatus,
+        render: renderMDMStatusRow,
       },
     ];
+
+    data.push({
+      id: "mdm-checkin",
+      value: lastMDMCheckIn,
+      render: renderMDMCheckinRow,
+    });
 
     return (
       <List<IStatusRowItem>
         data={data}
-        renderItemRow={renderStatusRow}
-        onClickRow={handleClickStatusRow}
+        renderItemRow={(item) => item.render(item)}
+        isRowClickable={(row) => row.id === "mdm-status"}
+        onClickRow={(row) => {
+          if (row.id === "mdm-status" && handleClickStatusRow)
+            handleClickStatusRow();
+        }}
       />
     );
   };

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -35,6 +35,8 @@ import ViewAllHostsLink from "components/ViewAllHostsLink";
 import TooltipWrapper from "components/TooltipWrapper";
 import { IconNames } from "components/icons";
 import { notify } from "components/ToastNotification";
+import { IUser } from "interfaces/user";
+import permissions from "utilities/permissions";
 
 const baseClass = "mdm-status-modal";
 
@@ -48,6 +50,7 @@ interface IMDMStatusModal {
   isAppleDevice?: boolean;
   lastMDMCheckIn: string;
   onSuccessfulCheckIn: () => void;
+  user: IUser | null;
   onExit: () => void;
 }
 
@@ -154,6 +157,7 @@ interface IProfileRowItem {
 const MDMStatusModal = ({
   fleetId,
   hostId,
+  user,
   enrollmentStatus,
   depProfileError = false,
   isPremiumTier = false,
@@ -280,7 +284,9 @@ const MDMStatusModal = ({
         {isAppleDevice &&
           !(["Off", "Pending"] as MdmEnrollmentStatus[]).includes(
             enrollmentStatus
-          ) && (
+          ) &&
+          (permissions.isTeamMaintainerOrTeamAdmin(user, fleetId ?? null) ||
+            permissions.isGlobalMaintainerOrGlobalAdmin(user)) && (
             <Button
               onClick={handleClickCheckInNow}
               icon="refresh"

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/_styles.scss
@@ -8,6 +8,7 @@
   }
 
   .list__row {
+    min-height: 28px; // keep same row height for rows with no button
     button {
       visibility: hidden;
     }

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -95,6 +95,12 @@ export default {
 
     return sendRequest("POST", path);
   },
+  apnsPing: (deviceAuthToken: string) => {
+    const { DEVICE_USER_APNS_PING } = endpoints;
+    const path = DEVICE_USER_APNS_PING(deviceAuthToken);
+
+    return sendRequest("POST", path);
+  },
 
   /** Starts the Fleet Desktop SSO flow. Sets the SSO handshake cookie and
    * returns the IdP URL to navigate to; the session cookie is set server-side

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -572,6 +572,12 @@ export default {
 
     return sendRequest("POST", path);
   },
+  apnsPing: (hostID: number) => {
+    const { HOST_APNS_PING } = endpoints;
+    const path = `${HOST_APNS_PING(hostID)}`;
+
+    return sendRequest("POST", path);
+  },
   search: (searchText: string) => {
     const { HOSTS } = endpoints;
     const path = `${HOSTS}?query=${searchText}`;

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -441,6 +441,7 @@ export const HOST_SUMMARY_DATA: (keyof IHost)[] = [
   "maintenance_window", // Not rendered on my device page
   "os_version",
   "mdm",
+  "last_mdm_checked_in_at",
 ];
 
 export const HOST_VITALS_DATA = [

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -40,6 +40,9 @@ export default {
 
   // Device endpoints
   DEVICE_USER_DETAILS: `/${API_VERSION}/fleet/device`,
+  DEVICE_USER_APNS_PING: (token: string): string => {
+    return `/${API_VERSION}/fleet/device/${token}/apns_ping`;
+  },
   DEVICE_SOFTWARE: (token: string) =>
     `/${API_VERSION}/fleet/device/${token}/software`,
   DEVICE_SOFTWARE_INSTALL: (token: string, softwareTitleId: number) =>
@@ -122,6 +125,7 @@ export default {
     `/${API_VERSION}/fleet/hosts/${id}/device_mapping/idp`,
   HOST_DEP_ASSIGNMENT: (id: number) =>
     `/${API_VERSION}/fleet/hosts/${id}/dep_assignment`,
+  HOST_APNS_PING: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/apns_ping`,
 
   INVITES: `/${API_VERSION}/fleet/invites`,
   INVITE_VERIFY: (token: string) => `/${API_VERSION}/fleet/invites/${token}`,

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -40,9 +40,9 @@ export const isGlobalMaintainer = (user: IUser | null): boolean => {
   return user?.global_role === "maintainer";
 };
 
-export const isGlobalObserver = (user: IUser): boolean => {
+export const isGlobalObserver = (user: IUser | null): boolean => {
   return (
-    user.global_role === "observer" || user.global_role === "observer_plus"
+    user?.global_role === "observer" || user?.global_role === "observer_plus"
   );
 };
 
@@ -109,10 +109,6 @@ const isTeamMaintainerOrTeamAdmin = (
   return userTeamRole === "admin" || userTeamRole === "maintainer";
 };
 
-const isGlobalMaintainerOrGlobalAdmin = (user: IUser | null): boolean => {
-  return isGlobalMaintainer(user) || isGlobalAdmin(user);
-};
-
 // This checks against all teams
 const isAnyTeamObserverPlus = (user: IUser): boolean => {
   if (!isOnGlobalTeam(user)) {
@@ -146,8 +142,8 @@ export const isAnyTeamTechnician = (user: IUser): boolean => {
   return false;
 };
 
-export const isGlobalTechnician = (user: IUser): boolean => {
-  return user.global_role === "technician";
+export const isGlobalTechnician = (user: IUser | null): boolean => {
+  return user?.global_role === "technician";
 };
 
 const isAnyTeamAdmin = (user: IUser): boolean => {
@@ -238,6 +234,22 @@ export const canDownloadSoftwareInstaller = (
   );
 };
 
+const isGlobalOrTeamObserverOrAbove = (
+  user: IUser | null,
+  teamId: number | null
+): boolean => {
+  return (
+    isGlobalObserver(user) ||
+    isGlobalTechnician(user) ||
+    isGlobalMaintainer(user) ||
+    isGlobalAdmin(user) ||
+    isTeamObserver(user, teamId) ||
+    isTeamTechnician(user, teamId) ||
+    isTeamMaintainer(user, teamId) ||
+    isTeamAdmin(user, teamId)
+  );
+};
+
 export default {
   isSandboxMode,
   isFreeTier,
@@ -254,7 +266,6 @@ export default {
   isTeamObserverPlus,
   isTeamMaintainer,
   isTeamMaintainerOrTeamAdmin,
-  isGlobalMaintainerOrGlobalAdmin,
   isAnyTeamObserverPlus,
   isAnyTeamMaintainer,
   isAnyTeamMaintainerOrTeamAdmin,
@@ -269,4 +280,5 @@ export default {
   isNoAccess,
   canWriteSoftware,
   canDownloadSoftwareInstaller,
+  isGlobalOrTeamObserverOrAbove,
 };

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -32,12 +32,12 @@ export const isEndUserIdPConfigured = (config: IConfig): boolean => {
   );
 };
 
-export const isGlobalAdmin = (user: IUser): boolean => {
-  return user.global_role === "admin";
+export const isGlobalAdmin = (user: IUser | null): boolean => {
+  return user?.global_role === "admin";
 };
 
-export const isGlobalMaintainer = (user: IUser): boolean => {
-  return user.global_role === "maintainer";
+export const isGlobalMaintainer = (user: IUser | null): boolean => {
+  return user?.global_role === "maintainer";
 };
 
 export const isGlobalObserver = (user: IUser): boolean => {
@@ -107,6 +107,10 @@ const isTeamMaintainerOrTeamAdmin = (
 ): boolean => {
   const userTeamRole = user?.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "admin" || userTeamRole === "maintainer";
+};
+
+const isGlobalMaintainerOrGlobalAdmin = (user: IUser | null): boolean => {
+  return isGlobalMaintainer(user) || isGlobalAdmin(user);
 };
 
 // This checks against all teams
@@ -250,6 +254,7 @@ export default {
   isTeamObserverPlus,
   isTeamMaintainer,
   isTeamMaintainerOrTeamAdmin,
+  isGlobalMaintainerOrGlobalAdmin,
   isAnyTeamObserverPlus,
   isAnyTeamMaintainer,
   isAnyTeamMaintainerOrTeamAdmin,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51635


https://github.com/user-attachments/assets/c180a9d4-ae95-4218-aac4-778a4bd25e15

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Part of backend story


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple MDM-enrolled hosts can now be prompted to check in immediately from the MDM status panel.
  * Host details refresh automatically after a successful check-in, with the latest check-in time displayed.
  * “Last fetched” information now includes a tooltip with MDM check-in and fetch times.
  * Missing MDM check-in times display as “Never.”
  * Secondary action buttons now display their configured icons.

* **Bug Fixes**
  * Check-in failures show an error notification while host refresh continues.
  * Check-in actions are limited to supported devices and authorized roles.
  * MDM status rows now maintain consistent spacing when actions are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->