### PR TITLE
Support host deletion scenario (hub should disconnect such host)

### DIFF
--- a/server/agentws/hub.go
+++ b/server/agentws/hub.go
@@ -103,6 +103,27 @@ func (h *Hub) unregister(hostID uint, c *conn) {
 	h.mu.Unlock()
 }
 
+// Disconnect closes and removes the connections held for hostIDs, and returns
+// how many were closed. Used when a host no longer exists: the agent
+// reconnects (re-enrolled, under its new host ID) instead of lingering under
+// a stale one.
+func (h *Hub) Disconnect(hostIDs []uint) int {
+	h.mu.Lock()
+	conns := make([]*conn, 0, len(hostIDs))
+	for _, id := range hostIDs {
+		if c, ok := h.conns[id]; ok {
+			delete(h.conns, id)
+			conns = append(conns, c)
+		}
+	}
+	h.mu.Unlock()
+
+	for _, c := range conns {
+		c.close()
+	}
+	return len(conns)
+}
+
 // Notify enqueues a notification of the given type and reason to each of
 // hostIDs whose connection this instance holds, and returns how many were
 // notified. Hosts connected to other instances (or not connected at all) are

--- a/server/agentws/interval_checker.go
+++ b/server/agentws/interval_checker.go
@@ -58,7 +58,7 @@ func (c *IntervalChecker) checkOnce(ctx context.Context) {
 	// (see orbit/pkg/wstransport).
 	hostIDs := c.Hub.HeldHostIDs()
 
-	notified := 0
+	notified, disconnected := 0, 0
 	for start := 0; start < len(hostIDs); start += c.BatchSize {
 		if ctx.Err() != nil {
 			return
@@ -84,12 +84,19 @@ func (c *IntervalChecker) checkOnce(ctx context.Context) {
 			byReason[reason] = append(byReason[reason], id)
 		}
 		for reason, ids := range byReason {
+			if reason == fleet.AgentWSReasonHostNotFound {
+				// The host was deleted while its agent held a connection.
+				// Nothing else closes it, so it would linger under the stale
+				// host ID (and keep marking it seen) indefinitely.
+				disconnected += c.Hub.Disconnect(ids)
+				continue
+			}
 			notified += c.Hub.Notify(fleet.AgentWSMessageTypeDistributedRead, reason, ids)
 		}
 	}
 
-	if notified > 0 {
-		c.Logger.DebugContext(ctx, "notified agents with due interval work",
-			"checked", len(hostIDs), "notified", notified)
+	if notified > 0 || disconnected > 0 {
+		c.Logger.DebugContext(ctx, "checked agents for due interval work",
+			"checked", len(hostIDs), "notified", notified, "disconnected", disconnected)
 	}
 }

--- a/server/agentws/interval_checker_test.go
+++ b/server/agentws/interval_checker_test.go
@@ -2,12 +2,15 @@ package agentws
 
 import (
 	"context"
+	"errors"
+	"io"
 	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,6 +94,44 @@ func TestIntervalCheckerNotifiesDueHosts(t *testing.T) {
 	require.NoError(t, ws1.SetReadDeadline(time.Now().Add(300*time.Millisecond)))
 	_, _, err = ws1.ReadMessage()
 	require.Error(t, err)
+}
+
+func TestIntervalCheckerDisconnectsDeletedHosts(t *testing.T) {
+	hub := NewHub(discardLogger(), time.Minute, 30*time.Second)
+	srv := newTestServer(t, hub)
+
+	ws1 := dial(t, srv, "key-1")
+	ws2 := dial(t, srv, "key-2")
+	waitForConnCount(t, hub, 2)
+
+	// Host 1 was deleted while its agent held a connection; host 2 is due.
+	lister := &fakeDueLister{due: map[uint]string{
+		1: fleet.AgentWSReasonHostNotFound,
+		2: fleet.AgentWSReasonLabel,
+	}}
+	checker := &IntervalChecker{
+		Hub:       hub,
+		Svc:       lister,
+		Interval:  time.Minute,
+		BatchSize: 10,
+		Logger:    discardLogger(),
+	}
+	checker.checkOnce(t.Context())
+
+	// The deleted host's connection is closed (the agent reconnects under its
+	// new identity) and dropped from the hub, never notified.
+	require.NoError(t, ws1.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, _, err := ws1.ReadMessage()
+	require.Error(t, err)
+	assert.True(t, websocket.IsCloseError(err, websocket.CloseAbnormalClosure) || errors.Is(err, io.ErrUnexpectedEOF), "unexpected error: %v", err)
+	waitForConnCount(t, hub, 1)
+	assert.Equal(t, []uint{2}, hub.HeldHostIDs())
+
+	// The due host is notified as usual.
+	require.NoError(t, ws2.SetReadDeadline(time.Now().Add(2*time.Second)))
+	var msg fleet.AgentWSMessage
+	require.NoError(t, ws2.ReadJSON(&msg))
+	assert.Equal(t, fleet.AgentWSReasonLabel, msg.Reason)
 }
 
 func TestIntervalCheckerBatching(t *testing.T) {

--- a/server/fleet/agent_websocket.go
+++ b/server/fleet/agent_websocket.go
@@ -36,6 +36,12 @@ const (
 	AgentWSReasonPolicy  = "policy"  // policy queries due per PolicyUpdateInterval
 	AgentWSReasonDetail  = "detail"  // detail (host vitals) queries due per DetailUpdateInterval
 	AgentWSReasonRefetch = "refetch" // a host refetch was requested (or critical queries are being refetched)
+
+	// AgentWSReasonHostNotFound is returned by ListHostIDsDueForDistributedRead
+	// for IDs with no hosts row (the host was deleted while its agent held a
+	// connection). It is never sent to agents: the interval check job closes
+	// such connections so the agent reconnects with its new identity.
+	AgentWSReasonHostNotFound = "host-not-found"
 )
 
 // AgentWSReasonLiveQuery is the reason for a distributed/read notification

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -86,6 +86,7 @@ type OsqueryService interface {
 	// constant or a live-<campaign ID> reason; the first due gate wins). Used
 	// by the WebSocket transport's interval check job; applies the same
 	// staleness gates (including per-host jitter) as GetDistributedQueries.
+	// IDs with no hosts row are returned with AgentWSReasonHostNotFound.
 	ListHostIDsDueForDistributedRead(ctx context.Context, hostIDs []uint) (map[uint]string, error)
 }
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1019,7 +1019,9 @@ const dueHostsChunkSize = 1000
 // distributed/read would include interval work or an unanswered live query
 // campaign, keyed by host ID with the reason it is due. It reuses the read
 // path's staleness gates (shouldUpdate, including the per-host jitter
-// tables), so notification and read decisions agree by construction.
+// tables), so notification and read decisions agree by construction. IDs
+// with no hosts row (deleted while their agent held a connection) are also
+// returned, with AgentWSReasonHostNotFound, so the caller can drop them.
 //
 // The live query check makes the pub/sub wake-up a latency optimization only:
 // a campaign whose one-shot wake-up was lost anywhere along the way is

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1050,6 +1050,15 @@ func (svc *Service) ListHostIDsDueForDistributedRead(ctx context.Context, hostID
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "list hosts due for distributed read")
 		}
+		found := make(map[uint]struct{}, len(hosts))
+		for _, host := range hosts {
+			found[host.ID] = struct{}{}
+		}
+		for _, id := range hostIDs[start:end] {
+			if _, ok := found[id]; !ok {
+				due[id] = fleet.AgentWSReasonHostNotFound
+			}
+		}
 		for _, host := range hosts {
 			if reason := svc.hostDueForDistributedRead(host); reason != "" {
 				due[host.ID] = reason

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -800,6 +800,18 @@ func TestListHostIDsDueForDistributedRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, intervalDue, due)
 	})
+
+	t.Run("deleted hosts are reported as not found", func(t *testing.T) {
+		svc, ctx, lq, _ := setup(t)
+		lq.On("LoadActiveQueryNames").Return([]string{}, nil)
+
+		// IDs 8 and 9 have no hosts row (deleted while their agent was connected).
+		due, err := svc.ListHostIDsDueForDistributedRead(ctx, append(slices.Clone(allIDs), 8, 9))
+		require.NoError(t, err)
+		want := map[uint]string{8: fleet.AgentWSReasonHostNotFound, 9: fleet.AgentWSReasonHostNotFound}
+		maps.Copy(want, intervalDue)
+		assert.Equal(t, want, due)
+	})
 }
 
 func TestAuthenticateHostContextCanceled(t *testing.T) {


### PR DESCRIPTION
Fixes the below bug in #50639.

This PR fixes the below scenario:
1. Host is connected via websockets.
2. Delete host from Fleet.
3. Host re-enrolls to Fleet (with new host_id).
4. Websocket for such host is not closed and notifications won't reach the re-enrolled host (has a stale/unexistent host_id, because when the host re-enrolls after the deletion its assigned a new host_id).

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
- [X] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically closes stale agent connections when their associated hosts have been deleted.
  * Prevents deleted hosts from receiving distributed-read notifications.
  * Correctly identifies missing hosts while preserving notifications for valid hosts.
  * Improves connection cleanup reporting when stale connections are removed.

* **Tests**
  * Added coverage confirming deleted-host connections are closed and active hosts continue to be notified.

* **Documentation**
  * Clarified handling of host IDs that no longer exist and connection cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->