### PR TITLE
Update Windows profile name on edit

### DIFF
--- a/changes/51104-windows-profile-rename-on-edit
+++ b/changes/51104-windows-profile-rename-on-edit
@@ -1,0 +1,1 @@
+* Fixed editing a Windows configuration profile so that uploading a replacement file with a different name updates the profile's name. Previously the contents were replaced but the profile kept its original name, so the configuration profiles list, the downloaded file and the activity feed all still showed the old one.

--- a/changes/51104-windows-profile-rename-on-edit
+++ b/changes/51104-windows-profile-rename-on-edit
@@ -1,1 +1,2 @@
 * Fixed editing a Windows configuration profile so that uploading a replacement file with a different name updates the profile's name. Previously the contents were replaced but the profile kept its original name, so the configuration profiles list, the downloaded file and the activity feed all still showed the old one.
+* Fixed uploading a Windows configuration profile whose file name is longer than 255 characters returning a database error instead of a validation message.

--- a/changes/51104-windows-profile-rename-on-edit
+++ b/changes/51104-windows-profile-rename-on-edit
@@ -1,2 +1,2 @@
-* Fixed editing a Windows configuration profile so that uploading a replacement file with a different name updates the profile's name. Previously the contents were replaced but the profile kept its original name, so the configuration profiles list, the downloaded file and the activity feed all still showed the old one.
-* Fixed uploading a Windows configuration profile whose file name is longer than 255 characters returning a database error instead of a validation message.
+* Fixed editing a Windows configuration profile so that uploading a replacement file with a different name updates the profile's name.
+* Fixed uploading a Windows configuration profile with a file name longer than 255 characters returning a database error.

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3126,31 +3126,6 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 			contentChanged := !bytes.Equal(existing.SyncML, cp.SyncML)
 			nameChanged := existing.Name != cp.Name
 
-			// A name is unique per team across ALL profile platforms, and the
-			// UPDATE below can only rely on this table's own unique index, so the
-			// other three tables have to be checked explicitly (same set the
-			// insert paths guard with NOT EXISTS).
-			if nameChanged {
-				var collides bool
-				err := sqlx.GetContext(ctx, tx, &collides, `SELECT EXISTS (
-	SELECT 1 FROM mdm_apple_configuration_profiles WHERE name = ? AND team_id = ?
-) OR EXISTS (
-	SELECT 1 FROM mdm_apple_declarations WHERE name = ? AND team_id = ?
-) OR EXISTS (
-	SELECT 1 FROM mdm_android_configuration_profiles WHERE name = ? AND team_id = ?
-)`, cp.Name, teamID, cp.Name, teamID, cp.Name, teamID)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "checking cross-platform profile name collision")
-				}
-				if collides {
-					return ctxerr.Wrap(ctx, &existsError{
-						ResourceType: "MDMWindowsConfigProfile.Name",
-						Identifier:   cp.Name,
-						TeamID:       cp.TeamID,
-					})
-				}
-			}
-
 			// Retain the outgoing version before overwriting it so the
 			// profile-manager cron can build <Delete> commands for LocURIs the
 			// new content drops (same guarantee as the upsert and batch edit
@@ -3161,13 +3136,31 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 				}
 			}
 
-			// uploaded_at is preserved only when nothing the admin uploaded
-			// changed, matching the batch path's
-			// IF(syncml = VALUES(syncml) AND name = VALUES(name), ...) -- a rename
-			// is a new upload even when the bytes are identical, and a no-op edit
-			// must not read as a fresh one.
-			stmt := `UPDATE mdm_windows_configuration_profiles SET syncml = ?, name = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at) WHERE profile_uuid = ?`
-			res, err := tx.ExecContext(ctx, stmt, cp.SyncML, cp.Name, contentChanged || nameChanged, cp.ProfileUUID)
+			// A rename is a fresh upload even when the bytes are identical, so
+			// uploaded_at survives only a true no-op, matching the batch path's
+			// IF(syncml = VALUES(syncml) AND name = VALUES(name), ...).
+			const setClause = `UPDATE mdm_windows_configuration_profiles
+SET syncml = ?, name = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at)
+WHERE profile_uuid = ?`
+
+			// A name is unique per team across all four profile tables, but the
+			// UPDATE can only rely on this table's own index. Guarding with
+			// NOT EXISTS in the statement itself, rather than a preceding SELECT,
+			// keeps the check and the write atomic -- the same shape
+			// NewMDMWindowsConfigProfile uses on insert. Applied only on a rename
+			// so a content-only edit can't start failing on a pre-existing
+			// cross-table duplicate.
+			stmt := setClause
+			args := []any{cp.SyncML, cp.Name, contentChanged || nameChanged, cp.ProfileUUID}
+			if nameChanged {
+				stmt += `
+	AND NOT EXISTS (SELECT 1 FROM mdm_apple_configuration_profiles WHERE name = ? AND team_id = ?)
+	AND NOT EXISTS (SELECT 1 FROM mdm_apple_declarations WHERE name = ? AND team_id = ?)
+	AND NOT EXISTS (SELECT 1 FROM mdm_android_configuration_profiles WHERE name = ? AND team_id = ?)`
+				args = append(args, cp.Name, teamID, cp.Name, teamID, cp.Name, teamID)
+			}
+
+			res, err := tx.ExecContext(ctx, stmt, args...)
 			if err != nil {
 				switch {
 				case IsDuplicate(err):
@@ -3181,14 +3174,23 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 					return ctxerr.Wrap(ctx, err, "updating windows mdm config profile contents")
 				}
 			}
+			// The row was read at the top of this transaction, so on a rename the
+			// only thing that can match nothing is the NOT EXISTS guard.
 			if aff, _ := res.RowsAffected(); aff == 0 {
+				if nameChanged {
+					return ctxerr.Wrap(ctx, &existsError{
+						ResourceType: "MDMWindowsConfigProfile.Name",
+						Identifier:   cp.Name,
+						TeamID:       cp.TeamID,
+					})
+				}
 				return ctxerr.Wrap(ctx, notFound("MDMWindowsProfile").WithName(cp.ProfileUUID))
 			}
 
-			// host_mdm_windows_profiles denormalizes the name. A content change
-			// refreshes it via the reinstall upsert, but a rename on identical
-			// content enqueues nothing, so the per-host rows would keep the old
-			// name forever. Same fix the GitOps declaration path applies.
+			// The per-host rows denormalize the name. A content change refreshes
+			// them through the reinstall upsert, but a rename on identical content
+			// enqueues nothing, so update them here (as the GitOps declaration
+			// path does).
 			if nameChanged {
 				if _, err := tx.ExecContext(ctx,
 					`UPDATE host_mdm_windows_profiles SET profile_name = ? WHERE profile_uuid = ?`,

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3101,9 +3101,8 @@ INSERT INTO
 }
 
 // UpdateMDMWindowsConfigProfile updates an existing profile's contents (if
-// cp.SyncML is non-empty) and/or label targeting in place. cp.Name must
-// match the existing profile's -- name is a Windows profile's only
-// identity, so it never changes on this path.
+// cp.SyncML is non-empty), name and/or label targeting in place. The profile is
+// keyed by cp.ProfileUUID, so a rename keeps the same row.
 func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
 	var teamID uint
 	if cp.TeamID != nil {
@@ -3123,14 +3122,34 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 			}
 			return ctxerr.Wrap(ctx, err, "get existing windows config profile")
 		}
-		if existing.Name != cp.Name {
-			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
-				Message: "The new profile's name must match the existing profile's name.",
-			})
-		}
-
 		if len(cp.SyncML) > 0 {
 			contentChanged := !bytes.Equal(existing.SyncML, cp.SyncML)
+			nameChanged := existing.Name != cp.Name
+
+			// A name is unique per team across ALL profile platforms, and the
+			// UPDATE below can only rely on this table's own unique index, so the
+			// other three tables have to be checked explicitly (same set the
+			// insert paths guard with NOT EXISTS).
+			if nameChanged {
+				var collides bool
+				err := sqlx.GetContext(ctx, tx, &collides, `SELECT EXISTS (
+	SELECT 1 FROM mdm_apple_configuration_profiles WHERE name = ? AND team_id = ?
+) OR EXISTS (
+	SELECT 1 FROM mdm_apple_declarations WHERE name = ? AND team_id = ?
+) OR EXISTS (
+	SELECT 1 FROM mdm_android_configuration_profiles WHERE name = ? AND team_id = ?
+)`, cp.Name, teamID, cp.Name, teamID, cp.Name, teamID)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "checking cross-platform profile name collision")
+				}
+				if collides {
+					return ctxerr.Wrap(ctx, &existsError{
+						ResourceType: "MDMWindowsConfigProfile.Name",
+						Identifier:   cp.Name,
+						TeamID:       cp.TeamID,
+					})
+				}
+			}
 
 			// Retain the outgoing version before overwriting it so the
 			// profile-manager cron can build <Delete> commands for LocURIs the
