### PR TITLE
Center homepage hero on tablet/mobile breakpoints

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -105,6 +105,7 @@
     [purpose='button-row'] {
       display: flex;
       flex-direction: row;
+      justify-content: flex-start;
     }
   }
 
@@ -1244,7 +1245,7 @@
     [purpose='homepage-hero'] {
       // height: 100%;
       // padding: 48px 27px 330px 24px;
-      height: 540px;
+      height: 600px;
     }
     [purpose='hero-container'] {
       background: linear-gradient(180deg, #FFF 0%, #EEF7F8 150px);
@@ -1258,7 +1259,19 @@
     [purpose='hero-text'] {
       width: 100%;
       max-width: 100%;
+      h1 {
+        text-align: center;
+        max-width: 480px;
+        font-size: 48px;
+        margin: 0 auto 24px;
+      }
+      [purpose='hero-subtitle'] {
+        text-align: center;
+        max-width: 600px;
+        margin: 0 auto 24px;
+      }
       [purpose='button-row'] {
+        justify-content: center;
         [purpose='cta-button'] {
           width: unset;
         }
@@ -1470,7 +1483,8 @@
 
     [purpose='hero-text'] {
       h1 {
-        font-size: 24px;
+        max-width: 360px;
+        font-size: 36px;
       }
     }
     [purpose='homepage-content'] {
@@ -1677,7 +1691,7 @@
       padding-top: 44px;
       padding-left: 16px;
       padding-right: 17px;
-      padding-bottom: 200px;
+      padding-bottom: 240px;
       height: unset;
     }
 

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -15,7 +15,7 @@
               Manage devices like it's 2026
             </h1>
             <p purpose="hero-subtitle">AI device management, patching, and governance for every OS.</p>
-            <div purpose="button-row" class="d-flex justify-content-start align-items-center">
+            <div purpose="button-row">
               <a purpose="cta-button" href="/register">Try it yourself</a>
               <animated-arrow-button href="#compare-features">Compare features</animated-arrow-button>
             </div>


### PR DESCRIPTION
**Related issue:** N/A

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (verified at 767px, 575px, and 375px)

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

## Summary

Centers the homepage hero (heading, subtitle, button row) at the 767px, 575px, and 375px breakpoints, adjusts the hero container's height/padding at those sizes, and removes Bootstrap utility classes on the button row that were overriding the layout's own centering rules with `!important`. Desktop (>767px) is unchanged.

<img width="870" height="919" alt="image" src="https://github.com/user-attachments/assets/63013d10-0ce7-4c11-b578-e4fb11b2ab89" />

<img width="893" height="1087" alt="image" src="https://github.com/user-attachments/assets/630a9638-505c-4110-94c3-ab30603265d8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the homepage hero layout on mobile with centered text and buttons.
  * Increased mobile hero height and adjusted heading sizing for better readability.
  * Added spacing refinements for smaller screens.
  * Preserved left-aligned hero buttons on desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->