### PR TITLE
Product design rituals: Stop creating issues on drafting board

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -115,9 +115,6 @@
   description: "After kickoff: 1. Check for API design PRs on estimated stories that were not brought into the release cycle, then @-mention the product designer to request documentation changes be reverted. 2. Check for unmerged API design PRs on the release docs branch (filter: is:pr is:open base:docs-vX.X.X). For stories that made it into the release cycle, merge the PR. For stories that did not make it in, close the PR and @-mention the author."
   moreInfoUrl: ""
   dri: "rachaelshaw"
-  autoIssue:
-    labels: [ ":product" ]
-    repo: "fleet"
 -
   task: "Create release documentation PR"
   startedOn: "2025-10-31"
@@ -125,9 +122,6 @@
   description: "1. Close any draft PRs (to auto-generated docs) for released features. 2. Prepare documentation PR to `main`. 3. @-mention release DRI"
   moreInfoUrl: ""
   dri: "rachaelshaw"
-  autoIssue:
-    labels: [ ":product" ]
-    repo: "fleet"
 -
   task: "Update release documentation branches"
   startedOn: "2025-10-31"
@@ -135,6 +129,3 @@
   description: "After a release documentation PR is merged to `main`, merge the latest from `main` into each upcoming release docs branch."
   moreInfoUrl: ""
   dri: "rachaelshaw"
-  autoIssue:
-    labels: [ ":product" ]
-    repo: "fleet"


### PR DESCRIPTION
Keeping the rituals around to document the release doc processes, but removed the automatic issue creation (tracked in Reclaim habit instead).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic issue creation for the “Create release documentation PR” and “Update release documentation branches” tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->