@@ -3142,16 +3161,40 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 				}
 			}
 
-			// uploaded_at is preserved when the content didn't change, matching
-			// the upsert's IF(syncml = VALUES(syncml), ...) convention -- a
-			// no-op edit must not read as a fresh upload.
-			stmt := `UPDATE mdm_windows_configuration_profiles SET syncml = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at) WHERE profile_uuid = ? AND name = ?`
-			res, err := tx.ExecContext(ctx, stmt, cp.SyncML, contentChanged, cp.ProfileUUID, cp.Name)
+			// uploaded_at is preserved only when nothing the admin uploaded
+			// changed, matching the batch path's
+			// IF(syncml = VALUES(syncml) AND name = VALUES(name), ...) -- a rename
+			// is a new upload even when the bytes are identical, and a no-op edit
+			// must not read as a fresh one.
+			stmt := `UPDATE mdm_windows_configuration_profiles SET syncml = ?, name = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at) WHERE profile_uuid = ?`
+			res, err := tx.ExecContext(ctx, stmt, cp.SyncML, cp.Name, contentChanged || nameChanged, cp.ProfileUUID)
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "updating windows mdm config profile contents")
+				switch {
+				case IsDuplicate(err):
+					// Another Windows profile in the team already holds the name.
+					return ctxerr.Wrap(ctx, &existsError{
+						ResourceType: "MDMWindowsConfigProfile.Name",
+						Identifier:   cp.Name,
+						TeamID:       cp.TeamID,
+					})
+				default:
+					return ctxerr.Wrap(ctx, err, "updating windows mdm config profile contents")
+				}
 			}
 			if aff, _ := res.RowsAffected(); aff == 0 {
 				return ctxerr.Wrap(ctx, notFound("MDMWindowsProfile").WithName(cp.ProfileUUID))
+			}
+
+			// host_mdm_windows_profiles denormalizes the name. A content change
+			// refreshes it via the reinstall upsert, but a rename on identical
+			// content enqueues nothing, so the per-host rows would keep the old
+			// name forever. Same fix the GitOps declaration path applies.
+			if nameChanged {
+				if _, err := tx.ExecContext(ctx,
+					`UPDATE host_mdm_windows_profiles SET profile_name = ? WHERE profile_uuid = ?`,
+					cp.Name, cp.ProfileUUID); err != nil {
+					return ctxerr.Wrap(ctx, err, "updating host windows profile names")
+				}
 			}
 
 			// Track/untrack the team's OS-update profile in the same transaction

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -2245,15 +2245,10 @@ func (ds *Datastore) retainWindowsProfilePriorContentDB(ctx context.Context, tx 
 }
 
 // snapshotWindowsProfileNamesForDeletionDB copies each profile's live name onto its host
-// rows before the profile row is deleted. Those rows outlive the profile so the removal can
-// still be tracked and displayed, and their denormalized profile_name is what reads fall back
-// to once the live name is gone. No-op unless a name actually drifted, so an unrenamed
-// profile costs nothing to delete. The comparison casts to BINARY because the column's
-// utf8mb4_unicode_ci collation is case-insensitive and PAD SPACE, so a plain != would
-// skip a rename that only changed case or trailing space.
-//
-// Only the delete paths need this. While the profile row exists, reads resolve the name from
-// it, so an edit has nothing to snapshot.
+// rows before the profile row is deleted: those rows outlive it, and their denormalized
+// profile_name is what reads fall back to once the live name is gone. Casts to BINARY
+// because the column's collation is case-insensitive, so a plain != would skip a rename
+// that only changed case.
 func snapshotWindowsProfileNamesForDeletionDB(ctx context.Context, tx sqlx.ExtContext, profileUUIDs []string) error {
 	if len(profileUUIDs) == 0 {
 		return nil
@@ -3176,12 +3171,10 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 SET syncml = ?, name = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at)
 WHERE profile_uuid = ?`
 
-			// A name is unique per team across all four profile tables. Each has
-			// its own unique index, but none of them span tables, so a rename
-			// into another platform's name has to be checked here. Guarding in
-			// the statement rather than a preceding SELECT keeps check and write
-			// atomic, as NewMDMWindowsConfigProfile does on insert. Rename-only,
-			// so a content edit can't fail on a pre-existing cross-table duplicate.
+			// A name is unique per team across all four profile tables and no index
+			// spans them, so a cross-platform clash is checked here. In the statement
+			// rather than a preceding SELECT so check and write are atomic, as
+			// NewMDMWindowsConfigProfile does on insert.
 			stmt := setClause
 			args := []any{cp.SyncML, cp.Name, contentChanged || nameChanged, cp.ProfileUUID}
 			if nameChanged {

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3137,11 +3137,6 @@ INSERT INTO
 // UpdateMDMWindowsConfigProfile updates an existing profile's contents (if
 // cp.SyncML is non-empty), name and/or label targeting in place. The profile is
 // keyed by cp.ProfileUUID, so a rename keeps the same row.
-//
-// Retried, because a rename's cross-table NOT EXISTS guard locks rows in the
-// other platforms' profile tables while the create paths lock this one, which
-// deadlocks under concurrent claims of the same name. Every attempt re-reads
-// the profile, so the retry recomputes its own state.
 func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
 	var teamID uint
 	if cp.TeamID != nil {
@@ -3213,9 +3208,10 @@ WHERE profile_uuid = ?`
 			}
 			if aff, _ := res.RowsAffected(); aff == 0 {
 				if nameChanged {
-					// Nothing matched: either the NOT EXISTS guard blocked the
-					// rename, or the row was deleted after the read above. The
-					// read is non-locking, so both are possible.
+					// Nothing matched. Either the NOT EXISTS guard blocked the
+					// rename, or another transaction deleted the profile after
+					// this one read it: the SELECT at the top of this transaction
+					// is a non-locking read, so it doesn't hold the row.
 					var stillExists bool
 					if err := sqlx.GetContext(ctx, tx, &stillExists,
 						`SELECT EXISTS (SELECT 1 FROM mdm_windows_configuration_profiles WHERE profile_uuid = ?)`,

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3142,11 +3142,12 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 SET syncml = ?, name = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at)
 WHERE profile_uuid = ?`
 
-			// A name is unique per team across all four profile tables, but only
-			// this table has an index for it. Guarding in the statement rather
-			// than a preceding SELECT keeps check and write atomic, as
-			// NewMDMWindowsConfigProfile does on insert. Rename-only, so a
-			// content edit can't fail on a pre-existing cross-table duplicate.
+			// A name is unique per team across all four profile tables. Each has
+			// its own unique index, but none of them span tables, so a rename
+			// into another platform's name has to be checked here. Guarding in
+			// the statement rather than a preceding SELECT keeps check and write
+			// atomic, as NewMDMWindowsConfigProfile does on insert. Rename-only,
+			// so a content edit can't fail on a pre-existing cross-table duplicate.
 			stmt := setClause
 			args := []any{cp.SyncML, cp.Name, contentChanged || nameChanged, cp.ProfileUUID}
 			if nameChanged {
@@ -3171,15 +3172,24 @@ WHERE profile_uuid = ?`
 					return ctxerr.Wrap(ctx, err, "updating windows mdm config profile contents")
 				}
 			}
-			// The row was read at the top of this transaction, so on a rename the
-			// only thing that can match nothing is the NOT EXISTS guard.
 			if aff, _ := res.RowsAffected(); aff == 0 {
 				if nameChanged {
-					return ctxerr.Wrap(ctx, &existsError{
-						ResourceType: "MDMWindowsConfigProfile.Name",
-						Identifier:   cp.Name,
-						TeamID:       cp.TeamID,
-					})
+					// Nothing matched: either the NOT EXISTS guard blocked the
+					// rename, or the row was deleted after the read above. The
+					// read is non-locking, so both are possible.
+					var stillExists bool
+					if err := sqlx.GetContext(ctx, tx, &stillExists,
+						`SELECT EXISTS (SELECT 1 FROM mdm_windows_configuration_profiles WHERE profile_uuid = ?)`,
+						cp.ProfileUUID); err != nil {
+						return ctxerr.Wrap(ctx, err, "checking windows config profile after blocked update")
+					}
+					if stillExists {
+						return ctxerr.Wrap(ctx, &existsError{
+							ResourceType: "MDMWindowsConfigProfile.Name",
+							Identifier:   cp.Name,
+							TeamID:       cp.TeamID,
+						})
+					}
 				}
 				return ctxerr.Wrap(ctx, notFound("MDMWindowsProfile").WithName(cp.ProfileUUID))
 			}

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3137,19 +3137,16 @@ func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet
 			}
 
 			// A rename is a fresh upload even when the bytes are identical, so
-			// uploaded_at survives only a true no-op, matching the batch path's
-			// IF(syncml = VALUES(syncml) AND name = VALUES(name), ...).
+			// uploaded_at survives only a true no-op (as in the batch path).
 			const setClause = `UPDATE mdm_windows_configuration_profiles
 SET syncml = ?, name = ?, uploaded_at = IF(?, CURRENT_TIMESTAMP(), uploaded_at)
 WHERE profile_uuid = ?`
 
