### PR TITLE
Implement PSSO user registration for non-setup, no prior setup flows

### DIFF
--- a/apps/fleet-desktop-macos/CHANGELOG.md
+++ b/apps/fleet-desktop-macos/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Fleet Desktop macOS v1.4.0 (July 24, 2026)
+
+* Migrated Fleet Desktop macOS from allenhouchins/fleet-desktop to fleetdm/fleet repo
+* Added a Platform SSO Extension that when used with Fleet's Apple Account Provisioning feature allows password synchronization and account provisioning during Setup Assistant with any Oauth ROPG supporting IdP

--- a/apps/fleet-desktop-macos/FleetDesktop/Info.plist
+++ b/apps/fleet-desktop-macos/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>11</string>
+    <string>12</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.5.0</string>
+    <string>1.5.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+Networking.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+Networking.swift
@@ -24,32 +24,40 @@ extension AuthenticationViewController {
     // assertion. Fleet always publishes an encryption key, so the caller treats
     // nil as fatal rather than proceeding with password encryption disabled.
     func loginRequestEncryptionKey(jwksURL: URL) async -> SecKey? {
-        let data: Data
         do {
-            let (body, resp) = try await URLSession.shared.data(from: jwksURL)
-            guard let http = resp as? HTTPURLResponse,
-                  (200...299).contains(http.statusCode) else {
-                let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
-                logger.error("loginRequestEncryptionKey: JWKS fetch returned HTTP \(status, privacy: .public)")
-                return nil
-            }
-            data = body
+            return try await fetchLoginRequestEncryptionKey(jwksURL: jwksURL)
         } catch {
-            logger.error("loginRequestEncryptionKey: JWKS fetch failed: \(String(describing: error), privacy: .public)")
+            logger.error("loginRequestEncryptionKey: \(String(describing: error), privacy: .public)")
             return nil
+        }
+    }
+
+    // fetchLoginRequestEncryptionKey is the throwing form, keeping the failure
+    // category (network vs. server vs. malformed) so an interactive caller can
+    // tell the user something more specific than "something went wrong".
+    func fetchLoginRequestEncryptionKey(jwksURL: URL) async throws -> SecKey {
+        let data: Data
+        let resp: URLResponse
+        do {
+            (data, resp) = try await URLSession.shared.data(from: jwksURL)
+        } catch {
+            throw UserRegistrationError.network(error)
+        }
+        guard let http = resp as? HTTPURLResponse else {
+            throw UserRegistrationError.internalFailure("jwks: non-HTTP response")
+        }
+        guard (200...299).contains(http.statusCode) else {
+            throw UserRegistrationError.server(status: http.statusCode)
         }
         guard let jwks = try? JSONDecoder().decode(JWKSet.self, from: data) else {
-            logger.error("loginRequestEncryptionKey: JWKS decode failed")
-            return nil
+            throw UserRegistrationError.internalFailure("jwks: undecodable response")
         }
-
         for jwk in jwks.keys where jwk.use == "enc" {
             if let key = jwk.ecPublicSecKey() {
                 return key
             }
         }
-        logger.error("loginRequestEncryptionKey: no usable enc key in JWKS")
-        return nil
+        throw UserRegistrationError.internalFailure("jwks: no usable enc key published")
     }
 
     // postDeviceRegistration POSTs the registration payload to Fleet and

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+Networking.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+Networking.swift
@@ -79,6 +79,61 @@ extension AuthenticationViewController {
         }
     }
 
+    // fetchRequestNonce obtains the single-use request_nonce every token request
+    // must carry. The body mirrors what AppSSOAgent sends; Fleet ignores it.
+    func fetchRequestNonce(nonceURL: URL) async throws -> String {
+        var req = URLRequest(url: nonceURL)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        req.httpBody = Data("grant_type=srv_challenge".utf8)
+        let body: Data
+        let resp: URLResponse
+        do {
+            (body, resp) = try await URLSession.shared.data(for: req)
+        } catch {
+            logger.error("fetchRequestNonce: request failed: \(String(describing: error), privacy: .public)")
+            throw UserRegistrationError.network(error)
+        }
+        guard let http = resp as? HTTPURLResponse else {
+            throw UserRegistrationError.internalFailure("nonce: non-HTTP response")
+        }
+        guard (200...299).contains(http.statusCode) else {
+            logger.error("fetchRequestNonce: HTTP \(http.statusCode, privacy: .public)")
+            throw UserRegistrationError.server(status: http.statusCode)
+        }
+        struct NonceResponse: Decodable {
+            let nonce: String
+            enum CodingKeys: String, CodingKey { case nonce = "Nonce" }
+        }
+        guard let decoded = try? JSONDecoder().decode(NonceResponse.self, from: body), !decoded.nonce.isEmpty else {
+            throw UserRegistrationError.internalFailure("nonce: undecodable response")
+        }
+        return decoded.nonce
+    }
+
+    // postTokenRequest submits a signed login assertion and returns the HTTP
+    // status. The response JWE is encrypted to the device key and not needed
+    // here: the status alone says whether the IdP accepted the credentials.
+    func postTokenRequest(assertion: String, tokenURL: URL) async throws -> Int {
+        var req = URLRequest(url: tokenURL)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        req.httpBody = formURLEncodedBody([URLQueryItem(name: "assertion", value: assertion)])
+        do {
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            guard let http = resp as? HTTPURLResponse else {
+                throw UserRegistrationError.internalFailure("token: non-HTTP response")
+            }
+            logger.log("postTokenRequest: HTTP \(http.statusCode, privacy: .public)")
+            return http.statusCode
+        } catch let error as UserRegistrationError {
+            throw error
+        } catch {
+            logger.error("postTokenRequest: request failed: \(String(describing: error), privacy: .public)")
+            throw UserRegistrationError.network(error)
+        }
+    }
+
     // formURLEncodedBody serializes query items as an x-www-form-urlencoded
     // body, percent-encoding everything outside the RFC 3986 unreserved set so
     // '+', '/', '=', spaces and newlines in PEM values survive intact.

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+PSSO.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+PSSO.swift
@@ -90,21 +90,24 @@ extension AuthenticationViewController:
         // reports "no user configuration for user" and never finishes binding
         // the PSSO user to the local account, so the unlock-key/SecureToken
         // setup stays incomplete and key unwrap fails at login ("previous
