### PR TITLE
Use hardcoded string for skipped install details

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -41,6 +41,8 @@ import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 import {
   INSTALL_DETAILS_STATUS_ICONS,
+  SKIPPED_INSTALL_DETAILS,
+  SKIPPED_PRE_INSTALL_OUTPUT,
   getInstallDetailsStatusPredicate,
 } from "../constants";
 
@@ -156,8 +158,7 @@ export const StatusMessage = ({
           <span>
             Fleet skipped install of <b>{software_title}</b> ({software_package}
             ) on {formattedHost}
-            {displayTimeStamp}. The app was open. It will update once the user
-            closes it and policy runs again, or update via self service.
+            {displayTimeStamp}. {SKIPPED_INSTALL_DETAILS}
           </span>
         }
       />
@@ -318,7 +319,7 @@ export const SoftwareInstallDetailsModal = ({
       {
         label: "Pre-install query output:",
         value: detailsFromProps.skipped_install
-          ? "Query didn't return result or failed\nThe app was open"
+          ? SKIPPED_PRE_INSTALL_OUTPUT
           : swInstallResult?.pre_install_query_output,
       },
       {

--- a/frontend/components/ActivityDetails/InstallDetails/constants.ts
+++ b/frontend/components/ActivityDetails/InstallDetails/constants.ts
@@ -22,6 +22,13 @@ export const INSTALL_DETAILS_STATUS_ICONS: Record<
   skipped_install: "error-outline",
 } as const;
 
+export const SKIPPED_INSTALL_DETAILS =
+  "The app was open. It will update once the user closes it and policy runs again, or update via self service.";
+
+// A skip stores an empty pre-install query output, so there is nothing to echo back.
+export const SKIPPED_PRE_INSTALL_OUTPUT =
+  "Query didn't return result or failed\nThe app was open";
+
 const INSTALL_DETAILS_STATUS_PREDICATES: Record<
   EnhancedSoftwareInstallUninstallStatus | "skipped_install",
   string

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
@@ -113,6 +113,32 @@ describe("PolicyAutomationActivityDetailsModal", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("explains a patch-when-closed skip instead of showing empty output sections", () => {
+    render(
+      <PolicyAutomationActivityDetailsModal
+        activity={{
+          ...failedSoftwareActivity,
+          details: {
+            policy_id: 123,
+            software_title: "1Password",
+            skipped_install: true,
+          },
+          output: null,
+          pre_install_output: "",
+        }}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Patch skipped (1Password)")).toBeInTheDocument();
+
+    // Shown inline, the same way a failing row shows its output sections.
+    expect(screen.getByText("Pre-install query output")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Query didn't return result or failed/)
+    ).toBeInTheDocument();
+  });
+
   it("omits the details box when there is no output or error", () => {
     render(
       <PolicyAutomationActivityDetailsModal

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -21,6 +21,9 @@ import {
 
 const baseClass = "policy-automation-activity-details-modal";
 
+const SKIPPED_PRE_INSTALL_OUTPUT =
+  "Query didn't return result or failed\nThe app was open";
+
 interface IPolicyAutomationActivityDetailsModalProps {
   activity: IPolicyAutomationActivity;
   onCancel: () => void;
@@ -96,7 +99,9 @@ const PolicyAutomationActivityDetailsModal = ({
           <>
             {renderOutputSection(
               "Pre-install query output",
-              activity.pre_install_output
+              activity.details?.skipped_install
+                ? SKIPPED_PRE_INSTALL_OUTPUT
+                : activity.pre_install_output
             )}
             {renderOutputSection("Details", activity.output)}
             {renderOutputSection(

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -11,6 +11,7 @@ import CustomLink from "components/CustomLink";
 import DataSet from "components/DataSet";
 import Textarea from "components/Textarea";
 import Icon from "components/Icon";
+import { SKIPPED_PRE_INSTALL_OUTPUT } from "components/ActivityDetails/InstallDetails/constants";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import {
@@ -20,9 +21,6 @@ import {
 } from "../PolicyAutomationsActivitiesTable/helpers";
 
 const baseClass = "policy-automation-activity-details-modal";
-
-const SKIPPED_PRE_INSTALL_OUTPUT =
-  "Query didn't return result or failed\nThe app was open";
 
 interface IPolicyAutomationActivityDetailsModalProps {
   activity: IPolicyAutomationActivity;

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -7,12 +7,13 @@ import { createCustomRenderer } from "test/test-utils";
 
 import policiesAPI from "services/entities/policies";
 
+import { SKIPPED_INSTALL_DETAILS } from "components/ActivityDetails/InstallDetails/constants";
+
 import PolicyAutomationsActivitiesTable from "./PolicyAutomationsActivitiesTable";
 import {
   getAutomationRunDisplayName,
   getAutomationStatusIcon,
   getDetailOutputText,
-  SKIPPED_INSTALL_DETAILS,
 } from "./helpers";
 
 jest.mock("services/entities/policies");

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -11,6 +11,8 @@ import PolicyAutomationsActivitiesTable from "./PolicyAutomationsActivitiesTable
 import {
   getAutomationRunDisplayName,
   getAutomationStatusIcon,
+  getDetailOutputText,
+  SKIPPED_INSTALL_DETAILS,
 } from "./helpers";
 
 jest.mock("services/entities/policies");
@@ -167,6 +169,23 @@ describe("getAutomationStatusIcon", () => {
     expect(
       getAutomationStatusIcon(mockActivity({ status: "success" }))
     ).toEqual({ name: "success-outline" });
+  });
+});
+
+describe("getDetailOutputText", () => {
+  it("explains a patch-when-closed skip rather than returning empty text", () => {
+    expect(
+      getDetailOutputText(
+        mockActivity({
+          status: "error",
+          details: {
+            policy_id: 123,
+            software_title: "1Password",
+            skipped_install: true,
+          },
+        })
+      )
+    ).toBe(SKIPPED_INSTALL_DETAILS);
   });
 });
 

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -1,5 +1,6 @@
 import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
+import { SKIPPED_INSTALL_DETAILS } from "components/ActivityDetails/InstallDetails/constants";
 import { Colors } from "styles/var/colors";
 
 const withName = (base: string, name?: string) =>
@@ -72,9 +73,6 @@ export const getAutomationStatusIcon = (
     ? { name: "error-outline" }
     : { name: "success-outline" };
 };
-
-export const SKIPPED_INSTALL_DETAILS =
-  "The app was open. It will update once the user closes it and policy runs again, or update via self service.";
 
 /**
  * Text shown in the "Details" column: the explanation for a deferred patch, the

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -73,14 +73,20 @@ export const getAutomationStatusIcon = (
     : { name: "success-outline" };
 };
 
+export const SKIPPED_INSTALL_DETAILS =
+  "The app was open. It will update once the user closes it and policy runs again, or update via self service.";
+
 /**
- * Text shown in the "Details" column (and the modal's primary block): the
- * remote error response for failures, or the script/install output for the
- * task activities. Empty when neither applies.
+ * Text shown in the "Details" column: the explanation for a deferred patch, the
+ * remote error response for failures, or the script/install output for the task
+ * activities. Empty when none apply.
  */
 export const getDetailOutputText = (
   activity: IPolicyAutomationActivity
 ): string => {
+  if (activity.details?.skipped_install) {
+    return SKIPPED_INSTALL_DETAILS;
+  }
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;
   }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51682

Uses copy text that's already there in the install details modal.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
  - N/A - unreleased bug

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

See reported bug for before.
<img width="3264" height="1774" alt="image" src="https://github.com/user-attachments/assets/3c231395-9c74-42cf-8723-9deb10c78763" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity details for skipped software installations.
  * Added clear messaging explaining that updates will proceed after the app is closed, policy runs again, or through self-service.
  * Added fallback text when pre-install query results are unavailable because the app was open.
* **Tests**
  * Added coverage for skipped-install status and pre-install output displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->