### PR TITLE
Update FMA scripts in auto-update job when they change in manifest without a version change

### DIFF
--- a/changes/51989-fma-script-only-update
+++ b/changes/51989-fma-script-only-update
@@ -1,0 +1,1 @@
+- Fixed the Fleet-maintained apps auto-update cron job not updating scripts when they change in the manifest without a version change.

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -175,6 +175,8 @@ func downloadNewVersionIfEligible(
 		return "", err
 	}
 
+	versionAlreadyCached := false
+
 	// For a concrete manifest version the eligibility gates can run up front. For a
 	// "latest" manifest the real version isn't known until the installer is
 	// extracted, so the caret-major and cache checks are deferred until after that.
@@ -193,8 +195,7 @@ func downloadNewVersionIfEligible(
 		// the GitOps path: a rebuilt package (same version, new hash) is downloaded and
 		// replaces them. A manifest without a hash can't be compared, so it downloads again.
 		if versionExists && cachedHash == app.SHA256 {
-			// Nothing to download, and this cached version is what the manifest publishes.
-			return app.Version, nil
+			versionAlreadyCached = true
 		}
 	}
 
@@ -202,7 +203,9 @@ func downloadNewVersionIfEligible(
 	// team cached the same version), skip the HTTP download and reuse the bytes.
 	storageID := app.SHA256
 	needBytes := true
-	if app.SHA256 != noCheckHash && !isLatest {
+	if versionAlreadyCached {
+		needBytes = false
+	} else if app.SHA256 != noCheckHash && !isLatest {
 		exists, err := store.Exists(ctx, app.SHA256)
 		if err != nil {
 			return "", ctxerr.Wrap(ctx, err, "checking installer store")
@@ -212,6 +215,7 @@ func downloadNewVersionIfEligible(
 
 	version := app.Version
 	filename := ""
+	extension := ""
 	upgradeCode := app.UpgradeCode
 	var packageIDs []string
 	var tfr *fleet.TempFileReader
@@ -258,15 +262,18 @@ func downloadNewVersionIfEligible(
 		}
 	} else {
 		// Bytes already cached (possibly only on an inactive row after a rollback):
-		// recover the package IDs and upgrade code from any installer with the same
-		// content hash so the uninstall script can still be substituted.
-		pids, ucode, err := ds.GetSoftwareInstallerMetadataByStorageID(ctx, storageID)
+		// describe them from any installer with the same content hash. The extension
+		// decides how the uninstall script is substituted, and an installer URL often
+		// ends in something that isn't one, so it has to come off the row.
+		cached, err := ds.GetSoftwareInstallerMetadataByStorageID(ctx, storageID)
 		if err != nil {
 			return "", ctxerr.Wrap(ctx, err, "recovering cached installer metadata")
 		}
-		packageIDs = pids
-		if ucode != "" {
-			upgradeCode = ucode
+		packageIDs = cached.PackageIDs
+		filename = cached.Filename
+		extension = cached.Extension
+		if cached.UpgradeCode != "" {
+			upgradeCode = cached.UpgradeCode
 		}
 	}
 
@@ -281,7 +288,7 @@ func downloadNewVersionIfEligible(
 		}
 		// Same as above, except the hash to compare is the one just downloaded.
 		if versionExists && cachedHash == storageID {
-			return version, nil
+			versionAlreadyCached = true
 		}
 	}
 
@@ -290,12 +297,15 @@ func downloadNewVersionIfEligible(
 			filename = path.Base(u.Path)
 		}
 	}
+	if extension == "" {
+		extension = extensionFromFilename(filename)
+	}
 
 	payload := &fleet.UploadSoftwareInstallerPayload{
 		TeamID:          c.TeamID,
 		Version:         version,
 		Filename:        filename,
-		Extension:       extensionFromFilename(filename),
+		Extension:       extension,
 		StorageID:       storageID,
 		URL:             app.InstallerURL,
 		UpgradeCode:     upgradeCode,
@@ -307,12 +317,13 @@ func downloadNewVersionIfEligible(
 		InstallerFile:   tfr,
 	}
 
-	// Carry an admin's scripts across the version bump. Read the active installer
-	// rather than trust the candidate, which was listed before the download and can
-	// be stale. The insert copies the flags off that same row.
+	// Carry an admin's scripts across the version bump. Read the row again rather
+	// than trust the candidate, which was listed before the download and can be
+	// stale. A title can hold more than one active package, so it has to be the
+	// candidate's own row. The insert copies the flags off that same row.
 	payload.InstallScriptEdited = c.InstallScriptEdited
 	payload.UninstallScriptEdited = c.UninstallScriptEdited
-	active, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, c.TeamID, c.TitleID, true)
+	active, err := ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctx, c.TeamID, c.TitleID, c.InstallerID, true)
 	if err != nil && !fleet.IsNotFound(err) {
 		return "", ctxerr.Wrap(ctx, err, "getting active installer to preserve custom scripts")
 	}
@@ -332,6 +343,26 @@ func downloadNewVersionIfEligible(
 	if err := preProcessUninstallScript(payload); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "processing uninstall script")
 	}
+
+	// No row to write, so the scripts and queries go onto the one already there.
+	if versionAlreadyCached {
+		if file.PackageIDRegex.MatchString(payload.UninstallScript) ||
+			file.UpgradeCodeRegex.MatchString(payload.UninstallScript) {
+			logger.WarnContext(ctx, "manifest uninstall script has unsubstituted template variables", "slug", c.Slug)
+			return version, nil
+		}
+		if active == nil || (payload.InstallScript == active.InstallScript &&
+			payload.UninstallScript == active.UninstallScript &&
+			payload.PatchQuery == active.PatchQuery && payload.AppOpenQuery == active.AppOpenQuery) {
+			return version, nil
+		}
+		if err := ds.UpdateInstallerScriptsAndQueries(ctx, active.InstallerID, version,
+			payload.InstallScript, payload.UninstallScript, payload.PatchQuery, payload.AppOpenQuery); err != nil {
+			logger.WarnContext(ctx, "refreshing installer scripts and queries", "slug", c.Slug, "err", err)
+		}
+		return version, nil
+	}
+
 	// Refuse to persist a row whose uninstall script still has unsubstituted
 	// template variables (e.g. metadata extraction failed and preProcess silently
 	// no-op'd): promoting it would record uninstalls as succeeding while the app

--- a/ee/server/service/maintained_apps_auto_update_download_test.go
+++ b/ee/server/service/maintained_apps_auto_update_download_test.go
@@ -139,8 +139,8 @@ func baseDownloadStoreWithEditedScripts(t *testing.T, activeVersion string, acti
 		return false, "", nil
 	}
 	// No recoverable metadata by default (byte-dedup path).
-	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) ([]string, string, error) {
-		return nil, "", nil
+	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) (fleet.CachedInstallerMetadata, error) {
+		return fleet.CachedInstallerMetadata{}, nil
 	}
 	// After the insert, the new version is the newest cached one.
 	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint) ([]fleet.FleetMaintainedVersion, error) {
@@ -157,7 +157,7 @@ func baseDownloadStoreWithEditedScripts(t *testing.T, activeVersion string, acti
 	// By default the active installer has no custom scripts to carry forward, so the
 	// cron keeps the manifest scripts. nil signals "nothing to preserve". Tests that
 	// exercise custom-script carry-forward override this.
-	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+	ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerIDFunc = func(ctx context.Context, tmID *uint, titleID uint, installerID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
 		return nil, nil
 	}
 	return ds
@@ -328,8 +328,8 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 	ds.HasFMAInstallerVersionFunc = func(ctx context.Context, tmID *uint, fmaID uint, version string) (bool, string, error) {
 		return false, "", nil
 	}
-	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) ([]string, string, error) {
-		return nil, "", nil
+	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) (fleet.CachedInstallerMetadata, error) {
+		return fleet.CachedInstallerMetadata{}, nil
 	}
 	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 		return 13, nil
@@ -344,7 +344,7 @@ func TestAutoUpdateFetchesManifestOncePerSlug(t *testing.T) {
 	ds.MarkFleetMaintainedAppVersionCurrentFunc = func(ctx context.Context, installerID uint) error {
 		return nil
 	}
-	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+	ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerIDFunc = func(ctx context.Context, tmID *uint, titleID uint, installerID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
 		return nil, nil
 	}
 
@@ -380,8 +380,8 @@ func TestAutoUpdateSubstitutesUninstallScript(t *testing.T) {
 	srv := newFakeManifestServer(t)
 	srv.uninstall = "msiexec /x $PACKAGE_ID /qn"
 	ds := baseDownloadStore(t, "149.0.0", 9)
-	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) ([]string, string, error) {
-		return []string{"ABC"}, "", nil
+	ds.GetSoftwareInstallerMetadataByStorageIDFunc = func(ctx context.Context, storageID string) (fleet.CachedInstallerMetadata, error) {
+		return fleet.CachedInstallerMetadata{PackageIDs: []string{"ABC"}, Filename: "cached-installer.msi", Extension: "msi"}, nil
 	}
 	var gotPayload *fleet.UploadSoftwareInstallerPayload
 	ds.InsertFleetMaintainedAppVersionFunc = func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
@@ -394,6 +394,9 @@ func TestAutoUpdateSubstitutesUninstallScript(t *testing.T) {
 	require.NotNil(t, gotPayload)
 	require.NotContains(t, gotPayload.UninstallScript, "$PACKAGE_ID", "placeholder must be substituted")
 	require.Contains(t, gotPayload.UninstallScript, "ABC")
+	// The file was never downloaded, so these come off the same-content row.
+	require.Equal(t, "cached-installer.msi", gotPayload.Filename)
+	require.Equal(t, "msi", gotPayload.Extension)
 }
 
 // [6] A caret pin with a "latest" manifest must not early-return before the real
@@ -436,7 +439,7 @@ func TestAutoUpdateUnsubstitutedUninstallSkipsInsert(t *testing.T) {
 func TestAutoUpdatePreservesEditedScripts(t *testing.T) {
 	newFakeManifestServer(t)
 	ds := baseDownloadStoreWithEditedScripts(t, "149.0.0", 9, true, true)
-	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+	ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerIDFunc = func(ctx context.Context, tmID *uint, titleID uint, installerID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
 		return &fleet.SoftwareInstaller{
 			InstallScript:         "echo CUSTOM install",
 			UninstallScript:       "echo CUSTOM uninstall",
@@ -464,7 +467,7 @@ func TestAutoUpdateAdoptsManifestScriptsWhenNotEdited(t *testing.T) {
 	ds := baseDownloadStore(t, "149.0.0", 9)
 	// The active installer is always read, but neither flag is set on it, so its
 	// scripts lose to the manifest.
-	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+	ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerIDFunc = func(ctx context.Context, tmID *uint, titleID uint, installerID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
 		return &fleet.SoftwareInstaller{
 			InstallScript:   "echo STALE install",
 			UninstallScript: "echo STALE uninstall",
@@ -489,7 +492,7 @@ func TestAutoUpdatePicksUpEditsMadeDuringDownload(t *testing.T) {
 	// The candidate says unedited and the active installer says otherwise, which is an
 	// admin editing the script while the installer downloaded.
 	ds := baseDownloadStore(t, "149.0.0", 9)
-	ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+	ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerIDFunc = func(ctx context.Context, tmID *uint, titleID uint, installerID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
 		return &fleet.SoftwareInstaller{
 			InstallScript:       "echo JUST EDITED",
 			UninstallScript:     "echo uninstall",

--- a/server/datastore/mysql/migrations/tables/20260827170502_AddFMAScriptEditedFlags.go
+++ b/server/datastore/mysql/migrations/tables/20260827170502_AddFMAScriptEditedFlags.go
@@ -115,7 +115,8 @@ func backfillScriptEditedFlags(tx *sql.Tx, increment incrementCountFn) error {
 			increment()
 			// a row changed after the hash map was generated may be carrying a script
 			// Fleet published later, which the map can't contain, so a miss proves
-			// nothing. Leave it at the default and let it follow the manifest.
+			// nothing. Setting the flag would make the cron keep this script instead
+			// of the manifest's on every later run, so it stays at the default.
 			if row.ChangedAfterHashMap {
 				continue
 			}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1061,33 +1061,40 @@ FROM software_installers WHERE id = ?`,
 	return installerID, nil
 }
 
-// GetSoftwareInstallerMetadataByStorageID returns the package IDs and upgrade
-// code of any cached installer (active or inactive) with the given storage_id.
-// A content hash uniquely identifies the bytes, so the metadata is the same
-// regardless of which row is currently active — the auto-update cron uses this to
-// recover uninstall-script substitution values on the byte-dedup path without
-// re-downloading. Returns empty values (no error) when nothing matches.
-func (ds *Datastore) GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error) {
+// GetSoftwareInstallerMetadataByStorageID describes any cached installer (active
+// or inactive) with the given storage_id. A content hash uniquely identifies the
+// bytes, so the metadata is the same regardless of which row is currently active —
+// the auto-update cron uses this to recover what it would otherwise have taken off
+// the downloaded file, on the byte-dedup path. Returns a zero value (no error)
+// when nothing matches.
+func (ds *Datastore) GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (fleet.CachedInstallerMetadata, error) {
 	var row struct {
 		PackageIDs  string `db:"package_ids"`
 		UpgradeCode string `db:"upgrade_code"`
+		Filename    string `db:"filename"`
+		Extension   string `db:"extension"`
 	}
 	// Prefer a row that actually carries package IDs (the MSI/EXE row).
-	err = sqlx.GetContext(ctx, ds.reader(ctx), &row, `
-		SELECT package_ids, upgrade_code FROM software_installers
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &row, `
+		SELECT package_ids, upgrade_code, filename, extension FROM software_installers
 		WHERE storage_id = ?
 		ORDER BY (package_ids = '') ASC, id ASC
 		LIMIT 1`, storageID)
 	switch {
 	case err == nil:
-		if row.PackageIDs != "" {
-			packageIDs = strings.Split(row.PackageIDs, ",")
+		cached := fleet.CachedInstallerMetadata{
+			UpgradeCode: row.UpgradeCode,
+			Filename:    row.Filename,
+			Extension:   row.Extension,
 		}
-		return packageIDs, row.UpgradeCode, nil
+		if row.PackageIDs != "" {
+			cached.PackageIDs = strings.Split(row.PackageIDs, ",")
+		}
+		return cached, nil
 	case errors.Is(err, sql.ErrNoRows):
-		return nil, "", nil
+		return fleet.CachedInstallerMetadata{}, nil
 	default:
-		return nil, "", ctxerr.Wrap(ctx, err, "get software installer metadata by storage id")
+		return fleet.CachedInstallerMetadata{}, ctxerr.Wrap(ctx, err, "get software installer metadata by storage id")
 	}
 }
 
@@ -4110,6 +4117,43 @@ func (ds *Datastore) UpdateInstallerUpgradeCode(ctx context.Context, id uint, up
 		return ctxerr.Wrap(ctx, err, "update software installer upgrade code")
 	}
 	return nil
+}
+
+func (ds *Datastore) UpdateInstallerScriptsAndQueries(ctx context.Context, installerID uint, version string, installScript string, uninstallScript string, patchQuery string, appOpenQuery string) error {
+	installScriptID, err := ds.getOrGenerateScriptContentsID(ctx, installScript)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get or generate install script contents ID")
+	}
+	uninstallScriptID, err := ds.getOrGenerateScriptContentsID(ctx, uninstallScript)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get or generate uninstall script contents ID")
+	}
+
+	// Pinned by version, so a row that moved to another one is left alone, and a
+	// script replaced since the caller read the row keeps what the admin wrote.
+	res, err := ds.writer(ctx).ExecContext(ctx, `
+UPDATE
+	software_installers
+SET
+	install_script_content_id = IF(install_script_edited, install_script_content_id, ?),
+	uninstall_script_content_id = IF(uninstall_script_edited, uninstall_script_content_id, ?),
+	patch_query = ?,
+	app_open_query = ?
+WHERE
+	id = ? AND version = ?
+`, installScriptID, uninstallScriptID, patchQuery, appOpenQuery, installerID, version)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "update installer scripts and queries")
+	}
+	matched, err := res.RowsAffected()
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "rows affected updating installer scripts and queries")
+	}
+	if matched == 0 {
+		return nil
+	}
+
+	return ds.ProcessInstallerUpdateSideEffects(ctx, installerID, true, false)
 }
 
 func (ds *Datastore) UpdateSoftwareInstallerWithoutPackageIDs(ctx context.Context, id uint,

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -5843,16 +5843,20 @@ func testGetSoftwareInstallerMetadataByStorageID(t *testing.T, ds *Datastore) {
 		return err
 	})
 
-	pids, ucode, err := ds.GetSoftwareInstallerMetadataByStorageID(ctx, "hash-meta-1")
+	cached, err := ds.GetSoftwareInstallerMetadataByStorageID(ctx, "hash-meta-1")
 	require.NoError(t, err)
-	require.Equal(t, []string{"PROD-CODE"}, pids, "recovers package IDs from an inactive row")
-	require.Equal(t, "UP-CODE", ucode)
+	require.Equal(t, []string{"PROD-CODE"}, cached.PackageIDs, "recovers package IDs from an inactive row")
+	require.Equal(t, "UP-CODE", cached.UpgradeCode)
+	require.Equal(t, "foo.msi", cached.Filename)
+	require.Equal(t, "msi", cached.Extension)
 
 	// Unknown hash → empty, no error.
-	pids, ucode, err = ds.GetSoftwareInstallerMetadataByStorageID(ctx, "no-such-hash")
+	cached, err = ds.GetSoftwareInstallerMetadataByStorageID(ctx, "no-such-hash")
 	require.NoError(t, err)
-	require.Empty(t, pids)
-	require.Empty(t, ucode)
+	require.Empty(t, cached.PackageIDs)
+	require.Empty(t, cached.UpgradeCode)
+	require.Empty(t, cached.Filename)
+	require.Empty(t, cached.Extension)
 }
 
 func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3058,11 +3058,11 @@ type Datastore interface {
 	// Used by the auto-update cron to decide whether to advance versions.
 	ListFleetMaintainedAppActiveInstallers(ctx context.Context) ([]FMAAutoUpdateCandidate, error)
 
-	// GetSoftwareInstallerMetadataByStorageID returns the package IDs and upgrade
-	// code of any cached installer (active or inactive) with the given storage_id.
-	// Used by the auto-update cron to recover uninstall-script substitution values
-	// on the byte-dedup path. Returns empty values (no error) when nothing matches.
-	GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error)
+	// GetSoftwareInstallerMetadataByStorageID describes any cached installer (active
+	// or inactive) with the given storage_id. Used by the auto-update cron to recover
+	// what it would otherwise have taken off the downloaded file, on the byte-dedup
+	// path. Returns a zero value (no error) when nothing matches.
+	GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (CachedInstallerMetadata, error)
 
 	// InsertFleetMaintainedAppVersion caches a newly downloaded version of an
 	// already-installed Fleet-maintained app, cloning the active installer's
@@ -3096,6 +3096,11 @@ type Datastore interface {
 	// HasFMAInstallerVersion returns true if the given FMA version is already
 	// cached as a software installer for the given team, and its storage hash.
 	HasFMAInstallerVersion(ctx context.Context, teamID *uint, fmaID uint, version string) (versionExists bool, storageID string, err error)
+
+	// UpdateInstallerScriptsAndQueries writes the scripts and queries onto an
+	// installer still on the given version, cancelling pending installs as an edit
+	// does. The version can't be cached as a second row, being the dedup token.
+	UpdateInstallerScriptsAndQueries(ctx context.Context, installerID uint, version string, installScript string, uninstallScript string, patchQuery string, appOpenQuery string) error
 
 	// GetCachedFMAInstallerMetadata returns the cached metadata for a specific
 	// FMA installer version, including install/uninstall scripts, URL, SHA256,

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -628,6 +628,16 @@ func (s *HostSoftwareInstallerResultAuthz) AuthzType() string {
 	return "host_software_installer_result"
 }
 
+// CachedInstallerMetadata describes installer bytes already in the store, for a
+// version being cached without downloading the file again. Filename and Extension
+// come off the stored row because an installer URL often ends in neither.
+type CachedInstallerMetadata struct {
+	PackageIDs  []string
+	UpgradeCode string
+	Filename    string
+	Extension   string
+}
+
 type UploadSoftwareInstallerPayload struct {
 	TeamID               *uint
 	TitleID              *uint

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1712,7 +1712,7 @@ type MarkFleetMaintainedAppVersionCurrentFunc func(ctx context.Context, installe
 
 type ListFleetMaintainedAppActiveInstallersFunc func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error)
 
-type GetSoftwareInstallerMetadataByStorageIDFunc func(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error)
+type GetSoftwareInstallerMetadataByStorageIDFunc func(ctx context.Context, storageID string) (fleet.CachedInstallerMetadata, error)
 
 type InsertFleetMaintainedAppVersionFunc func(ctx context.Context, activeInstallerID uint, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, err error)
 
@@ -1727,6 +1727,8 @@ type SetPinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint, 
 type DeletePinnedVersionFunc func(ctx context.Context, teamID *uint, titleID uint) error
 
 type HasFMAInstallerVersionFunc func(ctx context.Context, teamID *uint, fmaID uint, version string) (versionExists bool, storageID string, err error)
+
+type UpdateInstallerScriptsAndQueriesFunc func(ctx context.Context, installerID uint, version string, installScript string, uninstallScript string, patchQuery string, appOpenQuery string) error
 
 type GetCachedFMAInstallerMetadataFunc func(ctx context.Context, teamID *uint, fmaID uint, version string) (*fleet.MaintainedApp, error)
 
@@ -4922,6 +4924,9 @@ type DataStore struct {
 
 	HasFMAInstallerVersionFunc        HasFMAInstallerVersionFunc
 	HasFMAInstallerVersionFuncInvoked bool
+
+	UpdateInstallerScriptsAndQueriesFunc        UpdateInstallerScriptsAndQueriesFunc
+	UpdateInstallerScriptsAndQueriesFuncInvoked bool
 
 	GetCachedFMAInstallerMetadataFunc        GetCachedFMAInstallerMetadataFunc
 	GetCachedFMAInstallerMetadataFuncInvoked bool
@@ -11791,7 +11796,7 @@ func (s *DataStore) ListFleetMaintainedAppActiveInstallers(ctx context.Context) 
 	return s.ListFleetMaintainedAppActiveInstallersFunc(ctx)
 }
 
-func (s *DataStore) GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (packageIDs []string, upgradeCode string, err error) {
+func (s *DataStore) GetSoftwareInstallerMetadataByStorageID(ctx context.Context, storageID string) (fleet.CachedInstallerMetadata, error) {
 	s.mu.Lock()
 	s.GetSoftwareInstallerMetadataByStorageIDFuncInvoked = true
 	s.mu.Unlock()
@@ -11845,6 +11850,13 @@ func (s *DataStore) HasFMAInstallerVersion(ctx context.Context, teamID *uint, fm
 	s.HasFMAInstallerVersionFuncInvoked = true
 	s.mu.Unlock()
 	return s.HasFMAInstallerVersionFunc(ctx, teamID, fmaID, version)
+}
+
+func (s *DataStore) UpdateInstallerScriptsAndQueries(ctx context.Context, installerID uint, version string, installScript string, uninstallScript string, patchQuery string, appOpenQuery string) error {
+	s.mu.Lock()
+	s.UpdateInstallerScriptsAndQueriesFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpdateInstallerScriptsAndQueriesFunc(ctx, installerID, version, installScript, uninstallScript, patchQuery, appOpenQuery)
 }
 
 func (s *DataStore) GetCachedFMAInstallerMetadata(ctx context.Context, teamID *uint, fmaID uint, version string) (*fleet.MaintainedApp, error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29309,6 +29309,61 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 	editedInstall, editedUninstall = activeScriptEditedFlags(team.ID, titleID)
 	require.True(t, editedInstall)
 	require.False(t, editedUninstall)
+
+	// A manifest can change a script or a query without publishing a new version.
+	// There is nothing to download then, and the version can't be cached a second
+	// time, so the row that is already there is refreshed in place.
+	cachedRows := func() (count int) {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &count,
+				`SELECT COUNT(*) FROM software_installers WHERE global_or_team_id = ? AND title_id = ?`, team.ID, titleID)
+		})
+		return count
+	}
+	activePatchQuery := func() (query string) {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &query,
+				`SELECT patch_query FROM software_installers WHERE global_or_team_id = ? AND title_id = ? AND is_active = 1`,
+				team.ID, titleID)
+		})
+		return query
+	}
+	rowsBefore := cachedRows()
+	installerBefore := activeInstallerID(team.ID, titleID)
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", host.ID, titleID), installSoftwareRequest{}, http.StatusAccepted)
+
+	warp.installScript = "#!/bin/sh\necho refreshed\n"
+	warp.patchQuery = fmt.Sprintf(warpPatchQueryFmt, "7.0.1")
+	runCron()
+
+	require.Equal(t, "7.0", activeTitle(team.ID).SoftwarePackage.Version, "no version was published")
+	require.Equal(t, rowsBefore, cachedRows(), "the version can't be cached twice")
+	require.Equal(t, installerBefore, activeInstallerID(team.ID, titleID), "refreshed in place")
+	gotInstall, gotUninstall = activeScripts(team.ID, titleID)
+	require.Equal(t, patchedInstall, gotInstall, "the edited script is still left alone")
+	require.Equal(t, warp.installScript, gotUninstall, "the unedited script follows the manifest")
+	require.Equal(t, warp.patchQuery, activePatchQuery(), "the patch query follows the manifest too")
+
+	// The queued install would otherwise have run a script it was never queued against.
+	var canceled bool
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &canceled, `SELECT canceled FROM host_software_installs
+			WHERE host_id = ? ORDER BY created_at DESC LIMIT 1`, host.ID)
+	})
+	require.True(t, canceled)
+
+	// Nothing changed upstream, so a second pass leaves the scripts alone and the
+	// install queued against them keeps running.
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/software/%d/install", host.ID, titleID), installSoftwareRequest{}, http.StatusAccepted)
+	runCron()
+	gotInstall, gotUninstall = activeScripts(team.ID, titleID)
+	require.Equal(t, patchedInstall, gotInstall)
+	require.Equal(t, warp.installScript, gotUninstall)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &canceled, `SELECT canceled FROM host_software_installs
+			WHERE host_id = ? ORDER BY created_at DESC LIMIT 1`, host.ID)
+	})
+	require.False(t, canceled)
 }
 
 func (s *integrationEnterpriseTestSuite) TestFMAVersionRollback() {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51989

This should be how GitOps FMA updates work currently.
Also fixes an issue where an already existing installer would try to infer filename and extension from the URL rather than from the stored data in `software_installers`.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fleet-maintained app updates now apply manifest-only changes to installation scripts and queries, even when the app version is unchanged.
  * Existing cached installers are updated without creating duplicate versions or re-downloading unchanged files.
  * Administrator-edited scripts remain preserved, while unedited content follows the latest manifest.
  * Pending installs using stale installer content are canceled to prevent outdated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->