-			// A name is unique per team across all four profile tables, but the
-			// UPDATE can only rely on this table's own index. Guarding with
-			// NOT EXISTS in the statement itself, rather than a preceding SELECT,
-			// keeps the check and the write atomic -- the same shape
-			// NewMDMWindowsConfigProfile uses on insert. Applied only on a rename
-			// so a content-only edit can't start failing on a pre-existing
-			// cross-table duplicate.
+			// A name is unique per team across all four profile tables, but only
+			// this table has an index for it. Guarding in the statement rather
+			// than a preceding SELECT keeps check and write atomic, as
+			// NewMDMWindowsConfigProfile does on insert. Rename-only, so a
+			// content edit can't fail on a pre-existing cross-table duplicate.
 			stmt := setClause
 			args := []any{cp.SyncML, cp.Name, contentChanged || nameChanged, cp.ProfileUUID}
 			if nameChanged {
@@ -3187,10 +3184,9 @@ WHERE profile_uuid = ?`
 				return ctxerr.Wrap(ctx, notFound("MDMWindowsProfile").WithName(cp.ProfileUUID))
 			}
 
-			// The per-host rows denormalize the name. A content change refreshes
-			// them through the reinstall upsert, but a rename on identical content
-			// enqueues nothing, so update them here (as the GitOps declaration
-			// path does).
+			// The per-host rows denormalize the name, and a rename on identical
+			// content enqueues no reinstall to refresh them (as in the GitOps
+			// declaration path).
 			if nameChanged {
 				if _, err := tx.ExecContext(ctx,
 					`UPDATE host_mdm_windows_profiles SET profile_name = ? WHERE profile_uuid = ?`,

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3103,13 +3103,18 @@ INSERT INTO
 // UpdateMDMWindowsConfigProfile updates an existing profile's contents (if
 // cp.SyncML is non-empty), name and/or label targeting in place. The profile is
 // keyed by cp.ProfileUUID, so a rename keeps the same row.
+//
+// Retried, because a rename's cross-table NOT EXISTS guard locks rows in the
+// other platforms' profile tables while the create paths lock this one, which
+// deadlocks under concurrent claims of the same name. Every attempt re-reads
+// the profile, so the retry recomputes its own state.
 func (ds *Datastore) UpdateMDMWindowsConfigProfile(ctx context.Context, cp fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
 	var teamID uint
 	if cp.TeamID != nil {
 		teamID = *cp.TeamID
 	}
 
-	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		var existing struct {
 			Name   string `db:"name"`
 			SyncML []byte `db:"syncml"`

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -2110,6 +2110,9 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfile(ctx context.Context, profileU
 		if err := ds.retainWindowsProfilePriorContentDB(ctx, tx, []string{profileUUID}); err != nil {
 			return err
 		}
+		if err := snapshotWindowsProfileNamesForDeletionDB(ctx, tx, []string{profileUUID}); err != nil {
+			return err
+		}
 		if err := deleteMDMWindowsConfigProfile(ctx, tx, profileUUID); err != nil {
 			return err
 		}
@@ -2241,6 +2244,34 @@ func (ds *Datastore) retainWindowsProfilePriorContentDB(ctx context.Context, tx 
 	return nil
 }
 
+// snapshotWindowsProfileNamesForDeletionDB copies each profile's live name onto its host
+// rows before the profile row is deleted. Those rows outlive the profile so the removal can
+// still be tracked and displayed, and their denormalized profile_name is what reads fall back
+// to once the live name is gone. No-op unless a name actually drifted, so an unrenamed
+// profile costs nothing to delete. The comparison casts to BINARY because the column's
+// utf8mb4_unicode_ci collation is case-insensitive and PAD SPACE, so a plain != would
+// skip a rename that only changed case or trailing space.
+//
+// Only the delete paths need this. While the profile row exists, reads resolve the name from
+// it, so an edit has nothing to snapshot.
+func snapshotWindowsProfileNamesForDeletionDB(ctx context.Context, tx sqlx.ExtContext, profileUUIDs []string) error {
+	if len(profileUUIDs) == 0 {
+		return nil
+	}
+	stmt, args, err := sqlx.In(`
+		UPDATE host_mdm_windows_profiles hmwp
+		JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = hmwp.profile_uuid
+		SET hmwp.profile_name = mwcp.name
+		WHERE hmwp.profile_uuid IN (?) AND hmwp.profile_name != CAST(mwcp.name AS BINARY)`, profileUUIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building IN for profile name snapshot")
+	}
+	if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "snapshotting windows profile names before deletion")
+	}
+	return nil
+}
+
 // GetWindowsMDMProfilePriorContents returns the retained syncml for the given (profile_uuid, checksum) version keys.
 // Reader-backed; callers that cannot tolerate a replica-lag miss (the reconcile pass consumes each modify-install once) wrap the
 // context with ctxdb.RequirePrimary.
@@ -2289,6 +2320,9 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfileByTeamAndName(ctx context.Cont
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		// Retain the profile's content for the cron to build <Delete> commands from, before the definition row is deleted (#46993).
 		if err := ds.retainWindowsProfilePriorContentDB(ctx, tx, []string{profile.ProfileUUID}); err != nil {
+			return err
+		}
+		if err := snapshotWindowsProfileNamesForDeletionDB(ctx, tx, []string{profile.ProfileUUID}); err != nil {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM mdm_windows_configuration_profiles WHERE profile_uuid=?`, profile.ProfileUUID); err != nil {
@@ -3199,17 +3233,6 @@ WHERE profile_uuid = ?`
 				return ctxerr.Wrap(ctx, notFound("MDMWindowsProfile").WithName(cp.ProfileUUID))
 			}
 
-			// The per-host rows denormalize the name, and a rename on identical
-			// content enqueues no reinstall to refresh them (as in the GitOps
-			// declaration path).
-			if nameChanged {
-				if _, err := tx.ExecContext(ctx,
-					`UPDATE host_mdm_windows_profiles SET profile_name = ? WHERE profile_uuid = ?`,
-					cp.Name, cp.ProfileUUID); err != nil {
-					return ctxerr.Wrap(ctx, err, "updating host windows profile names")
-				}
-			}
-
 			// Track/untrack the team's OS-update profile in the same transaction
 			// so it rolls back with the update. Untracking matters: a profile
 			// edited away from OS-update content must stop blocking the team's
@@ -3489,6 +3512,9 @@ ON DUPLICATE KEY UPDATE
 		if err := ds.retainWindowsProfilePriorContentDB(ctx, tx, deletedProfileUUIDs); err != nil {
 			return false, nil, ctxerr.Wrap(ctx, err, "retain deleted profiles for async removal")
 		}
+		if err := snapshotWindowsProfileNamesForDeletionDB(ctx, tx, deletedProfileUUIDs); err != nil {
+			return false, nil, err
+		}
 	}
 
 	// Step 3: Delete the config profile rows.
@@ -3571,20 +3597,27 @@ ON DUPLICATE KEY UPDATE
 func (ds *Datastore) GetHostMDMWindowsProfiles(ctx context.Context, hostUUID string) ([]fleet.HostMDMWindowsProfile, error) {
 	stmt := fmt.Sprintf(`
 SELECT
-	profile_uuid,
-	profile_name AS name,
+	hmwp.profile_uuid,
+	-- the live profile is the source of truth for the name; hmwp.profile_name is a
+	-- denormalized copy that only answers once the profile row is gone (deleted
+	-- profiles keep their host rows so the removal can still be tracked).
+	COALESCE(mwcp.name, hmwp.profile_name) AS name,
 	-- internally, a NULL status implies that the cron needs to pick up
 	-- this profile, for the user that difference doesn't exist, the
 	-- profile is effectively pending. This is consistent with all our
 	-- aggregation functions.
-	COALESCE(status, '%s') AS status,
-	COALESCE(operation_type, '') AS operation_type,
-	COALESCE(detail, '') AS detail,
-	command_uuid
+	COALESCE(hmwp.status, '%s') AS status,
+	COALESCE(hmwp.operation_type, '') AS operation_type,
+	COALESCE(hmwp.detail, '') AS detail,
+	hmwp.command_uuid
 FROM
-	host_mdm_windows_profiles
+	host_mdm_windows_profiles hmwp
+	LEFT JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = hmwp.profile_uuid
 WHERE
-host_uuid = ? AND profile_name NOT IN(?) AND NOT (operation_type = '%s' AND COALESCE(status, '%s') IN('%s', '%s'))`,
+-- the Fleet-reserved filter reads the stored copy, not the resolved name: reserved
+-- profiles are Fleet-managed and can't be renamed, so the two always agree, and the
+-- stored copy keeps working once a reserved profile has been deleted.
+hmwp.host_uuid = ? AND hmwp.profile_name NOT IN(?) AND NOT (hmwp.operation_type = '%s' AND COALESCE(hmwp.status, '%s') IN('%s', '%s'))`,
 		fleet.MDMDeliveryPending,
 		fleet.MDMOperationTypeRemove,
 		fleet.MDMDeliveryPending,

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -2661,8 +2661,10 @@ func testUpdateMDMWindowsConfigProfile(t *testing.T, ds *Datastore) {
 	require.Equal(t, "A Different Name", stored.Name)
 	require.NoError(t, ds.DeleteMDMAppleConfigProfile(ctx, appleProf.ProfileUUID))
 
-	// a rename must also refresh the denormalized name on the per-host rows,
-	// which a content-only edit gets for free from the reinstall upsert.
+	// A rename does NOT write the per-host rows: reads resolve the name from the
+	// live profile, so the denormalized copy is allowed to go stale while the
+	// profile exists. Renaming with identical content enqueues nothing, so if the
+	// rename wrote those rows this host would be touched.
 	hostUUID := uuid.NewString()
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx,
@@ -2683,7 +2685,67 @@ func testUpdateMDMWindowsConfigProfile(t *testing.T, ds *Datastore) {
 			`SELECT profile_name FROM host_mdm_windows_profiles WHERE host_uuid = ? AND profile_uuid = ?`,
 			hostUUID, initial.ProfileUUID)
 	})
