### PR TITLE
Show manual BYOD re-enroll instructions for manual BYOD hosts

### DIFF
--- a/changes/50868-byod-reenroll-instructions
+++ b/changes/50868-byod-reenroll-instructions
@@ -1,0 +1,1 @@
+- Fixed the turn off MDM modal showing Account-driven User Enrollment re-enrollment instructions for iOS and iPadOS hosts that enrolled with the manual BYOD enrollment link.

--- a/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseJson.json
@@ -39,6 +39,7 @@
     "last_enrolled_at": "0001-01-01T00:00:00Z",
     "last_mdm_checked_in_at": null,
     "last_mdm_enrolled_at": null,
+    "last_mdm_enrollment_type": null,
     "last_restarted_at": "0001-01-01T00:00:00Z",
     "logger_tls_period": 0,
     "mdm": {

--- a/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseYaml.yml
@@ -38,6 +38,7 @@ spec:
   last_enrolled_at: "0001-01-01T00:00:00Z"
   last_mdm_checked_in_at: null
   last_mdm_enrolled_at: null
+  last_mdm_enrollment_type: null
   last_restarted_at: "0001-01-01T00:00:00Z"
   logger_tls_period: 0
   mdm:

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -195,13 +195,6 @@ export interface IHostMdmData {
   pending_action: HostMdmPendingAction;
   connected_to_fleet?: boolean;
   /**
-   * account_driven_user_enrollment indicates an iOS/iPadOS host enrolled through
-   * Account-Driven User Enrollment rather than the manual BYOD flow. Both report
-   * enrollment_status "On (manual - personal)", so the status alone cannot tell
-   * them apart. Only populated for GET /hosts/:id.
-   */
-  account_driven_user_enrollment?: boolean;
-  /**
    * wipe/lock/clear_passcode_allowed indicate whether the corresponding MDM
    * commands are permitted for this host based on the AccessRights delivered
    * in the host's manual (SCEP/ACME) enrollment profile. They are only
@@ -403,6 +396,14 @@ export interface IHost {
   last_enrolled_at: string;
   last_mdm_enrolled_at: string;
   last_mdm_checked_in_at: string | null;
+  /**
+   * last_mdm_enrollment_type is the MDM enrollment channel reported by the device,
+   * e.g. "Device" or "User Enrollment (Device)". Manual BYOD and Account-Driven
+   * User Enrollment both report enrollment_status "On (manual - personal)", so
+   * this is what distinguishes them. Null for hosts with no Apple MDM enrollment.
+   * Only populated for GET /hosts/:id.
+   */
+  last_mdm_enrollment_type?: string | null;
   seen_time: string;
   refetch_requested: boolean;
   refetch_critical_queries_until: string | null;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -195,6 +195,13 @@ export interface IHostMdmData {
   pending_action: HostMdmPendingAction;
   connected_to_fleet?: boolean;
   /**
+   * account_driven_user_enrollment indicates an iOS/iPadOS host enrolled through
+   * Account-Driven User Enrollment rather than the manual BYOD flow. Both report
+   * enrollment_status "On (manual - personal)", so the status alone cannot tell
+   * them apart. Only populated for GET /hosts/:id.
+   */
+  account_driven_user_enrollment?: boolean;
+  /**
    * wipe/lock/clear_passcode_allowed indicate whether the corresponding MDM
    * commands are permitted for this host based on the AccessRights delivered
    * in the host's manual (SCEP/ACME) enrollment profile. They are only

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -396,13 +396,6 @@ export interface IHost {
   last_enrolled_at: string;
   last_mdm_enrolled_at: string;
   last_mdm_checked_in_at: string | null;
-  /**
-   * last_mdm_enrollment_type is the MDM enrollment channel reported by the device,
-   * e.g. "Device" or "User Enrollment (Device)". Manual BYOD and Account-Driven
-   * User Enrollment both report enrollment_status "On (manual - personal)", so
-   * this is what distinguishes them. Null for hosts with no Apple MDM enrollment.
-   * Only populated for GET /hosts/:id.
-   */
   last_mdm_enrollment_type?: string | null;
   seen_time: string;
   refetch_requested: boolean;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -338,10 +338,23 @@ export const isBYODManualEnrollment = (
   return enrollmentStatus === "On (manual)";
 };
 
+/** MDM enrollment channels as reported by the device. Account-Driven User
+ * Enrollment is the only personal (BYOD) flow that enrolls on the user channel;
+ * manual BYOD enrolls on the device channel like company-owned hosts. */
+export const MDM_ENROLLMENT_TYPE_ACCOUNT_DRIVEN = "User Enrollment (Device)";
+
+/** Whether a host enrolled through Account-Driven User Enrollment, which decides
+ * how the end user re-enrolls. The enrollment status can't answer this: manual
+ * BYOD reports the same "On (manual - personal)". See #50868. */
+export const isAccountDrivenUserEnrollment = (
+  lastMdmEnrollmentType?: string | null
+) => {
+  return lastMdmEnrollmentType === MDM_ENROLLMENT_TYPE_ACCOUNT_DRIVEN;
+};
+
 /** Personal (BYOD) enrollment status. Note this covers BOTH manual BYOD and
  * Account-Driven User Enrollment — the status alone cannot tell them apart, so
- * use the host's `account_driven_user_enrollment` field when the difference
- * matters (e.g. re-enrollment instructions). See #50868. */
+ * use `isAccountDrivenUserEnrollment` when the difference matters. See #50868. */
 export const isPersonalEnrollmentStatus = (
   enrollmentStatus: MdmEnrollmentStatus | null
 ) => {

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -338,6 +338,16 @@ export const isBYODManualEnrollment = (
   return enrollmentStatus === "On (manual)";
 };
 
+/** Personal (BYOD) enrollment status. Note this covers BOTH manual BYOD and
+ * Account-Driven User Enrollment — the status alone cannot tell them apart, so
+ * use the host's `account_driven_user_enrollment` field when the difference
+ * matters (e.g. re-enrollment instructions). See #50868. */
+export const isPersonalEnrollmentStatus = (
+  enrollmentStatus: MdmEnrollmentStatus | null
+) => {
+  return enrollmentStatus === "On (manual - personal)";
+};
+
 /** This checks if the device is enrolled via an Apple ID user enrollment.
  * We refer to that as "account driven user enrollment". Note that this same
  * status now also covers manual BYOD enrollments (Apple) and Android BYO

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1917,9 +1917,7 @@ const HostDetailsPage = ({
               hostPlatform={host.platform}
               hostName={host.display_name}
               enrollmentStatus={host.mdm.enrollment_status}
-              isAccountDrivenUserEnrollment={
-                host.mdm.account_driven_user_enrollment
-              }
+              lastMdmEnrollmentType={host.last_mdm_enrollment_type}
               onClose={toggleUnenrollMdmModal}
               onSuccess={() => {
                 // The server marks the host unenrolled immediately, so refresh

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1917,6 +1917,9 @@ const HostDetailsPage = ({
               hostPlatform={host.platform}
               hostName={host.display_name}
               enrollmentStatus={host.mdm.enrollment_status}
+              isAccountDrivenUserEnrollment={
+                host.mdm.account_driven_user_enrollment
+              }
               onClose={toggleUnenrollMdmModal}
               onSuccess={() => {
                 // The server marks the host unenrolled immediately, so refresh

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tests.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
+import { MDM_ENROLLMENT_TYPE_ACCOUNT_DRIVEN } from "interfaces/mdm";
+
 import UnenrollMdmModal from "./UnenrollMdmModal";
 
 const MOCK_PROPS = {
@@ -27,7 +29,7 @@ describe("UnenrollMdmModal", () => {
       <UnenrollMdmModal
         {...MOCK_PROPS}
         enrollmentStatus="On (manual - personal)"
-        isAccountDrivenUserEnrollment={false}
+        lastMdmEnrollmentType="Device"
       />
     );
 
@@ -45,7 +47,7 @@ describe("UnenrollMdmModal", () => {
       <UnenrollMdmModal
         {...MOCK_PROPS}
         enrollmentStatus="On (manual - personal)"
-        isAccountDrivenUserEnrollment
+        lastMdmEnrollmentType={MDM_ENROLLMENT_TYPE_ACCOUNT_DRIVEN}
       />
     );
 
@@ -63,7 +65,7 @@ describe("UnenrollMdmModal", () => {
       <UnenrollMdmModal
         {...MOCK_PROPS}
         enrollmentStatus="On (automatic)"
-        isAccountDrivenUserEnrollment={false}
+        lastMdmEnrollmentType="Device"
       />
     );
 

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tests.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import UnenrollMdmModal from "./UnenrollMdmModal";
+
+const MOCK_PROPS = {
+  hostId: 7,
+  hostPlatform: "ios",
+  hostName: "iphone-1",
+  onSuccess: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("UnenrollMdmModal", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // Manual BYOD and account-driven hosts share the "On (manual - personal)"
+  // status, so the status alone must not decide which instructions to show.
+  // Following the account-driven steps on a manual BYOD device fails with
+  // "Your Apple Account does not support the expected services". See #50868.
+  it("shows enrollment link instructions for a manual BYOD host", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <UnenrollMdmModal
+        {...MOCK_PROPS}
+        enrollmentStatus="On (manual - personal)"
+        isAccountDrivenUserEnrollment={false}
+      />
+    );
+
+    expect(
+      screen.getByText(/Hosts > Add hosts > iOS\/iPadOS/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Sign in to Work or School Account/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows sign-in instructions for an account-driven host", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <UnenrollMdmModal
+        {...MOCK_PROPS}
+        enrollmentStatus="On (manual - personal)"
+        isAccountDrivenUserEnrollment
+      />
+    );
+
+    expect(
+      screen.getByText(/Sign in to Work or School Account/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Hosts > Add hosts > iOS\/iPadOS/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Apple Business instructions for an automatically enrolled host", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(
+      <UnenrollMdmModal
+        {...MOCK_PROPS}
+        enrollmentStatus="On (automatic)"
+        isAccountDrivenUserEnrollment={false}
+      />
+    );
+
+    expect(
+      screen.getByText(/make sure that the host is still in Apple Business/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -9,6 +9,7 @@ import mdmAPI from "services/entities/mdm";
 import { getErrorReason, hasStatusKey } from "interfaces/errors";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 import {
+  isAccountDrivenUserEnrollment,
   isAutomaticDeviceEnrollment,
   isBYODManualEnrollment,
   isPersonalEnrollmentStatus,
@@ -22,10 +23,11 @@ interface IUnenrollMdmModalProps {
   hostPlatform: string;
   hostName: string;
   enrollmentStatus: MdmEnrollmentStatus | null;
-  /** Account-Driven User Enrollment re-enrolls through Apple's "Sign in to Work
-   * or School Account" flow; every other personal enrollment re-enrolls through
-   * the enrollment link. Both report the same enrollmentStatus. */
-  isAccountDrivenUserEnrollment?: boolean;
+  /** MDM enrollment channel. Account-Driven User Enrollment re-enrolls through
+   * Apple's "Sign in to Work or School Account" flow; every other personal
+   * enrollment re-enrolls through the enrollment link, and both report the same
+   * enrollmentStatus. */
+  lastMdmEnrollmentType?: string | null;
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -35,7 +37,7 @@ const UnenrollMdmModal = ({
   hostPlatform,
   hostName,
   enrollmentStatus,
-  isAccountDrivenUserEnrollment,
+  lastMdmEnrollmentType,
   onClose,
   onSuccess,
 }: IUnenrollMdmModalProps) => {
@@ -85,7 +87,7 @@ const UnenrollMdmModal = ({
   };
 
   const generateIosOrIpadosDescription = () => {
-    if (isAccountDrivenUserEnrollment) {
+    if (isAccountDrivenUserEnrollment(lastMdmEnrollmentType)) {
       return (
         <p>
           To re-enroll, ask your end user to navigate to{" "}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -10,8 +10,8 @@ import { getErrorReason, hasStatusKey } from "interfaces/errors";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 import {
   isAutomaticDeviceEnrollment,
-  isBYODAccountDrivenUserEnrollment,
   isBYODManualEnrollment,
+  isPersonalEnrollmentStatus,
   MdmEnrollmentStatus,
 } from "interfaces/mdm";
 
@@ -22,6 +22,10 @@ interface IUnenrollMdmModalProps {
   hostPlatform: string;
   hostName: string;
   enrollmentStatus: MdmEnrollmentStatus | null;
+  /** Account-Driven User Enrollment re-enrolls through Apple's "Sign in to Work
+   * or School Account" flow; every other personal enrollment re-enrolls through
+   * the enrollment link. Both report the same enrollmentStatus. */
+  isAccountDrivenUserEnrollment?: boolean;
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -31,6 +35,7 @@ const UnenrollMdmModal = ({
   hostPlatform,
   hostName,
   enrollmentStatus,
+  isAccountDrivenUserEnrollment,
   onClose,
   onSuccess,
 }: IUnenrollMdmModalProps) => {
@@ -80,14 +85,7 @@ const UnenrollMdmModal = ({
   };
 
   const generateIosOrIpadosDescription = () => {
-    if (isBYODManualEnrollment(enrollmentStatus)) {
-      return (
-        <p>
-          To re-enroll, go to <b>Hosts &gt; Add hosts &gt; iOS/iPadOS</b> and
-          share the link with end user.
-        </p>
-      );
-    } else if (isBYODAccountDrivenUserEnrollment(enrollmentStatus)) {
+    if (isAccountDrivenUserEnrollment) {
       return (
         <p>
           To re-enroll, ask your end user to navigate to{" "}
@@ -96,6 +94,16 @@ const UnenrollMdmModal = ({
             to Work or School Account...
           </b>{" "}
           on their host and to log in with their work email.
+        </p>
+      );
+    } else if (
+      isBYODManualEnrollment(enrollmentStatus) ||
+      isPersonalEnrollmentStatus(enrollmentStatus)
+    ) {
+      return (
+        <p>
+          To re-enroll, go to <b>Hosts &gt; Add hosts &gt; iOS/iPadOS</b> and
+          share the link with end user.
         </p>
       );
     } else if (isAutomaticDeviceEnrollment(enrollmentStatus)) {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -7563,7 +7563,7 @@ func (ds *Datastore) GetNanoMDMEnrollmentDetails(ctx context.Context, hostUUID s
 	query := `
 	SELECT nd.authenticate_at, ne.last_seen_at, ne.hardware_attested, nd.unlock_token,
 	  nd.bootstrap_token_b64 IS NOT NULL AS bootstrap_token_escrowed,
-	  ne.type = 'User Enrollment (Device)' AS account_driven_user_enrollment
+	  ne.type AS enrollment_type
 	FROM nano_devices nd
 	  INNER JOIN nano_enrollments ne ON ne.id = nd.id
 	WHERE ne.type IN ('Device', 'User Enrollment (Device)') AND nd.id = ?`

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -7562,7 +7562,8 @@ func (ds *Datastore) GetNanoMDMEnrollmentDetails(ctx context.Context, hostUUID s
 	// enroll process and as such is a good indicator of the last enrollment or reenrollment.
 	query := `
 	SELECT nd.authenticate_at, ne.last_seen_at, ne.hardware_attested, nd.unlock_token,
-	  nd.bootstrap_token_b64 IS NOT NULL AS bootstrap_token_escrowed
+	  nd.bootstrap_token_b64 IS NOT NULL AS bootstrap_token_escrowed,
+	  ne.type = 'User Enrollment (Device)' AS account_driven_user_enrollment
 	FROM nano_devices nd
 	  INNER JOIN nano_enrollments ne ON ne.id = nd.id
 	WHERE ne.type IN ('Device', 'User Enrollment (Device)') AND nd.id = ?`

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -133,6 +133,7 @@ func TestMDMApple(t *testing.T) {
 		{"GetMDMAppleEnrolledDeviceDeletedFromFleet", testGetMDMAppleEnrolledDeviceDeletedFromFleet},
 		{"SetMDMAppleProfilesWithVariables", testSetMDMAppleProfilesWithVariables},
 		{"GetNanoMDMEnrollmentDetails", testGetNanoMDMEnrollmentDetails},
+		{"GetNanoMDMEnrollmentDetailsAccountDriven", testGetNanoMDMEnrollmentDetailsAccountDriven},
 		{"GetNanoMDMUserEnrollment", testGetNanoMDMUserEnrollment},
 		{"TestDeleteMDMAppleDeclarationWithPendingInstalls", testDeleteMDMAppleDeclarationWithPendingInstalls},
 		{"TestUpdateNanoMDMUserEnrollmentUsername", testUpdateNanoMDMUserEnrollmentUsername},
@@ -15632,4 +15633,37 @@ FROM mdm_apple_configuration_profiles WHERE team_id = 0 AND identifier = ?`,
 			mobileconfig.FleetFileVaultPayloadIdentifier)
 	})
 	require.Equal(t, 2, count)
+}
+
+// Manual BYOD and Account-Driven User Enrollment both report the
+// "On (manual - personal)" status, so the enrollment channel is the only way to
+// tell them apart. See #50868.
+func testGetNanoMDMEnrollmentDetailsAccountDriven(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	newHost := func(suffix string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:      "adue-host-" + suffix,
+			OsqueryHostID: new("adue-osq-" + suffix),
+			NodeKey:       new("adue-key-" + suffix),
+			UUID:          "adue-uuid-" + suffix,
+			Platform:      "ios",
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	manualBYOD := newHost("manual")
+	nanoEnroll(t, ds, manualBYOD, false)
+
+	accountDriven := newHost("account-driven")
+	nanoEnrollUserDevice(t, ds, accountDriven)
+
+	details, err := ds.GetNanoMDMEnrollmentDetails(ctx, manualBYOD.UUID)
+	require.NoError(t, err)
+	require.False(t, details.AccountDrivenUserEnrollment)
+
+	details, err = ds.GetNanoMDMEnrollmentDetails(ctx, accountDriven.UUID)
+	require.NoError(t, err)
+	require.True(t, details.AccountDrivenUserEnrollment)
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -133,7 +133,7 @@ func TestMDMApple(t *testing.T) {
 		{"GetMDMAppleEnrolledDeviceDeletedFromFleet", testGetMDMAppleEnrolledDeviceDeletedFromFleet},
 		{"SetMDMAppleProfilesWithVariables", testSetMDMAppleProfilesWithVariables},
 		{"GetNanoMDMEnrollmentDetails", testGetNanoMDMEnrollmentDetails},
-		{"GetNanoMDMEnrollmentDetailsAccountDriven", testGetNanoMDMEnrollmentDetailsAccountDriven},
+		{"GetNanoMDMEnrollmentDetailsEnrollmentType", testGetNanoMDMEnrollmentDetailsEnrollmentType},
 		{"GetNanoMDMUserEnrollment", testGetNanoMDMUserEnrollment},
 		{"TestDeleteMDMAppleDeclarationWithPendingInstalls", testDeleteMDMAppleDeclarationWithPendingInstalls},
 		{"TestUpdateNanoMDMUserEnrollmentUsername", testUpdateNanoMDMUserEnrollmentUsername},
@@ -15638,7 +15638,7 @@ FROM mdm_apple_configuration_profiles WHERE team_id = 0 AND identifier = ?`,
 // Manual BYOD and Account-Driven User Enrollment both report the
 // "On (manual - personal)" status, so the enrollment channel is the only way to
 // tell them apart. See #50868.
-func testGetNanoMDMEnrollmentDetailsAccountDriven(t *testing.T, ds *Datastore) {
+func testGetNanoMDMEnrollmentDetailsEnrollmentType(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
 	newHost := func(suffix string) *fleet.Host {
@@ -15661,9 +15661,9 @@ func testGetNanoMDMEnrollmentDetailsAccountDriven(t *testing.T, ds *Datastore) {
 
 	details, err := ds.GetNanoMDMEnrollmentDetails(ctx, manualBYOD.UUID)
 	require.NoError(t, err)
-	require.False(t, details.AccountDrivenUserEnrollment)
+	require.Equal(t, "Device", details.EnrollmentType)
 
 	details, err = ds.GetNanoMDMEnrollmentDetails(ctx, accountDriven.UUID)
 	require.NoError(t, err)
-	require.True(t, details.AccountDrivenUserEnrollment)
+	require.Equal(t, "User Enrollment (Device)", details.EnrollmentType)
 }

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -717,13 +717,6 @@ type MDMHostData struct {
 	// host-returning methods.
 	ConnectedToFleet *bool `json:"connected_to_fleet" csv:"-" db:"connected_to_fleet"`
 
-	// AccountDrivenUserEnrollment reports whether an iOS/iPadOS host enrolled
-	// through Account-Driven User Enrollment rather than the manual BYOD flow.
-	// Both produce the "On (manual - personal)" enrollment status, so the status
-	// alone can't tell them apart and re-enrollment instructions differ. Only
-	// filled in by getHostDetails.
-	AccountDrivenUserEnrollment *bool `json:"account_driven_user_enrollment,omitempty" db:"-" csv:"-"`
-
 	// WipeAllowed, LockAllowed, and ClearPasscodeAllowed indicate whether the
 	// corresponding MDM commands are permitted for this host based on the
 	// AccessRights delivered in the host's enrollment profile. They are nil for
@@ -1213,6 +1206,11 @@ type HostDetail struct {
 
 	LastMDMEnrolledAt  *time.Time `json:"last_mdm_enrolled_at"`
 	LastMDMCheckedInAt *time.Time `json:"last_mdm_checked_in_at"`
+	// LastMDMEnrollmentType is the MDM enrollment channel reported by the device,
+	// e.g. "Device" or "User Enrollment (Device)". Manual BYOD and Account-Driven
+	// User Enrollment both report the "On (manual - personal)" status, so this is
+	// what distinguishes them. Nil for hosts with no Apple MDM enrollment.
+	LastMDMEnrollmentType *string `json:"last_mdm_enrollment_type"`
 
 	MDMEnrollmentHardwareAttested bool `json:"mdm_enrollment_hardware_attested"`
 

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -717,6 +717,13 @@ type MDMHostData struct {
 	// host-returning methods.
 	ConnectedToFleet *bool `json:"connected_to_fleet" csv:"-" db:"connected_to_fleet"`
 
+	// AccountDrivenUserEnrollment reports whether an iOS/iPadOS host enrolled
+	// through Account-Driven User Enrollment rather than the manual BYOD flow.
+	// Both produce the "On (manual - personal)" enrollment status, so the status
+	// alone can't tell them apart and re-enrollment instructions differ. Only
+	// filled in by getHostDetails.
+	AccountDrivenUserEnrollment *bool `json:"account_driven_user_enrollment,omitempty" db:"-" csv:"-"`
+
 	// WipeAllowed, LockAllowed, and ClearPasscodeAllowed indicate whether the
 	// corresponding MDM commands are permitted for this host based on the
 	// AccessRights delivered in the host's enrollment profile. They are nil for

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1449,6 +1449,11 @@ type NanoMDMEnrollmentDetails struct {
 	HardwareAttested       bool       `db:"hardware_attested"`
 	UnlockToken            *string    `db:"unlock_token"`
 	BootstrapTokenEscrowed bool       `db:"bootstrap_token_escrowed"`
+	// AccountDrivenUserEnrollment reports whether the host enrolled through
+	// Account-Driven User Enrollment. Manual BYOD enrollment produces the same
+	// "On (manual - personal)" status, so the enrollment channel is the only way
+	// to tell the two apart.
+	AccountDrivenUserEnrollment bool `db:"account_driven_user_enrollment"`
 }
 
 // MDM SSO initiator constants identify which enrollment flow initiated the SSO

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1449,11 +1449,11 @@ type NanoMDMEnrollmentDetails struct {
 	HardwareAttested       bool       `db:"hardware_attested"`
 	UnlockToken            *string    `db:"unlock_token"`
 	BootstrapTokenEscrowed bool       `db:"bootstrap_token_escrowed"`
-	// AccountDrivenUserEnrollment reports whether the host enrolled through
-	// Account-Driven User Enrollment. Manual BYOD enrollment produces the same
-	// "On (manual - personal)" status, so the enrollment channel is the only way
-	// to tell the two apart.
-	AccountDrivenUserEnrollment bool `db:"account_driven_user_enrollment"`
+	// EnrollmentType is the MDM enrollment channel as reported by nanomdm, e.g.
+	// "Device" or "User Enrollment (Device)". Manual BYOD and Account-Driven User
+	// Enrollment both produce the "On (manual - personal)" status, so the channel
+	// is the only way to tell them apart.
+	EnrollmentType string `db:"enrollment_type"`
 }
 
 // MDM SSO initiator constants identify which enrollment flow initiated the SSO

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1867,6 +1867,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 	var profiles []fleet.HostMDMProfile
 	var mdmLastEnrollment *time.Time
 	var mdmLastCheckedIn *time.Time
+	var mdmEnrollmentType *string
 	var mdmHardwareAttested bool
 	if ac.MDM.EnabledAndConfigured || ac.MDM.WindowsEnabledAndConfigured || ac.MDM.AndroidEnabledAndConfigured {
 		host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
@@ -2016,10 +2017,10 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				}
 
 				// Manual BYOD and Account-Driven User Enrollment both report the
-				// "On (manual - personal)" status, so the UI needs the enrollment
-				// channel to tell them apart.
-				if fleet.IsAppleMobilePlatform(host.Platform) && details != nil {
-					host.MDM.AccountDrivenUserEnrollment = &details.AccountDrivenUserEnrollment
+				// "On (manual - personal)" status, so the enrollment channel is what
+				// tells them apart.
+				if details != nil && details.EnrollmentType != "" {
+					mdmEnrollmentType = &details.EnrollmentType
 				}
 			}
 		}
@@ -2136,6 +2137,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		CustomHostVitals:              customHostVitals,
 		LastMDMEnrolledAt:             mdmLastEnrollment,
 		LastMDMCheckedInAt:            mdmLastCheckedIn,
+		LastMDMEnrollmentType:         mdmEnrollmentType,
 		MDMEnrollmentHardwareAttested: mdmHardwareAttested,
 		ConditionalAccessBypassed:     conditionalAccessBypassed,
 		OSUpdateMinimumVersion:        osUpdateMinVersion,

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2014,6 +2014,13 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				if host.Platform == "darwin" && details != nil {
 					host.MDM.BootstrapTokenEscrowed = &details.BootstrapTokenEscrowed
 				}
+
+				// Manual BYOD and Account-Driven User Enrollment both report the
+				// "On (manual - personal)" status, so the UI needs the enrollment
+				// channel to tell them apart.
+				if fleet.IsAppleMobilePlatform(host.Platform) && details != nil {
+					host.MDM.AccountDrivenUserEnrollment = &details.AccountDrivenUserEnrollment
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Related issue:** Resolves #50868

Manual BYOD enrollment and Account-Driven User Enrollment both report the `On (manual - personal)` status, so the turn off MDM modal couldn't tell them apart and always showed the account-driven steps. End users on a manual BYOD host followed those and hit "Your Apple Account does not support the expected services on this device".

Host details now returns `last_mdm_enrollment_type` — the enrollment channel as reported by the device — and the modal branches on that. The manual BYOD copy already existed but was unreachable: its condition matched `On (manual)`, the company-owned manual status.

```json
"last_mdm_enrolled_at": "2026-05-27T20:25:41Z",
"last_mdm_checked_in_at": "2026-05-29T16:19:20Z",
"last_mdm_enrollment_type": "User Enrollment (Device)"
```

Returned alongside the other `last_mdm_*` fields, which come from the same query. Null for hosts with no Apple MDM enrollment. It's on `GET /hosts/:id` only, not the hosts list.

Returning the raw type rather than a derived boolean means enrollment types Fleet doesn't distinguish today, such as Shared iPad, won't need another field.

Docs for the new field will follow in a separate PR.

## Manual BYOD (`last_mdm_enrollment_type: "Device"`)

<img width="1239" height="432" alt="manual_personal" src="https://github.com/user-attachments/assets/013412e0-ab8a-4cf1-b54c-20e0b8fc24e5" />

## Account-driven (`last_mdm_enrollment_type: "User Enrollment (Device)"`)

<img width="953" height="368" alt="new_field_true" src="https://github.com/user-attachments/assets/fce6d84f-d714-4751-b737-276f0d2d1ab2" />

Both screenshots are the same host with the same `On (manual - personal)` enrollment status — only the enrollment channel differs.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

QA'd on a local instance against both enrollment states, plus a check that an ADE host still shows the Apple Business instructions. The BYOD and account-driven states were simulated at the database level rather than by enrolling a device through the enrollment link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected iOS and iPadOS MDM unenrollment guidance for devices enrolled through manual BYOD links.
  * Account-Driven User Enrollment devices now receive the appropriate re-enrollment instructions.
  * Host details now accurately distinguish manual BYOD enrollment from Account-Driven User Enrollment.
  * Enrollment-specific guidance is now displayed consistently when devices share the same personal enrollment status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->