### PR TITLE
Fleet UI: Add spacing to Munki issues section on host details

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1460,7 +1460,7 @@ const HostDetailsPage = ({
                 <TabText>Library</TabText>
               </Tab>
             </TabList>
-            <TabPanel>
+            <TabPanel className={`${baseClass}__software-inventory-tab-panel`}>
               <SoftwareInventoryCard
                 id={host.id}
                 platform={host.platform}
@@ -1531,7 +1531,7 @@ const HostDetailsPage = ({
             </TabPanel>
           </>
         ) : (
-          <>
+          <div className={`${baseClass}__software-inventory-tab-panel`}>
             <SoftwareInventoryCard
               id={host.id}
               platform={host.platform}
@@ -1553,7 +1553,7 @@ const HostDetailsPage = ({
                 deviceType={host?.platform === "darwin" ? "macos" : ""}
               />
             )}
-          </>
+          </div>
         )}
       </div>
     );

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -14,6 +14,10 @@
     gap: $pad-medium;
   }
 
+  &__software-inventory-tab-panel {
+    @include vertical-card-layout;
+  }
+
   @media screen and (min-width: $break-md) {
     // This details tab must be selected to use these grid stylings. They are
     // irrelevant for the other tabs.

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -15,7 +15,7 @@
   }
 
   &__software-inventory-tab-panel {
-    @include vertical-card-layout;
+    @include vertical-page-tab-panel-layout;
   }
 
   @media screen and (min-width: $break-md) {

--- a/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssues.tsx
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssues.tsx
@@ -8,7 +8,7 @@ import CardHeader from "components/CardHeader";
 
 import { munkiIssuesTableHeaders } from "./MunkiIssuesTableConfig";
 
-const baseClass = "munki-issues-card";
+const baseClass = "munki-issues-section";
 
 interface IMunkiIssuesTableProps {
   isLoading: boolean;

--- a/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssues.tsx
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/MunkiIssues.tsx
@@ -4,7 +4,6 @@ import { IMunkiIssue } from "interfaces/host";
 
 import TableContainer from "components/TableContainer";
 import EmptyState from "components/EmptyState";
-import Card from "components/Card";
 import CardHeader from "components/CardHeader";
 
 import { munkiIssuesTableHeaders } from "./MunkiIssuesTableConfig";
@@ -23,7 +22,7 @@ const MunkiIssuesTable = ({
   deviceType,
 }: IMunkiIssuesTableProps): JSX.Element => {
   return (
-    <Card className={baseClass} borderRadiusSize="xxlarge" paddingSize="xlarge">
+    <div className={baseClass}>
       <CardHeader header="Munki issues" />
       <div className={deviceType || ""}>
         <TableContainer
@@ -44,7 +43,7 @@ const MunkiIssuesTable = ({
           isClientSidePagination
         />
       </div>
-    </Card>
+    </div>
   );
 };
 export default MunkiIssuesTable;

--- a/frontend/pages/hosts/details/cards/MunkiIssues/_styles.scss
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/_styles.scss
@@ -1,4 +1,4 @@
-.munki-issues-card {
+.munki-issues-section {
   @include vertical-card-layout;
 
   .data-table-block {

--- a/frontend/pages/hosts/details/cards/MunkiIssues/_styles.scss
+++ b/frontend/pages/hosts/details/cards/MunkiIssues/_styles.scss
@@ -1,4 +1,6 @@
 .munki-issues-card {
+  @include vertical-card-layout;
+
   .data-table-block {
     .issue_tooltip,
     .time_tooltip {

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -42,7 +42,7 @@ import { generateSoftwareTableHeaders as generateDeviceSoftwareTableConfig } fro
 import HostSoftwareTable from "./HostSoftwareTable";
 import { getSoftwareSubheader } from "./helpers";
 
-const baseClass = "host-software-card";
+const baseClass = "host-software-section";
 
 export interface ITableSoftware extends Omit<ISoftware, "vulnerabilities"> {
   vulnerabilities: string[]; // for client-side search purposes, we only want an array of cve strings

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -1,4 +1,4 @@
-.host-software-card {
+.host-software-section {
   @include vertical-page-tab-panel-layout;
 
   .table-container {


### PR DESCRIPTION
## Issue
Closes #47660

## Description
- Bug fix (root cause): the software section and Munki issues section sat as sibling children of either a `<TabPanel>` (premium) or the `__software-card` wrapper (free) with no flex layout on the parent, so the two boxes rendered flush against each other on macOS hosts running Munki. Added a shared `__software-inventory-tab-panel` class with `vertical-page-tab-panel-layout` (24px flex column gap) on both branches so the two sections separate cleanly.
- UX: per one of the potential fixes on the issue, dropped the Card wrapper around the Munki issues section so the title and table render directly under the software section without their own bordered container. Kept the internal 24px gap between the "Munki issues" title and its table via `vertical-card-layout` on `.munki-issues-section`.
- Cleanup: renamed `.host-software-card` and `.munki-issues-card` to `.host-software-section` and `.munki-issues-section` since neither component wraps its content in a `<Card>` anymore. Class names now match the actual DOM shape.

## Screenrecording
- Munki issues section on the host details Software tab, after

https://github.com/user-attachments/assets/6e2da2a8-0471-485c-97fc-bad9f140508b

Fleet Free:


<img width="588" height="578" alt="Screenshot 2026-08-28 at 9 35 05 AM" src="https://github.com/user-attachments/assets/b513e599-f509-4249-882f-9369b0f303d1" />


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout of the software inventory panel with a consistent vertical tab presentation.
  * Updated software inventory and Munki issues sections for more consistent vertical spacing and alignment.
  * Standardized section styling across Host Details and My Device views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->