-	require.Equal(t, "Renamed Again", hostProfileName)
+	require.Equal(t, "A Different Name", hostProfileName, "the rename must not write per-host rows")
+
+	// but the host's profile list still reports the current name, resolved from the
+	// live profile row rather than the stale copy above
+	hostProfs, err := ds.GetHostMDMWindowsProfiles(ctx, hostUUID)
+	require.NoError(t, err)
+	require.Len(t, hostProfs, 1)
+	require.Equal(t, "Renamed Again", hostProfs[0].Name)
+
+	// once the profile is deleted the live name is gone, so the copy has to have been
+	// snapshotted on the way out or the host would show the pre-rename name
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`UPDATE host_mdm_windows_profiles SET operation_type = ?, status = NULL WHERE profile_uuid = ?`,
+			fleet.MDMOperationTypeRemove, initial.ProfileUUID)
+		return err
+	})
+	require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, initial.ProfileUUID))
+	hostProfs, err = ds.GetHostMDMWindowsProfiles(ctx, hostUUID)
+	require.NoError(t, err)
+	require.Len(t, hostProfs, 1)
+	require.Equal(t, "Renamed Again", hostProfs[0].Name, "deleted profile must keep its post-rename name")
+
+	// recreate so the assertions below keep reading as before
+	initial, err = ds.NewMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		Name:   "Renamed Again",
+		SyncML: newSyncML,
+	}, nil)
+	require.NoError(t, err)
+
+	// A rename that only changes case must still be snapshotted on delete. The
+	// name column is utf8mb4_unicode_ci, so the snapshot's "has it drifted" check
+	// has to compare as BINARY or MySQL calls these two names equal and skips it.
+	caseHostUUID := uuid.NewString()
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO host_mdm_windows_profiles (host_uuid, profile_uuid, profile_name, command_uuid, checksum)
+			 VALUES (?, ?, ?, ?, UNHEX(MD5(?)))`,
+			caseHostUUID, initial.ProfileUUID, "Renamed Again", uuid.NewString(), newSyncML)
+		return err
+	})
+	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		ProfileUUID: initial.ProfileUUID,
+		Name:        "RENAMED AGAIN",
+		SyncML:      newSyncML,
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, initial.ProfileUUID))
+	var caseStoredName string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &caseStoredName,
+			`SELECT profile_name FROM host_mdm_windows_profiles WHERE host_uuid = ?`, caseHostUUID)
+	})
+	require.Equal(t, "RENAMED AGAIN", caseStoredName, "a case-only rename must still be snapshotted")
+
+	// recreate again for the remaining assertions
+	initial, err = ds.NewMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		Name:   "Renamed Again",
+		SyncML: newSyncML,
+	}, nil)
+	require.NoError(t, err)
 
 	// put the name back so the assertions below keep reading as before
 	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5" // nolint:gosec // used only to hash for efficient comparisons
 	"database/sql"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -22,6 +23,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
+	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/test"
@@ -2592,16 +2594,84 @@ func testUpdateMDMWindowsConfigProfile(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, newSyncML, stored.SyncML)
 
-	// mismatched name is rejected -- Windows profiles have no separate identifier
-	// field, so name is the only identity a profile has. This is the only layer
-	// this can be tested at: the service layer never exposes a way for a client
-	// to submit a different name on an edit.
-	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+	// a rename is applied in place: same row, new name, and uploaded_at moves
+	// because the admin uploaded a differently named file.
+	// Backdate uploaded_at rather than comparing against "now": the column is
+	// written with CURRENT_TIMESTAMP(), which is second-granular, so a rename in
+	// the same second as the previous write would otherwise look unchanged.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`UPDATE mdm_windows_configuration_profiles SET uploaded_at = DATE_SUB(NOW(), INTERVAL 1 HOUR) WHERE profile_uuid = ?`,
+			initial.ProfileUUID)
+		return err
+	})
+	beforeRename, err := ds.GetMDMWindowsConfigProfile(ctx, initial.ProfileUUID)
+	require.NoError(t, err)
+	// identical content, so only the rename can move uploaded_at
+	renamed, err := ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
 		ProfileUUID: initial.ProfileUUID,
 		Name:        "A Different Name",
 		SyncML:      newSyncML,
 	}, nil)
-	require.ErrorContains(t, err, "must match the existing profile's name")
+	require.NoError(t, err)
+	require.Equal(t, initial.ProfileUUID, renamed.ProfileUUID)
+	require.Equal(t, "A Different Name", renamed.Name)
+	require.True(t, renamed.UploadedAt.After(beforeRename.UploadedAt))
+
+	stored, err = ds.GetMDMWindowsConfigProfile(ctx, initial.ProfileUUID)
+	require.NoError(t, err)
+	require.Equal(t, "A Different Name", stored.Name)
+
+	// the old name is free again, so a new profile can claim it
+	reclaimed, err := ds.NewMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		Name:   "Update Test Profile",
+		SyncML: newSyncML,
+	}, nil)
+	require.NoError(t, err)
+
+	// renaming onto a name another profile in the team already holds is rejected
+	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		ProfileUUID: initial.ProfileUUID,
+		Name:        "Update Test Profile",
+		SyncML:      newSyncML,
+	}, nil)
+	require.Error(t, err)
+	_, isExists := errors.AsType[endpointer.ExistsErrorInterface](err)
+	require.True(t, isExists, "expected an exists error, got %v", err)
+
+	require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, reclaimed.ProfileUUID))
+
+	// a rename must also refresh the denormalized name on the per-host rows,
+	// which a content-only edit gets for free from the reinstall upsert.
+	hostUUID := uuid.NewString()
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO host_mdm_windows_profiles (host_uuid, profile_uuid, profile_name, command_uuid, checksum)
+			 VALUES (?, ?, ?, ?, UNHEX(MD5(?)))`,
+			hostUUID, initial.ProfileUUID, "A Different Name", uuid.NewString(), newSyncML)
+		return err
+	})
+	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		ProfileUUID: initial.ProfileUUID,
+		Name:        "Renamed Again",
+		SyncML:      newSyncML, // identical content, so nothing is enqueued for the host
+	}, nil)
+	require.NoError(t, err)
+	var hostProfileName string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &hostProfileName,
+			`SELECT profile_name FROM host_mdm_windows_profiles WHERE host_uuid = ? AND profile_uuid = ?`,
+			hostUUID, initial.ProfileUUID)
+	})
+	require.Equal(t, "Renamed Again", hostProfileName)
+
+	// put the name back so the assertions below keep reading as before
+	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		ProfileUUID: initial.ProfileUUID,
+		Name:        initial.Name,
+		SyncML:      newSyncML,
+	}, nil)
+	require.NoError(t, err)
 
 	// updating a nonexistent profile returns a not-found error
 	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -2641,6 +2641,26 @@ func testUpdateMDMWindowsConfigProfile(t *testing.T, ds *Datastore) {
 
 	require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, reclaimed.ProfileUUID))
 
