### PR TITLE
Document Windows profile rename on edit

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7210,6 +7210,13 @@ You can upload a new profile file to replace the contents of the existing profil
 
 If the new profile does not match the required identifiers, the request will be rejected.
 
+The profile's name is updated to match the new file:
+
+- **Windows profiles** (`.xml`): The profile is renamed to the uploaded file's name, without its extension. The profile keeps its `profile_uuid`, its targets, and its status on each host. If another configuration profile on the same fleet already uses that name, the request is rejected with a `409` status.
+- **.mobileconfig profiles**: The profile is renamed to the new file's **PayloadDisplayName**.
+
+Requests that only update labels don't include a file, so the profile's name is left unchanged.
+
 #### Example
 
 Update a configuration profile to target hosts with specific labels.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7203,17 +7203,16 @@ Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` 
 
 ##### Uploading a new profile file
 
-You can upload a new profile file to replace the contents of the existing profile. The new profile must match the identity of the existing profile:
+You can upload a new profile file to replace the contents of the existing profile. What the new file must match, and how the profile is named afterwards, depends on the profile type:
 
-- **DDM (declarative management) profiles** (`.json`): The new profile must have the same **Identifier** as the existing profile.
-- **.mobileconfig profiles**: The new profile must have the same **PayloadIdentifier** as the existing profile.
+- **.mobileconfig profiles**: The new file must have the same **PayloadIdentifier** as the existing profile. The profile is renamed to the new file's **PayloadDisplayName**.
+- **DDM (declarative management) profiles** (`.json`): The new file must have the same **Identifier** as the existing profile. The profile keeps its current name.
+- **Windows profiles** (`.xml`): There's no identifier to match, so any valid Windows profile is accepted. The profile is renamed to the uploaded file's name, without its extension.
+- **Android profiles** (`.json`): There's no identifier to match, so any valid Android profile is accepted. The profile keeps its current name.
 
-If the new profile does not match the required identifiers, the request will be rejected.
+If a `.mobileconfig` or DDM profile doesn't have the required identifier, the request is rejected.
 
-The profile's name is updated to match the new file:
-
-- **Windows profiles** (`.xml`): The profile is renamed to the uploaded file's name, without its extension. The profile keeps its `profile_uuid`, its targets, and its status on each host. If another configuration profile on the same fleet already uses that name, the request is rejected with a `409` status.
-- **.mobileconfig profiles**: The profile is renamed to the new file's **PayloadDisplayName**.
+Renaming a profile doesn't change its `profile_uuid` or which hosts it targets, and doesn't reinstall it on hosts unless the contents changed too. If another configuration profile on the same fleet already uses the new name, the request is rejected with a `409` status.
 
 Requests that only update labels don't include a file, so the profile's name is left unchanged.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7203,16 +7203,16 @@ Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` 
 
 ##### Uploading a new profile file
 
-You can upload a new profile file to replace the contents of the existing profile. What the new file must match, and how the profile is named afterwards, depends on the profile type:
+You can upload a new profile file to replace the contents of the existing profile. What the new file must match, and how the profile is renamed, depends on the profile type:
 
 - **.mobileconfig profiles**: The new file must have the same **PayloadIdentifier** as the existing profile. The profile is renamed to the new file's **PayloadDisplayName**.
 - **DDM (declarative management) profiles** (`.json`): The new file must have the same **Identifier** as the existing profile. The profile keeps its current name.
-- **Windows profiles** (`.xml`): There's no identifier to match, so any valid Windows profile is accepted. The profile is renamed to the uploaded file's name, without its extension.
-- **Android profiles** (`.json`): There's no identifier to match, so any valid Android profile is accepted. The profile keeps its current name.
+- **Windows profiles** (`.xml`): There's no identifier to match, so the new file's settings can differ completely from the ones it replaces. The profile is renamed to the uploaded file's name, without its extension.
+- **Android profiles** (`.json`): There's no identifier to match, so the new file's settings can differ completely from the ones it replaces. The profile keeps its current name.
 
 If a `.mobileconfig` or DDM profile doesn't have the required identifier, the request is rejected.
 
-Renaming a profile doesn't change its `profile_uuid` or which hosts it targets, and doesn't reinstall it on hosts unless the contents changed too. If another configuration profile on the same fleet already uses the new name, the request is rejected with a `409` status.
+Renaming a profile doesn't change its `profile_uuid` or which hosts it targets, and doesn't reinstall it on hosts unless the contents changed too. If another configuration profile in the same fleet already uses the new name, the request is rejected with a `409` status.
 
 Requests that only update labels don't include a file, so the profile's name is left unchanged.
 


### PR DESCRIPTION
Reference doc change for https://github.com/fleetdm/fleet/issues/51104

Implementation PR: https://github.com/fleetdm/fleet/pull/52055

Editing a Windows configuration profile and uploading a replacement file with a different name now renames the profile. Previously the contents were replaced but the name was kept.

Documenting that exposed a contradiction in the existing "Uploading a new profile file" section. It opened with "The new profile must match the identity of the existing profile" as a blanket rule, then listed only DDM and `.mobileconfig`. That's wrong for Windows and Android, which have no identifier inside the file and accept any valid replacement, and for Windows it now conflicts with the rename behaviour, since name is the only identity a Windows profile has.

So this rewrites the section as one list covering all four profile types, saying for each what the new file must match and what the profile is called afterwards. It also documents renaming for `.mobileconfig` via `PayloadDisplayName`, which already worked and was simply never written down, and the `409` on a name collision.

No behaviour change for Android or Apple DDM.