-        // password required"). For password mode saving the config is all the
-        // extension needs to do.
+        // password required").
         //
+        // When the framework already knows the user (Setup Assistant, where it
+        // ran the IdP login itself) saving the config is all that's needed.
         // Background repair runs can arrive without a userName; the user login
         // configuration saved by the original registration still names the
         // registered user, so fall back to it rather than failing the whole
-        // registration cycle.
+        // registration cycle. With neither — an existing local account being
+        // registered for the first time — the extension must authenticate the
+        // user itself, which needs UI.
         let userNameParam = userName?.isEmpty == false ? userName : nil
         guard let resolvedUserName = userNameParam ?? loginManager.userLoginConfiguration?.loginUserName,
               !resolvedUserName.isEmpty else {
             if options.contains(.userInteractionEnabled) {
-                logger.error("beginUserRegistration: no user name available")
-                completion(.failed)
+                logger.log("beginUserRegistration: no user name, presenting sign-in to verify IdP credentials")
+                beginInteractiveUserRegistration(loginManager: loginManager, completion: completion)
             } else {
-                logger.log("beginUserRegistration: no user name and interaction disabled, deferring to UI retry")
+                logger.log("beginUserRegistration: no user name and interaction disabled, requesting UI")
                 completion(.userInterfaceRequired)
             }
             return
@@ -123,6 +126,17 @@ extension AuthenticationViewController:
 
     func registrationDidComplete() {
         logger.log("registrationDidComplete")
+        DispatchQueue.main.async { self.discardRegistrationForm() }
+    }
+
+    // The framework cancelled on our behalf, so the pending completion is
+    // dropped rather than called.
+    func registrationDidCancel() {
+        logger.log("registrationDidCancel")
+        DispatchQueue.main.async {
+            self.userRegistrationCompletion = nil
+            self.discardRegistrationForm()
+        }
     }
 
     func protocolVersion() -> ASAuthorizationProviderExtensionPlatformSSOProtocolVersion {

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+PSSO.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+PSSO.swift
@@ -133,10 +133,7 @@ extension AuthenticationViewController:
     // dropped rather than called.
     func registrationDidCancel() {
         logger.log("registrationDidCancel")
-        DispatchQueue.main.async {
-            self.userRegistrationCompletion = nil
-            self.discardRegistrationForm()
-        }
+        DispatchQueue.main.async { self.abandonUserRegistration() }
     }
 
     func protocolVersion() -> ASAuthorizationProviderExtensionPlatformSSOProtocolVersion {

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+Shared.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+Shared.swift
@@ -79,12 +79,7 @@ extension AuthenticationViewController {
     func applyLoginConfiguration(
         _ mgr: ASAuthorizationProviderExtensionLoginManager
     ) async throws {
-        let data = mgr.extensionData
-        guard let baseString = data["BaseURL"] as? String,
-              let base = URL(string: baseString),
-              let host = base.host,
-              base.scheme?.lowercased() == "https"
-        else {
+        guard let base = fleetBaseURL(from: mgr.extensionData), let host = base.host else {
             logger.error("applyLoginConfiguration: missing or non-HTTPS BaseURL in profile ExtensionData")
             throw NSError(domain: "FleetPSSO", code: -1)
         }
@@ -109,7 +104,18 @@ extension AuthenticationViewController {
         try mgr.saveLoginConfiguration(cfg)
     }
 
-    private func pssoEndpointURL(_ base: URL, _ name: String) -> URL {
+    // fleetBaseURL returns the profile's BaseURL, or nil unless it is a
+    // well-formed HTTPS URL with a host.
+    func fleetBaseURL(from extensionData: [AnyHashable: Any]) -> URL? {
+        guard let baseString = extensionData["BaseURL"] as? String,
+              let base = URL(string: baseString),
+              base.host != nil,
+              base.scheme?.lowercased() == "https"
+        else { return nil }
+        return base
+    }
+
+    func pssoEndpointURL(_ base: URL, _ name: String) -> URL {
         base.appendingPathComponent("api/mdm/apple/psso/\(name)")
     }
 }

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+UserRegistration.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+UserRegistration.swift
@@ -64,6 +64,17 @@ extension AuthenticationViewController {
         registrationForm = nil
     }
 
+    // abandonUserRegistration drops everything an in-progress interactive
+    // registration holds. Cancelling the task matters: a verification that
+    // finishes after the framework cancelled must not save a configuration or
+    // complete the abandoned request.
+    func abandonUserRegistration() {
+        verificationTask?.cancel()
+        verificationTask = nil
+        userRegistrationCompletion = nil
+        discardRegistrationForm()
+    }
+
     private func showRegistrationForm(loginManager: ASAuthorizationProviderExtensionLoginManager) {
         discardRegistrationForm()
         let form = RegistrationFormView(initialUserName: loginManager.userLoginConfiguration?.loginUserName)
@@ -92,14 +103,22 @@ extension AuthenticationViewController {
         loginManager: ASAuthorizationProviderExtensionLoginManager
     ) {
         registrationForm?.setBusy(true)
-        Task {
+        verificationTask?.cancel()
+        verificationTask = Task {
             do {
                 try await self.verifyIdPCredentials(username: username, password: password, loginManager: loginManager)
+                try Task.checkCancellation()
                 let config = ASAuthorizationProviderExtensionUserLoginConfiguration(loginUserName: username)
                 try loginManager.saveUserLoginConfiguration(config)
                 logger.log("beginUserRegistration: credentials verified, user login configuration saved")
                 await MainActor.run { self.finishUserRegistration(.success) }
             } catch {
+                // URLSession surfaces cancellation as URLError.cancelled, which
+                // the networking helpers wrap; the task flag is the reliable signal.
+                if Task.isCancelled {
+                    logger.log("beginUserRegistration: credential verification cancelled")
+                    return
+                }
                 let registrationError = (error as? UserRegistrationError)
                     ?? .internalFailure(String(describing: error))
                 logger.error("beginUserRegistration: credential verification failed: \(String(describing: registrationError), privacy: .public)")
@@ -130,10 +149,7 @@ extension AuthenticationViewController {
         guard !signingKeyID.isEmpty else {
             throw UserRegistrationError.internalFailure("signing key export failed")
         }
-        guard let serverEncKey = await loginRequestEncryptionKey(jwksURL: pssoEndpointURL(base, "jwks")) else {
-            throw UserRegistrationError.internalFailure("failed to load Fleet encryption key from JWKS")
-        }
-
+        let serverEncKey = try await fetchLoginRequestEncryptionKey(jwksURL: pssoEndpointURL(base, "jwks"))
         let requestNonce = try await fetchRequestNonce(nonceURL: pssoEndpointURL(base, "nonce"))
 
         let builder = PSSOLoginRequestBuilder(
@@ -161,9 +177,8 @@ extension AuthenticationViewController {
     }
 
     private func finishUserRegistration(_ result: ASAuthorizationProviderExtensionRegistrationResult) {
-        discardRegistrationForm()
         let completion = userRegistrationCompletion
-        userRegistrationCompletion = nil
+        abandonUserRegistration()
         logger.log("beginUserRegistration: completing with \(result.rawValue, privacy: .public)")
         completion?(result)
     }

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+UserRegistration.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController+UserRegistration.swift
@@ -1,0 +1,170 @@
+// AuthenticationViewController+UserRegistration.swift
+// FleetPSSOExtension
+//
+// Interactive user registration. macOS reaches this path when it registers a
+// user it has never authenticated — an already-set-up Mac whose owner clicked
+// the "Registration required" banner. Setup Assistant registrations don't come
+// here: there the framework has already run the IdP login and passes the
+// username in.
+//
+// The extension presents its own sign-in form, verifies the credentials by
+// sending Fleet the same signed login request AppSSOAgent would, and only
+// then saves the user login configuration. Saving an unverified username
+// would leave the account bound to an identity that fails at every unlock.
+
+import AuthenticationServices
+import Cocoa
+import os
+
+enum UserRegistrationError: Error {
+    case invalidCredentials
+    case server(status: Int)
+    case network(Error)
+    case internalFailure(String)
+
+    var userMessage: String {
+        switch self {
+        case .invalidCredentials:
+            return "Incorrect username or password. Try again."
+        case .server(let status):
+            return "Fleet couldn't verify your credentials (HTTP \(status)). Try again later."
+        case .network:
+            return "Couldn't connect to Fleet. Check your network connection and try again."
+        case .internalFailure:
+            return "Something went wrong. Try again later."
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+extension AuthenticationViewController {
+
+    func beginInteractiveUserRegistration(
+        loginManager: ASAuthorizationProviderExtensionLoginManager,
+        completion: @escaping (ASAuthorizationProviderExtensionRegistrationResult) -> Void
+    ) {
+        DispatchQueue.main.async {
+            self.userRegistrationCompletion = completion
+            loginManager.presentRegistrationViewController { [weak self] error in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if let error {
+                        logger.error("beginUserRegistration: presentRegistrationViewController failed: \(String(describing: error), privacy: .public)")
+                        self.finishUserRegistration(.failed)
+                        return
+                    }
+                    self.showRegistrationForm(loginManager: loginManager)
+                }
+            }
+        }
+    }
+
+    func discardRegistrationForm() {
+        registrationForm?.removeFromSuperview()
+        registrationForm = nil
+    }
+
+    private func showRegistrationForm(loginManager: ASAuthorizationProviderExtensionLoginManager) {
+        discardRegistrationForm()
+        let form = RegistrationFormView(initialUserName: loginManager.userLoginConfiguration?.loginUserName)
+        form.onSubmit = { [weak self] username, password in
+            self?.verifyAndRegister(username: username, password: password, loginManager: loginManager)
+        }
+        form.onCancel = { [weak self] in
+            logger.log("beginUserRegistration: user cancelled sign-in")
+            self?.finishUserRegistration(.failed)
+        }
+        form.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(form)
+        NSLayoutConstraint.activate([
+            form.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            form.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            form.topAnchor.constraint(equalTo: view.topAnchor),
+            form.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        registrationForm = form
+        view.window?.makeFirstResponder(form.usernameField)
+    }
+
+    private func verifyAndRegister(
+        username: String,
+        password: String,
+        loginManager: ASAuthorizationProviderExtensionLoginManager
+    ) {
+        registrationForm?.setBusy(true)
+        Task {
+            do {
+                try await self.verifyIdPCredentials(username: username, password: password, loginManager: loginManager)
+                let config = ASAuthorizationProviderExtensionUserLoginConfiguration(loginUserName: username)
+                try loginManager.saveUserLoginConfiguration(config)
+                logger.log("beginUserRegistration: credentials verified, user login configuration saved")
+                await MainActor.run { self.finishUserRegistration(.success) }
+            } catch {
+                let registrationError = (error as? UserRegistrationError)
+                    ?? .internalFailure(String(describing: error))
+                logger.error("beginUserRegistration: credential verification failed: \(String(describing: registrationError), privacy: .public)")
+                await MainActor.run {
+                    self.registrationForm?.setBusy(false)
+                    self.registrationForm?.showError(registrationError.userMessage)
+                }
+            }
+        }
+    }
+
+    // verifyIdPCredentials round-trips a device-signed login request through
+    // Fleet's token endpoint. A 2xx means the IdP accepted the password; Fleet
+    // maps an IdP rejection to 401.
+    private func verifyIdPCredentials(
+        username: String,
+        password: String,
+        loginManager: ASAuthorizationProviderExtensionLoginManager
+    ) async throws {
+        guard let base = fleetBaseURL(from: loginManager.extensionData) else {
+            throw UserRegistrationError.internalFailure("missing or non-HTTPS BaseURL in profile ExtensionData")
+        }
+        guard let signKey = loginManager.key(for: .sharedDeviceSigning),
+              let encKey = loginManager.key(for: .sharedDeviceEncryption) else {
+            throw UserRegistrationError.internalFailure("shared device keys unavailable")
+        }
+        let signingKeyID = keyID(signKey)
+        guard !signingKeyID.isEmpty else {
+            throw UserRegistrationError.internalFailure("signing key export failed")
+        }
+        guard let serverEncKey = await loginRequestEncryptionKey(jwksURL: pssoEndpointURL(base, "jwks")) else {
+            throw UserRegistrationError.internalFailure("failed to load Fleet encryption key from JWKS")
+        }
+
+        let requestNonce = try await fetchRequestNonce(nonceURL: pssoEndpointURL(base, "nonce"))
+
+        let builder = PSSOLoginRequestBuilder(
+            clientID: Bundle.main.bundleIdentifier ?? "",
+            signingKey: signKey,
+            signingKeyID: signingKeyID,
+            deviceEncryptionKey: encKey,
+            serverEncryptionKey: serverEncKey)
+        let assertion: String
+        do {
+            assertion = try builder.build(username: username, password: password, requestNonce: requestNonce)
+        } catch {
+            throw UserRegistrationError.internalFailure("build login request: \(error)")
+        }
+
+        let status = try await postTokenRequest(assertion: assertion, tokenURL: pssoEndpointURL(base, "token"))
+        switch status {
+        case 200...299:
+            return
+        case 401:
+            throw UserRegistrationError.invalidCredentials
+        default:
+            throw UserRegistrationError.server(status: status)
+        }
+    }
+
+    private func finishUserRegistration(_ result: ASAuthorizationProviderExtensionRegistrationResult) {
+        discardRegistrationForm()
+        let completion = userRegistrationCompletion
+        userRegistrationCompletion = nil
+        logger.log("beginUserRegistration: completing with \(result.rawValue, privacy: .public)")
+        completion?(result)
+    }
+}

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController.swift
@@ -27,6 +27,7 @@ final class AuthenticationViewController: NSViewController,
     var registrationEndpointURL: URL?
     var registrationForm: RegistrationFormView?
     var userRegistrationCompletion: ((ASAuthorizationProviderExtensionRegistrationResult) -> Void)?
+    var verificationTask: Task<Void, Never>?
 
     static let formSize = NSSize(width: 480, height: 300)
 

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/AuthenticationViewController.swift
@@ -5,7 +5,8 @@
 // ASAuthorizationProviderExtensionLoginManager. Conforms minimally to
 // ASAuthorizationProviderExtensionAuthorizationRequestHandler so the
 // extension binary loads; Password-mode registration and sign-in have no
-// browser leg, so no web view is needed.
+// browser leg, so no web view is needed. The view only ever hosts the native
+// sign-in form used for interactive user registration.
 
 import AuthenticationServices
 import Cocoa
@@ -24,9 +25,14 @@ final class AuthenticationViewController: NSViewController,
     var loginManager: ASAuthorizationProviderExtensionLoginManager?
     var pendingRequest: ASAuthorizationProviderExtensionAuthorizationRequest?
     var registrationEndpointURL: URL?
+    var registrationForm: RegistrationFormView?
+    var userRegistrationCompletion: ((ASAuthorizationProviderExtensionRegistrationResult) -> Void)?
+
+    static let formSize = NSSize(width: 480, height: 300)
 
     override func loadView() {
-        view = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 720))
+        view = NSView(frame: NSRect(origin: .zero, size: Self.formSize))
+        preferredContentSize = Self.formSize
     }
 
     func beginAuthorization(

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/PSSOLoginRequest.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/PSSOLoginRequest.swift
@@ -77,8 +77,6 @@ struct PSSOLoginRequestBuilder {
         return try signES256(header: header, claims: claims)
     }
 
-    // MARK: - JWS
-
     private func signES256(header: [String: Any], claims: [String: Any]) throws -> String {
         let headerB64 = try Self.jsonData(header).base64URLEncodedString()
         let claimsB64 = try Self.jsonData(claims).base64URLEncodedString()
@@ -90,61 +88,15 @@ struct PSSOLoginRequestBuilder {
         else {
             throw PSSOLoginRequestError.signing(Self.describe(error))
         }
-        // Security returns an X9.62 DER ECDSA-Sig-Value; JWS wants raw R || S.
-        let raw = try Self.ecdsaDERToRaw(der, componentLength: 32)
+        // Security returns a DER ECDSA-Sig-Value; JWS wants raw R || S.
+        let raw: Data
+        do {
+            raw = try P256.Signing.ECDSASignature(derRepresentation: der).rawRepresentation
+        } catch {
+            throw PSSOLoginRequestError.signing("undecodable DER signature: \(error)")
+        }
         return "\(headerB64).\(claimsB64).\(raw.base64URLEncodedString())"
     }
-
-    // ecdsaDERToRaw converts SEQUENCE { INTEGER r, INTEGER s } into fixed-width
-    // R || S, stripping DER sign padding and left-padding short components.
-    static func ecdsaDERToRaw(_ der: Data, componentLength: Int) throws -> Data {
-        var cursor = der.startIndex
-
-        func readByte() throws -> UInt8 {
-            guard cursor < der.endIndex else {
-                throw PSSOLoginRequestError.signing("truncated DER signature")
-            }
-            defer { cursor += 1 }
-            return der[cursor]
-        }
-        func readLength() throws -> Int {
-            let first = try readByte()
-            guard first & 0x80 != 0 else { return Int(first) }
-            var length = 0
-            for _ in 0..<Int(first & 0x7f) {
-                length = (length << 8) | Int(try readByte())
-            }
-            return length
-        }
-        func readInteger() throws -> Data {
-            guard try readByte() == 0x02 else {
-                throw PSSOLoginRequestError.signing("DER signature component is not an INTEGER")
-            }
-            let length = try readLength()
-            guard cursor + length <= der.endIndex else {
-                throw PSSOLoginRequestError.signing("DER signature component overruns buffer")
-            }
-            var value = der[cursor..<(cursor + length)]
-            cursor += length
-            while value.count > componentLength, value.first == 0 {
-                value = value.dropFirst()
-            }
-            guard value.count <= componentLength else {
-                throw PSSOLoginRequestError.signing("DER signature component too large")
-            }
-            return Data(repeating: 0, count: componentLength - value.count) + value
-        }
-
-        guard try readByte() == 0x30 else {
-            throw PSSOLoginRequestError.signing("DER signature is not a SEQUENCE")
-        }
-        _ = try readLength()
-        let r = try readInteger()
-        let s = try readInteger()
-        return r + s
-    }
-
-    // MARK: - JWE (ECDH-ES direct + A256GCM)
 
     static func encryptECDHES(plaintext: Data, recipientPoint: Data, apv: Data, typ: String) throws -> String {
         let recipient: P256.KeyAgreement.PublicKey
@@ -226,8 +178,6 @@ struct PSSOLoginRequestBuilder {
     private static func bigEndian(_ value: UInt32) -> Data {
         withUnsafeBytes(of: value.bigEndian) { Data($0) }
     }
-
-    // MARK: - Keys
 
     // rawPublicPoint returns the ANSI X9.63 uncompressed point (0x04 || X || Y)
     // for a public or private EC SecKey — the encoding Fleet hashes into key IDs

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/PSSOLoginRequest.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/PSSOLoginRequest.swift
@@ -1,0 +1,259 @@
+// PSSOLoginRequest.swift
+// FleetPSSOExtension
+//
+// Builds the PSSO v2 password login request that AppSSOAgent normally sends
+// to Fleet's token endpoint, so the extension can verify a user's IdP
+// credentials itself during interactive user registration — the one point in
+// the lifecycle where macOS hasn't authenticated the user yet and hands the
+// job to the extension.
+//
+// Wire format (mirrors server/mdm/apple/psso/pssocrypto on the Fleet side):
+//   - Outer JWS: ES256, signed by the shared device signing key, `kid` = the
+//     key ID registered with Fleet. Claims carry username, nonces, and a
+//     jwe_crypto recipe telling Fleet how to encrypt its response.
+//   - Embedded assertion: compact JWE (ECDH-ES + A256GCM) encrypted to Fleet's
+//     published encryption key, carrying only the password. Fleet reads the
+//     username from the signed outer JWT.
+//   - Party info (apu/apv) is Apple's length-prefixed blob format:
+//     apv = "Apple" || recipientKey || nonce, apu = "APPLE" || ephemeralKey.
+
+import CryptoKit
+import Foundation
+import Security
+
+enum PSSOLoginRequestError: Error {
+    case keyExport(String)
+    case signing(String)
+    case encoding(String)
+}
+
+struct PSSOLoginRequestBuilder {
+    static let grantTypeJWTBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    static let typEncryptedLoginAssertion = "platformsso-encrypted-login-assertion+jwt"
+    static let protocolVersion = "1.0"
+    static let requestLifetime: TimeInterval = 5 * 60
+
+    let clientID: String
+    let signingKey: SecKey
+    let signingKeyID: String
+    let deviceEncryptionKey: SecKey
+    let serverEncryptionKey: SecKey
+
+    // build returns the compact JWS to POST as the `assertion` form field.
+    func build(username: String, password: String, requestNonce: String) throws -> String {
+        let sessionNonce = Data(UUID().uuidString.utf8)
+        let deviceEncPoint = try Self.rawPublicPoint(deviceEncryptionKey)
+        let serverEncPoint = try Self.rawPublicPoint(serverEncryptionKey)
+
+        let responseAPV = Self.applePartyInfo([Data("Apple".utf8), deviceEncPoint, sessionNonce])
+        let assertionAPV = Self.applePartyInfo([Data("Apple".utf8), serverEncPoint, sessionNonce])
+
+        let assertionPlaintext = try Self.jsonData(["password": password])
+        let assertion = try Self.encryptECDHES(
+            plaintext: assertionPlaintext,
+            recipientPoint: serverEncPoint,
+            apv: assertionAPV,
+            typ: Self.typEncryptedLoginAssertion)
+
+        let now = Int(Date().timeIntervalSince1970)
+        let claims: [String: Any] = [
+            "iss": clientID,
+            "sub": username,
+            "iat": now,
+            "exp": now + Int(Self.requestLifetime),
+            "version": Self.protocolVersion,
+            "grant_type": Self.grantTypeJWTBearer,
+            "assertion": assertion,
+            "username": username,
+            "nonce": String(decoding: sessionNonce, as: UTF8.self),
+            "request_nonce": requestNonce,
+            "jwe_crypto": [
+                "alg": "ECDH-ES",
+                "enc": "A256GCM",
+                "apv": responseAPV.base64URLEncodedString(),
+            ],
+        ]
+        let header: [String: Any] = ["alg": "ES256", "typ": "JWT", "kid": signingKeyID]
+        return try signES256(header: header, claims: claims)
+    }
+
+    // MARK: - JWS
+
+    private func signES256(header: [String: Any], claims: [String: Any]) throws -> String {
+        let headerB64 = try Self.jsonData(header).base64URLEncodedString()
+        let claimsB64 = try Self.jsonData(claims).base64URLEncodedString()
+        let signingInput = Data("\(headerB64).\(claimsB64)".utf8)
+
+        var error: Unmanaged<CFError>?
+        guard let der = SecKeyCreateSignature(
+            signingKey, .ecdsaSignatureMessageX962SHA256, signingInput as CFData, &error) as Data?
+        else {
+            throw PSSOLoginRequestError.signing(Self.describe(error))
+        }
+        // Security returns an X9.62 DER ECDSA-Sig-Value; JWS wants raw R || S.
+        let raw = try Self.ecdsaDERToRaw(der, componentLength: 32)
+        return "\(headerB64).\(claimsB64).\(raw.base64URLEncodedString())"
+    }
+
+    // ecdsaDERToRaw converts SEQUENCE { INTEGER r, INTEGER s } into fixed-width
+    // R || S, stripping DER sign padding and left-padding short components.
+    static func ecdsaDERToRaw(_ der: Data, componentLength: Int) throws -> Data {
+        var cursor = der.startIndex
+
+        func readByte() throws -> UInt8 {
+            guard cursor < der.endIndex else {
+                throw PSSOLoginRequestError.signing("truncated DER signature")
+            }
+            defer { cursor += 1 }
+            return der[cursor]
+        }
+        func readLength() throws -> Int {
+            let first = try readByte()
+            guard first & 0x80 != 0 else { return Int(first) }
+            var length = 0
+            for _ in 0..<Int(first & 0x7f) {
+                length = (length << 8) | Int(try readByte())
+            }
+            return length
+        }
+        func readInteger() throws -> Data {
+            guard try readByte() == 0x02 else {
+                throw PSSOLoginRequestError.signing("DER signature component is not an INTEGER")
+            }
+            let length = try readLength()
+            guard cursor + length <= der.endIndex else {
+                throw PSSOLoginRequestError.signing("DER signature component overruns buffer")
+            }
+            var value = der[cursor..<(cursor + length)]
+            cursor += length
+            while value.count > componentLength, value.first == 0 {
+                value = value.dropFirst()
+            }
+            guard value.count <= componentLength else {
+                throw PSSOLoginRequestError.signing("DER signature component too large")
+            }
+            return Data(repeating: 0, count: componentLength - value.count) + value
+        }
+
+        guard try readByte() == 0x30 else {
+            throw PSSOLoginRequestError.signing("DER signature is not a SEQUENCE")
+        }
+        _ = try readLength()
+        let r = try readInteger()
+        let s = try readInteger()
+        return r + s
+    }
+
+    // MARK: - JWE (ECDH-ES direct + A256GCM)
+
+    static func encryptECDHES(plaintext: Data, recipientPoint: Data, apv: Data, typ: String) throws -> String {
+        let recipient: P256.KeyAgreement.PublicKey
+        do {
+            recipient = try P256.KeyAgreement.PublicKey(x963Representation: recipientPoint)
+        } catch {
+            throw PSSOLoginRequestError.keyExport("recipient key is not a P-256 point: \(error)")
+        }
+        let ephemeral = P256.KeyAgreement.PrivateKey()
+        let epkPoint = ephemeral.publicKey.x963Representation
+        let apu = applePartyInfo([Data("APPLE".utf8), epkPoint])
+
+        let shared = try ephemeral.sharedSecretFromKeyAgreement(with: recipient)
+        let z = shared.withUnsafeBytes { Data($0) }
+        // ECDH-ES direct: the agreed key is the content-encryption key, so the
+        // KDF algorithm ID is the content-encryption alg.
+        let cek = concatKDF(z: z, algorithmID: "A256GCM", apu: apu, apv: apv, keyBits: 256)
+
+        let header: [String: Any] = [
+            "alg": "ECDH-ES",
+            "enc": "A256GCM",
+            "typ": typ,
+            "epk": [
+                "kty": "EC",
+                "crv": "P-256",
+                "x": epkPoint.subdata(in: 1..<33).base64URLEncodedString(),
+                "y": epkPoint.subdata(in: 33..<65).base64URLEncodedString(),
+            ],
+            "apu": apu.base64URLEncodedString(),
+            "apv": apv.base64URLEncodedString(),
+        ]
+        let protectedB64 = try jsonData(header).base64URLEncodedString()
+
+        let iv = AES.GCM.Nonce()
+        let sealed: AES.GCM.SealedBox
+        do {
+            // Compact-serialization AAD is the ASCII protected header.
+            sealed = try AES.GCM.seal(plaintext, using: SymmetricKey(data: cek), nonce: iv,
+                                      authenticating: Data(protectedB64.utf8))
+        } catch {
+            throw PSSOLoginRequestError.encoding("AES-GCM seal failed: \(error)")
+        }
+        // encrypted_key is empty for ECDH-ES direct key agreement.
+        return [
+            protectedB64,
+            "",
+            Data(iv).base64URLEncodedString(),
+            sealed.ciphertext.base64URLEncodedString(),
+            sealed.tag.base64URLEncodedString(),
+        ].joined(separator: ".")
+    }
+
+    // concatKDF is NIST SP 800-56A Concat KDF as used by JWE (RFC 7518 §4.6.2):
+    // SHA-256(counter || Z || len(algID)||algID || len(apu)||apu || len(apv)||apv || keyBits).
+    // CryptoKit's x963DerivedSymmetricKey puts the counter after Z (ANSI X9.63),
+    // which is not what JOSE peers derive, so this is done by hand. A 256-bit
+    // key needs exactly one SHA-256 round.
+    static func concatKDF(z: Data, algorithmID: String, apu: Data, apv: Data, keyBits: UInt32) -> Data {
+        var input = Data()
+        input.append(bigEndian(1))
+        input.append(z)
+        input.append(lengthPrefixed(Data(algorithmID.utf8)))
+        input.append(lengthPrefixed(apu))
+        input.append(lengthPrefixed(apv))
+        input.append(bigEndian(keyBits))
+        return Data(SHA256.hash(data: input))
+    }
+
+    // applePartyInfo serializes fields as Apple's party-info blob: each field is
+    // a 4-byte big-endian length followed by its bytes.
+    static func applePartyInfo(_ fields: [Data]) -> Data {
+        fields.reduce(into: Data()) { $0.append(lengthPrefixed($1)) }
+    }
+
+    private static func lengthPrefixed(_ data: Data) -> Data {
+        bigEndian(UInt32(data.count)) + data
+    }
+
+    private static func bigEndian(_ value: UInt32) -> Data {
+        withUnsafeBytes(of: value.bigEndian) { Data($0) }
+    }
+
+    // MARK: - Keys
+
+    // rawPublicPoint returns the ANSI X9.63 uncompressed point (0x04 || X || Y)
+    // for a public or private EC SecKey — the encoding Fleet hashes into key IDs
+    // and expects inside apv.
+    static func rawPublicPoint(_ key: SecKey) throws -> Data {
+        let pub = SecKeyCopyPublicKey(key) ?? key
+        var error: Unmanaged<CFError>?
+        guard let data = SecKeyCopyExternalRepresentation(pub, &error) as Data? else {
+            throw PSSOLoginRequestError.keyExport(describe(error))
+        }
+        guard data.count == 65, data.first == 0x04 else {
+            throw PSSOLoginRequestError.keyExport("unexpected EC public key encoding (\(data.count) bytes)")
+        }
+        return data
+    }
+
+    private static func jsonData(_ object: Any) throws -> Data {
+        do {
+            return try JSONSerialization.data(withJSONObject: object)
+        } catch {
+            throw PSSOLoginRequestError.encoding("JSON serialization failed: \(error)")
+        }
+    }
+
+    private static func describe(_ error: Unmanaged<CFError>?) -> String {
+        guard let error else { return "unknown Security error" }
+        return String(describing: error.takeRetainedValue())
+    }
+}

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/RegistrationFormView.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/RegistrationFormView.swift
@@ -1,0 +1,129 @@
+// RegistrationFormView.swift
+// FleetPSSOExtension
+//
+// Native username/password form shown inside the Platform SSO registration
+// window when macOS asks the extension to register a user it hasn't
+// authenticated yet. Fleet proxies password grants to the IdP, so there is no
+// browser leg — a plain AppKit form is the whole sign-in surface.
+
+import Cocoa
+
+final class RegistrationFormView: NSView {
+    var onSubmit: ((_ username: String, _ password: String) -> Void)?
+    var onCancel: (() -> Void)?
+
+    let usernameField = NSTextField()
+    private let passwordField = NSSecureTextField()
+    private let errorLabel = NSTextField(wrappingLabelWithString: "")
+    private let spinner = NSProgressIndicator()
+    private let signInButton = NSButton(title: "Sign in", target: nil, action: nil)
+    private let cancelButton = NSButton(title: "Cancel", target: nil, action: nil)
+    private var isBusy = false
+
+    init(initialUserName: String?) {
+        super.init(frame: .zero)
+        usernameField.stringValue = initialUserName ?? ""
+        buildLayout()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("RegistrationFormView is built programmatically")
+    }
+
+    func setBusy(_ busy: Bool) {
+        isBusy = busy
+        usernameField.isEnabled = !busy
+        passwordField.isEnabled = !busy
+        signInButton.isEnabled = !busy
+        cancelButton.isEnabled = !busy
+        if busy {
+            errorLabel.isHidden = true
+            spinner.startAnimation(nil)
+        } else {
+            spinner.stopAnimation(nil)
+        }
+        spinner.isHidden = !busy
+    }
+
+    func showError(_ message: String) {
+        errorLabel.stringValue = message
+        errorLabel.isHidden = false
+        passwordField.stringValue = ""
+        window?.makeFirstResponder(passwordField)
+    }
+
+    private func buildLayout() {
+        let title = NSTextField(labelWithString: "Sign in to your organization")
+        title.font = .systemFont(ofSize: 17, weight: .semibold)
+
+        let subtitle = NSTextField(wrappingLabelWithString:
+            "Enter the username and password you use with your identity provider "
+            + "to finish setting up Platform SSO for this Mac account.")
+        subtitle.font = .systemFont(ofSize: 12)
+        subtitle.textColor = .secondaryLabelColor
+
+        usernameField.placeholderString = "Username or email"
+        usernameField.nextKeyView = passwordField
+        passwordField.placeholderString = "Password"
+        passwordField.nextKeyView = usernameField
+
+        errorLabel.font = .systemFont(ofSize: 12)
+        errorLabel.textColor = .systemRed
+        errorLabel.isHidden = true
+
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isHidden = true
+
+        signInButton.target = self
+        signInButton.action = #selector(submit)
+        signInButton.keyEquivalent = "\r"
+        cancelButton.target = self
+        cancelButton.action = #selector(cancel)
+        cancelButton.keyEquivalent = "\u{1b}"
+
+        let buttons = NSStackView(views: [spinner, NSView(), cancelButton, signInButton])
+        buttons.orientation = .horizontal
+        buttons.spacing = 8
+
+        let stack = NSStackView(views: [title, subtitle, usernameField, passwordField, errorLabel, buttons])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 12
+        stack.setCustomSpacing(20, after: subtitle)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+
+        for view in [subtitle, usernameField, passwordField, errorLabel, buttons] {
+            view.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        }
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 28),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -28),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 28),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -28),
+        ])
+    }
+
+    // Return in either field hits the default button, so this doubles as the
+    // "advance to the next empty field" handler.
+    @objc private func submit() {
+        guard !isBusy else { return }
+        let username = usernameField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !username.isEmpty else {
+            window?.makeFirstResponder(usernameField)
+            return
+        }
+        let password = passwordField.stringValue
+        guard !password.isEmpty else {
+            window?.makeFirstResponder(passwordField)
+            return
+        }
+        onSubmit?(username, password)
+    }
+
+    @objc private func cancel() {
+        onCancel?()
+    }
+}

--- a/apps/fleet-desktop-macos/FleetPSSOExtension/RegistrationFormView.swift
+++ b/apps/fleet-desktop-macos/FleetPSSOExtension/RegistrationFormView.swift
@@ -64,9 +64,7 @@ final class RegistrationFormView: NSView {
         subtitle.textColor = .secondaryLabelColor
 
         usernameField.placeholderString = "Username or email"
-        usernameField.nextKeyView = passwordField
         passwordField.placeholderString = "Password"
-        passwordField.nextKeyView = usernameField
 
         errorLabel.font = .systemFont(ofSize: 12)
         errorLabel.textColor = .systemRed

--- a/apps/fleet-desktop-macos/README.md
+++ b/apps/fleet-desktop-macos/README.md
@@ -128,6 +128,9 @@ apps/fleet-desktop-macos/
 │   ├── AuthenticationViewController+PSSO.swift        # Registration handler
 │   ├── AuthenticationViewController+Shared.swift      # Payload / key-ID / config helpers
 │   ├── AuthenticationViewController+Networking.swift  # URLSession against Fleet
+│   ├── AuthenticationViewController+UserRegistration.swift  # Interactive user registration (sign-in form → Fleet /token)
+│   ├── PSSOLoginRequest.swift                         # Device-signed login JWS + encrypted password assertion
+│   ├── RegistrationFormView.swift                     # Native username/password form
 │   ├── Info.plist                                     # appex metadata (NSExtension dict)
 │   └── FleetPSSOExtension.entitlements                # Extension entitlements
 ├── fleet-sso-extension-example.mobileconfig          # Example com.apple.extensiblesso profile

--- a/apps/fleet-desktop-macos/build.sh
+++ b/apps/fleet-desktop-macos/build.sh
@@ -94,6 +94,9 @@ EXT_SOURCES=(
     "$EXT_SRC_DIR/AuthenticationViewController+PSSO.swift"
     "$EXT_SRC_DIR/AuthenticationViewController+Shared.swift"
     "$EXT_SRC_DIR/AuthenticationViewController+Networking.swift"
+    "$EXT_SRC_DIR/AuthenticationViewController+UserRegistration.swift"
+    "$EXT_SRC_DIR/PSSOLoginRequest.swift"
+    "$EXT_SRC_DIR/RegistrationFormView.swift"
 )
 EXT_SWIFT_FLAGS=(
     -sdk "$SDK" -parse-as-library -O

--- a/apps/fleet-desktop-macos/changes/51666-psso-existing-account-registration
+++ b/apps/fleet-desktop-macos/changes/51666-psso-existing-account-registration
@@ -1,0 +1,1 @@
+- Fixed Platform SSO user registration on Macs that were set up before the PSSO profile was installed. The extension now prompts for IdP credentials and verifies them through Fleet instead of failing registration immediately.

--- a/docs/Contributing/research/mdm/psso.md
+++ b/docs/Contributing/research/mdm/psso.md
@@ -83,6 +83,13 @@ sequenceDiagram
     end
 ```
 
+### User registration
+
+Between phases 1 and 2 macOS registers the user (`beginUserRegistration`). The extension's job is to persist an `ASAuthorizationProviderExtensionUserLoginConfiguration` naming the IdP username the framework should send as `username` on every login request. Two paths:
+
+- **Setup Assistant (ADE).** The framework has already run the IdP login through Fleet's token endpoint to create the account, so it passes the username in and the extension just saves it.
+- **Already-set-up Mac ("Registration required" banner).** The framework has only collected the *local* password and passes `userName = nil` with `userInteractionEnabled`. The extension must authenticate the user itself: it calls `presentRegistrationViewController`, shows a native username/password form, and verifies the credentials by sending Fleet the same device-signed login request AppSSOAgent would (`/nonce` → `/token`, password in an ECDH-ES/A256GCM embedded assertion). A 2xx means the IdP accepted the password; only then is the username saved and `.success` returned. A 401 is shown inline for retry; cancelling returns `.failed` so macOS keeps the banner and retries later. Saving an unverified username would bind the account to an identity that fails at every unlock.
+
 ## Known limitations
 
 - **OIDC ROPG has provider-specific limitations.** Okta: ROPG must be explicitly enabled on the application and the app must be Native or Service type. Entra: MFA-required users and federated (AD FS) users cannot authenticate via ROPG. These are upstream constraints, not Fleet bugs. Customers in those configurations need an alternative `PSSOIdPClient` backend (LDAP bind or a direct-trust flow).


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51666 and inadvertently #51667

TLDR is that on a device that never went through PSSO setup during setup assistant, so basically trying to link a completely local account to PSSO, we don't have a username and need to request macOS let us show a little user registration thing which we will use to verify the user's credentials and get their username before handing off to macOS to enable Password Sync. THis was an escape from our prior test plan which almost exclusively tested setup flows

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.
<img width="1656" height="1446" alt="image" src="https://github.com/user-attachments/assets/2168c6e0-de22-43bd-9727-fa96378466ff" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive macOS Platform SSO registration with a native username and password sign-in form.
  * Added credential verification before saving login configuration.
  * Added clear error messages for invalid credentials, network issues, and server failures.
  * Added Cancel support and improved registration form sizing and behavior.
  * Added secure request handling for registration authentication.

* **Bug Fixes**
  * Fixed registration for Macs provisioned before the Platform SSO profile was installed. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->