+	// renaming onto a name held by ANOTHER PLATFORM's profile is rejected too:
+	// that collision has no index behind it, so it's the NOT EXISTS guard in the
+	// UPDATE that catches it, not a duplicate-key error.
+	appleProf, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("cross-platform-name", "com.example.cross", 0), nil)
+	require.NoError(t, err)
+	_, err = ds.UpdateMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		ProfileUUID: initial.ProfileUUID,
+		Name:        "cross-platform-name",
+		SyncML:      newSyncML,
+	}, nil)
+	require.Error(t, err)
+	_, isExists = errors.AsType[endpointer.ExistsErrorInterface](err)
+	require.True(t, isExists, "expected an exists error, got %v", err)
+
+	// the blocked rename left the profile alone
+	stored, err = ds.GetMDMWindowsConfigProfile(ctx, initial.ProfileUUID)
+	require.NoError(t, err)
+	require.Equal(t, "A Different Name", stored.Name)
+	require.NoError(t, ds.DeleteMDMAppleConfigProfile(ctx, appleProf.ProfileUUID))
+
 	// a rename must also refresh the denormalized name on the per-host rows,
 	// which a content-only edit gets for free from the reinstall upsert.
 	hostUUID := uuid.NewString()

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -342,6 +342,9 @@ func (ds *Datastore) prepareWindowsProfilesForTeamDeletion(ctx context.Context, 
 		if err := ds.retainWindowsProfilePriorContentDB(ctx, tx, profileUUIDs); err != nil {
 			return ctxerr.Wrapf(ctx, err, "retaining windows profiles for team %d", tid)
 		}
+		if err := snapshotWindowsProfileNamesForDeletionDB(ctx, tx, profileUUIDs); err != nil {
+			return ctxerr.Wrapf(ctx, err, "snapshotting windows profile names for team %d", tid)
+		}
 
 		hosts, err := ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, profileUUIDs)
 		if err != nil {

--- a/server/fleet/request.go
+++ b/server/fleet/request.go
@@ -16,8 +16,9 @@ const (
 	// enforces (the extra 0.5 MiB is base64 headroom, not usable content).
 	MaxProfileSizeErrMsg = "maximum configuration profile file size is 1 MB"
 	// MaxProfileNameLength matches the `name` column on the profile tables, which
-	// is varchar(255) and so counts characters, not bytes. Validated up front
-	// because MySQL would otherwise reject the write as a 500.
+	// is varchar(255) and so counts characters, not bytes. Validated up front so
+	// the caller gets this message instead of MySQL's raw "Data too long for
+	// column 'name'".
 	MaxProfileNameLength             = 255
 	MaxProfileNameLengthErrMsg       = "maximum configuration profile name length is 255 characters"
 	MaxMDMAssetSize            int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding

--- a/server/fleet/request.go
+++ b/server/fleet/request.go
@@ -14,11 +14,16 @@ const (
 	MaxBatchProfileSize      int64 = 25 * units.MiB
 	// MaxProfileSizeErrMsg reports the ~1MB content limit that MaxProfileSize
 	// enforces (the extra 0.5 MiB is base64 headroom, not usable content).
-	MaxProfileSizeErrMsg       = "maximum configuration profile file size is 1 MB"
-	MaxMDMAssetSize      int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
-	MaxEULASize          int64 = 25 * units.MiB
-	MaxSoftwareBatchSize int64 = 25 * units.MiB // Takes multiple installers, with scripts and queries
-	MaxMDMCommandSize    int64 = 2 * units.MiB
+	MaxProfileSizeErrMsg = "maximum configuration profile file size is 1 MB"
+	// MaxProfileNameLength matches the `name` column on the profile tables, which
+	// is varchar(255) and so counts characters, not bytes. Validated up front
+	// because MySQL would otherwise reject the write as a 500.
+	MaxProfileNameLength             = 255
+	MaxProfileNameLengthErrMsg       = "maximum configuration profile name length is 255 characters"
+	MaxMDMAssetSize            int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
+	MaxEULASize                int64 = 25 * units.MiB
+	MaxSoftwareBatchSize       int64 = 25 * units.MiB // Takes multiple installers, with scripts and queries
+	MaxMDMCommandSize          int64 = 2 * units.MiB
 	// MaxMultiScriptQuerySize, sets a max size for payloads that take multiple scripts and SQL queries.
 	MaxMultiScriptQuerySize int64 = 5 * units.MiB
 	MaxMicrosoftMDMSize     int64 = 2 * units.MiB

--- a/server/fleet/request.go
+++ b/server/fleet/request.go
@@ -15,10 +15,8 @@ const (
 	// MaxProfileSizeErrMsg reports the ~1MB content limit that MaxProfileSize
 	// enforces (the extra 0.5 MiB is base64 headroom, not usable content).
 	MaxProfileSizeErrMsg = "maximum configuration profile file size is 1 MB"
-	// MaxProfileNameLength matches the `name` column on the profile tables, which
-	// is varchar(255) and so counts characters, not bytes. Validated up front so
-	// the caller gets this message instead of MySQL's raw "Data too long for
-	// column 'name'".
+	// MaxProfileNameLength matches the profile tables' varchar(255) `name` column,
+	// so it counts characters, not bytes.
 	MaxProfileNameLength             = 255
 	MaxProfileNameLengthErrMsg       = "maximum configuration profile name length is 255 characters"
 	MaxMDMAssetSize            int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1299,9 +1299,8 @@ type Service interface {
 	// Android profiles.
 	//
 	// profileName is the uploaded file's name without its extension, empty when
-	// the request carried no file. Only profile types whose name comes from the
-	// file name use it; an Apple .mobileconfig takes its name from the content's
-	// PayloadDisplayName instead.
+	// the request carried no file. Unused by Apple .mobileconfig, which is named
+	// by the PayloadDisplayName in its content.
 	UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error
 
 	// ListMDMConfigProfiles returns a list of paginated configuration profiles.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1297,7 +1297,12 @@ type Service interface {
 	// contents and/or label targeting in place. Supported for Apple
 	// .mobileconfig profiles, Apple DDM declarations, Windows profiles, and
 	// Android profiles.
-	UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error
+	//
+	// profileName is the uploaded file's name without its extension, empty when
+	// the request carried no file. Only profile types whose name comes from the
+	// file name use it; an Apple .mobileconfig takes its name from the content's
+	// PayloadDisplayName instead.
+	UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error
 
 	// ListMDMConfigProfiles returns a list of paginated configuration profiles.
 	ListMDMConfigProfiles(ctx context.Context, teamID *uint, opt ListOptions) ([]*MDMConfigProfilePayload, *PaginationMetadata, error)

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
@@ -113,6 +114,9 @@ func (m *MDMWindowsConfigProfile) ValidateUserProvided(allowCustomDiskEncryption
 	fleetNames := mdm.FleetReservedProfileNames()
 	if _, ok := fleetNames[m.Name]; ok {
 		return fmt.Errorf("Profile name %q is not allowed.", m.Name)
+	}
+	if utf8.RuneCountInString(m.Name) > MaxProfileNameLength {
+		return errors.New(MaxProfileNameLengthErrMsg + ".")
 	}
 
 	validator := newWindowsProfileValidator(m.SyncML, allowCustomDiskEncryption)

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -773,7 +773,7 @@ type NewMDMActivationUnsupportedProfileFunc func(ctx context.Context, teamID uin
 
 type NewMDMInvalidJSONConfigProfileFunc func(ctx context.Context, teamID uint, err error) error
 
-type UpdateMDMConfigProfileFunc func(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error
+type UpdateMDMConfigProfileFunc func(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error
 
 type ListMDMConfigProfilesFunc func(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.MDMConfigProfilePayload, *fleet.PaginationMetadata, error)
 
@@ -5132,11 +5132,11 @@ func (s *Service) NewMDMInvalidJSONConfigProfile(ctx context.Context, teamID uin
 	return s.NewMDMInvalidJSONConfigProfileFunc(ctx, teamID, err)
 }
 
-func (s *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error {
+func (s *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error {
 	s.mu.Lock()
 	s.UpdateMDMConfigProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpdateMDMConfigProfileFunc(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny, activation)
+	return s.UpdateMDMConfigProfileFunc(ctx, profileUUID, profileName, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny, activation)
 }
 
 func (s *Service) ListMDMConfigProfiles(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.MDMConfigProfilePayload, *fleet.PaginationMetadata, error) {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1013,7 +1013,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		assert.Empty(t, updated.Mobileconfig)
@@ -1043,7 +1043,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, mcBytes, []byte(updated.Mobileconfig))
 		assert.Equal(t, "Test Profile", updated.Name)
@@ -1070,7 +1070,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, "New Name", updated.Name)
 
@@ -1097,7 +1097,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarHostEndUserEmailIDP)
 	})
@@ -1120,7 +1120,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		require.NotNil(t, updated.SecretsUpdatedAt)
 		assert.True(t, secretsUpdatedAt.Equal(*updated.SecretsUpdatedAt))
@@ -1140,7 +1140,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, mcBytes, []byte(updated.Mobileconfig))
 		require.Len(t, updated.LabelsIncludeAny, 1)
@@ -1162,7 +1162,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "PayloadIdentifier must match")
 	})
@@ -1182,7 +1182,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, existsErrorForTest{}
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, SameProfileNameUploadErrorMsg)
 
@@ -1203,7 +1203,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -1215,7 +1215,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "a"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, "a"+uuid.NewString(), "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -1232,7 +1232,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "Scoping configuration profiles")
 
@@ -1241,7 +1241,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 		mcBytes := mcBytesForTest("Test Profile", "com.fleetdm.test", "UUID")
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 	})
 
@@ -1261,13 +1261,13 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 		}
 
 		mcBytes := mcBytesForTest("Test Profile", "com.fleetdm.test", "UUID")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", mcBytes, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -1322,10 +1322,10 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 				// this isolates the authz checks from content/label validation,
 				// so a failure can only come from permissions, not some other
 				// unrelated rejection.
