### PR TITLE
Unfreeze Fire Alpaca (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/firealpaca.json
+++ b/ee/maintained-apps/inputs/homebrew/firealpaca.json
@@ -6,6 +6,5 @@
   "slug": "firealpaca/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/firealpaca/darwin.json
+++ b/ee/maintained-apps/outputs/firealpaca/darwin.json
@@ -1,10 +1,11 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.16.0') < 0);",
+        "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.firealpaca');"
       },
       "installer_url": "https://firealpaca.com/download/mac",
       "install_script_ref": "a03f6a1f",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
test-fma-darwin-pr-only can validate `firealpaca/darwin` at its current upstream version.

Frozen since: 2026-06-15
Version: 2.15.2 -> 2.16.0

Note: this is a re-probe of the same advertised version that failed on #51756 (2026-08-22), where
the Homebrew cask advertised `2.16.0` but the installer payload still reported `2.15.2`. Upstream
has not bumped the version string since, but the cask's `sha256` is `no_check`, so a corrected
`2.16.0` installer could have been re-cut without a version change. This probe is what tells them apart.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puk2vkFF8UnyZrePTXcz7f)_