### PR TITLE
Include the failing script's filename in fleetctl gitops script errors

### DIFF
--- a/changes/51530-fleetctl-script-batch-error-filename
+++ b/changes/51530-fleetctl-script-batch-error-filename
@@ -1,0 +1,1 @@
+- Fixed `fleetctl gitops` reporting script validation errors without saying which script failed. Errors from applying scripts now include the offending script's filename.

--- a/client/base_client.go
+++ b/client/base_client.go
@@ -73,9 +73,11 @@ func (bc *BaseClient) ParseResponse(verb, path string, response *http.Response, 
 			break
 		}
 
+		name, reason := ExtractServerErrorNameReason(response.Body)
 		e := &StatusCodeErr{
 			Code: response.StatusCode,
-			Body: ExtractServerErrorText(response.Body),
+			Body: reason,
+			Name: name,
 		}
 		return fmt.Errorf("%s %s received status %w", verb, path, e)
 	}

--- a/client/base_client_errors.go
+++ b/client/base_client_errors.go
@@ -202,6 +202,11 @@ func ExtractServerErrorNameReasons(body io.Reader) ([]string, []string) {
 type StatusCodeErr struct {
 	Code int
 	Body string
+	// Name is the field name the server reported alongside the error reason
+	// (e.g. "scripts[3]"), empty when the response carried none. It is not
+	// part of the Error() output; callers can use it to point at the
+	// offending input.
+	Name string
 }
 
 func (e *StatusCodeErr) Error() string {

--- a/client/base_client_test.go
+++ b/client/base_client_test.go
@@ -132,6 +132,23 @@ func TestParseResponseGeneralErrors(t *testing.T) {
 		err = bc.ParseResponse("GET", "", response, &struct{}{})
 		require.Error(t, err)
 	})
+
+	t.Run("server-provided error name is kept", func(t *testing.T) {
+		bc, err := NewBaseClient("https://test.com", true, "", "", nil, fleet.CapabilityMap{}, nil)
+		require.NoError(t, err)
+		response := &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"message": "Validation Failed", "errors": [{"name": "scripts[1]", "reason": "boom"}]}`)),
+		}
+		err = bc.ParseResponse("POST", "/api/latest/fleet/scripts/batch", response, &struct{}{})
+		var scErr *StatusCodeErr
+		require.ErrorAs(t, err, &scErr)
+		require.Equal(t, "scripts[1]", scErr.Name)
+		require.Equal(t, "Validation Failed: boom", scErr.Body)
+		require.Equal(t, http.StatusUnprocessableEntity, scErr.Code)
+		// the name must not leak into the printed message
+		require.NotContains(t, err.Error(), "scripts[1]")
+	})
 }
 
 func TestNewBaseClient(t *testing.T) {

--- a/server/service/client_scripts.go
+++ b/server/service/client_scripts.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -141,7 +142,32 @@ func (c *Client) ApplyNoTeamScripts(scripts []fleet.ScriptPayload, opts fleet.Ap
 	var resp fleet.BatchSetScriptsResponse
 	err := c.authenticatedRequestWithQuery(map[string]interface{}{"scripts": scripts}, verb, path, &resp, opts.RawQuery())
 
-	return resp.Scripts, err
+	return resp.Scripts, rewrapScriptBatchIndexErr(err, scripts)
+}
+
+// rewrapScriptBatchIndexErr surfaces the offending script's filename when the
+// batch-set scripts endpoint rejects one of them. The server identifies the
+// script only by its position ("scripts[N]"), which is meaningless in fleetctl
+// output; the payload name is the filename, unique within a batch (the server
+// rejects duplicates), so naming it identifies the script unambiguously.
+func rewrapScriptBatchIndexErr(err error, scripts []fleet.ScriptPayload) error {
+	var scErr *StatusCodeErr
+	if !errors.As(err, &scErr) {
+		return err
+	}
+	idxStr, ok := strings.CutPrefix(scErr.Name, "scripts[")
+	if !ok {
+		return err
+	}
+	idxStr, ok = strings.CutSuffix(idxStr, "]")
+	if !ok {
+		return err
+	}
+	idx, convErr := strconv.Atoi(idxStr)
+	if convErr != nil || idx < 0 || idx >= len(scripts) {
+		return err
+	}
+	return fmt.Errorf("script %q: %w", scripts[idx].Name, err)
 }
 
 func (c *Client) validateMacOSSetupScript(fileName string) ([]byte, error) {

--- a/server/service/client_scripts_test.go
+++ b/server/service/client_scripts_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyScriptsBatchErrorNamesScript(t *testing.T) {
+	t.Parallel()
+
+	// 422 response as returned by POST /api/latest/fleet/scripts/batch when
+	// one script in the batch fails validation.
+	newClient := func(t *testing.T, status int, body map[string]any) *Client {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(body)
+		}))
+		t.Cleanup(srv.Close)
+		client, err := NewClient(srv.URL, true, "", "")
+		require.NoError(t, err)
+		client.SetToken("test-token")
+		return client
+	}
+
+	scripts := []fleet.ScriptPayload{
+		{Name: "ok.sh", ScriptContents: []byte("echo ok")},
+		{Name: "nonexistent.sh", ScriptContents: []byte("echo $FLEET_VAR_NONEXISTENT")},
+	}
+	invalidBody := map[string]any{
+		"message": "Validation Failed",
+		"errors":  []map[string]string{{"name": "scripts[1]", "reason": "Fleet variable $FLEET_VAR_NONEXISTENT is not supported in scripts."}},
+	}
+
+	t.Run("team scripts name the failing file", func(t *testing.T) {
+		client := newClient(t, http.StatusUnprocessableEntity, invalidBody)
+		_, err := client.ApplyTeamScripts("Workstations", scripts, fleet.ApplySpecOptions{})
+		require.ErrorContains(t, err, `script "nonexistent.sh"`)
+		require.ErrorContains(t, err, "Fleet variable $FLEET_VAR_NONEXISTENT is not supported in scripts.")
+		// the original error stays in the chain for status-code checks
+		var scErr *StatusCodeErr
+		require.ErrorAs(t, err, &scErr)
+		require.Equal(t, http.StatusUnprocessableEntity, scErr.Code)
+	})
+
+	t.Run("no-team scripts name the failing file", func(t *testing.T) {
+		client := newClient(t, http.StatusUnprocessableEntity, invalidBody)
+		_, err := client.ApplyNoTeamScripts(scripts, fleet.ApplySpecOptions{})
+		require.ErrorContains(t, err, `script "nonexistent.sh"`)
+	})
+
+	t.Run("errors without a scripts index pass through unchanged", func(t *testing.T) {
+		client := newClient(t, http.StatusUnprocessableEntity, map[string]any{
+			"message": "Validation Failed",
+			"errors":  []map[string]string{{"name": "script", "reason": "secret not found"}},
+		})
+		_, err := client.ApplyTeamScripts("Workstations", scripts, fleet.ApplySpecOptions{})
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), `script "`)
+		require.ErrorContains(t, err, "secret not found")
+	})
+}
+
+func TestRewrapScriptBatchIndexErr(t *testing.T) {
+	t.Parallel()
+
+	scripts := []fleet.ScriptPayload{{Name: "a.sh"}, {Name: "b.sh"}}
+
+	statusErr := func(name string) error {
+		return &StatusCodeErr{Code: http.StatusUnprocessableEntity, Body: "Validation Failed: boom", Name: name}
+	}
+
+	require.NoError(t, rewrapScriptBatchIndexErr(nil, scripts))
+
+	plain := errors.New("boom")
+	require.Equal(t, plain, rewrapScriptBatchIndexErr(plain, scripts))
+
+	cases := []struct {
+		desc     string
+		name     string
+		wantWrap string // empty means unchanged
+	}{
+		{"valid index", "scripts[1]", `script "b.sh"`},
+		{"first index", "scripts[0]", `script "a.sh"`},
+		{"no name", "", ""},
+		{"non-script field", "team_id", ""},
+		{"index out of range", "scripts[2]", ""},
+		{"negative index", "scripts[-1]", ""},
+		{"not a number", "scripts[x]", ""},
+		{"missing closing bracket", "scripts[1", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			in := statusErr(c.name)
+			out := rewrapScriptBatchIndexErr(in, scripts)
+			if c.wantWrap == "" {
+				require.Equal(t, in, out)
+			} else {
+				require.ErrorContains(t, out, c.wantWrap)
+				require.ErrorIs(t, out, in)
+			}
+		})
+	}
+}

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -125,7 +125,7 @@ func (c *Client) ApplyTeamScripts(tmName string, scripts []fleet.ScriptPayload, 
 
 	var resp fleet.BatchSetScriptsResponse
 	err = c.authenticatedRequestWithQuery(map[string]interface{}{"scripts": scripts}, verb, path, &resp, query.Encode())
-	return resp.Scripts, err
+	return resp.Scripts, rewrapScriptBatchIndexErr(err, scripts)
 }
 
 func (c *Client) ApplyTeamSoftwareInstallers(


### PR DESCRIPTION
**Related issue:** Resolves #51530

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Details

As discussed in https://github.com/fleetdm/fleet/issues/51530#issuecomment-5435386956 (thanks @MagnusHJensen and @JordanMontgomery for the go-ahead), this is a fleetctl/client-only change — no API changes.

**Where the index was lost:** the server already returns the failing script's position (`errors[0].name = "scripts[N]"`), but `BaseClient.ParseResponse` collapsed every non-2xx response through `ExtractServerErrorText`, which discards the error name. By the time gitops wrapped the error, only the reason survived:

```
Error: applying scripts for fleet "46837-scripts-vars-qa": Validation Failed: Fleet variable $FLEET_VAR_NONEXISTENT is not supported in scripts.
```

**The fix:**

1. `client.StatusCodeErr` keeps the server-provided error name in a new `Name` field (populated in `ParseResponse` via the existing `ExtractServerErrorNameReason`). Additive: `Error()` output is unchanged, so nothing else in fleetctl changes behavior.
2. `ApplyNoTeamScripts` and `ApplyTeamScripts` re-wrap a `StatusCodeErr` whose name matches `scripts[N]` with the script's filename from the payload at index N (GitOps sets `ScriptPayload.Name` to the file's base name, and the server rejects duplicate names within a batch, so the name is unambiguous). The wrap uses `%w`, so the original error stays in the chain for status-code checks, and `CleanStatusCodeErr` still strips the `POST /path received status 422 ` prefix at print time. Result:

```
Error: applying scripts for fleet "46837-scripts-vars-qa": script "nonexistent.sh": Validation Failed: Fleet variable $FLEET_VAR_NONEXISTENT is not supported in scripts.
```

Errors without a `scripts[N]` name (e.g. `script`, `team_id`) pass through unchanged, as do out-of-range or malformed indexes.

The same gap exists for `profiles[N]` on the batch profiles endpoint; leaving that for a follow-up using the same helper.

**Tests:** `ParseResponse` test asserting `Name` is populated (and doesn't leak into the printed message); client tests against a mocked 422 batch response asserting the filename appears for both team and no-team paths; table-driven tests for the re-wrap helper's edge cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `fleetctl gitops` validation errors now identify the filename of the script that failed.
  - Batch script errors provide clearer details by identifying the affected script while preserving the original error information.
  - Unrelated validation errors continue to display unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->