-				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 				checkShouldFail(t, err, tt.shouldFailGlobal)
 
-				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 				checkShouldFail(t, err, tt.shouldFailTeam)
 			})
 		}
@@ -1468,7 +1468,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1508,7 +1508,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newAct := activationBytesForTest("com.fleet.actD1.v2", "com.fleet.configD1")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.SetSlice(newAct))
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.SetSlice(newAct))
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1546,7 +1546,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		// no profile content, no activation -- just labels. The datastore
 		// clears the activation of any declaration written without one, so the
 		// stored activation has to be carried forward here.
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label-1"}, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, []string{"label-1"}, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1575,7 +1575,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return d, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID,
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "",
 			declBytesForTest("D1", "updated-content"), nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
@@ -1603,7 +1603,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		// activationSet with no content is how the API says "remove it".
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{Set: true})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{Set: true})
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1628,7 +1628,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1663,7 +1663,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return d, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarHostUUID)
 		require.NotNil(t, capturedDecl)
@@ -1686,10 +1686,10 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -1707,7 +1707,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1737,7 +1737,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1766,7 +1766,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		mismatchedContent := declarationForTestWithType("com.fleet.configD2", "com.apple.configuration.management.test")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, mismatchedContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", mismatchedContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Identifier must match the existing profile's")
 	})
@@ -1784,7 +1784,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		invalidContent := declarationForTestWithType(existing.Identifier, "com.example.not-a-real-type")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", invalidContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
 	})
@@ -1801,7 +1801,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"}, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"}, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `label "label1" cannot appear in both include and exclude lists`)
 	})
@@ -1818,7 +1818,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -1830,7 +1830,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "d"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, "d"+uuid.NewString(), "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -1851,7 +1851,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		// generic ExistsErrorInterface -> 409 mapping rather than any specific
 		// identifier collision.
 		newContent := declarationForTestWithType(existing.Identifier, "com.apple.configuration.management.test")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Couldn't edit. A configuration profile with this identifier already exists.")
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -4100,10 +4100,9 @@ func (s *integrationMDMTestSuite) TestUpdateConfigProfile() {
 	// Windows
 	//
 
-	// content-only edit; the uploaded filename is ignored, the profile keeps
-	// its name
+	// an edit keeping the same file name leaves the name alone
 	winContent2 := syncMLForTest("./TestUpdateProfileEdited")
-	res = patchProfile(winUUID, "some-other-filename.xml", winContent2, nil, http.StatusOK)
+	res = patchProfile(winUUID, "update-win-profile.xml", winContent2, nil, http.StatusOK)
 	patchResp = decodePatchResp(res)
 	require.Equal(t, winUUID, patchResp.ProfileUUID)
 	require.Equal(t, winContent2, downloadProfile(winUUID))
@@ -4111,7 +4110,27 @@ func (s *integrationMDMTestSuite) TestUpdateConfigProfile() {
 	require.Equal(t, "update-win-profile", prof.Name)
 	assertEditedActivity(fleet.ActivityTypeEditedWindowsProfile{}.ActivityName(), "update-win-profile", "")
 
-	// labels-only edit
+	// a differently named file renames the profile in place: same UUID, and the
+	// activity reports the new name
+	winContent3 := syncMLForTest("./TestUpdateProfileRenamed")
+	res = patchProfile(winUUID, "update-win-profile-renamed.xml", winContent3, nil, http.StatusOK)
+	patchResp = decodePatchResp(res)
+	require.Equal(t, winUUID, patchResp.ProfileUUID)
+	require.Equal(t, winContent3, downloadProfile(winUUID))
+	prof = getProfile(winUUID)
+	require.Equal(t, "update-win-profile-renamed", prof.Name)
+	assertEditedActivity(fleet.ActivityTypeEditedWindowsProfile{}.ActivityName(), "update-win-profile-renamed", "")
+
+	// renaming onto a name another profile in the fleet holds is rejected, and
+	// leaves the profile untouched
+	winOtherUUID := createProfile("update-win-other.xml", syncMLForTest("./TestUpdateOther"), fleet.MDMWindowsProfileUUIDPrefix)
+	require.NotEmpty(t, winOtherUUID)
+	res = patchProfile(winUUID, "update-win-other.xml", winContent3, nil, http.StatusConflict)
+	require.Contains(t, extractServerErrorText(res.Body), "already exists")
+	require.Equal(t, "update-win-profile-renamed", getProfile(winUUID).Name)
+	require.Equal(t, winContent3, downloadProfile(winUUID))
+
+	// labels-only edit; no file, so the name is left alone
 	res = patchProfile(winUUID, "", nil, map[string][]string{"labels_include_all": {lblA.Name, lblB.Name}}, http.StatusOK)
 	patchResp = decodePatchResp(res)
 	require.Equal(t, winUUID, patchResp.ProfileUUID)
@@ -4123,8 +4142,9 @@ func (s *integrationMDMTestSuite) TestUpdateConfigProfile() {
 		{LabelID: lblA.ID, LabelName: lblA.Name},
 		{LabelID: lblB.ID, LabelName: lblB.Name},
 	}, prof.LabelsIncludeAll)
-	require.Equal(t, winContent2, downloadProfile(winUUID))
-	assertEditedActivity(fleet.ActivityTypeEditedWindowsProfile{}.ActivityName(), "update-win-profile", "")
+	require.Equal(t, "update-win-profile-renamed", prof.Name)
+	require.Equal(t, winContent3, downloadProfile(winUUID))
+	assertEditedActivity(fleet.ActivityTypeEditedWindowsProfile{}.ActivityName(), "update-win-profile-renamed", "")
 
 	//
 	// Apple DDM declaration

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2083,9 +2083,8 @@ func updateMDMConfigProfileEndpoint(ctx context.Context, request any, svc fleet.
 		activation.Set = true
 	}
 
-	// Mirrors the create endpoint: the name of a profile type that has no
-	// identifier inside its content comes from the uploaded file's name. Empty
-	// when the request is labels-only, which leaves the stored name alone.
+	// Named after the uploaded file, like the create endpoint. Empty on a
+	// labels-only edit, which keeps the stored name.
 	var profileName string
 	if req.Profile != nil {
 		profileName = strings.TrimSuffix(filepath.Base(req.Profile.Filename), filepath.Ext(req.Profile.Filename))

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2083,7 +2083,15 @@ func updateMDMConfigProfileEndpoint(ctx context.Context, request any, svc fleet.
 		activation.Set = true
 	}
 
-	if err := svc.UpdateMDMConfigProfile(ctx, req.ProfileUUID, data, labels, labelsMode, req.LabelsExcludeAny, activation); err != nil {
+	// Mirrors the create endpoint: the name of a profile type that has no
+	// identifier inside its content comes from the uploaded file's name. Empty
+	// when the request is labels-only, which leaves the stored name alone.
+	var profileName string
+	if req.Profile != nil {
+		profileName = strings.TrimSuffix(filepath.Base(req.Profile.Filename), filepath.Ext(req.Profile.Filename))
+	}
+
+	if err := svc.UpdateMDMConfigProfile(ctx, req.ProfileUUID, profileName, data, labels, labelsMode, req.LabelsExcludeAny, activation); err != nil {
 		return &updateMDMConfigProfileResponse{Err: err}, nil
 	}
 
@@ -2168,7 +2176,7 @@ func (svc *Service) checkLabelsOnlyProfileUpdate(ctx context.Context, labelsIncl
 // UpdateMDMConfigProfile updates an existing configuration profile's contents
 // and/or label targeting in place, dispatching by profile UUID to the
 // platform-specific implementation.
-func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error {
+func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation optjson.Slice[byte]) error {
 	// The edit path resolves the profile type here rather than in the endpoint.
 	// Keyed on activationSet, not on the content: clearing an activation is just
 	// as meaningless on a profile that can't have one.
@@ -2186,7 +2194,7 @@ func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID stri
 	case isAppleProfileUUID(profileUUID):
 		return svc.updateMDMAppleConfigProfile(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 	case isWindowsProfileUUID(profileUUID):
-		return svc.updateMDMWindowsConfigProfile(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
+		return svc.updateMDMWindowsConfigProfile(ctx, profileUUID, profileName, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 	case isAndroidProfileUUID(profileUUID):
 		return svc.updateMDMAndroidConfigProfile(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 	case isAppleDeclarationUUID(profileUUID):

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2033,12 +2033,12 @@ func TestUpdateMDMConfigProfileDispatch(t *testing.T) {
 		return nil, errors.New("simulated declaration lookup error")
 	}
 
-	err := svc.UpdateMDMConfigProfile(ctx, declUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+	err := svc.UpdateMDMConfigProfile(ctx, declUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 	require.ErrorContains(t, err, "simulated declaration lookup error")
 	require.True(t, ds.GetMDMAppleDeclarationFuncInvoked)
 
 	// an unrecognized profile UUID prefix still falls through to "not supported".
-	err = svc.UpdateMDMConfigProfile(ctx, "unrecognized-"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+	err = svc.UpdateMDMConfigProfile(ctx, "unrecognized-"+uuid.NewString(), "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "updating this profile type is not yet supported")
 
@@ -2054,7 +2054,7 @@ func TestUpdateMDMConfigProfileDispatch(t *testing.T) {
 			{"explicitly emptied", nil},
 		} {
 			t.Run(prefix+" "+tc.name, func(t *testing.T) {
-				err := svc.UpdateMDMConfigProfile(ctx, prefix+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, optjson.SetSlice(tc.activation))
+				err := svc.UpdateMDMConfigProfile(ctx, prefix+uuid.NewString(), "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.SetSlice(tc.activation))
 				require.Error(t, err)
 				assert.ErrorContains(t, err, ActivationUnsupportedProfileErrorMsg)
 			})
@@ -4337,7 +4337,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		assert.Empty(t, updated.RawJSON)
@@ -4370,7 +4370,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, newContent, updated.RawJSON)
 		assert.Equal(t, existing.Name, updated.Name)
@@ -4400,7 +4400,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, newContent, updated.RawJSON)
 		require.NotNil(t, updated.TeamID)
@@ -4429,7 +4429,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, newContent, updated.RawJSON)
 		require.Len(t, updated.LabelsIncludeAny, 1)
@@ -4451,7 +4451,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 		}
 
 		invalidContent := []byte(`{"notARealAndroidPolicyField": true}`)
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", invalidContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Invalid JSON payload")
 	})
@@ -4468,7 +4468,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"}, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"}, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `label "label1" cannot appear in both include and exclude lists`)
 	})
@@ -4485,7 +4485,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -4497,7 +4497,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "g"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, "g"+uuid.NewString(), "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -4514,7 +4514,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "Scoping configuration profiles with labels requires Fleet Premium license")
 
@@ -4523,7 +4523,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 		newContent := []byte(`{"screenCaptureDisabled": false}`)
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 	})
 
@@ -4544,14 +4544,14 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 		}
 
 		newContent := []byte(`{"name": "$FLEET_VAR_HOST_UUID"}`)
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarHostUUID)
 
 		// labels-only edit passes no variables -- the datastore leaves the
 		// existing associations untouched when no content is provided
 		capturedVars = []fleet.FleetVarName{fleet.FleetVarName("sentinel")}
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Empty(t, capturedVars)
 	})
