### PR TITLE
Docs: path/paths support for fleet_maintained_apps and app_store_apps

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -811,6 +811,8 @@ software:
 
 ### app_store_apps
 
+App Store apps support `path:` (single file) and `paths:` (glob pattern) references, so you can define an app once in a separate file and reference it from multiple fleets. See [`path:` vs `paths:`](#path-vs-paths-glob-patterns) for details. Filenames must not contain `*`, `?`, `[`, or `{` when using `path:`.
+
 - `app_store_id` is the ID of the Apple App Store or Android Play Store app. You can find this ID at the end of the app's URL. For example, "Bear - Markdown Notes" URL is "https://apps.apple.com/us/app/bear-markdown-notes/id1016366447" making the `app_store_id` is "1016366447". Similarly, the URL for "Google Chrome" on Android is "https://play.google.com/store/apps/details?id=com.android.chrome," so the `app_store_id` is "com.android.chrome."
   + For Apple App Store apps, make sure to include only the ID itself, and not the `id` prefix shown in the URL. The ID must be wrapped in quotes as shown in the example so that it is processed as a string.
 - `platform` is the platform of the app (`darwin`, `ios`, `ipados`, or `android`). If not specified, and `app_store_id` is Apple App Store ID, one app for each of the Apple App Store app's supported platforms is added. For example, adding [Bear](https://apps.apple.com/us/app/bear-markdown-notes/id1016366447) (supported on iOS and iPadOS) adds both the iOS and iPadOS apps to your software that's available to install in Fleet.
@@ -826,7 +828,31 @@ To add the same App Store app for multiple platforms, specify the `app_store_id`
 
 When you update an Android app's configuration via GitOps, the app's settings are applied without reinstalling the app. The install status will show as "Pending" until the configuration is applied.
 
+#### Separate file
+
+`fleets/fleet-name.yml`, or `fleets/unassigned.yml`
+
+```yaml
+software:
+  app_store_apps:
+    - path: ../lib/software/zoom.app-store-app.yml
+    - paths: "../lib/software/vpp/*.yml"
+```
+
+`lib/software/zoom.app-store-app.yml`
+
+```yaml
+- app_store_id: "546505307"
+  platform: ios
+  categories:
+    - "👬 Communication"
+  configuration:
+    path: ../lib/software/zoom-config.xml
+```
+
 ### fleet_maintained_apps
+
+Fleet-maintained apps support `path:` (single file) and `paths:` (glob pattern) references, so you can define an app once in a separate file and reference it from multiple fleets. See [`path:` vs `paths:`](#path-vs-paths-glob-patterns) for details. Filenames must not contain `*`, `?`, `[`, or `{` when using `path:`.
 
 - `fleet_maintained_apps` is a list of Fleet-maintained apps. Provide the `slug` field to include a Fleet-maintained app on a fleet. To find the `slug`, head to **Software > Add software** and select a Fleet-maintained app, then select **Show details**. You can also see the [list of app slugs on GitHub](https://github.com/fleetdm/fleet/blob/main/ee/maintained-apps/outputs/apps.json).
 
@@ -846,6 +872,27 @@ If the fields below are omitted, they default to values specified in [the app's 
 - `install_script.path` specifies the command Fleet will run on hosts to install software.
 - `uninstall_script.path` is the script Fleet will run on hosts to uninstall software.
 - `categories` is an array of categories, see [categories](#self-service-labels-categories-and-setup-experience).
+
+#### Separate file
+
+`fleets/fleet-name.yml`, or `fleets/unassigned.yml`
+
+```yaml
+software:
+  fleet_maintained_apps:
+    - path: ../lib/software/slack.fma.yml
+    - paths: "../lib/software/fma/*.yml"
+```
+
+`lib/software/slack.fma.yml`
+
+```yaml
+- slug: slack/darwin
+  version: "4.47.65"
+  self_service: true
+  categories:
+    - "👬 Communication"
+```
 
 ## org_settings and settings
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52339

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

<!-- No changes file: the user-visible changes file lives in the companion code PR, #52080. -->

## Testing

- [x] QA'd all new/changed functionality manually

<!-- Docs-only change: proofread rendering and verified the added YAML examples are syntactically valid and
     consistent with the existing labels/policies/reports "Separate file" examples. -->

---

## Summary

Documents the `path`/`paths` file-reference support being added to `software.app_store_apps` and
`software.fleet_maintained_apps` in [fleetdm/fleet#52080](https://github.com/fleetdm/fleet/pull/52080) (the
companion code PR for fleetdm/fleet#42385).

Adds, for both `app_store_apps` and `fleet_maintained_apps`:
- An intro sentence noting `path:`/`paths:` support, matching the wording already used for `labels`, `policies`,
  `reports`, and `controls.scripts`.
- A "Separate file" example subsection (mirroring the existing pattern for `labels`, `policies`, and `reports`)
  showing a fleet YAML referencing a shared library file, plus a glob example.

This PR is docs-only; it depends on nothing merging first (the docs read correctly regardless of merge order), but
should ideally land close to [#52080](https://github.com/fleetdm/fleet/pull/52080) so the documented behavior matches
what's shipped.

