### PR TITLE
Use MDM on/off language in Controls card empty state

### DIFF
--- a/changes/mdm-on-off-no-controls-copy
+++ b/changes/mdm-on-off-no-controls-copy
@@ -1,0 +1,1 @@
+- Updated the host details "Controls" card's empty state to use "MDM is off" instead of "isn't enrolled in MDM," matching Fleet's "MDM on/off" terminology.

--- a/changes/mdm-on-off-no-controls-copy
+++ b/changes/mdm-on-off-no-controls-copy
@@ -1,1 +1,0 @@
-- Updated the host details "Controls" card's empty state to say the host/device "isn't talking to Fleet for MDM features" instead of "isn't enrolled in MDM," matching Fleet's "MDM on/off" terminology.

--- a/changes/mdm-on-off-no-controls-copy
+++ b/changes/mdm-on-off-no-controls-copy
@@ -1,1 +1,1 @@
-- Updated the host details "Controls" card's empty state to use "MDM is off" instead of "isn't enrolled in MDM," matching Fleet's "MDM on/off" terminology.
+- Updated the host details "Controls" card's empty state to say the host/device "isn't talking to Fleet for MDM features" instead of "isn't enrolled in MDM," matching Fleet's "MDM on/off" terminology.

--- a/frontend/pages/hosts/details/cards/Controls/Controls.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/Controls.tests.tsx
@@ -198,19 +198,23 @@ describe("Controls card", () => {
     // A host Fleet has no MDM connection to can't receive controls at all, so
     // "none have been added" would point at the wrong problem.
     describe("a host not connected to Fleet MDM", () => {
-      it("says MDM is off for the host", () => {
+      it("says the host isn't talking to Fleet for MDM features", () => {
         renderControls({ canAddControls: true, isConnectedToFleetMdm: false });
 
         expect(
-          screen.getByText("No controls available. MDM is off for this host.")
+          screen.getByText(
+            "No controls available. This host isn't talking to Fleet for MDM features."
+          )
         ).toBeInTheDocument();
       });
 
-      it("says MDM is off on My device", () => {
+      it("says the device isn't talking to Fleet for MDM features on My device", () => {
         renderControls({ isDeviceUser: true, isConnectedToFleetMdm: false });
 
         expect(
-          screen.getByText("No controls available. MDM is off for your device.")
+          screen.getByText(
+            "No controls available. Your device isn't talking to Fleet for MDM features."
+          )
         ).toBeInTheDocument();
       });
 

--- a/frontend/pages/hosts/details/cards/Controls/Controls.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/Controls.tests.tsx
@@ -198,23 +198,19 @@ describe("Controls card", () => {
     // A host Fleet has no MDM connection to can't receive controls at all, so
     // "none have been added" would point at the wrong problem.
     describe("a host not connected to Fleet MDM", () => {
-      it("says the host isn't enrolled", () => {
+      it("says MDM is off for the host", () => {
         renderControls({ canAddControls: true, isConnectedToFleetMdm: false });
 
         expect(
-          screen.getByText(
-            "No controls available. This host isn't enrolled in MDM."
-          )
+          screen.getByText("No controls available. MDM is off for this host.")
         ).toBeInTheDocument();
       });
 
-      it("says the device isn't enrolled on My device", () => {
+      it("says MDM is off on My device", () => {
         renderControls({ isDeviceUser: true, isConnectedToFleetMdm: false });
 
         expect(
-          screen.getByText(
-            "No controls available. Your device isn't enrolled in MDM."
-          )
+          screen.getByText("No controls available. MDM is off for your device.")
         ).toBeInTheDocument();
       });
 

--- a/frontend/pages/hosts/details/cards/Controls/Controls.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/Controls.tsx
@@ -102,8 +102,8 @@ const Controls = ({
   const emptyStateInfo = () => {
     if (!isConnectedToFleetMdm) {
       return isDeviceUser
-        ? "No controls available. Your device isn't enrolled in MDM."
-        : "No controls available. This host isn't enrolled in MDM.";
+        ? "No controls available. MDM is off for your device."
+        : "No controls available. MDM is off for this host.";
     }
     return isDeviceUser
       ? "No controls have been added for your device."

--- a/frontend/pages/hosts/details/cards/Controls/Controls.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/Controls.tsx
@@ -102,8 +102,8 @@ const Controls = ({
   const emptyStateInfo = () => {
     if (!isConnectedToFleetMdm) {
       return isDeviceUser
-        ? "No controls available. MDM is off for your device."
-        : "No controls available. MDM is off for this host.";
+        ? "No controls available. Your device isn't talking to Fleet for MDM features."
+        : "No controls available. This host isn't talking to Fleet for MDM features.";
     }
     return isDeviceUser
       ? "No controls have been added for your device."


### PR DESCRIPTION
- Went with "isn't talking to Fleet for MDM features" (more explicit than a first pass at "MDM is off") because it's also accurate for a host enrolled in a third-party MDM (e.g Jamf)
  - "MDM is off" would be wrong since its MDM is on, just not with Fleet.

Context: https://fleetdm.slack.com/archives/C03C41L5YEL/p1787933252223669



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Controls card messaging for hosts not connected to Fleet for MDM features.
  * Clarified empty-state text in both host and “My device” views.
  * Updated related tests to reflect the revised messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->