@@ -4572,10 +4572,10 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 		}
 
 		newContent := []byte(`{"screenCaptureDisabled": false}`)
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", newContent, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -4628,10 +4628,10 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 
 				// profile content and labels are deliberately nil/empty here --
 				// this isolates the authz checks from content/label validation.
-				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 				checkShouldFail(t, err, tt.shouldFailGlobal)
 
-				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 				checkShouldFail(t, err, tt.shouldFailTeam)
 			})
 		}

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -160,11 +160,12 @@ func (svc *Service) parseAndValidateWindowsConfigProfile(ctx context.Context, te
 }
 
 // updateMDMWindowsConfigProfile implements the Windows branch of
-// UpdateMDMConfigProfile. A profile's name cannot change here: unlike Apple
-// profiles there is no separate identifier, so name is a Windows profile's
-// only identity (GitOps likewise treats a rename as delete-then-insert, not
-// an edit).
-func (svc *Service) updateMDMWindowsConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error {
+// UpdateMDMConfigProfile. A Windows .xml carries no identifier, so the profile
+// is identified by its UUID here and the uploaded file's name replaces the
+// stored one. The rename is in place: the profile keeps its UUID, its label
+// targeting and its per-host delivery state, unlike GitOps where a renamed
+// profile is delete-then-insert because that path matches on name.
+func (svc *Service) updateMDMWindowsConfigProfile(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error {
 	// first we perform a basic authz check
 	if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionRead); err != nil {
 		return ctxerr.Wrap(ctx, err)
@@ -197,7 +198,15 @@ func (svc *Service) updateMDMWindowsConfigProfile(ctx context.Context, profileUU
 	var cp *fleet.MDMWindowsConfigProfile
 	var usesFleetVars []fleet.FleetVarName
 	if len(profile) > 0 {
-		cp, usesFleetVars, _, err = svc.parseAndValidateWindowsConfigProfile(ctx, teamID, existing.Name, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
+		// A caller that sends content without a file name (not reachable from the
+		// endpoint, which always derives one) keeps the stored name.
+		newName := profileName
+		if newName == "" {
+			newName = existing.Name
+		}
+		// parseAndValidateWindowsConfigProfile validates the name too, so a rename
+		// onto a Fleet-reserved name is rejected here just like on create.
+		cp, usesFleetVars, _, err = svc.parseAndValidateWindowsConfigProfile(ctx, teamID, newName, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 		if err != nil {
 			return err
 		}
@@ -225,6 +234,9 @@ func (svc *Service) updateMDMWindowsConfigProfile(ctx context.Context, profileUU
 	cp.ProfileUUID = profileUUID
 
 	if _, err := svc.ds.UpdateMDMWindowsConfigProfile(ctx, *cp, usesFleetVars); err != nil {
+		if _, ok := errors.AsType[endpointer.ExistsErrorInterface](err); ok {
+			err = fleet.NewInvalidArgumentError("profile", SameProfileNameUploadErrorMsg).WithStatus(http.StatusConflict)
+		}
 		return ctxerr.Wrap(ctx, err)
 	}
 

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -160,11 +160,10 @@ func (svc *Service) parseAndValidateWindowsConfigProfile(ctx context.Context, te
 }
 
 // updateMDMWindowsConfigProfile implements the Windows branch of
-// UpdateMDMConfigProfile. A Windows .xml carries no identifier, so the profile
-// is identified by its UUID here and the uploaded file's name replaces the
-// stored one. The rename is in place: the profile keeps its UUID, its label
-// targeting and its per-host delivery state, unlike GitOps where a renamed
-// profile is delete-then-insert because that path matches on name.
+// UpdateMDMConfigProfile. A Windows .xml carries no identifier, so the profile is
+// keyed by UUID here and the uploaded file's name replaces the stored one. The
+// rename is in place, unlike GitOps, which matches on name and so treats a rename
+// as delete-then-insert.
 func (svc *Service) updateMDMWindowsConfigProfile(ctx context.Context, profileUUID string, profileName string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error {
 	// first we perform a basic authz check
 	if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionRead); err != nil {
@@ -198,14 +197,13 @@ func (svc *Service) updateMDMWindowsConfigProfile(ctx context.Context, profileUU
 	var cp *fleet.MDMWindowsConfigProfile
 	var usesFleetVars []fleet.FleetVarName
 	if len(profile) > 0 {
-		// A caller that sends content without a file name (not reachable from the
-		// endpoint, which always derives one) keeps the stored name.
+		// Content with no file name is not reachable from the endpoint; fall back
+		// rather than blanking the name.
 		newName := profileName
 		if newName == "" {
 			newName = existing.Name
 		}
-		// parseAndValidateWindowsConfigProfile validates the name too, so a rename
-		// onto a Fleet-reserved name is rejected here just like on create.
+		// Validates the name too, so a rename onto a Fleet-reserved name is rejected.
 		cp, usesFleetVars, _, err = svc.parseAndValidateWindowsConfigProfile(ctx, teamID, newName, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 		if err != nil {
 			return err

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -678,7 +678,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 
 		assert.Empty(t, updated.SyncML)
@@ -714,7 +714,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, syncML, updated.SyncML)
 		assert.Equal(t, existing.Name, updated.Name)
@@ -723,6 +723,75 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 		act, ok := firedActivity.(*fleet.ActivityTypeEditedWindowsProfile)
 		require.True(t, ok)
 		assert.Equal(t, existing.Name, act.ProfileName)
+	})
+
+	t.Run("uploading a differently named file renames the profile", func(t *testing.T) {
+		svc, ctx, ds, opts := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingProfile("disable-onedrive", 0)
+		syncML := syncMLForTest("./Device/Vendor/MSFT/Firewall/MdmStore/DomainProfile/EnableFirewall")
+
+		ds.GetMDMWindowsConfigProfileFunc = func(ctx context.Context, puid string) (*fleet.MDMWindowsConfigProfile, error) {
+			return existing, nil
+		}
+		var updated fleet.MDMWindowsConfigProfile
+		ds.UpdateMDMWindowsConfigProfileFunc = func(ctx context.Context, p fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
+			updated = p
+			return &p, nil
+		}
+		var firedActivity activity_api.ActivityDetails
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+			firedActivity = activity
+			return nil
+		}
+
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "enable-firewall", syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		require.NoError(t, err)
+		assert.Equal(t, syncML, updated.SyncML)
+		assert.Equal(t, "enable-firewall", updated.Name)
+		// the profile keeps its identity: a rename is not a delete + recreate
+		assert.Equal(t, existing.ProfileUUID, updated.ProfileUUID)
+
+		// the activity has to name the profile as it is now, not as it was
+		require.NotNil(t, firedActivity)
+		act, ok := firedActivity.(*fleet.ActivityTypeEditedWindowsProfile)
+		require.True(t, ok)
+		assert.Equal(t, "enable-firewall", act.ProfileName)
+	})
+
+	t.Run("a labels-only edit keeps the stored name", func(t *testing.T) {
+		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingProfile("disable-onedrive", 0)
+
+		ds.GetMDMWindowsConfigProfileFunc = func(ctx context.Context, puid string) (*fleet.MDMWindowsConfigProfile, error) {
+			return existing, nil
+		}
+		var updated fleet.MDMWindowsConfigProfile
+		ds.UpdateMDMWindowsConfigProfileFunc = func(ctx context.Context, p fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
+			updated = p
+			return &p, nil
+		}
+
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		require.NoError(t, err)
+		assert.Equal(t, "disable-onedrive", updated.Name)
+	})
+
+	t.Run("renaming onto a Fleet-reserved name is rejected", func(t *testing.T) {
+		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingProfile("disable-onedrive", 0)
+		syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode")
+
+		ds.GetMDMWindowsConfigProfileFunc = func(ctx context.Context, puid string) (*fleet.MDMWindowsConfigProfile, error) {
+			return existing, nil
+		}
+		ds.UpdateMDMWindowsConfigProfileFunc = func(ctx context.Context, p fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
+			return &p, nil
+		}
+
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mdm.FleetWindowsOSUpdatesProfileName, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "is not allowed")
+		require.False(t, ds.UpdateMDMWindowsConfigProfileFuncInvoked)
 	})
 
 	t.Run("profile content update for a team-scoped profile", func(t *testing.T) {
@@ -744,7 +813,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, syncML, updated.SyncML)
 		require.NotNil(t, updated.TeamID)
@@ -773,7 +842,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", syncML, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Equal(t, syncML, updated.SyncML)
 		require.Len(t, updated.LabelsIncludeAny, 1)
@@ -794,7 +863,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -806,7 +875,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "w"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, "w"+uuid.NewString(), "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -823,7 +892,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "Scoping configuration profiles with labels requires Fleet Premium license")
 
@@ -832,7 +901,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 		syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode")
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 	})
 
@@ -852,10 +921,10 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 		}
 
 		syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, optjson.Slice[byte]{})
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -874,7 +943,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarName("HOST_UUID"))
 	})
@@ -895,7 +964,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 				return &p, nil
 			}
 
-			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 			require.NoError(t, err)
 			assert.Equal(t, osUpdateSyncML, updated.SyncML)
 		})
