### PR TITLE
Website: add Newsletters and Industry news article categories

### DIFF
--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -111,6 +111,14 @@ module.exports = {
         pageTitleForMeta = 'Webinars';
         pageDescriptionForMeta = 'Watch Fleet and industry practitioners discuss real-world device management and IT operations.';
         break;
+      case 'newsletters':
+        pageTitleForMeta = 'Newsletters';
+        pageDescriptionForMeta = 'Catch up on past issues of the Fleet newsletter.';
+        break;
+      case 'industry-news':
+        pageTitleForMeta = 'Industry news';
+        pageDescriptionForMeta = 'Device management and security news, and what it means for the devices you manage.';
+        break;
     }
 
 

--- a/website/api/controllers/articles/view-basic-article.js
+++ b/website/api/controllers/articles/view-basic-article.js
@@ -77,6 +77,8 @@ module.exports = {
       'podcasts': 'Podcasts',
       'report': 'Reports',
       'articles': 'Blog',
+      'newsletters': 'Newsletters',
+      'industry-news': 'Industry news',
     };
     let categoryFriendlyName = categoryFriendlyNamesByCategorySlug[articleCategorySlug];
 

--- a/website/api/controllers/download-rss-feed.js
+++ b/website/api/controllers/download-rss-feed.js
@@ -23,6 +23,8 @@ module.exports = {
         'podcasts',
         'report',
         'articles',
+        'newsletters',
+        'industry-news',
       ],
     }
 
