### PR TITLE
Clarify 'Product design kickoff' task description

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Product design kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "1. Pull up all contributors' calendars to review time off and, if needed, update design review calendar events. 2. Create reference docs release branches for any milestones newly added to the drafting board 3. Each Product Designer pulls up the release planning project and walks the team through prioritized stories."
+  description: "1. Pull up all contributors' calendars to review time off and, if needed, update design review calendar events. 2. Each Product Designer pulls up the release planning project and walks the team through stories that are about to go through drafting."
   moreInfoUrl: 
   dri: "noahtalerman"
 -


### PR DESCRIPTION
Updated the description of the 'Product design kickoff' task to clarify the focus on stories about to go through drafting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Product Design Kickoff ritual guidance.
  - Clarified that teams should review stories about to enter drafting.
  - Removed the step about creating reference documentation release branches for newly added milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->