### PR TITLE
Build the in-house app manifest URL from the Apple server URL

### DIFF
--- a/changes/52134-in-house-manifest-apple-server-url
+++ b/changes/52134-in-house-manifest-apple-server-url
@@ -1,1 +1,1 @@
-- Fixed iOS in-house app installs failing with "Could not validate manifest" on deployments that set `mdm.apple_server_url`, by building the `InstallApplication` manifest URL from the hostname Apple devices reach Fleet on rather than from `server_settings.server_url`.
+- Fixed iOS in-house app installs failing on deployments that set `mdm.apple_server_url`, by building both the `InstallApplication` manifest URL and the `.ipa` download URL inside that manifest from the hostname Apple devices reach Fleet on rather than from `server_settings.server_url`.

--- a/changes/52134-in-house-manifest-apple-server-url
+++ b/changes/52134-in-house-manifest-apple-server-url
@@ -1,0 +1,1 @@
+- Fixed iOS in-house app installs failing with "Could not validate manifest" on deployments that set `mdm.apple_server_url`, by building the `InstallApplication` manifest URL from the hostname Apple devices reach Fleet on rather than from `server_settings.server_url`.

--- a/ee/server/service/in_house_apps.go
+++ b/ee/server/service/in_house_apps.go
@@ -203,9 +203,11 @@ func (svc *Service) GetInHouseAppManifest(ctx context.Context, titleID uint, tok
 		return nil, ctxerr.Wrap(ctx, err, "get in house app manifest: get in house app metadata")
 	}
 
+	// The device downloads the .ipa named here itself, so like the manifest URL that
+	// pointed it at this plist, it has to be the URL Apple devices reach Fleet on.
 	downloadURL := fmt.Sprintf(
 		"%s/api/latest/fleet/software/titles/%d/in_house_app/%s",
-		appConfig.ServerSettings.ServerURL, titleID, token,
+		appConfig.MDMUrl(), titleID, token,
 	)
 
 	if svc.config.S3.SoftwareInstallersCloudFrontSigner != nil || svc.config.S3.SoftwareInstallersSignedURL {

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -857,6 +857,46 @@ func TestGetInHouseAppManifest(t *testing.T) {
 	require.Contains(t, string(manifest), signerURL)
 }
 
+// The device fetches the manifest and then the .ipa named inside it, so on a
+// split-hostname deploy both URLs have to be the one Apple devices reach Fleet on.
+func TestGetInHouseAppManifestAppleServerURL(t *testing.T) {
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+	ctx := context.Background()
+
+	const validToken = "00000000-0000-0000-0000-000000000003"
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			ServerSettings: fleet.ServerSettings{ServerURL: "https://admin.example.com"},
+			MDM:            fleet.MDM{AppleServerURL: "https://devices.example.com"},
+		}, nil
+	}
+	ds.GetInHouseAppInstallTokenMetadataFunc = func(ctx context.Context, token string) (*fleet.InHouseAppInstallTokenMetadata, error) {
+		return &fleet.InHouseAppInstallTokenMetadata{
+			Token:           validToken,
+			SoftwareTitleID: 1,
+			TeamID:          0,
+			HostID:          7,
+			ExpiresAt:       time.Now().Add(time.Hour),
+		}, nil
+	}
+	ds.GetInHouseAppMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{
+			BundleIdentifier: "com.foo.bar",
+			Version:          "1.2.3",
+			SoftwareTitle:    "test in-house app",
+			StorageID:        "123storageid",
+		}, nil
+	}
+
+	manifest, err := svc.GetInHouseAppManifest(ctx, 1, validToken)
+	require.NoError(t, err)
+	assert.Contains(t, string(manifest),
+		"<string>https://devices.example.com/api/latest/fleet/software/titles/1/in_house_app/"+validToken+"</string>")
+	assert.NotContains(t, string(manifest), "admin.example.com")
+}
+
 func TestGetInHouseAppPackageTokenAuth(t *testing.T) {
 	ds := new(mock.Store)
 	svc := newTestService(t, ds)

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -1862,9 +1862,11 @@ WHERE
 		if err := ds.CreateInHouseAppInstallToken(ctx, tx, token, p.SoftwareTitle, tid, hostID); err != nil {
 			return ctxerr.Wrap(ctx, err, "mint in-house app install token")
 		}
+		// The device fetches this itself, so it has to be the URL Apple devices
+		// reach Fleet on, which is a separate hostname when apple_server_url is set.
 		manifestURL := fmt.Sprintf(
 			"%s/api/latest/fleet/software/titles/%d/in_house_app/manifest/%s",
-			appConfig.ServerSettings.ServerURL, p.SoftwareTitle, token)
+			appConfig.MDMUrl(), p.SoftwareTitle, token)
 		cfg := configsByAppID[p.InHouseAppID]
 		if len(cfg) > 0 {
 			substituted, err := apple_mdm.SubstituteFleetVarsInAppConfig(ctx, ds, cfg, subHost)

--- a/server/datastore/mysql/in_house_apps_test.go
+++ b/server/datastore/mysql/in_house_apps_test.go
@@ -41,6 +41,7 @@ func TestInHouseApps(t *testing.T) {
 		{"InHouseAppInstallTokens", testInHouseAppInstallTokens},
 		{"SummaryUpcomingPerHostNoDropout", testInHouseSummaryUpcomingPerHostNoDropout},
 		{"BatchSetInHouseInstallersInstallDuringSetup", testBatchSetInHouseInstallersInstallDuringSetup},
+		{"ManifestURLUsesAppleServerURL", testInHouseAppManifestURLUsesAppleServerURL},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2193,4 +2194,56 @@ func testBatchSetInHouseInstallersInstallDuringSetup(t *testing.T, ds *Datastore
 	})
 	require.NoError(t, err)
 	require.Equal(t, map[string]bool{"ios": false, "ipados": true}, flagsByPlatform())
+}
+
+func testInHouseAppManifestURLUsesAppleServerURL(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	const (
+		adminURL  = "https://admin.example.com"
+		deviceURL = "https://devices.example.com"
+	)
+	appCfg, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+	appCfg.ServerSettings.ServerURL = adminURL
+	appCfg.MDM.AppleServerURL = deviceURL
+	require.NoError(t, ds.SaveAppConfig(ctx, appCfg))
+
+	err = ds.BatchSetInHouseAppsInstallers(ctx, nil, []*fleet.UploadSoftwareInstallerPayload{
+		{
+			StorageID:        "ipa0",
+			Filename:         "ipa0.ipa",
+			Title:            "ipa0",
+			Source:           "ios_apps",
+			Version:          "1.0.0",
+			UserID:           user.ID,
+			Platform:         "ios",
+			URL:              "https://example.com/0",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+			BundleIdentifier: "com.ipa0",
+		},
+	})
+	require.NoError(t, err)
+
+	installers, err := ds.GetSoftwareInstallers(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, installers, 1)
+	ipa, err := ds.GetInHouseAppMetadataByTeamAndTitleID(ctx, nil, *installers[0].TitleID)
+	require.NoError(t, err)
+
+	host := test.NewHost(t, ds, "host1", "1", "host1key", "host1uuid", time.Now(), test.WithPlatform("ios"))
+	nanoEnroll(t, ds, host, false)
+
+	cmdUUID := createInHouseAppInstallRequest(t, ds, host.ID, ipa.InstallerID, *installers[0].TitleID, user)
+
+	var rawCmd string
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &rawCmd,
+		`SELECT command FROM nano_commands WHERE command_uuid = ?`, cmdUUID))
+
+	// The device fetches the manifest itself, so the command has to carry the
+	// hostname Apple devices reach Fleet on rather than the admin one, which a
+	// split-hostname deployment does not expose to them.
+	require.Contains(t, rawCmd, deviceURL+"/api/latest/fleet/software/titles/")
+	require.NotContains(t, rawCmd, adminURL)
 }