@@ -921,7 +990,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 				return nil, nil
 			}
 
-			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 			require.Error(t, err)
 			assert.ErrorContains(t, err, fleet.OSUpdatesAlreadyConfiguredErrorMessage)
 		})
@@ -938,7 +1007,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 				return nil, nil
 			}
 
-			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, "", osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 			require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		})
 	})
@@ -992,10 +1061,10 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 
 				// profile content and labels are deliberately nil/empty here --
 				// this isolates the authz checks from content/label validation.
-				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 				checkShouldFail(t, err, tt.shouldFailGlobal)
 
-				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, "", nil, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 				checkShouldFail(t, err, tt.shouldFailTeam)
 			})
 		}

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
@@ -791,6 +792,24 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mdm.FleetWindowsOSUpdatesProfileName, syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "is not allowed")
+		require.False(t, ds.UpdateMDMWindowsConfigProfileFuncInvoked)
+	})
+
+	t.Run("a file name longer than the name column is rejected", func(t *testing.T) {
+		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingProfile("disable-onedrive", 0)
+		syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode")
+
+		ds.GetMDMWindowsConfigProfileFunc = func(ctx context.Context, puid string) (*fleet.MDMWindowsConfigProfile, error) {
+			return existing, nil
+		}
+		ds.UpdateMDMWindowsConfigProfileFunc = func(ctx context.Context, p fleet.MDMWindowsConfigProfile, usesFleetVars []fleet.FleetVarName) (*fleet.MDMWindowsConfigProfile, error) {
+			return &p, nil
+		}
+
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, strings.Repeat("a", fleet.MaxProfileNameLength+1), syncML, nil, fleet.LabelsIncludeAll, nil, optjson.Slice[byte]{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, fleet.MaxProfileNameLengthErrMsg)
 		require.False(t, ds.UpdateMDMWindowsConfigProfileFuncInvoked)
 	})
 


### PR DESCRIPTION
**Related issue:** Resolves #51104

Reference doc PR: https://github.com/fleetdm/fleet/pull/52072

## What was done

Editing a Windows configuration profile and uploading a replacement file with a different name replaced the contents but kept the original name, so the profile list, the downloaded file and the activity all kept showing the old one.

The edit endpoint already receives the uploaded file but dropped its file name before reaching the service, which then forced the stored name. It now passes the file name through and the profile is renamed in place: same `profile_uuid`, same targets, same per-host delivery state.

Host pages resolve the profile name from the live profile row rather than the denormalized `host_mdm_windows_profiles.profile_name` copy, so a rename writes no per-host rows at all. The delete paths snapshot the live name on the way out, since those rows outlive the profile and the copy is what reads fall back to once it's gone.

Scoped to Windows. Android and Apple DDM behave the same way and are unchanged. Apple `.mobileconfig` is unaffected, its name comes from `PayloadDisplayName` in the file and already updated.

Also adds a 255-character check on the profile name, which previously surfaced MySQL's raw `Data too long for column 'name'` to the caller.

## Steps to reproduce

1. **Controls > OS settings > Configuration profiles**, upload `disable-onedrive.xml`.
2. Hover the row, select the edit pencil, then the pencil in the modal, and upload `enable-firewall.xml`.

The profile is still called `disable-onedrive`, Download returns `<date>_disable-onedrive.xml` containing the firewall settings, and the activity reads `disable-onedrive`. Only "Updated" changes.

## How I tested

Scenarios run end to end against a local server on the `main` binary and then this branch:

| | pre-fix | post-fix |
|---|---|---|
| Edit `disable-onedrive.xml` with `enable-firewall.xml` | name, download and activity stay `disable-onedrive` | all three read `enable-firewall`, UUID unchanged |
| 300-char file name on create | `422`, `Error 1406 (22001): Data too long for column 'name'` | `400`, `maximum configuration profile name length is 255 characters` |
| 300-char file name on edit | `200`, silently ignored | `400`, same message, profile untouched |
| Rename onto a name already in use | `200` (rename was impossible) | `409`, profile untouched |
| Labels-only edit | name preserved | name preserved |

Host display, watching both the page and the stored copy:

```
start:             page=disable-onedrive  stored=disable-onedrive
after rename:      page=enable-firewall   stored=disable-onedrive   (no per-host write)
after case rename: page=ENABLE-FIREWALL   stored=disable-onedrive
after delete:      page=ENABLE-FIREWALL   stored=ENABLE-FIREWALL    (snapshotted)
```

```
TestMDMWindows / TestTeams / TestMDMShared (datastore) ... PASS
TestUpdateMDMWindowsConfigProfile (service) ............. PASS
TestIntegrationsMDM/TestUpdateConfigProfile ............. PASS
make lint-go-incremental ................................ 0 issues
```

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

### Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Notes for reviewers

- Resolving the name on read is what closes the reconcile-cron race @getvictor raised: there is no denormalized copy to go stale while the profile exists, so nothing for the cron to overwrite. It also removes the per-host write, so there's no 100K-host operation to load test.
- The delete snapshot compares with `CAST(mwcp.name AS BINARY)`. The column is `utf8mb4_unicode_ci`, so a plain `!=` treats `foo` and `Foo` as equal and would skip a case-only rename.
- The cross-platform name check is a `NOT EXISTS` inside the `UPDATE` rather than a preceding `SELECT`, so check and write are atomic. Same shape `NewMDMWindowsConfigProfile` uses on insert.
- `UpdateMDMWindowsConfigProfile` uses `withRetryTxx`: that cross-table guard deadlocks with the create paths under concurrent claims of the same name (`ERROR 1213` on 20 of 80 transactions locally).
- GitOps still matches Windows profiles by name, so a profile renamed in the UI and later reconciled from a YAML file using the old name is delete-then-insert, as before. GitOps mode disables the edit button.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editing a Windows configuration profile with a differently named file now renames the profile while preserving its identity.
  * Profile names are retained correctly when profiles or teams are deleted.
* **Bug Fixes**
  * Duplicate or reserved profile names are rejected without changing the existing profile.
  * File names longer than 255 characters now show a clear validation message instead of a database error.
  * Profile names remain accurate in profile lists, downloads, and activity history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->