### PR TITLE
Fleet UI: Auto updates indicator app-wide

### DIFF
--- a/frontend/components/Chip/Chip.tsx
+++ b/frontend/components/Chip/Chip.tsx
@@ -14,6 +14,9 @@ interface IChipProps {
   className?: string;
   onClick?: () => void;
   tooltip?: React.ReactNode;
+  /** Forwarded to TooltipWrapper. Set false when the tooltip has manual
+   * `<br />`s or inline links so the auto-balancer doesn't fight the layout. */
+  tooltipTextBalanced?: boolean;
 }
 
 const Chip = ({
@@ -23,6 +26,7 @@ const Chip = ({
   className,
   onClick,
   tooltip,
+  tooltipTextBalanced,
 }: IChipProps) => {
   const classNames = classnames(
     baseClass,
@@ -61,6 +65,7 @@ const Chip = ({
       underline={false}
       showArrow
       tipOffset={8}
+      textBalanced={tooltipTextBalanced}
     >
       {chip}
     </TooltipWrapper>

--- a/frontend/components/Chip/Chip.tsx
+++ b/frontend/components/Chip/Chip.tsx
@@ -14,8 +14,7 @@ interface IChipProps {
   className?: string;
   onClick?: () => void;
   tooltip?: React.ReactNode;
-  /** Forwarded to TooltipWrapper. Set false when the tooltip has manual
-   * `<br />`s or inline links so the auto-balancer doesn't fight the layout. */
+  /** Forwarded to TooltipWrapper; set false to opt out of auto-balancing. */
   tooltipTextBalanced?: boolean;
 }
 

--- a/frontend/components/CommandPalette/components/SoftwarePicker.tsx
+++ b/frontend/components/CommandPalette/components/SoftwarePicker.tsx
@@ -45,6 +45,9 @@ const getInstallerProps = (title: ISoftwareTitle) => {
     isIosOrIpadosApp: isIpadOrIphoneSoftwareSource(title.source),
     isAndroidPlayStoreApp:
       !!title.app_store_app && title.source === "android_apps",
+    autoUpdateEnabled: title.auto_update_enabled,
+    autoUpdateWindowStart: title.auto_update_window_start,
+    autoUpdateWindowEnd: title.auto_update_window_end,
   };
 };
 

--- a/frontend/components/CommandPalette/components/SoftwarePicker.tsx
+++ b/frontend/components/CommandPalette/components/SoftwarePicker.tsx
@@ -45,6 +45,7 @@ const getInstallerProps = (title: ISoftwareTitle) => {
     isIosOrIpadosApp: isIpadOrIphoneSoftwareSource(title.source),
     isAndroidPlayStoreApp:
       !!title.app_store_app && title.source === "android_apps",
+    isAppStoreApp: !!title.app_store_app,
     autoUpdateEnabled: title.auto_update_enabled,
     autoUpdateWindowStart: title.auto_update_window_start,
     autoUpdateWindowEnd: title.auto_update_window_end,

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -232,47 +232,87 @@ describe("SoftwareNameCell icon rendering", () => {
     ).toBeInTheDocument();
   });
 
-  // VPP auto-update badge — separate from the install-icon family. Renders
-  // alongside the install icon (both can be present on the same row).
-  it("shows a refresh badge with window tooltip when autoUpdateEnabled is true", async () => {
-    const render = createCustomRenderer({ withBackendMock: true });
-    render(
-      <SoftwareNameCell
-        {...defaultProps}
-        autoUpdateEnabled
-        autoUpdateWindowStart="02:00"
-        autoUpdateWindowEnd="04:00"
-      />
-    );
-    // No install icon on this VPP-only row, but the auto-update badge renders.
-    const icons = screen.getAllByTestId("refresh-icon");
-    expect(icons).toHaveLength(1);
-    await userEvent.hover(icons[0]);
-    expect(
-      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
-    ).toBeInTheDocument();
-  });
-
-  it("does not render the auto-update badge when autoUpdateEnabled is false", () => {
-    const render = createCustomRenderer({ withBackendMock: true });
-    render(<SoftwareNameCell {...defaultProps} autoUpdateEnabled={false} />);
-    expect(screen.queryByTestId("refresh-icon")).toBeNull();
-  });
-
-  it("renders both the install icon and the auto-update badge when both apply", async () => {
+  // VPP auto-update folds into the automatic icon family: same visual as
+  // policy-triggered auto-install, with an added tooltip line for the window.
+  it("shows the refresh icon with a window tooltip when autoUpdateEnabled is true (no policies, no self-service)", async () => {
     const render = createCustomRenderer({ withBackendMock: true });
     render(
       <SoftwareNameCell
         {...defaultProps}
         hasInstaller
-        automaticInstallPoliciesCount={1}
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"
         autoUpdateWindowEnd="04:00"
       />
     );
-    // Auto-install refresh + auto-update refresh — two separate icons.
-    const icons = screen.getAllByTestId("refresh-icon");
-    expect(icons).toHaveLength(2);
+    const icon = screen.getByTestId("refresh-icon");
+    await userEvent.hover(icon);
+    expect(
+      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows the composite automatic-self-service icon with a double-barrel tooltip when self-service + auto-update", async () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        hasInstaller
+        isSelfService
+        autoUpdateEnabled
+        autoUpdateWindowStart="02:00"
+        autoUpdateWindowEnd="04:00"
+      />
+    );
+    const icon = screen.getByTestId("automatic-self-service-icon");
+    await userEvent.hover(icon);
+    expect(
+      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/End users can install/i)
+    ).toBeInTheDocument();
+  });
+
+  it("stacks all three tooltip lines when policies + self-service + auto-update all apply", async () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        hasInstaller
+        isSelfService
+        automaticInstallPoliciesCount={2}
+        autoUpdateEnabled
+        autoUpdateWindowStart="02:00"
+        autoUpdateWindowEnd="04:00"
+      />
+    );
+    const icon = screen.getByTestId("automatic-self-service-icon");
+    await userEvent.hover(icon);
+    expect(
+      await screen.findByText(/2 policies trigger install\./i)
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(/End users can install/i)
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the self-service icon when autoUpdateEnabled is false (unchanged path)", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        hasInstaller
+        isSelfService
+        autoUpdateEnabled={false}
+      />
+    );
+    // No refresh, no composite — just the user icon.
+    expect(screen.getByTestId("user-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("refresh-icon")).toBeNull();
+    expect(screen.queryByTestId("automatic-self-service-icon")).toBeNull();
   });
 });

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -231,4 +231,48 @@ describe("SoftwareNameCell icon rendering", () => {
       await screen.findByText(/End users can install/i)
     ).toBeInTheDocument();
   });
+
+  // VPP auto-update badge — separate from the install-icon family. Renders
+  // alongside the install icon (both can be present on the same row).
+  it("shows a refresh badge with window tooltip when autoUpdateEnabled is true", async () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        autoUpdateEnabled
+        autoUpdateWindowStart="02:00"
+        autoUpdateWindowEnd="04:00"
+      />
+    );
+    // No install icon on this VPP-only row, but the auto-update badge renders.
+    const icons = screen.getAllByTestId("refresh-icon");
+    expect(icons).toHaveLength(1);
+    await userEvent.hover(icons[0]);
+    expect(
+      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the auto-update badge when autoUpdateEnabled is false", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<SoftwareNameCell {...defaultProps} autoUpdateEnabled={false} />);
+    expect(screen.queryByTestId("refresh-icon")).toBeNull();
+  });
+
+  it("renders both the install icon and the auto-update badge when both apply", async () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <SoftwareNameCell
+        {...defaultProps}
+        hasInstaller
+        automaticInstallPoliciesCount={1}
+        autoUpdateEnabled
+        autoUpdateWindowStart="02:00"
+        autoUpdateWindowEnd="04:00"
+      />
+    );
+    // Auto-install refresh + auto-update refresh — two separate icons.
+    const icons = screen.getAllByTestId("refresh-icon");
+    expect(icons).toHaveLength(2);
+  });
 });

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -241,6 +241,7 @@ describe("SoftwareNameCell icon rendering", () => {
       <SoftwareNameCell
         {...defaultProps}
         hasInstaller
+        isIosOrIpadosApp
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"
         autoUpdateWindowEnd="04:00"
@@ -269,6 +270,7 @@ describe("SoftwareNameCell icon rendering", () => {
         {...defaultProps}
         hasInstaller
         isSelfService
+        isIosOrIpadosApp
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"
         autoUpdateWindowEnd="04:00"
@@ -300,6 +302,7 @@ describe("SoftwareNameCell icon rendering", () => {
         {...defaultProps}
         hasInstaller
         isSelfService
+        isIosOrIpadosApp
         automaticInstallPoliciesCount={2}
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import userEvent from "@testing-library/user-event";
 import { screen } from "@testing-library/react";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import { internationalTimeOnlyFormat } from "utilities/helpers";
 import SoftwareNameCell from "./SoftwareNameCell";
 
 const mockRouter = createMockRouter();
@@ -249,7 +250,14 @@ describe("SoftwareNameCell icon rendering", () => {
     await userEvent.hover(icon);
     expect(
       await screen.findByText(
-        /Auto updates between 02:00 and 04:00 \(host local time\)\./i
+        new RegExp(
+          `Auto updates between ${internationalTimeOnlyFormat(
+            "02:00"
+          )} and ${internationalTimeOnlyFormat(
+            "04:00"
+          )} \\(host local time\\)\\.`,
+          "i"
+        )
       )
     ).toBeInTheDocument();
   });
@@ -270,7 +278,14 @@ describe("SoftwareNameCell icon rendering", () => {
     await userEvent.hover(icon);
     expect(
       await screen.findByText(
-        /Auto updates between 02:00 and 04:00 \(host local time\)\./i
+        new RegExp(
+          `Auto updates between ${internationalTimeOnlyFormat(
+            "02:00"
+          )} and ${internationalTimeOnlyFormat(
+            "04:00"
+          )} \\(host local time\\)\\.`,
+          "i"
+        )
       )
     ).toBeInTheDocument();
     expect(
@@ -298,7 +313,14 @@ describe("SoftwareNameCell icon rendering", () => {
     ).toBeInTheDocument();
     expect(
       await screen.findByText(
-        /Auto updates between 02:00 and 04:00 \(host local time\)\./i
+        new RegExp(
+          `Auto updates between ${internationalTimeOnlyFormat(
+            "02:00"
+          )} and ${internationalTimeOnlyFormat(
+            "04:00"
+          )} \\(host local time\\)\\.`,
+          "i"
+        )
       )
     ).toBeInTheDocument();
     expect(

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -242,6 +242,7 @@ describe("SoftwareNameCell icon rendering", () => {
         {...defaultProps}
         hasInstaller
         isIosOrIpadosApp
+        isAppStoreApp
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"
         autoUpdateWindowEnd="04:00"
@@ -271,6 +272,7 @@ describe("SoftwareNameCell icon rendering", () => {
         hasInstaller
         isSelfService
         isIosOrIpadosApp
+        isAppStoreApp
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"
         autoUpdateWindowEnd="04:00"
@@ -303,6 +305,7 @@ describe("SoftwareNameCell icon rendering", () => {
         hasInstaller
         isSelfService
         isIosOrIpadosApp
+        isAppStoreApp
         automaticInstallPoliciesCount={2}
         autoUpdateEnabled
         autoUpdateWindowStart="02:00"

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tests.tsx
@@ -248,7 +248,9 @@ describe("SoftwareNameCell icon rendering", () => {
     const icon = screen.getByTestId("refresh-icon");
     await userEvent.hover(icon);
     expect(
-      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+      await screen.findByText(
+        /Auto updates between 02:00 and 04:00 \(host local time\)\./i
+      )
     ).toBeInTheDocument();
   });
 
@@ -267,7 +269,9 @@ describe("SoftwareNameCell icon rendering", () => {
     const icon = screen.getByTestId("automatic-self-service-icon");
     await userEvent.hover(icon);
     expect(
-      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+      await screen.findByText(
+        /Auto updates between 02:00 and 04:00 \(host local time\)\./i
+      )
     ).toBeInTheDocument();
     expect(
       await screen.findByText(/End users can install/i)
@@ -293,7 +297,9 @@ describe("SoftwareNameCell icon rendering", () => {
       await screen.findByText(/2 policies trigger install\./i)
     ).toBeInTheDocument();
     expect(
-      await screen.findByText(/Auto updates between 02:00 and 04:00\./i)
+      await screen.findByText(
+        /Auto updates between 02:00 and 04:00 \(host local time\)\./i
+      )
     ).toBeInTheDocument();
     expect(
       await screen.findByText(/End users can install/i)

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -28,22 +28,25 @@ interface InstallIconTooltip {
   pageContext?: PageContext;
   isIosOrIpadosApp?: boolean;
   isAndroidPlayStoreApp?: boolean;
+  autoUpdateEnabled?: boolean;
+  autoUpdateWindowStart?: string;
+  autoUpdateWindowEnd?: string;
 }
 
 interface InstallIconConfig {
   iconName: IconNames;
-  tooltip: ({
-    automaticInstallPoliciesCount,
-    pageContext,
-    isIosOrIpadosApp,
-    isAndroidPlayStoreApp,
-  }: InstallIconTooltip) => JSX.Element;
+  tooltip: (args: InstallIconTooltip) => JSX.Element;
 }
 
 const getPolicyTooltip = (count = 0) =>
   count === 1
     ? "A policy triggers install."
     : `${count} policies trigger install.`;
+
+const getAutoUpdateTooltip = (start?: string, end?: string) =>
+  start && end
+    ? `Auto updates between ${start} and ${end}.`
+    : "Auto updates enabled.";
 
 const installIconMap: Record<InstallType, InstallIconConfig> = {
   manual: {
@@ -62,8 +65,23 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
   },
   automatic: {
     iconName: "refresh",
-    tooltip: ({ automaticInstallPoliciesCount = 0 }) => (
-      <>{getPolicyTooltip(automaticInstallPoliciesCount)}</>
+    tooltip: ({
+      automaticInstallPoliciesCount = 0,
+      autoUpdateEnabled = false,
+      autoUpdateWindowStart,
+      autoUpdateWindowEnd,
+    }) => (
+      <>
+        {automaticInstallPoliciesCount > 0 && (
+          <>{getPolicyTooltip(automaticInstallPoliciesCount)}</>
+        )}
+        {automaticInstallPoliciesCount > 0 && autoUpdateEnabled && <br />}
+        {autoUpdateEnabled && (
+          <>
+            {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
+          </>
+        )}
+      </>
     ),
   },
   automaticSelfService: {
@@ -72,10 +90,23 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       automaticInstallPoliciesCount = 0,
       isIosOrIpadosApp = false,
       isAndroidPlayStoreApp = false,
+      autoUpdateEnabled = false,
+      autoUpdateWindowStart,
+      autoUpdateWindowEnd,
     }) => (
       <>
-        {getPolicyTooltip(automaticInstallPoliciesCount)}
-        <br />
+        {automaticInstallPoliciesCount > 0 && (
+          <>
+            {getPolicyTooltip(automaticInstallPoliciesCount)}
+            <br />
+          </>
+        )}
+        {autoUpdateEnabled && (
+          <>
+            {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
+            <br />
+          </>
+        )}
         {getSelfServiceTooltip(isIosOrIpadosApp, isAndroidPlayStoreApp)}
       </>
     ),
@@ -88,52 +119,25 @@ interface IInstallIconWithTooltipProps {
   pageContext?: PageContext;
   isIosOrIpadosApp: boolean;
   isAndroidPlayStoreApp: boolean;
+  autoUpdateEnabled?: boolean;
+  autoUpdateWindowStart?: string;
+  autoUpdateWindowEnd?: string;
 }
 
+// A row can be "automatic" via a policy-triggered install or a VPP scheduled
+// auto-update. Either signal promotes the icon to the automatic family so the
+// visual language stays consistent with the details page chip.
 const getInstallIconType = (
   isSelfService: boolean,
-  automaticInstallPoliciesCount = 0
+  automaticInstallPoliciesCount = 0,
+  autoUpdateEnabled = false
 ): InstallType => {
-  if (automaticInstallPoliciesCount > 0) {
+  const isAutomatic = automaticInstallPoliciesCount > 0 || autoUpdateEnabled;
+  if (isAutomatic) {
     return isSelfService ? "automaticSelfService" : "automatic";
   }
   return isSelfService ? "selfService" : "manual";
 };
-
-interface IAutoUpdateIconWithTooltipProps {
-  windowStart?: string;
-  windowEnd?: string;
-}
-
-export const AutoUpdateIconWithTooltip = ({
-  windowStart,
-  windowEnd,
-}: IAutoUpdateIconWithTooltipProps) => (
-  <div className={`${baseClass}__install-icon-with-tooltip`}>
-    <TooltipWrapper
-      tipContent={
-        windowStart && windowEnd ? (
-          <>
-            Auto updates between {windowStart} and {windowEnd}.
-          </>
-        ) : (
-          <>Auto updates enabled.</>
-        )
-      }
-      showArrow
-      underline={false}
-      position="top"
-      tipOffset={12}
-      fixedPositionStrategy
-    >
-      <Icon
-        name="refresh"
-        className={`${baseClass}__install-icon`}
-        color="ui-fleet-black-50"
-      />
-    </TooltipWrapper>
-  </div>
-);
 
 export const InstallIconWithTooltip = ({
   isSelfService,
@@ -141,10 +145,14 @@ export const InstallIconWithTooltip = ({
   pageContext,
   isIosOrIpadosApp,
   isAndroidPlayStoreApp,
+  autoUpdateEnabled,
+  autoUpdateWindowStart,
+  autoUpdateWindowEnd,
 }: IInstallIconWithTooltipProps) => {
   const iconType = getInstallIconType(
     isSelfService,
-    automaticInstallPoliciesCount
+    automaticInstallPoliciesCount,
+    autoUpdateEnabled
   );
 
   // Don't show installer icon on host software library page
@@ -158,6 +166,9 @@ export const InstallIconWithTooltip = ({
     pageContext,
     isIosOrIpadosApp,
     isAndroidPlayStoreApp,
+    autoUpdateEnabled,
+    autoUpdateWindowStart,
+    autoUpdateWindowEnd,
   });
 
   return (
@@ -197,8 +208,9 @@ interface ISoftwareNameCellProps {
   iconUrl?: string | null;
   isIosOrIpadosApp?: boolean;
   isAndroidPlayStoreApp?: boolean;
-  /** VPP auto-updates flag from the list response; when true, renders a refresh-icon
-   * badge alongside the install icon. */
+  /** VPP auto-updates flag from the list response. Promotes the install icon
+   * to the automatic (or automatic-self-service) variant and adds a window
+   * line to the tooltip. */
   autoUpdateEnabled?: boolean;
   autoUpdateWindowStart?: string;
   autoUpdateWindowEnd?: string;
@@ -263,24 +275,17 @@ const SoftwareNameCell = ({
       prefix={icon}
       value={softwareDisplayName}
       suffix={
-        hasInstaller || autoUpdateEnabled ? (
-          <>
-            {hasInstaller && (
-              <InstallIconWithTooltip
-                isSelfService={isSelfService}
-                automaticInstallPoliciesCount={automaticInstallPoliciesCount}
-                pageContext={pageContext}
-                isIosOrIpadosApp={isIosOrIpadosApp}
-                isAndroidPlayStoreApp={isAndroidPlayStoreApp}
-              />
-            )}
-            {autoUpdateEnabled && (
-              <AutoUpdateIconWithTooltip
-                windowStart={autoUpdateWindowStart}
-                windowEnd={autoUpdateWindowEnd}
-              />
-            )}
-          </>
+        hasInstaller ? (
+          <InstallIconWithTooltip
+            isSelfService={isSelfService}
+            automaticInstallPoliciesCount={automaticInstallPoliciesCount}
+            pageContext={pageContext}
+            isIosOrIpadosApp={isIosOrIpadosApp}
+            isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            autoUpdateEnabled={autoUpdateEnabled}
+            autoUpdateWindowStart={autoUpdateWindowStart}
+            autoUpdateWindowEnd={autoUpdateWindowEnd}
+          />
         ) : undefined
       }
     />

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -43,10 +43,8 @@ const getPolicyTooltip = (count = 0) =>
     ? "A policy triggers install."
     : `${count} policies trigger install.`;
 
-const getAutoUpdateTooltip = (start?: string, end?: string) =>
-  start && end
-    ? `Auto updates between ${start} and ${end}.`
-    : "Auto updates enabled.";
+const getAutoUpdateTooltip = (start: string, end: string) =>
+  `Auto updates between ${start} and ${end}.`;
 
 const installIconMap: Record<InstallType, InstallIconConfig> = {
   manual: {
@@ -70,19 +68,23 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateEnabled = false,
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
-    }) => (
-      <>
-        {automaticInstallPoliciesCount > 0 && (
-          <>{getPolicyTooltip(automaticInstallPoliciesCount)}</>
-        )}
-        {automaticInstallPoliciesCount > 0 && autoUpdateEnabled && <br />}
-        {autoUpdateEnabled && (
-          <>
-            {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
-          </>
-        )}
-      </>
-    ),
+    }) => {
+      const showAutoUpdate =
+        autoUpdateEnabled && !!autoUpdateWindowStart && !!autoUpdateWindowEnd;
+      return (
+        <>
+          {automaticInstallPoliciesCount > 0 && (
+            <>{getPolicyTooltip(automaticInstallPoliciesCount)}</>
+          )}
+          {automaticInstallPoliciesCount > 0 && showAutoUpdate && <br />}
+          {showAutoUpdate && (
+            <>
+              {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
+            </>
+          )}
+        </>
+      );
+    },
   },
   automaticSelfService: {
     iconName: "automatic-self-service",
@@ -93,23 +95,27 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateEnabled = false,
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
-    }) => (
-      <>
-        {automaticInstallPoliciesCount > 0 && (
-          <>
-            {getPolicyTooltip(automaticInstallPoliciesCount)}
-            <br />
-          </>
-        )}
-        {autoUpdateEnabled && (
-          <>
-            {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
-            <br />
-          </>
-        )}
-        {getSelfServiceTooltip(isIosOrIpadosApp, isAndroidPlayStoreApp)}
-      </>
-    ),
+    }) => {
+      const showAutoUpdate =
+        autoUpdateEnabled && !!autoUpdateWindowStart && !!autoUpdateWindowEnd;
+      return (
+        <>
+          {automaticInstallPoliciesCount > 0 && (
+            <>
+              {getPolicyTooltip(automaticInstallPoliciesCount)}
+              <br />
+            </>
+          )}
+          {showAutoUpdate && (
+            <>
+              {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
+              <br />
+            </>
+          )}
+          {getSelfServiceTooltip(isIosOrIpadosApp, isAndroidPlayStoreApp)}
+        </>
+      );
+    },
   },
 };
 

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -100,6 +100,41 @@ const getInstallIconType = (
   return isSelfService ? "selfService" : "manual";
 };
 
+interface IAutoUpdateIconWithTooltipProps {
+  windowStart?: string;
+  windowEnd?: string;
+}
+
+export const AutoUpdateIconWithTooltip = ({
+  windowStart,
+  windowEnd,
+}: IAutoUpdateIconWithTooltipProps) => (
+  <div className={`${baseClass}__install-icon-with-tooltip`}>
+    <TooltipWrapper
+      tipContent={
+        windowStart && windowEnd ? (
+          <>
+            Auto updates between {windowStart} and {windowEnd}.
+          </>
+        ) : (
+          <>Auto updates enabled.</>
+        )
+      }
+      showArrow
+      underline={false}
+      position="top"
+      tipOffset={12}
+      fixedPositionStrategy
+    >
+      <Icon
+        name="refresh"
+        className={`${baseClass}__install-icon`}
+        color="ui-fleet-black-50"
+      />
+    </TooltipWrapper>
+  </div>
+);
+
 export const InstallIconWithTooltip = ({
   isSelfService,
   automaticInstallPoliciesCount,
@@ -162,6 +197,11 @@ interface ISoftwareNameCellProps {
   iconUrl?: string | null;
   isIosOrIpadosApp?: boolean;
   isAndroidPlayStoreApp?: boolean;
+  /** VPP auto-updates flag from the list response; when true, renders a refresh-icon
+   * badge alongside the install icon. */
+  autoUpdateEnabled?: boolean;
+  autoUpdateWindowStart?: string;
+  autoUpdateWindowEnd?: string;
   /** Only used on Edit icon modal to render a preview of the chosen unsaved icon */
   previewIcon?: JSX.Element;
 }
@@ -179,6 +219,9 @@ const SoftwareNameCell = ({
   iconUrl,
   isIosOrIpadosApp = false,
   isAndroidPlayStoreApp = false,
+  autoUpdateEnabled = false,
+  autoUpdateWindowStart,
+  autoUpdateWindowEnd,
   previewIcon,
 }: ISoftwareNameCellProps) => {
   const softwareDisplayName = getDisplayedSoftwareName(name, display_name);
@@ -220,14 +263,24 @@ const SoftwareNameCell = ({
       prefix={icon}
       value={softwareDisplayName}
       suffix={
-        hasInstaller ? (
-          <InstallIconWithTooltip
-            isSelfService={isSelfService}
-            automaticInstallPoliciesCount={automaticInstallPoliciesCount}
-            pageContext={pageContext}
-            isIosOrIpadosApp={isIosOrIpadosApp}
-            isAndroidPlayStoreApp={isAndroidPlayStoreApp}
-          />
+        hasInstaller || autoUpdateEnabled ? (
+          <>
+            {hasInstaller && (
+              <InstallIconWithTooltip
+                isSelfService={isSelfService}
+                automaticInstallPoliciesCount={automaticInstallPoliciesCount}
+                pageContext={pageContext}
+                isIosOrIpadosApp={isIosOrIpadosApp}
+                isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+              />
+            )}
+            {autoUpdateEnabled && (
+              <AutoUpdateIconWithTooltip
+                windowStart={autoUpdateWindowStart}
+                windowEnd={autoUpdateWindowEnd}
+              />
+            )}
+          </>
         ) : undefined
       }
     />

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -186,6 +186,7 @@ export const InstallIconWithTooltip = ({
         position="top"
         tipOffset={12}
         fixedPositionStrategy
+        textBalanced={false}
       >
         <Icon
           name={iconName}

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -49,6 +49,29 @@ const getAutoUpdateTooltip = (start: string, end: string) =>
     start
   )} and ${internationalTimeOnlyFormat(end)} (host local time).`;
 
+// A VPP auto-update schedule only counts as "valid" — meaning the icon /
+// tooltip should treat it as active — when the window is fully populated
+// AND the row is iOS/iPadOS. `MDMAppleCheckinAndCommandService.handleScheduledUpdates`
+// only acts on `ios_apps` / `ipados_apps` sources, so a stale schedule row
+// on a macOS VPP title must not promote the icon or leak a window line.
+// Single source of truth for both the icon-type decision and each tooltip
+// branch's `showAutoUpdate` gate.
+const hasValidAutoUpdate = ({
+  autoUpdateEnabled = false,
+  autoUpdateWindowStart,
+  autoUpdateWindowEnd,
+  isIosOrIpadosApp = false,
+}: {
+  autoUpdateEnabled?: boolean;
+  autoUpdateWindowStart?: string;
+  autoUpdateWindowEnd?: string;
+  isIosOrIpadosApp?: boolean;
+}): boolean =>
+  autoUpdateEnabled &&
+  !!autoUpdateWindowStart &&
+  !!autoUpdateWindowEnd &&
+  isIosOrIpadosApp;
+
 const installIconMap: Record<InstallType, InstallIconConfig> = {
   manual: {
     iconName: "install",
@@ -73,16 +96,12 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateWindowEnd,
       isIosOrIpadosApp = false,
     }) => {
-      // Mirror the getInstallIconType source gate: the auto-update cron in
-      // apple_mdm.go only acts on ios_apps / ipados_apps. A stale schedule
-      // row on a macOS VPP title paired with a policy would otherwise leak
-      // an "Auto updates between …" line even though nothing will actually
-      // run against that schedule.
-      const showAutoUpdate =
-        autoUpdateEnabled &&
-        !!autoUpdateWindowStart &&
-        !!autoUpdateWindowEnd &&
-        isIosOrIpadosApp;
+      const showAutoUpdate = hasValidAutoUpdate({
+        autoUpdateEnabled,
+        autoUpdateWindowStart,
+        autoUpdateWindowEnd,
+        isIosOrIpadosApp,
+      });
       return (
         <>
           {automaticInstallPoliciesCount > 0 && (
@@ -91,7 +110,11 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
           {automaticInstallPoliciesCount > 0 && showAutoUpdate && " "}
           {showAutoUpdate && (
             <>
-              {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
+              {/* hasValidAutoUpdate above guarantees both fields are set. */}
+              {getAutoUpdateTooltip(
+                autoUpdateWindowStart!,
+                autoUpdateWindowEnd!
+              )}
             </>
           )}
         </>
@@ -108,12 +131,12 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
     }) => {
-      // Same source gate as the `automatic` branch above — see comment there.
-      const showAutoUpdate =
-        autoUpdateEnabled &&
-        !!autoUpdateWindowStart &&
-        !!autoUpdateWindowEnd &&
-        isIosOrIpadosApp;
+      const showAutoUpdate = hasValidAutoUpdate({
+        autoUpdateEnabled,
+        autoUpdateWindowStart,
+        autoUpdateWindowEnd,
+        isIosOrIpadosApp,
+      });
       return (
         <>
           {automaticInstallPoliciesCount > 0 && (
@@ -121,7 +144,11 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
           )}
           {showAutoUpdate && (
             <>
-              {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}{" "}
+              {/* hasValidAutoUpdate above guarantees both fields are set. */}
+              {getAutoUpdateTooltip(
+                autoUpdateWindowStart!,
+                autoUpdateWindowEnd!
+              )}{" "}
             </>
           )}
           {getSelfServiceTooltip(isIosOrIpadosApp, isAndroidPlayStoreApp)}
@@ -144,10 +171,7 @@ interface IInstallIconWithTooltipProps {
 
 // A row can be "automatic" via a policy-triggered install or a VPP scheduled
 // auto-update. Either signal promotes the icon to the automatic family so the
-// visual language stays consistent with the details page chip. Auto-updates
-// only counts when the window is fully populated AND the row is iOS/iPadOS —
-// the auto-update cron in apple_mdm.go only acts on ios_apps / ipados_apps
-// sources, so promoting the icon for a macOS VPP row would misrepresent it.
+// visual language stays consistent with the details page chip.
 const getInstallIconType = (
   isSelfService: boolean,
   automaticInstallPoliciesCount = 0,
@@ -156,12 +180,14 @@ const getInstallIconType = (
   autoUpdateWindowEnd?: string,
   isIosOrIpadosApp = false
 ): InstallType => {
-  const hasValidAutoUpdate =
-    autoUpdateEnabled &&
-    !!autoUpdateWindowStart &&
-    !!autoUpdateWindowEnd &&
-    isIosOrIpadosApp;
-  const isAutomatic = automaticInstallPoliciesCount > 0 || hasValidAutoUpdate;
+  const isAutomatic =
+    automaticInstallPoliciesCount > 0 ||
+    hasValidAutoUpdate({
+      autoUpdateEnabled,
+      autoUpdateWindowStart,
+      autoUpdateWindowEnd,
+      isIosOrIpadosApp,
+    });
   if (isAutomatic) {
     return isSelfService ? "automaticSelfService" : "automatic";
   }

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -76,12 +76,7 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
           {automaticInstallPoliciesCount > 0 && (
             <>{getPolicyTooltip(automaticInstallPoliciesCount)}</>
           )}
-          {automaticInstallPoliciesCount > 0 && showAutoUpdate && (
-            <>
-              <br />
-              <br />
-            </>
-          )}
+          {automaticInstallPoliciesCount > 0 && showAutoUpdate && " "}
           {showAutoUpdate && (
             <>
               {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
@@ -106,17 +101,11 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       return (
         <>
           {automaticInstallPoliciesCount > 0 && (
-            <>
-              {getPolicyTooltip(automaticInstallPoliciesCount)}
-              <br />
-              <br />
-            </>
+            <>{getPolicyTooltip(automaticInstallPoliciesCount)} </>
           )}
           {showAutoUpdate && (
             <>
-              {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
-              <br />
-              <br />
+              {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}{" "}
             </>
           )}
           {getSelfServiceTooltip(isIosOrIpadosApp, isAndroidPlayStoreApp)}

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -44,7 +44,7 @@ const getPolicyTooltip = (count = 0) =>
     : `${count} policies trigger install.`;
 
 const getAutoUpdateTooltip = (start: string, end: string) =>
-  `Auto updates between ${start} and ${end}.`;
+  `Auto updates between ${start} and ${end} (host local time).`;
 
 const installIconMap: Record<InstallType, InstallIconConfig> = {
   manual: {

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -76,7 +76,12 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
           {automaticInstallPoliciesCount > 0 && (
             <>{getPolicyTooltip(automaticInstallPoliciesCount)}</>
           )}
-          {automaticInstallPoliciesCount > 0 && showAutoUpdate && <br />}
+          {automaticInstallPoliciesCount > 0 && showAutoUpdate && (
+            <>
+              <br />
+              <br />
+            </>
+          )}
           {showAutoUpdate && (
             <>
               {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
@@ -104,11 +109,13 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
             <>
               {getPolicyTooltip(automaticInstallPoliciesCount)}
               <br />
+              <br />
             </>
           )}
           {showAutoUpdate && (
             <>
               {getAutoUpdateTooltip(autoUpdateWindowStart, autoUpdateWindowEnd)}
+              <br />
               <br />
             </>
           )}

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -49,13 +49,10 @@ const getAutoUpdateTooltip = (start: string, end: string) =>
     start
   )} and ${internationalTimeOnlyFormat(end)} (host local time).`;
 
-// A VPP auto-update schedule only counts as "valid" — meaning the icon /
-// tooltip should treat it as active — when the window is fully populated
-// AND the row is iOS/iPadOS. `MDMAppleCheckinAndCommandService.handleScheduledUpdates`
-// only acts on `ios_apps` / `ipados_apps` sources, so a stale schedule row
-// on a macOS VPP title must not promote the icon or leak a window line.
-// Single source of truth for both the icon-type decision and each tooltip
-// branch's `showAutoUpdate` gate.
+// True when the window is fully populated and the row is iOS/iPadOS.
+// `MDMAppleCheckinAndCommandService.handleScheduledUpdates` only acts on
+// `ios_apps` / `ipados_apps` sources, so a stale schedule row on a macOS
+// VPP title must not promote the icon or leak a window line.
 const hasValidAutoUpdate = ({
   autoUpdateEnabled = false,
   autoUpdateWindowStart,

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -29,6 +29,7 @@ interface InstallIconTooltip {
   pageContext?: PageContext;
   isIosOrIpadosApp?: boolean;
   isAndroidPlayStoreApp?: boolean;
+  isAppStoreApp?: boolean;
   autoUpdateEnabled?: boolean;
   autoUpdateWindowStart?: string;
   autoUpdateWindowEnd?: string;
@@ -49,25 +50,30 @@ const getAutoUpdateTooltip = (start: string, end: string) =>
     start
   )} and ${internationalTimeOnlyFormat(end)} (host local time).`;
 
-// True when the window is fully populated and the row is iOS/iPadOS.
-// `MDMAppleCheckinAndCommandService.handleScheduledUpdates` only acts on
-// `ios_apps` / `ipados_apps` sources, so a stale schedule row on a macOS
-// VPP title must not promote the icon or leak a window line.
+// True when the window is fully populated, the row is iOS/iPadOS, AND the
+// title has an app_store_app (VPP). `handleScheduledUpdates` only acts on
+// `ios_apps` / `ipados_apps` sources, and auto-update configuration is a
+// VPP-only feature — an in-house `.ipa` (iOS source, no app_store_app)
+// with a stale schedule row must not promote the icon or leak a window
+// line, nor must a macOS VPP row.
 const hasValidAutoUpdate = ({
   autoUpdateEnabled = false,
   autoUpdateWindowStart,
   autoUpdateWindowEnd,
   isIosOrIpadosApp = false,
+  isAppStoreApp = false,
 }: {
   autoUpdateEnabled?: boolean;
   autoUpdateWindowStart?: string;
   autoUpdateWindowEnd?: string;
   isIosOrIpadosApp?: boolean;
+  isAppStoreApp?: boolean;
 }): boolean =>
   autoUpdateEnabled &&
   !!autoUpdateWindowStart &&
   !!autoUpdateWindowEnd &&
-  isIosOrIpadosApp;
+  isIosOrIpadosApp &&
+  isAppStoreApp;
 
 const installIconMap: Record<InstallType, InstallIconConfig> = {
   manual: {
@@ -92,12 +98,14 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
       isIosOrIpadosApp = false,
+      isAppStoreApp = false,
     }) => {
       const showAutoUpdate = hasValidAutoUpdate({
         autoUpdateEnabled,
         autoUpdateWindowStart,
         autoUpdateWindowEnd,
         isIosOrIpadosApp,
+        isAppStoreApp,
       });
       return (
         <>
@@ -124,6 +132,7 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       automaticInstallPoliciesCount = 0,
       isIosOrIpadosApp = false,
       isAndroidPlayStoreApp = false,
+      isAppStoreApp = false,
       autoUpdateEnabled = false,
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
@@ -133,6 +142,7 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
         autoUpdateWindowStart,
         autoUpdateWindowEnd,
         isIosOrIpadosApp,
+        isAppStoreApp,
       });
       return (
         <>
@@ -161,6 +171,7 @@ interface IInstallIconWithTooltipProps {
   pageContext?: PageContext;
   isIosOrIpadosApp: boolean;
   isAndroidPlayStoreApp: boolean;
+  isAppStoreApp?: boolean;
   autoUpdateEnabled?: boolean;
   autoUpdateWindowStart?: string;
   autoUpdateWindowEnd?: string;
@@ -175,7 +186,8 @@ const getInstallIconType = (
   autoUpdateEnabled = false,
   autoUpdateWindowStart?: string,
   autoUpdateWindowEnd?: string,
-  isIosOrIpadosApp = false
+  isIosOrIpadosApp = false,
+  isAppStoreApp = false
 ): InstallType => {
   const isAutomatic =
     automaticInstallPoliciesCount > 0 ||
@@ -184,6 +196,7 @@ const getInstallIconType = (
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
       isIosOrIpadosApp,
+      isAppStoreApp,
     });
   if (isAutomatic) {
     return isSelfService ? "automaticSelfService" : "automatic";
@@ -197,6 +210,7 @@ export const InstallIconWithTooltip = ({
   pageContext,
   isIosOrIpadosApp,
   isAndroidPlayStoreApp,
+  isAppStoreApp,
   autoUpdateEnabled,
   autoUpdateWindowStart,
   autoUpdateWindowEnd,
@@ -207,7 +221,8 @@ export const InstallIconWithTooltip = ({
     autoUpdateEnabled,
     autoUpdateWindowStart,
     autoUpdateWindowEnd,
-    isIosOrIpadosApp
+    isIosOrIpadosApp,
+    isAppStoreApp
   );
 
   // Don't show installer icon on host software library page
@@ -221,6 +236,7 @@ export const InstallIconWithTooltip = ({
     pageContext,
     isIosOrIpadosApp,
     isAndroidPlayStoreApp,
+    isAppStoreApp,
     autoUpdateEnabled,
     autoUpdateWindowStart,
     autoUpdateWindowEnd,
@@ -263,6 +279,11 @@ interface ISoftwareNameCellProps {
   iconUrl?: string | null;
   isIosOrIpadosApp?: boolean;
   isAndroidPlayStoreApp?: boolean;
+  /** True when the row has an `app_store_app` payload (Apple VPP). Required
+   * alongside `isIosOrIpadosApp` for auto-update icon promotion so an
+   * in-house `.ipa` (iOS source, no app_store_app) with a stale schedule
+   * row can't leak the auto-update indicator. */
+  isAppStoreApp?: boolean;
   /** VPP auto-updates flag from the list response. Promotes the install icon
    * to the automatic (or automatic-self-service) variant and adds a window
    * line to the tooltip. */
@@ -286,6 +307,7 @@ const SoftwareNameCell = ({
   iconUrl,
   isIosOrIpadosApp = false,
   isAndroidPlayStoreApp = false,
+  isAppStoreApp = false,
   autoUpdateEnabled = false,
   autoUpdateWindowStart,
   autoUpdateWindowEnd,
@@ -337,6 +359,7 @@ const SoftwareNameCell = ({
             pageContext={pageContext}
             isIosOrIpadosApp={isIosOrIpadosApp}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            isAppStoreApp={isAppStoreApp}
             autoUpdateEnabled={autoUpdateEnabled}
             autoUpdateWindowStart={autoUpdateWindowStart}
             autoUpdateWindowEnd={autoUpdateWindowEnd}

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -5,6 +5,7 @@ import {
   getSelfServiceTooltip,
   getDisplayedSoftwareName,
 } from "pages/SoftwarePage/helpers";
+import { internationalTimeOnlyFormat } from "utilities/helpers";
 
 import TooltipWrapper from "components/TooltipWrapper";
 import Icon from "components/Icon";
@@ -44,7 +45,9 @@ const getPolicyTooltip = (count = 0) =>
     : `${count} policies trigger install.`;
 
 const getAutoUpdateTooltip = (start: string, end: string) =>
-  `Auto updates between ${start} and ${end} (host local time).`;
+  `Auto updates between ${internationalTimeOnlyFormat(
+    start
+  )} and ${internationalTimeOnlyFormat(end)} (host local time).`;
 
 const installIconMap: Record<InstallType, InstallIconConfig> = {
   manual: {
@@ -128,13 +131,19 @@ interface IInstallIconWithTooltipProps {
 
 // A row can be "automatic" via a policy-triggered install or a VPP scheduled
 // auto-update. Either signal promotes the icon to the automatic family so the
-// visual language stays consistent with the details page chip.
+// visual language stays consistent with the details page chip. Auto-updates
+// only counts when the window is fully populated — otherwise the tooltip
+// would render with no window text and the icon would look unexplained.
 const getInstallIconType = (
   isSelfService: boolean,
   automaticInstallPoliciesCount = 0,
-  autoUpdateEnabled = false
+  autoUpdateEnabled = false,
+  autoUpdateWindowStart?: string,
+  autoUpdateWindowEnd?: string
 ): InstallType => {
-  const isAutomatic = automaticInstallPoliciesCount > 0 || autoUpdateEnabled;
+  const hasValidAutoUpdate =
+    autoUpdateEnabled && !!autoUpdateWindowStart && !!autoUpdateWindowEnd;
+  const isAutomatic = automaticInstallPoliciesCount > 0 || hasValidAutoUpdate;
   if (isAutomatic) {
     return isSelfService ? "automaticSelfService" : "automatic";
   }
@@ -154,7 +163,9 @@ export const InstallIconWithTooltip = ({
   const iconType = getInstallIconType(
     isSelfService,
     automaticInstallPoliciesCount,
-    autoUpdateEnabled
+    autoUpdateEnabled,
+    autoUpdateWindowStart,
+    autoUpdateWindowEnd
   );
 
   // Don't show installer icon on host software library page

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -132,17 +132,22 @@ interface IInstallIconWithTooltipProps {
 // A row can be "automatic" via a policy-triggered install or a VPP scheduled
 // auto-update. Either signal promotes the icon to the automatic family so the
 // visual language stays consistent with the details page chip. Auto-updates
-// only counts when the window is fully populated — otherwise the tooltip
-// would render with no window text and the icon would look unexplained.
+// only counts when the window is fully populated AND the row is iOS/iPadOS —
+// the auto-update cron in apple_mdm.go only acts on ios_apps / ipados_apps
+// sources, so promoting the icon for a macOS VPP row would misrepresent it.
 const getInstallIconType = (
   isSelfService: boolean,
   automaticInstallPoliciesCount = 0,
   autoUpdateEnabled = false,
   autoUpdateWindowStart?: string,
-  autoUpdateWindowEnd?: string
+  autoUpdateWindowEnd?: string,
+  isIosOrIpadosApp = false
 ): InstallType => {
   const hasValidAutoUpdate =
-    autoUpdateEnabled && !!autoUpdateWindowStart && !!autoUpdateWindowEnd;
+    autoUpdateEnabled &&
+    !!autoUpdateWindowStart &&
+    !!autoUpdateWindowEnd &&
+    isIosOrIpadosApp;
   const isAutomatic = automaticInstallPoliciesCount > 0 || hasValidAutoUpdate;
   if (isAutomatic) {
     return isSelfService ? "automaticSelfService" : "automatic";
@@ -165,7 +170,8 @@ export const InstallIconWithTooltip = ({
     automaticInstallPoliciesCount,
     autoUpdateEnabled,
     autoUpdateWindowStart,
-    autoUpdateWindowEnd
+    autoUpdateWindowEnd,
+    isIosOrIpadosApp
   );
 
   // Don't show installer icon on host software library page
@@ -193,7 +199,6 @@ export const InstallIconWithTooltip = ({
         position="top"
         tipOffset={12}
         fixedPositionStrategy
-        textBalanced={false}
       >
         <Icon
           name={iconName}

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -50,12 +50,8 @@ const getAutoUpdateTooltip = (start: string, end: string) =>
     start
   )} and ${internationalTimeOnlyFormat(end)} (host local time).`;
 
-// True when the window is fully populated, the row is iOS/iPadOS, AND the
-// title has an app_store_app (VPP). `handleScheduledUpdates` only acts on
-// `ios_apps` / `ipados_apps` sources, and auto-update configuration is a
-// VPP-only feature — an in-house `.ipa` (iOS source, no app_store_app)
-// with a stale schedule row must not promote the icon or leak a window
-// line, nor must a macOS VPP row.
+// Auto-updates are iOS/iPadOS VPP only; macOS VPP or in-house .ipa
+// schedule rows must not promote the icon.
 const hasValidAutoUpdate = ({
   autoUpdateEnabled = false,
   autoUpdateWindowStart,
@@ -115,7 +111,6 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
           {automaticInstallPoliciesCount > 0 && showAutoUpdate && " "}
           {showAutoUpdate && (
             <>
-              {/* hasValidAutoUpdate above guarantees both fields are set. */}
               {getAutoUpdateTooltip(
                 autoUpdateWindowStart!,
                 autoUpdateWindowEnd!
@@ -151,7 +146,6 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
           )}
           {showAutoUpdate && (
             <>
-              {/* hasValidAutoUpdate above guarantees both fields are set. */}
               {getAutoUpdateTooltip(
                 autoUpdateWindowStart!,
                 autoUpdateWindowEnd!
@@ -177,9 +171,6 @@ interface IInstallIconWithTooltipProps {
   autoUpdateWindowEnd?: string;
 }
 
-// A row can be "automatic" via a policy-triggered install or a VPP scheduled
-// auto-update. Either signal promotes the icon to the automatic family so the
-// visual language stays consistent with the details page chip.
 const getInstallIconType = (
   isSelfService: boolean,
   automaticInstallPoliciesCount = 0,
@@ -279,14 +270,7 @@ interface ISoftwareNameCellProps {
   iconUrl?: string | null;
   isIosOrIpadosApp?: boolean;
   isAndroidPlayStoreApp?: boolean;
-  /** True when the row has an `app_store_app` payload (Apple VPP). Required
-   * alongside `isIosOrIpadosApp` for auto-update icon promotion so an
-   * in-house `.ipa` (iOS source, no app_store_app) with a stale schedule
-   * row can't leak the auto-update indicator. */
   isAppStoreApp?: boolean;
-  /** VPP auto-updates flag from the list response. Promotes the install icon
-   * to the automatic (or automatic-self-service) variant and adds a window
-   * line to the tooltip. */
   autoUpdateEnabled?: boolean;
   autoUpdateWindowStart?: string;
   autoUpdateWindowEnd?: string;

--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -71,9 +71,18 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateEnabled = false,
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
+      isIosOrIpadosApp = false,
     }) => {
+      // Mirror the getInstallIconType source gate: the auto-update cron in
+      // apple_mdm.go only acts on ios_apps / ipados_apps. A stale schedule
+      // row on a macOS VPP title paired with a policy would otherwise leak
+      // an "Auto updates between …" line even though nothing will actually
+      // run against that schedule.
       const showAutoUpdate =
-        autoUpdateEnabled && !!autoUpdateWindowStart && !!autoUpdateWindowEnd;
+        autoUpdateEnabled &&
+        !!autoUpdateWindowStart &&
+        !!autoUpdateWindowEnd &&
+        isIosOrIpadosApp;
       return (
         <>
           {automaticInstallPoliciesCount > 0 && (
@@ -99,8 +108,12 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
       autoUpdateWindowStart,
       autoUpdateWindowEnd,
     }) => {
+      // Same source gate as the `automatic` branch above — see comment there.
       const showAutoUpdate =
-        autoUpdateEnabled && !!autoUpdateWindowStart && !!autoUpdateWindowEnd;
+        autoUpdateEnabled &&
+        !!autoUpdateWindowStart &&
+        !!autoUpdateWindowEnd &&
+        isIosOrIpadosApp;
       return (
         <>
           {automaticInstallPoliciesCount > 0 && (

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
@@ -96,7 +96,7 @@ describe("TooltipWrapper", () => {
     expect(element).not.toHaveClass("component__tooltip-wrapper__underline");
   });
 
-  it("wraps tipContent in a display:contents span by default (textBalanced)", async () => {
+  it("wraps tipContent in an inline-block balance wrapper by default (textBalanced)", async () => {
     const { user } = renderWithSetup(
       <TooltipWrapper tipContent="Balanced tooltip">
         <span>Hover me</span>
@@ -107,9 +107,11 @@ describe("TooltipWrapper", () => {
 
     await waitFor(() => {
       const tipText = screen.getByText("Balanced tooltip");
-      // BalancedTipContent wraps content in a span with display:contents so
-      // measurement can find the tooltip root via el.parentElement.
-      const balancedWrapper = tipText.closest('span[style*="contents"]');
+      // BalancedTipContent wraps content in an inline-block div with
+      // text-wrap: balance so measurement can set width on the wrapper
+      // (react-tooltip-5 rewrites the outer tooltip element's style on
+      // every position update, so we can't set width there).
+      const balancedWrapper = tipText.closest('div[style*="balance"]');
       expect(balancedWrapper).not.toBeNull();
     });
   });
@@ -125,9 +127,9 @@ describe("TooltipWrapper", () => {
 
     await waitFor(() => {
       const tipText = screen.getByText("Unbalanced tooltip");
-      // Opt-out skips the BalancedTipContent span entirely — no display:contents
-      // wrapper should exist anywhere in the tooltip's DOM.
-      expect(tipText.closest('span[style*="contents"]')).toBeNull();
+      // Opt-out skips the BalancedTipContent wrapper entirely — no
+      // text-wrap: balance styled wrapper should exist in the tooltip DOM.
+      expect(tipText.closest('div[style*="balance"]')).toBeNull();
     });
   });
 

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -22,20 +22,22 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
     const el = ref.current;
     if (!el) return undefined;
 
-    // Measurement can race with (a) floating-ui repositioning the tooltip and
-    // (b) web-font loading changing bold/italic run widths. A single RAF fires
-    // before either has settled on first hover, so `widest` sometimes locks in
-    // near max-width and the tooltip stays wide until the next hover. Re-run
-    // the measurement after each likely settle point (double-RAF for layout,
-    // fonts.ready for font loading) — the latest measurement wins.
+    // Measurement can race with (a) floating-ui repositioning the tooltip,
+    // (b) web-font loading changing bold/italic run widths, and (c) balance
+    // needing multiple layout passes to converge as the container shrinks
+    // around each measurement. Re-run measurement iteratively until width
+    // stabilizes, with a small iteration cap to prevent runaway.
     let disposed = false;
+    let lastAppliedWidth = -1;
+    let iteration = 0;
+    const MAX_ITERATIONS = 6;
 
     const measure = () => {
       if (disposed) return;
-      // Clear our prior explicit width so wrap uses the tooltip's max-width.
+      // Clear our prior explicit width so balance re-runs against the outer
+      // tooltip's max-width. Force a reflow via offsetWidth so the browser
+      // recomputes the balanced layout before we sample rects.
       el.style.width = "";
-      // Force a reflow so the browser applies text-wrap: balance under the
-      // cleared width before we sample rects.
       void el.offsetWidth;
       const range = document.createRange();
       range.selectNodeContents(el);
@@ -52,8 +54,8 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       // Inline replaced elements (<svg>, <img>, <video>, <canvas>, <iframe>)
       // don't participate in Range text rects — they render as self-contained
       // visual boxes, so a line ending in e.g. a CustomLink external-link
-      // icon would otherwise be measured short by the icon's width. Add their
-      // bounding rects into the same per-line grouping.
+      // icon would otherwise be measured short by the icon's width. Add
+      // their bounding rects into the same per-line grouping.
       const rects: DOMRect[] = Array.from(range.getClientRects());
       el.querySelectorAll("svg, img, video, canvas, iframe").forEach(
         (child) => {
@@ -81,26 +83,39 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
         const lineWidth = right - left;
         if (lineWidth > widest) widest = lineWidth;
       });
-      if (widest > 0) {
-        el.style.width = `${Math.ceil(widest)}px`;
+      if (widest <= 0) return;
+      const next = Math.ceil(widest);
+      // Stop when we've stopped shrinking. Balance can produce slightly
+      // narrower widths as the container shrinks around each measurement;
+      // we keep going as long as it does, then lock in.
+      if (next >= lastAppliedWidth && lastAppliedWidth !== -1) {
+        // Restore the previous (narrower) width and stop.
+        el.style.width = `${lastAppliedWidth}px`;
+        return;
+      }
+      lastAppliedWidth = next;
+      el.style.width = `${next}px`;
+      iteration += 1;
+      if (iteration < MAX_ITERATIONS) {
+        requestAnimationFrame(measure);
       }
     };
 
-    // Double-RAF gives layout + floating-ui a full paint cycle to settle.
-    const raf1 = requestAnimationFrame(() => {
-      measure();
-      requestAnimationFrame(measure);
-    });
+    const raf1 = requestAnimationFrame(measure);
 
-    // Fonts loading after mount reflows bold/italic runs. Re-measure once
-    // fonts.ready resolves. Safe to skip when the API is missing.
+    // Fonts loading after mount reflows bold/italic runs. Reset and re-run
+    // the convergence loop once fonts.ready resolves. Safe to skip when the
+    // API is missing.
     if (
       typeof document !== "undefined" &&
       document.fonts &&
       document.fonts.ready
     ) {
       document.fonts.ready.then(() => {
-        if (!disposed) requestAnimationFrame(measure);
+        if (disposed) return;
+        lastAppliedWidth = -1;
+        iteration = 0;
+        requestAnimationFrame(measure);
       });
     }
 

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -47,42 +47,65 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       if (typeof range.getClientRects !== "function") return;
       // Range.getClientRects returns one rect per text run per line, so a
       // line containing text plus a nested <strong>/<em>/<b> produces
-      // multiple narrower rects. Group rects by their top edge (visual line)
-      // and compute each line's true width from the leftmost/rightmost
-      // extents, then pick the widest line.
-      //
-      // Inline replaced elements (<svg>, <img>, <video>, <canvas>, <iframe>)
-      // don't participate in Range text rects — they render as self-contained
-      // visual boxes, so a line ending in e.g. a CustomLink external-link
-      // icon would otherwise be measured short by the icon's width. Add
-      // their bounding rects into the same per-line grouping.
+      // multiple narrower rects. We collect rects from three sources:
+      //   1. Range text rects for text inside the wrapper.
+      //   2. Inline replaced elements (<svg>, <img>, <video>, <canvas>,
+      //      <iframe>) — these render as self-contained visual boxes and
+      //      never appear in Range text rects, so a line ending in e.g. a
+      //      CustomLink external-link icon would otherwise be measured
+      //      short by the icon's width.
+      //   3. Inline-flex / inline-block anchors — their outer box includes
+      //      internal `gap` / padding that isn't captured by summing child
+      //      text + child SVG rects. Adding the anchor's outer bounding
+      //      rect covers that gap.
       const rects: DOMRect[] = Array.from(range.getClientRects());
-      el.querySelectorAll("svg, img, video, canvas, iframe").forEach(
+      el.querySelectorAll("svg, img, video, canvas, iframe, a").forEach(
         (child) => {
           const rect = child.getBoundingClientRect();
           if (rect.width > 0) rects.push(rect);
         }
       );
-      const lineBounds = new Map<number, { left: number; right: number }>();
-      for (let i = 0; i < rects.length; i += 1) {
-        const rect = rects[i];
-        if (rect.width !== 0) {
-          // Round to bucket sub-pixel variation on the same visual line.
-          const lineKey = Math.round(rect.top);
-          const bounds = lineBounds.get(lineKey);
-          if (bounds) {
-            if (rect.left < bounds.left) bounds.left = rect.left;
-            if (rect.right > bounds.right) bounds.right = rect.right;
-          } else {
-            lineBounds.set(lineKey, { left: rect.left, right: rect.right });
-          }
+      // Group rects by visual line. Naive `Math.round(rect.top)` bucketing
+      // splits an inline-flex CustomLink's flex-centered SVG (with a
+      // slightly different `top` than the surrounding text baseline) into a
+      // separate "line" — so the last line's width misses the icon. Group
+      // by vertical center with a half-line fuzz instead: two rects belong
+      // to the same visual line when their centers are within ~half a line
+      // height of each other.
+      const style = window.getComputedStyle(el);
+      const parsedLineHeight = parseFloat(style.lineHeight);
+      const fontSize = parseFloat(style.fontSize) || 12;
+      const lineHeight = Number.isFinite(parsedLineHeight)
+        ? parsedLineHeight
+        : fontSize * 1.375;
+      const fuzz = lineHeight / 2;
+      const centersSorted = rects
+        .filter((r) => r.width !== 0)
+        .map((r) => ({
+          center: r.top + r.height / 2,
+          left: r.left,
+          right: r.right,
+        }))
+        .sort((a, b) => a.center - b.center);
+      const lines: Array<{
+        center: number;
+        left: number;
+        right: number;
+      }> = [];
+      for (const item of centersSorted) {
+        const last = lines[lines.length - 1];
+        if (last && Math.abs(item.center - last.center) < fuzz) {
+          if (item.left < last.left) last.left = item.left;
+          if (item.right > last.right) last.right = item.right;
+        } else {
+          lines.push({ ...item });
         }
       }
       let widest = 0;
-      lineBounds.forEach(({ left, right }) => {
-        const lineWidth = right - left;
+      for (const line of lines) {
+        const lineWidth = line.right - line.left;
         if (lineWidth > widest) widest = lineWidth;
-      });
+      }
       if (widest <= 0) return;
       const next = Math.ceil(widest);
       // Stop when we've stopped shrinking. Balance can produce slightly

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -38,7 +38,9 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       // tooltip's max-width. Force a reflow via offsetWidth so the browser
       // recomputes the balanced layout before we sample rects.
       el.style.width = "";
-      void el.offsetWidth;
+      // Reading a layout property forces the browser to apply the cleared
+      // width + text-wrap: balance before we sample rects.
+      el.getBoundingClientRect();
       const range = document.createRange();
       range.selectNodeContents(el);
       // jsdom (Jest) doesn't implement Range.getClientRects, so measurement
@@ -78,7 +80,7 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
         left: number;
         right: number;
       }> = [];
-      for (const item of centersSorted) {
+      centersSorted.forEach((item) => {
         const last = lines[lines.length - 1];
         if (last && Math.abs(item.center - last.center) < fuzz) {
           if (item.left < last.left) last.left = item.left;
@@ -86,12 +88,12 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
         } else {
           lines.push({ ...item });
         }
-      }
+      });
       let widest = 0;
-      for (const line of lines) {
+      lines.forEach((line) => {
         const lineWidth = line.right - line.left;
         if (lineWidth > widest) widest = lineWidth;
-      }
+      });
       if (widest <= 0) return;
       const next = Math.ceil(widest);
       // Stop when we've stopped shrinking. Balance can produce slightly
@@ -137,10 +139,7 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
   // inline-block so the wrapper has its own measurable box and the tooltip's
   // `width: max-content` shrinks to the wrapper's explicit width once set.
   return (
-    <div
-      ref={ref}
-      style={{ display: "inline-block", textWrap: "balance" }}
-    >
+    <div ref={ref} style={{ display: "inline-block", textWrap: "balance" }}>
       {children}
     </div>
   );

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -4,30 +4,32 @@ import { Tooltip as ReactTooltip5, PlacesType } from "react-tooltip-5";
 
 import { uniqueId } from "lodash";
 
-/** Renders tooltip content as-is, but on mount applies `text-wrap: balance`
- * to the tooltip's root element and measures the widest balanced line to set
- * an explicit width on the root — so the tooltip's background hugs the
- * balanced text. CSS alone can't shrink the container: the intrinsic width of
- * a `text-wrap: balance` box is computed as if wrap were `normal`, so it
- * stays at `max-width` even when the balanced text is narrower. */
+/** Renders tooltip content inside a measurable inline-block wrapper: applies
+ * `text-wrap: balance`, measures the widest balanced line via Range rects
+ * (plus inline replaced elements like SVG/IMG that don't participate in Range
+ * text runs), then sets an explicit width on the wrapper so the tooltip's
+ * background hugs the balanced text. CSS alone can't shrink the container:
+ * the intrinsic width of a `text-wrap: balance` box is computed as if wrap
+ * were `normal`, so it stays at `max-width` even when the balanced text is
+ * narrower. Applying width to an internal element (rather than the tooltip
+ * root) sidesteps react-tooltip-5 rewriting the root's `style` attribute on
+ * every position update. The outer tooltip's `width: max-content` then
+ * shrinks to this wrapper's explicit width. */
 const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
-  const ref = useRef<HTMLSpanElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return undefined;
-    const root = el.parentElement;
-    if (!root) return undefined;
 
     // react-tooltip positions/sizes the tip via floating-ui after mount, so
     // measuring synchronously here can land while the tooltip is still at
     // (0, 0) with an initial width. Defer to the next frame.
     const rafId = requestAnimationFrame(() => {
-      // Clear any prior explicit width so wrap uses the mixin's max-width.
-      root.style.width = "";
-      root.style.textWrap = "balance";
+      // Clear any prior explicit width so wrap uses the tooltip's max-width.
+      el.style.width = "";
       const range = document.createRange();
-      range.selectNodeContents(root);
+      range.selectNodeContents(el);
       // jsdom (Jest) doesn't implement Range.getClientRects, so measurement is
       // a no-op there — balancing is a visual concern with no test coverage
       // to preserve.
@@ -45,12 +47,12 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       // would otherwise be measured short by the icon's width. Add their
       // bounding rects into the same per-line grouping.
       const rects: DOMRect[] = Array.from(range.getClientRects());
-      root
-        .querySelectorAll("svg, img, video, canvas, iframe")
-        .forEach((el) => {
-          const rect = el.getBoundingClientRect();
+      el.querySelectorAll("svg, img, video, canvas, iframe").forEach(
+        (child) => {
+          const rect = child.getBoundingClientRect();
           if (rect.width > 0) rects.push(rect);
-        });
+        }
+      );
       const lineBounds = new Map<number, { left: number; right: number }>();
       for (let i = 0; i < rects.length; i += 1) {
         const rect = rects[i];
@@ -72,22 +74,22 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
         if (lineWidth > widest) widest = lineWidth;
       });
       if (widest > 0) {
-        const style = window.getComputedStyle(root);
-        const padLeft = parseFloat(style.paddingLeft) || 0;
-        const padRight = parseFloat(style.paddingRight) || 0;
-        root.style.width = `${Math.ceil(widest + padLeft + padRight)}px`;
+        el.style.width = `${Math.ceil(widest)}px`;
       }
     });
 
     return () => cancelAnimationFrame(rafId);
   }, [children]);
 
-  // display: contents so this span leaves no layout box — its children render
-  // as direct children of the tooltip root, and `el.parentElement` is that root.
+  // inline-block so the wrapper has its own measurable box and the tooltip's
+  // `width: max-content` shrinks to the wrapper's explicit width once set.
   return (
-    <span ref={ref} style={{ display: "contents" }}>
+    <div
+      ref={ref}
+      style={{ display: "inline-block", textWrap: "balance" }}
+    >
       {children}
-    </span>
+    </div>
   );
 };
 

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -45,19 +45,12 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       // is a no-op there — balancing is a visual concern with no test
       // coverage to preserve.
       if (typeof range.getClientRects !== "function") return;
-      // Range.getClientRects returns one rect per text run per line, so a
-      // line containing text plus a nested <strong>/<em>/<b> produces
-      // multiple narrower rects. We collect rects from three sources:
-      //   1. Range text rects for text inside the wrapper.
-      //   2. Inline replaced elements (<svg>, <img>, <video>, <canvas>,
-      //      <iframe>) — these render as self-contained visual boxes and
-      //      never appear in Range text rects, so a line ending in e.g. a
-      //      CustomLink external-link icon would otherwise be measured
-      //      short by the icon's width.
-      //   3. Inline-flex / inline-block anchors — their outer box includes
-      //      internal `gap` / padding that isn't captured by summing child
-      //      text + child SVG rects. Adding the anchor's outer bounding
-      //      rect covers that gap.
+      // Three widest-line quirks a naive `range.getClientRects()` misses:
+      // inline replaced elements (svg/img/…) never appear in Range rects,
+      // an inline-flex anchor's `gap` is nowhere in its children's rects,
+      // and a flex-centered icon's `top` differs from surrounding text
+      // baseline. Fix: also read bounding rects for `svg, img, …, a`, and
+      // group by vertical center (not `top`) with a half-line-height fuzz.
       const rects: DOMRect[] = Array.from(range.getClientRects());
       el.querySelectorAll("svg, img, video, canvas, iframe, a").forEach(
         (child) => {
@@ -65,13 +58,6 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
           if (rect.width > 0) rects.push(rect);
         }
       );
-      // Group rects by visual line. Naive `Math.round(rect.top)` bucketing
-      // splits an inline-flex CustomLink's flex-centered SVG (with a
-      // slightly different `top` than the surrounding text baseline) into a
-      // separate "line" — so the last line's width misses the icon. Group
-      // by vertical center with a half-line fuzz instead: two rects belong
-      // to the same visual line when their centers are within ~half a line
-      // height of each other.
       const style = window.getComputedStyle(el);
       const parsedLineHeight = parseFloat(style.lineHeight);
       const fontSize = parseFloat(style.fontSize) || 12;

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -32,13 +32,25 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       // a no-op there — balancing is a visual concern with no test coverage
       // to preserve.
       if (typeof range.getClientRects !== "function") return;
-      const rects = range.getClientRects();
       // Range.getClientRects returns one rect per text run per line, so a line
       // containing text plus a nested <strong>/<em>/<b> produces multiple
       // narrower rects. Taking the widest single rect would under-measure the
       // line width. Group rects by their top edge (visual line) and compute
       // each line's true width from the leftmost/rightmost extents, then pick
       // the widest line.
+      //
+      // Inline replaced elements (<svg>, <img>, <video>, <canvas>, <iframe>)
+      // don't participate in Range text rects — they render as self-contained
+      // visual boxes, so a line ending in e.g. a CustomLink external-link icon
+      // would otherwise be measured short by the icon's width. Add their
+      // bounding rects into the same per-line grouping.
+      const rects: DOMRect[] = Array.from(range.getClientRects());
+      root
+        .querySelectorAll("svg, img, video, canvas, iframe")
+        .forEach((el) => {
+          const rect = el.getBoundingClientRect();
+          if (rect.width > 0) rects.push(rect);
+        });
       const lineBounds = new Map<number, { left: number; right: number }>();
       for (let i = 0; i < rects.length; i += 1) {
         const rect = rects[i];

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -22,29 +22,37 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
     const el = ref.current;
     if (!el) return undefined;
 
-    // react-tooltip positions/sizes the tip via floating-ui after mount, so
-    // measuring synchronously here can land while the tooltip is still at
-    // (0, 0) with an initial width. Defer to the next frame.
-    const rafId = requestAnimationFrame(() => {
-      // Clear any prior explicit width so wrap uses the tooltip's max-width.
+    // Measurement can race with (a) floating-ui repositioning the tooltip and
+    // (b) web-font loading changing bold/italic run widths. A single RAF fires
+    // before either has settled on first hover, so `widest` sometimes locks in
+    // near max-width and the tooltip stays wide until the next hover. Re-run
+    // the measurement after each likely settle point (double-RAF for layout,
+    // fonts.ready for font loading) — the latest measurement wins.
+    let disposed = false;
+
+    const measure = () => {
+      if (disposed) return;
+      // Clear our prior explicit width so wrap uses the tooltip's max-width.
       el.style.width = "";
+      // Force a reflow so the browser applies text-wrap: balance under the
+      // cleared width before we sample rects.
+      void el.offsetWidth;
       const range = document.createRange();
       range.selectNodeContents(el);
-      // jsdom (Jest) doesn't implement Range.getClientRects, so measurement is
-      // a no-op there — balancing is a visual concern with no test coverage
-      // to preserve.
+      // jsdom (Jest) doesn't implement Range.getClientRects, so measurement
+      // is a no-op there — balancing is a visual concern with no test
+      // coverage to preserve.
       if (typeof range.getClientRects !== "function") return;
-      // Range.getClientRects returns one rect per text run per line, so a line
-      // containing text plus a nested <strong>/<em>/<b> produces multiple
-      // narrower rects. Taking the widest single rect would under-measure the
-      // line width. Group rects by their top edge (visual line) and compute
-      // each line's true width from the leftmost/rightmost extents, then pick
-      // the widest line.
+      // Range.getClientRects returns one rect per text run per line, so a
+      // line containing text plus a nested <strong>/<em>/<b> produces
+      // multiple narrower rects. Group rects by their top edge (visual line)
+      // and compute each line's true width from the leftmost/rightmost
+      // extents, then pick the widest line.
       //
       // Inline replaced elements (<svg>, <img>, <video>, <canvas>, <iframe>)
       // don't participate in Range text rects — they render as self-contained
-      // visual boxes, so a line ending in e.g. a CustomLink external-link icon
-      // would otherwise be measured short by the icon's width. Add their
+      // visual boxes, so a line ending in e.g. a CustomLink external-link
+      // icon would otherwise be measured short by the icon's width. Add their
       // bounding rects into the same per-line grouping.
       const rects: DOMRect[] = Array.from(range.getClientRects());
       el.querySelectorAll("svg, img, video, canvas, iframe").forEach(
@@ -76,9 +84,30 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       if (widest > 0) {
         el.style.width = `${Math.ceil(widest)}px`;
       }
+    };
+
+    // Double-RAF gives layout + floating-ui a full paint cycle to settle.
+    const raf1 = requestAnimationFrame(() => {
+      measure();
+      requestAnimationFrame(measure);
     });
 
-    return () => cancelAnimationFrame(rafId);
+    // Fonts loading after mount reflows bold/italic runs. Re-measure once
+    // fonts.ready resolves. Safe to skip when the API is missing.
+    if (
+      typeof document !== "undefined" &&
+      document.fonts &&
+      document.fonts.ready
+    ) {
+      document.fonts.ready.then(() => {
+        if (!disposed) requestAnimationFrame(measure);
+      });
+    }
+
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(raf1);
+    };
   }, [children]);
 
   // inline-block so the wrapper has its own measurable box and the tooltip's

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -4,17 +4,11 @@ import { Tooltip as ReactTooltip5, PlacesType } from "react-tooltip-5";
 
 import { uniqueId } from "lodash";
 
-/** Renders tooltip content inside a measurable inline-block wrapper: applies
- * `text-wrap: balance`, measures the widest balanced line via Range rects
- * (plus inline replaced elements like SVG/IMG that don't participate in Range
- * text runs), then sets an explicit width on the wrapper so the tooltip's
- * background hugs the balanced text. CSS alone can't shrink the container:
- * the intrinsic width of a `text-wrap: balance` box is computed as if wrap
- * were `normal`, so it stays at `max-width` even when the balanced text is
- * narrower. Applying width to an internal element (rather than the tooltip
- * root) sidesteps react-tooltip-5 rewriting the root's `style` attribute on
- * every position update. The outer tooltip's `width: max-content` then
- * shrinks to this wrapper's explicit width. */
+/** Shrinks the tooltip to hug balanced text. `text-wrap: balance` alone
+ * leaves the container at `max-width` (intrinsic width is computed as
+ * wrap: normal), and setting width on the tooltip root gets wiped by
+ * react-tooltip-5's per-render style spread — so measure widest line on
+ * an inline-block child and set width there. */
 const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -22,11 +16,8 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
     const el = ref.current;
     if (!el) return undefined;
 
-    // Measurement can race with (a) floating-ui repositioning the tooltip,
-    // (b) web-font loading changing bold/italic run widths, and (c) balance
-    // needing multiple layout passes to converge as the container shrinks
-    // around each measurement. Re-run measurement iteratively until width
-    // stabilizes, with a small iteration cap to prevent runaway.
+    // Convergence loop: balance re-runs as the container shrinks around
+    // each measurement, so iterate until width stops shrinking.
     let disposed = false;
     let lastAppliedWidth = -1;
     let iteration = 0;
@@ -34,25 +25,15 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
 
     const measure = () => {
       if (disposed) return;
-      // Clear our prior explicit width so balance re-runs against the outer
-      // tooltip's max-width. Force a reflow via offsetWidth so the browser
-      // recomputes the balanced layout before we sample rects.
       el.style.width = "";
-      // Reading a layout property forces the browser to apply the cleared
-      // width + text-wrap: balance before we sample rects.
-      el.getBoundingClientRect();
+      el.getBoundingClientRect(); // force reflow
       const range = document.createRange();
       range.selectNodeContents(el);
-      // jsdom (Jest) doesn't implement Range.getClientRects, so measurement
-      // is a no-op there — balancing is a visual concern with no test
-      // coverage to preserve.
+      // jsdom no-op — Range.getClientRects isn't implemented there.
       if (typeof range.getClientRects !== "function") return;
-      // Three widest-line quirks a naive `range.getClientRects()` misses:
-      // inline replaced elements (svg/img/…) never appear in Range rects,
-      // an inline-flex anchor's `gap` is nowhere in its children's rects,
-      // and a flex-centered icon's `top` differs from surrounding text
-      // baseline. Fix: also read bounding rects for `svg, img, …, a`, and
-      // group by vertical center (not `top`) with a half-line-height fuzz.
+      // Range misses inline replaced elements (svg/img) and inline-flex
+      // anchor gaps; querySelector fills both. Group by vertical center
+      // with half-line fuzz so a flex-centered icon rejoins its text line.
       const rects: DOMRect[] = Array.from(range.getClientRects());
       el.querySelectorAll("svg, img, video, canvas, iframe, a").forEach(
         (child) => {
@@ -96,11 +77,8 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
       });
       if (widest <= 0) return;
       const next = Math.ceil(widest);
-      // Stop when we've stopped shrinking. Balance can produce slightly
-      // narrower widths as the container shrinks around each measurement;
-      // we keep going as long as it does, then lock in.
+      // Restore the previous (narrower) width and stop once shrinking flattens.
       if (next >= lastAppliedWidth && lastAppliedWidth !== -1) {
-        // Restore the previous (narrower) width and stop.
         el.style.width = `${lastAppliedWidth}px`;
         return;
       }
@@ -114,9 +92,7 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
 
     const raf1 = requestAnimationFrame(measure);
 
-    // Fonts loading after mount reflows bold/italic runs. Reset and re-run
-    // the convergence loop once fonts.ready resolves. Safe to skip when the
-    // API is missing.
+    // Web-font load can reflow bold/italic runs; re-run the loop after.
     if (
       typeof document !== "undefined" &&
       document.fonts &&
@@ -136,8 +112,6 @@ const BalancedTipContent = ({ children }: { children: React.ReactNode }) => {
     };
   }, [children]);
 
-  // inline-block so the wrapper has its own measurable box and the tooltip's
-  // `width: max-content` shrinks to the wrapper's explicit width once set.
   return (
     <div ref={ref} style={{ display: "inline-block", textWrap: "balance" }}>
       {children}

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -224,6 +224,9 @@ export interface ISoftwareTitle {
    * `null` when the title has no custom packages. */
   packages: ISoftwarePackage[] | null;
   app_store_app: IAppStoreApp | null;
+  auto_update_enabled?: boolean;
+  auto_update_window_start?: string;
+  auto_update_window_end?: string;
   /** @deprecated Use extension_for instead */
   browser?: string;
 }

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -661,6 +661,9 @@ export interface IHostSoftware {
   bundle_identifier?: string;
   status: Exclude<SoftwareInstallUninstallStatus, "uninstalled"> | null;
   installed_versions: ISoftwareInstallVersion[] | null;
+  auto_update_enabled?: boolean;
+  auto_update_window_start?: string;
+  auto_update_window_end?: string;
 }
 
 /**

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTableConfig.tsx
@@ -131,6 +131,11 @@ const generateTableHeaders = (
             }
             isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(nameCellData.source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            autoUpdateEnabled={cellProps.row.original.auto_update_enabled}
+            autoUpdateWindowStart={
+              cellProps.row.original.auto_update_window_start
+            }
+            autoUpdateWindowEnd={cellProps.row.original.auto_update_window_end}
           />
         );
       },

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTableConfig.tsx
@@ -131,6 +131,7 @@ const generateTableHeaders = (
             }
             isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(nameCellData.source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            isAppStoreApp={!!cellProps.row.original.app_store_app}
             autoUpdateEnabled={cellProps.row.original.auto_update_enabled}
             autoUpdateWindowStart={
               cellProps.row.original.auto_update_window_start

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTableConfig.tsx
@@ -140,6 +140,11 @@ const generateTableHeaders = (
             }
             isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(nameCellData.source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            autoUpdateEnabled={cellProps.row.original.auto_update_enabled}
+            autoUpdateWindowStart={
+              cellProps.row.original.auto_update_window_start
+            }
+            autoUpdateWindowEnd={cellProps.row.original.auto_update_window_end}
           />
         );
       },

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTableConfig.tsx
@@ -140,6 +140,7 @@ const generateTableHeaders = (
             }
             isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(nameCellData.source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            isAppStoreApp={!!cellProps.row.original.app_store_app}
             autoUpdateEnabled={cellProps.row.original.auto_update_enabled}
             autoUpdateWindowStart={
               cellProps.row.original.auto_update_window_start

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
@@ -195,7 +195,7 @@ const EditAutoUpdateConfigModal = ({
     (formValidation.windowLength?.message ? "Latest start time" : undefined);
 
   const updateWindowLabel = formValidation.windowLength?.message || (
-    <>Update window (host&rsquo;s local time)</>
+    <>Update window (host local time)</>
   );
   const updateWindowLabelClass = classnames("form-field__label", {
     "form-field__label--error": !!formValidation.windowLength?.message,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -278,6 +278,7 @@ const LibraryItemAccordion = ({
       underline={false}
       position="top"
       tipOffset={8}
+      textBalanced={false}
     >
       {onClick && canClick ? (
         <Button

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tests.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import {
   createMockSoftwareTitle,
+  createMockSoftwareTitleDetails,
   createMockSoftwarePackage,
   createMockSoftwarePackageIos,
   createMockAppStoreApp,
@@ -730,6 +731,92 @@ describe("Software Summary Card", () => {
 
       expect(screen.getAllByText("Policy A").length).toBeGreaterThan(0);
       expect(screen.getAllByText("Policy B").length).toBeGreaterThan(0);
+    });
+
+    it("renders the Auto updates pill when a VPP app has auto_update_enabled", () => {
+      render(
+        <SoftwareSummaryCard
+          softwareTitle={createMockSoftwareTitleDetails({
+            source: "ios_apps",
+            app_store_app: createMockAppStoreAppIos(),
+            software_package: null,
+            auto_update_enabled: true,
+            auto_update_window_start: "02:00",
+            auto_update_window_end: "04:00",
+          })}
+          softwareId={1}
+          teamId={1}
+          router={router}
+          refetchSoftwareTitle={jest.fn()}
+          onClickVersions={jest.fn()}
+        />
+      );
+
+      expect(screen.getByText("Auto updates")).toBeInTheDocument();
+    });
+
+    it("does not render the Auto updates pill when auto_update_enabled is false", () => {
+      render(
+        <SoftwareSummaryCard
+          softwareTitle={createMockSoftwareTitleDetails({
+            source: "ios_apps",
+            app_store_app: createMockAppStoreAppIos(),
+            software_package: null,
+            auto_update_enabled: false,
+          })}
+          softwareId={1}
+          teamId={1}
+          router={router}
+          refetchSoftwareTitle={jest.fn()}
+          onClickVersions={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByText("Auto updates")).not.toBeInTheDocument();
+    });
+
+    it("opens the Schedule auto updates modal when the Auto updates pill is clicked", async () => {
+      // Modal fires a labels useQuery; needs withBackendMock so the tree has
+      // a QueryClient. The request itself can fail silently, we just check
+      // the dialog appears.
+      const renderWithBackend = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            isPremiumTier: true,
+            isGlobalAdmin: true,
+            config: {
+              gitops: {
+                gitops_mode_enabled: false,
+                repository_url: "",
+              },
+            },
+          },
+        },
+      });
+      const { user } = renderWithBackend(
+        <SoftwareSummaryCard
+          softwareTitle={createMockSoftwareTitleDetails({
+            source: "ios_apps",
+            app_store_app: createMockAppStoreAppIos(),
+            software_package: null,
+            auto_update_enabled: true,
+            auto_update_window_start: "02:00",
+            auto_update_window_end: "04:00",
+          })}
+          softwareId={1}
+          teamId={1}
+          router={router}
+          refetchSoftwareTitle={jest.fn()}
+          onClickVersions={jest.fn()}
+        />
+      );
+
+      await user.click(screen.getByText("Auto updates"));
+
+      // Actions dropdown item of the same text is only in the DOM when opened;
+      // asserting on the modal's title text is unambiguous here.
+      expect(screen.getByText("Schedule auto updates")).toBeInTheDocument();
     });
 
     it("does not render the pills row when there is no installer", () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -225,13 +225,10 @@ const SoftwareSummaryCard = ({
                 : undefined
             }
             tooltip={
-              softwareTitle.auto_update_window_start &&
-              softwareTitle.auto_update_window_end ? (
-                <>
-                  Between {softwareTitle.auto_update_window_start} and{" "}
-                  {softwareTitle.auto_update_window_end}.
-                </>
-              ) : undefined
+              <>
+                Between {softwareTitle.auto_update_window_start} and{" "}
+                {softwareTitle.auto_update_window_end}.
+              </>
             }
           />
         )}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -99,6 +99,8 @@ const SoftwareSummaryCard = ({
   const isFleetMaintainedApp = !!installerResult?.meta.isFleetMaintainedApp;
   const isAndroidPlayStoreApp = !!installerResult?.meta.isAndroidPlayStoreApp;
   const isCustomPackage = !!installerResult?.meta.isCustomPackage;
+  const isIosOrIpadosApp = !!installerResult?.meta.isIosOrIpadosApp;
+  const canManageSoftware = !!installerResult?.meta.canManageSoftware;
 
   // Depend on the optional-chained sources directly so the memo's cache hits
   // when both are nullish — `?? []` would mint a fresh array literal each
@@ -162,9 +164,15 @@ const SoftwareSummaryCard = ({
   // chips since they're single-package — the flag is owned by the page.
   const showSelfServiceChip = isSelfService && !canActivateMultiplePackages;
   const showAutoInstallChip = hasLinkedPolicies && !canActivateMultiplePackages;
+  const showAutoUpdateChip = isAppleVpp && !!softwareTitle.auto_update_enabled;
+  const canEditAutoUpdateConfig =
+    !!softwareTitle.app_store_app && isIosOrIpadosApp && canManageSoftware;
 
   const showHeaderPills =
-    !!installerKindLabel || showSelfServiceChip || showAutoInstallChip;
+    !!installerKindLabel ||
+    showSelfServiceChip ||
+    showAutoInstallChip ||
+    showAutoUpdateChip;
 
   const headerPills = useMemo(() => {
     if (!showHeaderPills) {
@@ -207,6 +215,26 @@ const SoftwareSummaryCard = ({
             )}
           />
         )}
+        {showAutoUpdateChip && (
+          <Chip
+            icon="refresh"
+            text="Auto updates"
+            onClick={
+              canEditAutoUpdateConfig
+                ? () => setShowEditAutoUpdateConfigModal(true)
+                : undefined
+            }
+            tooltip={
+              softwareTitle.auto_update_window_start &&
+              softwareTitle.auto_update_window_end ? (
+                <>
+                  Between {softwareTitle.auto_update_window_start} and{" "}
+                  {softwareTitle.auto_update_window_end}.
+                </>
+              ) : undefined
+            }
+          />
+        )}
       </>
     );
   }, [
@@ -217,6 +245,10 @@ const SoftwareSummaryCard = ({
     isPatchPolicyOnly,
     mergedPolicies,
     softwareTitle.source,
+    showAutoUpdateChip,
+    canEditAutoUpdateConfig,
+    softwareTitle.auto_update_window_start,
+    softwareTitle.auto_update_window_end,
     router,
     teamId,
   ]);
@@ -252,12 +284,7 @@ const SoftwareSummaryCard = ({
     );
   }
 
-  const {
-    softwareInstaller,
-    isIosOrIpadosApp,
-    isAndroidPlayStoreWebApp,
-    canManageSoftware,
-  } = installerResult.meta;
+  const { softwareInstaller, isAndroidPlayStoreWebApp } = installerResult.meta;
 
   const canEditAppearance = canManageSoftware;
   const canEditSoftware = canManageSoftware && !isAndroidPlayStoreApp;
@@ -273,9 +300,6 @@ const SoftwareSummaryCard = ({
   /** Installer modals require a specific team; hidden from "All Teams" */
   const hasValidTeamId = typeof teamId === "number" && teamId >= 0;
   const softwareInstallerOnTeam = hasValidTeamId && softwareInstaller;
-
-  const canEditAutoUpdateConfig =
-    softwareTitle.app_store_app && isIosOrIpadosApp && canManageSoftware;
 
   const onClickEditAppearance = () => setShowEditIconModal(true);
   const onClickEditSoftware = () => setShowEditSoftwareModal(true);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -227,7 +227,7 @@ const SoftwareSummaryCard = ({
             tooltip={
               <>
                 Between {softwareTitle.auto_update_window_start} and{" "}
-                {softwareTitle.auto_update_window_end}.
+                {softwareTitle.auto_update_window_end} (host local time).
               </>
             }
           />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -7,6 +7,7 @@ import { InjectedRouter } from "react-router";
 import PATHS from "router/paths";
 import { getPathWithQueryParams } from "utilities/url";
 import { pluralize } from "utilities/strings/stringUtils";
+import { internationalTimeOnlyFormat } from "utilities/helpers";
 import { AppContext } from "context/app";
 import { useSoftwareInstaller } from "hooks/useSoftwareInstallerMeta";
 import {
@@ -164,7 +165,13 @@ const SoftwareSummaryCard = ({
   // chips since they're single-package — the flag is owned by the page.
   const showSelfServiceChip = isSelfService && !canActivateMultiplePackages;
   const showAutoInstallChip = hasLinkedPolicies && !canActivateMultiplePackages;
-  const showAutoUpdateChip = isAppleVpp && !!softwareTitle.auto_update_enabled;
+  // Requires the full window; without both times the tooltip would render
+  // as a bare "Between  and  (host local time)." — bail rather than show.
+  const showAutoUpdateChip =
+    isAppleVpp &&
+    !!softwareTitle.auto_update_enabled &&
+    !!softwareTitle.auto_update_window_start &&
+    !!softwareTitle.auto_update_window_end;
   const canEditAutoUpdateConfig =
     !!softwareTitle.app_store_app && isIosOrIpadosApp && canManageSoftware;
 
@@ -227,8 +234,15 @@ const SoftwareSummaryCard = ({
             }
             tooltip={
               <>
-                Between {softwareTitle.auto_update_window_start} and{" "}
-                {softwareTitle.auto_update_window_end} (host local time).
+                Between{" "}
+                {internationalTimeOnlyFormat(
+                  softwareTitle.auto_update_window_start ?? ""
+                )}{" "}
+                and{" "}
+                {internationalTimeOnlyFormat(
+                  softwareTitle.auto_update_window_end ?? ""
+                )}{" "}
+                (host local time).
               </>
             }
           />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -167,9 +167,10 @@ const SoftwareSummaryCard = ({
   const showAutoInstallChip = hasLinkedPolicies && !canActivateMultiplePackages;
   // Requires the full window; without both times the tooltip would render
   // as a bare "Between  and  (host local time)." — bail rather than show.
-  // iOS/iPadOS-only: the auto-update cron in apple_mdm.go only acts on
-  // ios_apps / ipados_apps sources, so surfacing the chip on a macOS VPP
-  // row (if a schedule ever exists in the DB) would be misleading.
+  // iOS/iPadOS-only: `MDMAppleCheckinAndCommandService.handleScheduledUpdates`
+  // only acts on `ios_apps` / `ipados_apps` sources, so surfacing the chip
+  // on a macOS VPP row (if a schedule ever exists in the DB) would be
+  // misleading.
   const showAutoUpdateChip =
     isAppleVpp &&
     isIosOrIpadosApp &&

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -165,15 +165,8 @@ const SoftwareSummaryCard = ({
   // chips since they're single-package — the flag is owned by the page.
   const showSelfServiceChip = isSelfService && !canActivateMultiplePackages;
   const showAutoInstallChip = hasLinkedPolicies && !canActivateMultiplePackages;
-  // Requires the full window; without both times the tooltip would render
-  // as a bare "Between  and  (host local time)." — bail rather than show.
-  // iOS/iPadOS + VPP only: `MDMAppleCheckinAndCommandService.handleScheduledUpdates`
-  // only acts on `ios_apps` / `ipados_apps` sources, so surfacing the chip
-  // on a macOS VPP row (if a schedule ever exists in the DB) would be
-  // misleading. Gates on `softwareTitle.app_store_app` directly rather
-  // than `isAppleVpp` because `useSoftwareInstaller` prefers a co-existing
-  // custom package (mixed-installer state), which would flip `isAppleVpp`
-  // to false even though VPP auto-updates are legitimately configured.
+  // Gates on `app_store_app` directly since `isAppleVpp` flips false when
+  // a co-existing custom package hides the VPP installer.
   const showAutoUpdateChip =
     !!softwareTitle.app_store_app &&
     isIosOrIpadosApp &&

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -167,8 +167,12 @@ const SoftwareSummaryCard = ({
   const showAutoInstallChip = hasLinkedPolicies && !canActivateMultiplePackages;
   // Requires the full window; without both times the tooltip would render
   // as a bare "Between  and  (host local time)." — bail rather than show.
+  // iOS/iPadOS-only: the auto-update cron in apple_mdm.go only acts on
+  // ios_apps / ipados_apps sources, so surfacing the chip on a macOS VPP
+  // row (if a schedule ever exists in the DB) would be misleading.
   const showAutoUpdateChip =
     isAppleVpp &&
+    isIosOrIpadosApp &&
     !!softwareTitle.auto_update_enabled &&
     !!softwareTitle.auto_update_window_start &&
     !!softwareTitle.auto_update_window_end;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -167,12 +167,15 @@ const SoftwareSummaryCard = ({
   const showAutoInstallChip = hasLinkedPolicies && !canActivateMultiplePackages;
   // Requires the full window; without both times the tooltip would render
   // as a bare "Between  and  (host local time)." — bail rather than show.
-  // iOS/iPadOS-only: `MDMAppleCheckinAndCommandService.handleScheduledUpdates`
+  // iOS/iPadOS + VPP only: `MDMAppleCheckinAndCommandService.handleScheduledUpdates`
   // only acts on `ios_apps` / `ipados_apps` sources, so surfacing the chip
   // on a macOS VPP row (if a schedule ever exists in the DB) would be
-  // misleading.
+  // misleading. Gates on `softwareTitle.app_store_app` directly rather
+  // than `isAppleVpp` because `useSoftwareInstaller` prefers a co-existing
+  // custom package (mixed-installer state), which would flip `isAppleVpp`
+  // to false even though VPP auto-updates are legitimately configured.
   const showAutoUpdateChip =
-    isAppleVpp &&
+    !!softwareTitle.app_store_app &&
     isIosOrIpadosApp &&
     !!softwareTitle.auto_update_enabled &&
     !!softwareTitle.auto_update_window_start &&

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -189,6 +189,7 @@ const SoftwareSummaryCard = ({
               isIpadOrIphoneSoftwareSource(softwareTitle.source),
               isAndroidSoftwareSource(softwareTitle.source)
             )}
+            tooltipTextBalanced={false}
           />
         )}
         {showAutoInstallChip && (

--- a/frontend/pages/SoftwarePage/helpers.tests.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tests.tsx
@@ -37,15 +37,12 @@ describe("getSelfServiceTooltip", () => {
 
     render(tooltip as React.ReactElement);
 
+    // "self service" is the link text now — the sentence wraps it inline.
+    expect(screen.getByText(/End users can install from/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/End users can install from self service\./i)
+      screen.getByRole("link", { name: /self service/i })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /Learn how to deploy self service/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /Learn how to deploy self service/i })
-    ).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /self service/i })).toHaveAttribute(
       "href",
       expect.stringContaining("/deploy-self-service-to-ios")
     );
@@ -59,9 +56,9 @@ describe("getSelfServiceTooltip", () => {
     expect(screen.getByText(/End users can install from/i)).toBeInTheDocument();
     expect(screen.getByText(/Fleet Desktop/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: /Learn more/i })
+      screen.getByRole("link", { name: /Self service/i })
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Learn more/i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Self service/i })).toHaveAttribute(
       "href",
       expect.stringContaining("/self-service-software")
     );

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -238,11 +238,10 @@ export const getSelfServiceTooltip = (
         End users can install from{" "}
         <CustomLink
           newTab
-          text="self service"
+          text="self service."
           variant="tooltip-link"
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/deploy-self-service-to-ios`}
         />
-        .
       </>
     );
 
@@ -252,11 +251,10 @@ export const getSelfServiceTooltip = (
       <strong>Fleet Desktop</strong> &gt;{" "}
       <CustomLink
         newTab
-        text="Self service"
+        text="Self service."
         variant="tooltip-link"
         url={`${LEARN_MORE_ABOUT_BASE_LINK}/self-service-software`}
       />
-      .
     </>
   );
 };

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -238,7 +238,7 @@ export const getSelfServiceTooltip = (
         End users can install from{" "}
         <CustomLink
           newTab
-          text="self service."
+          text="self service"
           variant="tooltip-link"
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/deploy-self-service-to-ios`}
         />
@@ -251,7 +251,7 @@ export const getSelfServiceTooltip = (
       <strong>Fleet Desktop</strong> &gt;{" "}
       <CustomLink
         newTab
-        text="Self service."
+        text="Self service"
         variant="tooltip-link"
         url={`${LEARN_MORE_ABOUT_BASE_LINK}/self-service-software`}
       />

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -235,27 +235,28 @@ export const getSelfServiceTooltip = (
   if (isIosOrIpadosApp)
     return (
       <>
-        End users can install from self service.
-        <br />
+        End users can install from{" "}
         <CustomLink
           newTab
-          text="Learn how to deploy self service"
+          text="self service"
           variant="tooltip-link"
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/deploy-self-service-to-ios`}
         />
+        .
       </>
     );
 
   return (
     <>
       End users can install from <br />
-      <strong>Fleet Desktop</strong> &gt; <strong>Self service</strong>. <br />
+      <strong>Fleet Desktop</strong> &gt;{" "}
       <CustomLink
         newTab
-        text="Learn more"
+        text="Self service"
         variant="tooltip-link"
         url={`${LEARN_MORE_ABOUT_BASE_LINK}/self-service-software`}
       />
+      .
     </>
   );
 };
@@ -267,7 +268,7 @@ export const getAutoUpdatesTooltip = (startTime: string, endTime: string) => {
       <br />
       targeted hosts will begin updating between
       <br />
-      {startTime} and {endTime} (host&rsquo;s local time).
+      {startTime} and {endTime} (host local time).
     </>
   );
 };

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -22,6 +22,7 @@ import {
 import { IDropdownOption } from "interfaces/dropdownOption";
 
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import { internationalTimeOnlyFormat } from "utilities/helpers";
 
 import CustomLink from "components/CustomLink";
 
@@ -227,7 +228,7 @@ export const getSelfServiceTooltip = (
   if (isAndroidPlayStoreApp) {
     return (
       <>
-        End users can install from the <strong>Play Store</strong> <br />
+        End users can install from the <strong>Play Store</strong>
         in their work profile.
       </>
     );
@@ -247,8 +248,7 @@ export const getSelfServiceTooltip = (
 
   return (
     <>
-      End users can install from <br />
-      <strong>Fleet Desktop</strong> &gt;{" "}
+      End users can install from <strong>Fleet Desktop</strong> &gt;{" "}
       <CustomLink
         newTab
         text="Self service"
@@ -262,11 +262,9 @@ export const getSelfServiceTooltip = (
 export const getAutoUpdatesTooltip = (startTime: string, endTime: string) => {
   return (
     <>
-      When a new version is available,
-      <br />
-      targeted hosts will begin updating between
-      <br />
-      {startTime} and {endTime} (host local time).
+      When a new version is available, targeted hosts will begin updating
+      between {internationalTimeOnlyFormat(startTime)} and{" "}
+      {internationalTimeOnlyFormat(endTime)} (host local time).
     </>
   );
 };

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
@@ -102,6 +102,9 @@ export const generateHostSWLibraryTableHeaders = ({
           icon_url,
           app_store_app,
           software_package,
+          auto_update_enabled,
+          auto_update_window_start,
+          auto_update_window_end,
         } = cellProps.row.original;
 
         const softwareTitleDetailsPath = getPathWithQueryParams(
@@ -134,6 +137,9 @@ export const generateHostSWLibraryTableHeaders = ({
             pageContext="hostDetailsLibrary"
             isIosOrIpadosApp={isIosOrIpadosApp}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            autoUpdateEnabled={auto_update_enabled}
+            autoUpdateWindowStart={auto_update_window_start}
+            autoUpdateWindowEnd={auto_update_window_end}
           />
         );
       },

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
@@ -137,6 +137,7 @@ export const generateHostSWLibraryTableHeaders = ({
             pageContext="hostDetailsLibrary"
             isIosOrIpadosApp={isIosOrIpadosApp}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            isAppStoreApp={!!app_store_app}
             autoUpdateEnabled={auto_update_enabled}
             autoUpdateWindowStart={auto_update_window_start}
             autoUpdateWindowEnd={auto_update_window_end}

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -65,6 +65,9 @@ export const generateSoftwareTableHeaders = ({
           app_store_app,
           software_package,
           icon_url,
+          auto_update_enabled,
+          auto_update_window_start,
+          auto_update_window_end,
         } = cellProps.row.original;
 
         const softwareTitleDetailsPath = getPathWithQueryParams(
@@ -95,6 +98,9 @@ export const generateSoftwareTableHeaders = ({
             pageContext="hostDetails"
             isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            autoUpdateEnabled={auto_update_enabled}
+            autoUpdateWindowStart={auto_update_window_start}
+            autoUpdateWindowEnd={auto_update_window_end}
           />
         );
       },

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -98,6 +98,7 @@ export const generateSoftwareTableHeaders = ({
             pageContext="hostDetails"
             isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
+            isAppStoreApp={!!app_store_app}
             autoUpdateEnabled={auto_update_enabled}
             autoUpdateWindowStart={auto_update_window_start}
             autoUpdateWindowEnd={auto_update_window_end}

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -142,11 +142,11 @@ describe("helpers utilities", () => {
 
     it("renders 24-hour source times in 12-hour form for US locale", () => {
       setLanguage("en-US");
-      // Non-breaking space ( ) appears between the number and AM/PM in
-      // some ICU versions; matching just the substring keeps the assertion
-      // portable across Node/ICU versions.
-      expect(internationalTimeOnlyFormat("02:00")).toMatch(/2:00[\s  ]?AM/i);
-      expect(internationalTimeOnlyFormat("14:30")).toMatch(/2:30[\s  ]?PM/i);
+      // A narrow no-break space (U+202F) or NBSP (U+00A0) may appear
+      // between the number and AM/PM in some ICU versions; match any
+      // whitespace via \\s? to stay portable across Node/ICU versions.
+      expect(internationalTimeOnlyFormat("02:00")).toMatch(/2:00\s?AM/i);
+      expect(internationalTimeOnlyFormat("14:30")).toMatch(/2:30\s?PM/i);
     });
 
     it("keeps 24-hour form for a 24-hour locale (de-DE)", () => {
@@ -174,8 +174,8 @@ describe("helpers utilities", () => {
 
     it("handles edge times 00:00 and 23:59", () => {
       setLanguage("en-US");
-      expect(internationalTimeOnlyFormat("00:00")).toMatch(/12:00[\s  ]?AM/i);
-      expect(internationalTimeOnlyFormat("23:59")).toMatch(/11:59[\s  ]?PM/i);
+      expect(internationalTimeOnlyFormat("00:00")).toMatch(/12:00\s?AM/i);
+      expect(internationalTimeOnlyFormat("23:59")).toMatch(/11:59\s?PM/i);
     });
   });
 });

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -5,6 +5,7 @@ import helpers, {
   compareVersions,
   willExpireWithinXDays,
   humanLastSeen,
+  internationalTimeOnlyFormat,
 } from "./helpers";
 
 describe("helpers utilities", () => {
@@ -117,6 +118,64 @@ describe("helpers utilities", () => {
       const result = helpers.setupData(formData);
 
       expect(result.org_info).toEqual({ org_name: "Fleet" });
+    });
+  });
+
+  describe("internationalTimeOnlyFormat function", () => {
+    const setLanguage = (lang: string) => {
+      Object.defineProperty(window.navigator, "languages", {
+        value: [lang],
+        configurable: true,
+      });
+    };
+
+    let originalLanguages: readonly string[];
+    beforeAll(() => {
+      originalLanguages = window.navigator.languages;
+    });
+    afterAll(() => {
+      Object.defineProperty(window.navigator, "languages", {
+        value: originalLanguages,
+        configurable: true,
+      });
+    });
+
+    it("renders 24-hour source times in 12-hour form for US locale", () => {
+      setLanguage("en-US");
+      // Non-breaking space ( ) appears between the number and AM/PM in
+      // some ICU versions; matching just the substring keeps the assertion
+      // portable across Node/ICU versions.
+      expect(internationalTimeOnlyFormat("02:00")).toMatch(/2:00[\s  ]?AM/i);
+      expect(internationalTimeOnlyFormat("14:30")).toMatch(/2:30[\s  ]?PM/i);
+    });
+
+    it("keeps 24-hour form for a 24-hour locale (de-DE)", () => {
+      setLanguage("de-DE");
+      // German locale uses 24-hour; either 02:00 or 2:00 is acceptable
+      // depending on ICU version, but always without AM/PM.
+      expect(internationalTimeOnlyFormat("02:00")).toMatch(/^0?2:00$/);
+      expect(internationalTimeOnlyFormat("14:30")).toMatch(/^14:30$/);
+    });
+
+    it("passes through an unparseable string unchanged", () => {
+      setLanguage("en-US");
+      expect(internationalTimeOnlyFormat("nope")).toBe("nope");
+      expect(internationalTimeOnlyFormat("")).toBe("");
+      expect(internationalTimeOnlyFormat("2:")).toBe("2:");
+    });
+
+    it("passes through out-of-range times unchanged", () => {
+      setLanguage("en-US");
+      // These would otherwise silently wrap via Date.setHours (24:00 -> next day).
+      // Passthrough keeps the tooltip honest about bad data instead of hiding it.
+      expect(internationalTimeOnlyFormat("24:00")).toBe("24:00");
+      expect(internationalTimeOnlyFormat("10:60")).toBe("10:60");
+    });
+
+    it("handles edge times 00:00 and 23:59", () => {
+      setLanguage("en-US");
+      expect(internationalTimeOnlyFormat("00:00")).toMatch(/12:00[\s  ]?AM/i);
+      expect(internationalTimeOnlyFormat("23:59")).toMatch(/11:59[\s  ]?PM/i);
     });
   });
 });

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -630,14 +630,8 @@ export const internationalTimeFormat = (date: number | Date): string => {
   );
 };
 
-/** Renders an "HH:MM" 24-hour string in the viewer's locale. Backend stores
- * VPP auto-update windows as bare 24-hour strings; this projects that onto
- * a fixed UTC date so `intlFormat` can produce "2:00 AM" (en-US), "14:00"
- * (de-DE), etc. The UTC anchor + `timeZone: "UTC"` avoid DST wall-clock
- * shifts: `Date.setHours(2, 0)` on a spring-forward day in the viewer's
- * local zone would normalize to 03:00 and misrender the configured
- * window. Returns the input unchanged when it isn't parseable so callers
- * don't need a fallback branch. */
+/** Renders an "HH:MM" 24-hour string in the viewer's locale. UTC anchor
+ * + `timeZone: "UTC"` avoid DST wall-clock shifts on spring-forward. */
 export const internationalTimeOnlyFormat = (hhmm: string): string => {
   const match = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
   if (!match) return hhmm;

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -632,20 +632,22 @@ export const internationalTimeFormat = (date: number | Date): string => {
 
 /** Renders an "HH:MM" 24-hour string in the viewer's locale. Backend stores
  * VPP auto-update windows as bare 24-hour strings; this projects that onto
- * an arbitrary date so `intlFormat` can produce "2:00 AM" (en-US), "14:00"
- * (de-DE), etc. Returns the input unchanged when it isn't parseable so
- * callers don't need a fallback branch. */
+ * a fixed UTC date so `intlFormat` can produce "2:00 AM" (en-US), "14:00"
+ * (de-DE), etc. The UTC anchor + `timeZone: "UTC"` avoid DST wall-clock
+ * shifts: `Date.setHours(2, 0)` on a spring-forward day in the viewer's
+ * local zone would normalize to 03:00 and misrender the configured
+ * window. Returns the input unchanged when it isn't parseable so callers
+ * don't need a fallback branch. */
 export const internationalTimeOnlyFormat = (hhmm: string): string => {
   const match = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
   if (!match) return hhmm;
   const hours = Number(match[1]);
   const minutes = Number(match[2]);
   if (hours > 23 || minutes > 59) return hhmm;
-  const date = new Date();
-  date.setHours(hours, minutes, 0, 0);
+  const date = new Date(Date.UTC(2000, 0, 1, hours, minutes));
   return intlFormat(
     date,
-    { hour: "numeric", minute: "numeric" },
+    { hour: "numeric", minute: "numeric", timeZone: "UTC" },
     { locale: window.navigator.languages[0] }
   );
 };

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -630,6 +630,26 @@ export const internationalTimeFormat = (date: number | Date): string => {
   );
 };
 
+/** Renders an "HH:MM" 24-hour string in the viewer's locale. Backend stores
+ * VPP auto-update windows as bare 24-hour strings; this projects that onto
+ * an arbitrary date so `intlFormat` can produce "2:00 AM" (en-US), "14:00"
+ * (de-DE), etc. Returns the input unchanged when it isn't parseable so
+ * callers don't need a fallback branch. */
+export const internationalTimeOnlyFormat = (hhmm: string): string => {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
+  if (!match) return hhmm;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return hhmm;
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+  return intlFormat(
+    date,
+    { hour: "numeric", minute: "numeric" },
+    { locale: window.navigator.languages[0] }
+  );
+};
+
 export const internationalNumberFormat = (number: number): string => {
   return new Intl.NumberFormat(navigator.language).format(number);
 };
@@ -1045,6 +1065,7 @@ export default {
   humanHostDetailUpdated,
   humanLastSeen,
   internationalTimeFormat,
+  internationalTimeOnlyFormat,
   internallyTruncateText,
   hostTeamName,
   humanQueryLastRun,

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -7258,7 +7258,71 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 		software = append(software, &hs.HostSoftwareWithInstaller)
 	}
 
+	// Hydrate VPP auto-update fields from software_update_schedules. Cheaper as a
+	// post-pagination lookup than as a JOIN inside the assembly SQL: at most one
+	// row per title, small table, indexed by (team_id, title_id). Skip when the
+	// host has no team — schedules are per-team.
+	if host.TeamID != nil && len(software) > 0 {
+		if err := ds.hydrateHostSoftwareAutoUpdateFields(ctx, software, globalOrTeamID); err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "hydrate host software auto-update fields")
+		}
+	}
+
 	return software, metaData, nil
+}
+
+// hydrateHostSoftwareAutoUpdateFields looks up software_update_schedules rows for
+// the given team and the title IDs in `software`, then copies the enabled/window
+// fields onto each result. No-op when no schedules exist for the team.
+func (ds *Datastore) hydrateHostSoftwareAutoUpdateFields(
+	ctx context.Context,
+	software []*fleet.HostSoftwareWithInstaller,
+	teamID uint,
+) error {
+	titleIDs := make([]uint, 0, len(software))
+	for _, s := range software {
+		titleIDs = append(titleIDs, s.ID)
+	}
+
+	stmt, args, err := sqlx.In(`
+		SELECT title_id, enabled, start_time, end_time
+		FROM software_update_schedules
+		WHERE team_id = ? AND title_id IN (?)`,
+		teamID, titleIDs,
+	)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build auto-update schedule lookup")
+	}
+
+	type scheduleRow struct {
+		TitleID   uint   `db:"title_id"`
+		Enabled   bool   `db:"enabled"`
+		StartTime string `db:"start_time"`
+		EndTime   string `db:"end_time"`
+	}
+	var rows []scheduleRow
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "select auto-update schedules")
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	byTitle := make(map[uint]scheduleRow, len(rows))
+	for _, r := range rows {
+		byTitle[r.TitleID] = r
+	}
+	for _, s := range software {
+		if r, ok := byTitle[s.ID]; ok {
+			enabled := r.Enabled
+			start := r.StartTime
+			end := r.EndTime
+			s.AutoUpdateEnabled = &enabled
+			s.AutoUpdateStartTime = &start
+			s.AutoUpdateEndTime = &end
+		}
+	}
+	return nil
 }
 
 func (ds *Datastore) SetHostSoftwareInstallResult(ctx context.Context, result *fleet.HostSoftwareInstallResultPayload, attemptNumber *int) (wasCanceled bool, err error) {

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -7258,10 +7258,8 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 		software = append(software, &hs.HostSoftwareWithInstaller)
 	}
 
-	// Hydrate VPP auto-update fields from software_update_schedules. Cheaper as a
-	// post-pagination lookup than as a JOIN inside the assembly SQL: at most one
-	// row per title, small table, indexed by (team_id, title_id). Skip when the
-	// host has no team — schedules are per-team.
+	// Post-pagination lookup rather than an assembly-SQL JOIN — cheaper on
+	// the paginated title-ID set. Skipped when the host has no team.
 	if host.TeamID != nil && len(software) > 0 {
 		if err := ds.hydrateHostSoftwareAutoUpdateFields(ctx, software, globalOrTeamID); err != nil {
 			return nil, nil, ctxerr.Wrap(ctx, err, "hydrate host software auto-update fields")
@@ -7271,9 +7269,6 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 	return software, metaData, nil
 }
 
-// hydrateHostSoftwareAutoUpdateFields looks up software_update_schedules rows for
-// the given team and the title IDs in `software`, then copies the enabled/window
-// fields onto each result. No-op when no schedules exist for the team.
 func (ds *Datastore) hydrateHostSoftwareAutoUpdateFields(
 	ctx context.Context,
 	software []*fleet.HostSoftwareWithInstaller,

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -7314,12 +7314,9 @@ func (ds *Datastore) hydrateHostSoftwareAutoUpdateFields(
 	}
 	for _, s := range software {
 		if r, ok := byTitle[s.ID]; ok {
-			enabled := r.Enabled
-			start := r.StartTime
-			end := r.EndTime
-			s.AutoUpdateEnabled = &enabled
-			s.AutoUpdateStartTime = &start
-			s.AutoUpdateEndTime = &end
+			s.AutoUpdateEnabled = new(r.Enabled)
+			s.AutoUpdateStartTime = new(r.StartTime)
+			s.AutoUpdateEndTime = new(r.EndTime)
 		}
 	}
 	return nil

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -6272,6 +6272,31 @@ func testListHostSoftwareWithVPPApps(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.Len(t, sw, 1)
 	assert.Equal(t, icon.IconUrl(), *sw[0].IconUrl)
+
+	// Before a schedule exists, the fields marshal as nil.
+	require.Nil(t, sw[0].AutoUpdateEnabled)
+	require.Nil(t, sw[0].AutoUpdateStartTime)
+	require.Nil(t, sw[0].AutoUpdateEndTime)
+
+	// Enable auto-updates for the VPP title and confirm hydration surfaces the
+	// window on the host-software list. This is the plumbing that lets the
+	// FE host software / device software tables render the auto-update icon.
+	err = ds.UpdateSoftwareTitleAutoUpdateConfig(ctx, va1.TitleID, tm.ID, fleet.SoftwareAutoUpdateConfig{
+		AutoUpdateEnabled:   new(true),
+		AutoUpdateStartTime: new("02:00"),
+		AutoUpdateEndTime:   new("04:00"),
+	})
+	require.NoError(t, err)
+
+	sw, _, err = ds.ListHostSoftware(ctx, anotherHost, opts)
+	require.NoError(t, err)
+	assert.Len(t, sw, 1)
+	require.NotNil(t, sw[0].AutoUpdateEnabled)
+	assert.True(t, *sw[0].AutoUpdateEnabled)
+	require.NotNil(t, sw[0].AutoUpdateStartTime)
+	assert.Equal(t, "02:00", *sw[0].AutoUpdateStartTime)
+	require.NotNil(t, sw[0].AutoUpdateEndTime)
+	assert.Equal(t, "04:00", *sw[0].AutoUpdateEndTime)
 }
 
 func testListHostSoftwareVPPSelfService(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -761,6 +761,9 @@ SELECT
 		,iha.storage_id as in_house_app_storage_id
 		,iha.self_service as in_house_app_self_service
 		,iha.install_during_setup as in_house_app_install_during_setup
+		,sus.enabled as auto_update_enabled
+		,sus.start_time as auto_update_window_start
+		,sus.end_time as auto_update_window_end
 	{{end}}
 FROM software_titles st
 	{{if hasTeamID .}}
@@ -772,6 +775,7 @@ FROM software_titles st
 		LEFT JOIN vpp_apps vap ON vap.title_id = st.id AND {{yesNo .PackagesOnly "FALSE" "TRUE"}}
 		LEFT JOIN vpp_apps_teams vat ON vat.adam_id = vap.adam_id AND vat.platform = vap.platform AND
 			{{if .PackagesOnly}} FALSE {{else}} vat.global_or_team_id = {{teamID .}}{{end}}
+		LEFT JOIN software_update_schedules sus ON sus.title_id = st.id AND sus.team_id = {{teamID .}}
 	{{end}}
 	LEFT JOIN software_titles_host_counts sthc ON sthc.software_title_id = st.id AND
 		(sthc.team_id = {{teamID .}} AND sthc.global_stats = {{if hasTeamID .}} 0 {{else}} 1 {{end}})
@@ -866,6 +870,9 @@ GROUP BY
 		,in_house_app_storage_id
 		,in_house_app_self_service
 		,in_house_app_install_during_setup
+		,auto_update_enabled
+		,auto_update_window_start
+		,auto_update_window_end
 	{{end}}
 `
 	var args []any
@@ -1074,7 +1081,10 @@ func buildOptimizedListSoftwareTitlesSQL(opts fleet.SoftwareTitleListOptions) st
 			iha.platform AS in_house_app_platform,
 			iha.storage_id AS in_house_app_storage_id,
 			iha.self_service AS in_house_app_self_service,
-			iha.install_during_setup AS in_house_app_install_during_setup`
+			iha.install_during_setup AS in_house_app_install_during_setup,
+			sus.enabled AS auto_update_enabled,
+			sus.start_time AS auto_update_window_start,
+			sus.end_time AS auto_update_window_end`
 	}
 
 	outerSQL += fmt.Sprintf(`
@@ -1095,7 +1105,8 @@ func buildOptimizedListSoftwareTitlesSQL(opts fleet.SoftwareTitleListOptions) st
 		LEFT JOIN in_house_apps iha ON iha.title_id = st.id AND iha.global_or_team_id = %[1]d
 		LEFT JOIN vpp_apps vap ON vap.title_id = st.id
 		LEFT JOIN vpp_apps_teams vat ON vat.adam_id = vap.adam_id AND vat.platform = vap.platform
-			AND vat.global_or_team_id = %[1]d`, teamID)
+			AND vat.global_or_team_id = %[1]d
+		LEFT JOIN software_update_schedules sus ON sus.title_id = st.id AND sus.team_id = %[1]d`, teamID)
 	}
 
 	outerSQL += `

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -3012,6 +3012,26 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 	require.NotNil(t, titleResult.AutoUpdateEndTime)
 	require.Equal(t, endTime, *titleResult.AutoUpdateEndTime)
 
+	// Verify that ListSoftwareTitles surfaces the same auto_update fields (the
+	// list response embeds SoftwareAutoUpdateConfig, so the join must populate
+	// them for FE list-page indicators to render).
+	listTitles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{
+		TeamID: teamID,
+	}, fleet.TeamFilter{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+	require.NoError(t, err)
+	listed := titleByName(listTitles, "vpp1")
+	require.NotNil(t, listed.AutoUpdateEnabled)
+	require.True(t, *listed.AutoUpdateEnabled)
+	require.NotNil(t, listed.AutoUpdateStartTime)
+	require.Equal(t, startTime, *listed.AutoUpdateStartTime)
+	require.NotNil(t, listed.AutoUpdateEndTime)
+	require.Equal(t, endTime, *listed.AutoUpdateEndTime)
+	// A title with no schedule should marshal all three as nil.
+	unscheduled := titleByName(listTitles, "vpp3")
+	require.Nil(t, unscheduled.AutoUpdateEnabled)
+	require.Nil(t, unscheduled.AutoUpdateStartTime)
+	require.Nil(t, unscheduled.AutoUpdateEndTime)
+
 	// Add valid, disabled auto-update schedule for the other VPP app.
 	// The schedule should be ignored since it's disabled, but it should still be created.
 	err = ds.UpdateSoftwareTitleAutoUpdateConfig(ctx, title2ID, *teamID, fleet.SoftwareAutoUpdateConfig{

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -3036,6 +3036,24 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 	require.Nil(t, unscheduled.AutoUpdateStartTime)
 	require.Nil(t, unscheduled.AutoUpdateEndTime)
 
+	// The default `hosts_count` ordering above hits the two-phase optimized
+	// query path. Re-run with `name` ordering to exercise the templated
+	// fallback query, which has its own copy of the software_update_schedules
+	// JOIN and could regress independently.
+	listTitlesByName, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{
+		TeamID:      teamID,
+		ListOptions: fleet.ListOptions{OrderKey: "name"},
+	}, fleet.TeamFilter{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+	require.NoError(t, err)
+	listedByName := titleByName(listTitlesByName, "vpp1")
+	require.NotZero(t, listedByName.ID, "vpp1 fixture must be present in name-ordered results")
+	require.NotNil(t, listedByName.AutoUpdateEnabled)
+	require.True(t, *listedByName.AutoUpdateEnabled)
+	require.NotNil(t, listedByName.AutoUpdateStartTime)
+	require.Equal(t, startTime, *listedByName.AutoUpdateStartTime)
+	require.NotNil(t, listedByName.AutoUpdateEndTime)
+	require.Equal(t, endTime, *listedByName.AutoUpdateEndTime)
+
 	// Add valid, disabled auto-update schedule for the other VPP app.
 	// The schedule should be ignored since it's disabled, but it should still be created.
 	err = ds.UpdateSoftwareTitleAutoUpdateConfig(ctx, title2ID, *teamID, fleet.SoftwareAutoUpdateConfig{

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -3026,8 +3026,12 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 	require.Equal(t, startTime, *listed.AutoUpdateStartTime)
 	require.NotNil(t, listed.AutoUpdateEndTime)
 	require.Equal(t, endTime, *listed.AutoUpdateEndTime)
-	// A title with no schedule should marshal all three as nil.
+	// A title with no schedule should marshal all three as nil. Guard against
+	// `titleByName` returning a zero-value struct if the fixture ever gets
+	// renamed — otherwise the nil assertions would silently pass on an
+	// unrelated row.
 	unscheduled := titleByName(listTitles, "vpp3")
+	require.NotZero(t, unscheduled.ID, "vpp3 fixture must be present in list results")
 	require.Nil(t, unscheduled.AutoUpdateEnabled)
 	require.Nil(t, unscheduled.AutoUpdateStartTime)
 	require.Nil(t, unscheduled.AutoUpdateEndTime)

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -3012,9 +3012,7 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 	require.NotNil(t, titleResult.AutoUpdateEndTime)
 	require.Equal(t, endTime, *titleResult.AutoUpdateEndTime)
 
-	// Verify that ListSoftwareTitles surfaces the same auto_update fields (the
-	// list response embeds SoftwareAutoUpdateConfig, so the join must populate
-	// them for FE list-page indicators to render).
+	// ListSoftwareTitles must populate the same fields via its JOIN.
 	listTitles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{
 		TeamID: teamID,
 	}, fleet.TeamFilter{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
@@ -3026,20 +3024,16 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 	require.Equal(t, startTime, *listed.AutoUpdateStartTime)
 	require.NotNil(t, listed.AutoUpdateEndTime)
 	require.Equal(t, endTime, *listed.AutoUpdateEndTime)
-	// A title with no schedule should marshal all three as nil. Guard against
-	// `titleByName` returning a zero-value struct if the fixture ever gets
-	// renamed — otherwise the nil assertions would silently pass on an
-	// unrelated row.
+	// A title with no schedule should marshal all three as nil. NotZero
+	// guards against titleByName returning a zero-value struct on rename.
 	unscheduled := titleByName(listTitles, "vpp3")
 	require.NotZero(t, unscheduled.ID, "vpp3 fixture must be present in list results")
 	require.Nil(t, unscheduled.AutoUpdateEnabled)
 	require.Nil(t, unscheduled.AutoUpdateStartTime)
 	require.Nil(t, unscheduled.AutoUpdateEndTime)
 
-	// The default `hosts_count` ordering above hits the two-phase optimized
-	// query path. Re-run with `name` ordering to exercise the templated
-	// fallback query, which has its own copy of the software_update_schedules
-	// JOIN and could regress independently.
+	// Non-hosts_count order forces the templated fallback query, which has
+	// its own copy of the JOIN.
 	listTitlesByName, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{
 		TeamID:      teamID,
 		ListOptions: fleet.ListOptions{OrderKey: "name"},

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -921,6 +921,11 @@ type HostSoftwareWithInstaller struct {
 	// AppStoreApp provides VPP app information, it is only present if a VPP app
 	// is available for the software title.
 	AppStoreApp *SoftwarePackageOrApp `json:"app_store_app"`
+
+	// SoftwareAutoUpdateConfig carries VPP auto-update fields (enabled + window).
+	// Populated post-pagination from software_update_schedules keyed on the host's
+	// team + title ID. Nil for hosts with no team (matches list-titles semantics).
+	SoftwareAutoUpdateConfig
 }
 
 func (h *HostSoftwareWithInstaller) IsPackage() bool {


### PR DESCRIPTION
## Issue
Closes #51661

## Description
- Details page (root cause): the Software title details page had no persistent indicator that VPP auto-updates were scheduled. The configured update window was only visible by reopening the "Schedule auto updates" modal, and `auto_update_enabled` / `auto_update_window_start` / `auto_update_window_end` on `ISoftwareTitleDetails` were read only at modal open time. Adds an "Auto updates" chip (refresh icon) to the summary card header for VPP titles whose `auto_update_enabled` is true. Tooltip surfaces the configured window; for admins/maintainers the chip is clickable and opens the existing Schedule auto updates modal.
- Titles list (plumbing miss): `SoftwareTitleListResult` already embedded `SoftwareAutoUpdateConfig`, so the three fields were part of the JSON contract with `omitempty`, but `ListSoftwareTitles` never joined `software_update_schedules` — every list response marshaled them as null. Adds the LEFT JOIN in both the templated and optimized query paths (mirrors `SoftwareTitleByID`), index-covered via `software_update_schedules.idx_team_title` UNIQUE KEY on `(team_id, title_id)`.
- Host software: `HostSoftwareWithInstaller` now embeds the same config. `ListHostSoftware` hydrates via a post-pagination lookup on the paginated title IDs (cheaper than adding another JOIN to the assembly SQL); no-op when the host has no team.
- Icon fold: VPP auto-updates share the "automatic" family (refresh) with policy-triggered auto-install. Composite `automatic-self-service` icon renders when auto-update coexists with self-service; tooltip stacks the auto-update window line above the existing self-service line.
- Coverage: Software title details, Software > Library, Software > Inventory, Host details > Software, Host details > Library, and the command palette software picker all share `SoftwareNameCell`, so all surfaces get the same fold.

## Copy (design-confirmed)
- Details page chip tooltip: `Between {start} and {end} (host local time).`
- Name-cell auto-update tooltip: `Auto updates between {start} and {end} (host local time).`
- Composite (auto-update + self-service): auto-update line, then a line break, then the existing self-service sentence.
- Self-service sentence: the "self service" (iOS) / "Self service" (Fleet Desktop) text is now the inline link — the separate learn-more line below is removed.
- Schedule auto updates modal: update-window label reads `Update window (host local time)` (drop the possessive).

## Screenrecording
- Auto updates chip on the details page + refresh badge on the titles list and library list, both with the window tooltip



https://github.com/user-attachments/assets/2bbb7431-bc62-410f-8c35-e7714c597eaf




## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auto-update indicators for iOS/iPadOS App Store software.
  * Display configured update windows in software lists and detail views.
  * Added an “Auto updates” control for eligible software, opening scheduling settings when available.
  * Added localized formatting for update times.

* **Bug Fixes**
  * Improved tooltip layout, wrapping, and readability.
  * Auto-update details now appear consistently across inventory, library, and host views.
  * Updated installation and self-service tooltip wording for clarity.
  * Improved tooltip behavior for per-row installation indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->