### PR DESCRIPTION
**Related issue:** Resolves #52134

On a split-hostname deployment (`mdm.apple_server_url` set, so Apple devices talk to a different hostname than the admin/API URL), installing an iOS in-house `.ipa` failed with `DeviceManagement.error 2604 "Could not validate manifest."`.

The `InstallApplication` command carried a `ManifestURL` built from `server_settings.server_url`:

https://github.com/fleetdm/fleet/blob/main/server/datastore/mysql/activities.go#L1865-L1867

The device fetches that URL itself, so it has to be a hostname the device can reach. In the reporting deployment `server_url` sits behind a corporate proxy and only `apple_server_url` is device-reachable, so the install daemon could not fetch the manifest.

`AppConfig.MDMUrl()` already expresses "the URL Apple devices reach Fleet on", returning `mdm.apple_server_url` when set and falling back to `server_settings.server_url` otherwise. It is what the surrounding Apple MDM paths use to address devices — enrollment profiles, OTA enrollment, service discovery, and the SCEP/ACME adapters all go through it — so this makes the manifest URL agree with the rest of them.

The distinction is deliberate elsewhere and stays intact: `apple_mdm.go` keeps an explicit `ServerURL must be set to the Fleet URL. Do not use appCfg.MDMUrl() here.` where the Fleet URL is the right one. This call site is the device-facing kind.

This is the only place the in-house manifest URL is built, so there is no second entry point to change. Deployments that do not set `apple_server_url` are unaffected, since `MDMUrl()` returns `server_url` for them.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

No endpoint paths change; only which configured hostname is used to build an existing URL.

## Testing

- [x] Added/updated automated tests

`TestInHouseApps/ManifestURLUsesAppleServerURL` sets `server_url` and `apple_server_url` to different hostnames, enqueues an in-house app install for an enrolled iOS host, and asserts the resulting `nano_commands` row carries the device hostname and not the admin one.

Confirmed the test fails with the change reverted, reproducing the reported symptom rather than passing vacuously:

```
"...<key>ManifestURL</key>
   <string>https://admin.example.com/api/latest/fleet/software/titles/1/in_house_app/manifest/abcfd81c-...</string>..."
does not contain "https://devices.example.com/api/latest/fleet/software/titles/"
```

The existing coverage in `integration_vpp_install_test.go` asserts the manifest URL on a deployment with no `apple_server_url`, and still passes, which is the fallback path.

- [ ] QA'd all new/changed functionality manually

Not reproduced end to end against a real iOS device: the failure needs a split-hostname deployment where the admin URL is genuinely unreachable from the device, plus an in-house `.ipa` and an enrolled iPhone. The datastore test pins the command Fleet enqueues, which is the part that was wrong, but the device-side install was not exercised.

## Frontend

NA

## Database migrations

NA

## New Fleet configuration settings

NA

## fleetd/orbit/Fleet Desktop

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS in-house app installations that failed with “Could not validate manifest” when a separate Apple server URL was configured.
  * App installation manifests and embedded app download links now use the hostname reachable by Apple devices.

* **Tests**
  * Added coverage to verify manifest and download links use the configured Apple server URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->