@@ -85,6 +87,14 @@ module.exports = {
       case 'report':
         articleCategoryTitle = 'Reports | Fleet blog';
         categoryDescription = '';
+        break;
+      case 'newsletters':
+        articleCategoryTitle = 'Newsletters | Fleet blog';
+        categoryDescription = 'Catch up on past issues of the Fleet newsletter.';
+        break;
+      case 'industry-news':
+        articleCategoryTitle = 'Industry news | Fleet blog';
+        categoryDescription = 'Device management and security news, and what it means for the devices you manage.';
         break;
       case 'articles':
         articleCategoryTitle = 'Fleet blog | Fleet';

--- a/website/api/controllers/download-sitemap.js
+++ b/website/api/controllers/download-sitemap.js
@@ -64,6 +64,8 @@ module.exports = {
       '/podcasts',// « article category page
       '/whitepapers',// « article category page
       '/webinars',// « article category page
+      '/newsletters',// « article category page
+      '/industry-news',// « article category page
       // Product category pages:
       '/orchestration',
       '/device-management',

--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -54,6 +54,14 @@ parasails.registerPage('articles', {
         this.articleCategory = 'Webinars';
         this.categoryDescription = 'Watch Fleet and industry practitioners discuss real-world device management and IT operations.';
         break;
+      case 'newsletters':
+        this.articleCategory = 'Newsletters';
+        this.categoryDescription = 'Catch up on past issues of the Fleet newsletter.';
+        break;
+      case 'industry-news':
+        this.articleCategory = 'Industry news';
+        this.categoryDescription = 'Device management and security news, and what it means for the devices you manage.';
+        break;
       case 'articles':
         this.articleCategory = 'Blog';
         this.categoryDescription = 'Read the latest articles from the Fleet team and community.';

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -221,6 +221,38 @@ module.exports.routes = {
     }
   },// handles /announcements/foo
 
+  'GET /newsletters': {
+    skipAssets: false,
+    action: 'articles/view-articles',// Meta title and description set in view action
+    locals: {
+      currentSection: 'more',
+    }
+  },
+
+  'GET /newsletters/*': {
+    skipAssets: false,
+    action: 'articles/view-basic-article',// Meta title and description set in view action
+    locals: {
+      currentSection: 'more',
+    }
+  },// handles /newsletters/foo
+
+  'GET /industry-news': {
+    skipAssets: false,
+    action: 'articles/view-articles',// Meta title and description set in view action
+    locals: {
+      currentSection: 'more',
+    }
+  },
+
+  'GET /industry-news/*': {
+    skipAssets: false,
+    action: 'articles/view-basic-article',// Meta title and description set in view action
+    locals: {
+      currentSection: 'more',
+    }
+  },// handles /industry-news/foo
+
   'GET /podcasts': {
     skipAssets: false,
     action: 'articles/view-articles',// Meta title and description set in view action

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -664,7 +664,7 @@ module.exports = {
                   throw new Error(`Failed compiling markdown content: An article page is missing a category meta tag (<meta name="category" value="guides">) at "${path.join(topLvlRepoPath, pageSourcePath)}".  To resolve, add a meta tag with the category of the article`);
                 } else {
                   // Throwing an error if the article has an invalid category.
-                  let validArticleCategories = ['deploy', 'articles', 'security', 'engineering', 'announcements', 'guides', 'releases', 'podcasts', 'report', 'case study', 'comparison', 'whitepaper', 'webinar' ];
+                  let validArticleCategories = ['deploy', 'articles', 'security', 'engineering', 'announcements', 'guides', 'releases', 'podcasts', 'report', 'case study', 'comparison', 'whitepaper', 'webinar', 'newsletter', 'industry news' ];
                   if(!validArticleCategories.includes(embeddedMetadata.category)) {
                     throw new Error(`Failed compiling markdown content: An article page has an invalid category meta tag (<meta name="category" value="${embeddedMetadata.category}">) at "${path.join(topLvlRepoPath, pageSourcePath)}". To resolve, change the meta tag to a valid category, one of: ${validArticleCategories}`);
                   }
@@ -793,7 +793,7 @@ module.exports = {
                   // For article pages, we'll attach the category to the `rootRelativeUrlPath`.
                   rootRelativeUrlPath = (
                     '/' +
-                    (encodeURIComponent(embeddedMetadata.category === 'security' ? 'securing' : embeddedMetadata.category === 'whitepaper' ? 'whitepapers' : embeddedMetadata.category === 'webinar' ? 'webinars' : embeddedMetadata.category === 'case study' ? 'case-study' : embeddedMetadata.category)) + '/' +
+                    (encodeURIComponent(embeddedMetadata.category === 'security' ? 'securing' : embeddedMetadata.category === 'whitepaper' ? 'whitepapers' : embeddedMetadata.category === 'webinar' ? 'webinars' : embeddedMetadata.category === 'case study' ? 'case-study' : embeddedMetadata.category === 'newsletter' ? 'newsletters' : embeddedMetadata.category === 'industry news' ? 'industry-news' : embeddedMetadata.category)) + '/' +
                     (pageUnextensionedUnwhitespacedLowercasedRelPath.split(/\//).map((fileOrFolderName) => encodeURIComponent(fileOrFolderName.replace(/^[0-9]+[\-]+/,'').replace(/\./g, '-'))).join('/'))
                   );
                 }

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -35,6 +35,8 @@
         <div purpose="nav-links">
           <a href="/articles">All</a>
           <a href="/announcements">News</a>
+          <a href="/industry-news">Industry news</a>
+          <a href="/newsletters">Newsletters</a>
           <a href="/customers">Case studies</a>
           <a href="/guides">Guides</a>
           <a href="/whitepapers">Whitepapers</a>

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -95,7 +95,7 @@
             </div>
           </div>
         </div>
-        <div purpose="article-content" :class="[[['articles', 'releases', 'guides', 'announcements', 'podcasts', 'securing'].includes(articleCategorySlug) ? 'pb-0' : '']]" parasails-has-no-page-script>
+        <div purpose="article-content" :class="[[['articles', 'releases', 'guides', 'announcements', 'podcasts', 'securing', 'newsletters', 'industry-news'].includes(articleCategorySlug) ? 'pb-0' : '']]" parasails-has-no-page-script>
           <%- partial(path.relative(path.dirname(__filename), path.resolve( sails.config.appPath, path.join(sails.config.builtStaticContent.compiledPagePartialsAppPath, thisPage.htmlId)))) %>
 
           <div purpose="about-fleet-section" v-if="articleCategorySlug === 'customers'">
@@ -108,7 +108,7 @@
             <p>Fleet offers total deployment flexibility: on-premises, air-gapped, container-native (Docker and Kubernetes), or cloud-agnostic (AWS, Azure, GCP, DigitalOcean). Organizations can also choose fully managed SaaS via Fleet Cloud, ensuring complete control over data residency and legal jurisdiction.</p>
           </div>
           <div purpose="cta-container">
-            <div purpose="article-cta" v-if="['articles', 'releases', 'guides', 'announcements', 'podcasts', 'securing'].includes(articleCategorySlug)">
+            <div purpose="article-cta" v-if="['articles', 'releases', 'guides', 'announcements', 'podcasts', 'securing', 'newsletters', 'industry-news'].includes(articleCategorySlug)">
               <h2>Manage all your devices like it's 2026</h2>
               <p>Open MDM, patching, and vuln management for every OS.</p>
               <div purpose="button-row">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

Adds two new article categories to the blog, `Newsletters` and `Industry news`, so newsletter issues and industry news commentary get their own sidebar entries instead of being mixed into **News** and the **All** blog index.

Both categories ship empty. No existing articles are recategorized, so no article URLs change and no redirects are needed. Content gets filed into them going forward:

```
<meta name="category" value="newsletter">      -> /newsletters/<slug>
<meta name="category" value="industry news">   -> /industry-news/<slug>
```

The meta value stays singular and human-readable while the URL is pluralized/hyphenated, matching the existing `whitepaper` -> `whitepapers` and `case study` -> `case-study` precedent.

## What changed

Registered the two slugs at every place the existing categories are wired:

| File | Change |
|---|---|
| `website/scripts/build-static-content.js` | `newsletter` + `industry news` added to `validArticleCategories`, plus the category-to-URL-segment mapping |
| `website/config/routes.js` | 4 routes: category listing page and article pages for each |
| `website/views/pages/articles/articles.ejs` | Sidebar links, grouped next to **News** |
| `website/assets/js/pages/articles/articles.page.js` | Client-side category heading and description |
| `website/api/controllers/articles/view-articles.js` | Meta title/description for the listing pages |
| `website/api/controllers/articles/view-basic-article.js` | Friendly category name for the article breadcrumb |
| `website/api/controllers/download-rss-feed.js` | Feeds at `/rss/newsletters` and `/rss/industry-news` |
| `website/api/controllers/download-sitemap.js` | Both listing pages added to the sitemap |
| `website/views/pages/articles/basic-article.ejs` | Blog-style bottom CTA and padding treatment applies to both |

Sidebar order is now: All, News, **Industry news**, **Newsletters**, Case studies, Guides, Whitepapers, Webinars, Releases.

## Notes for reviewers

Two judgment calls that are easy to flip if you'd rather go the other way:

1. **Both categories appear in the All tab.** `view-articles.js` excludes only `/guides`, `/whitepapers`, and `/webinars` from the blog index, so newsletters and industry news will show up in **All** alongside News and Releases. If newsletters should be excluded like the other non-blog formats, that's a one-line change to the filter.
2. **Algolia search is off on these two listing pages**, matching `/securing`, `/podcasts`, and `/report`. The search box only renders for `articles`, `announcements`, `guides`, and `releases`.

# Checklist for submitter

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [ ] QA'd all new/changed functionality manually

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

> Not yet done: `website/node_modules` was not installed in the worktree this was written in, so `npm run lint` and `sails run build-static-content` have not been run and the pages have not been loaded in a browser. All nine changed JS files pass `node --check`. Before this comes out of draft it needs `cd website && npm install && npm run lint && sails run build-static-content`, plus a look at `/newsletters` and `/industry-news` (both will render as empty listing pages) and a screenshot of the new sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated **Newsletters** and **Industry news** sections with new navigation links and routes.
  * Added category-specific descriptions and page titles for both sections.
  * Included newsletter and industry news articles in RSS feeds and the sitemap.
  * Added support for correctly building and displaying article pages in these categories.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->