### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.760",
+      "version": "6.763",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.760') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.763') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hegenberg.BetterTouchTool');"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.760-2026082704.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.763-2026083003.zip",
       "install_script_ref": "17a00450",
       "uninstall_script_ref": "aef4d4fc",
-      "sha256": "56280e4db3c5721231fff7e0a63993c77ad43e979a67cd38b95363edcad129d1",
+      "sha256": "0f8fae5f036459fae8949a3dcd493a5bc561814f36d95b58942e5ffd58e487f6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/elephas/darwin.json
+++ b/ee/maintained-apps/outputs/elephas/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "11.8002",
+      "version": "12.0001",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.kamban.elephas';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.kamban.elephas' AND version_compare(bundle_short_version, '11.8002') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.kamban.elephas' AND version_compare(bundle_short_version, '12.0001') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.kamban.elephas');"
       },
-      "installer_url": "https://assets.elephas.app/Elephas_11.8002.dmg",
+      "installer_url": "https://assets.elephas.app/Elephas_12.0001.dmg",
       "install_script_ref": "9ed81db6",
       "uninstall_script_ref": "e557d015",
-      "sha256": "11fb08367487301269c7e4a2197dace2e74260a107139debdbd198d724128f00",
+      "sha256": "085c4188f1a797e737490ff9f09b67ca88f6355d8fa4b21c61522fbdd4de1d42",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "157.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.8.29') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.8.30') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-29-21-10-45-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-30-21-32-41-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "adb027776b208064d6738b10d738167485941f13efaa990b57e0fa3543ca09e5",
+      "sha256": "33cf1760115c75314d2a7a6e47532d63e20a0fa082a98e9f90ad2a69d809b962",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.25.7",
+      "version": "12.26.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.25.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.26.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.postmanlabs.mac');"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.25.7/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.26.0/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "727f8e9d",
-      "sha256": "34314dba2092ed99f4b99c580b49c6bb00124848c622714407a763d86928fbb9",
+      "sha256": "42d2e3bdf50a3286904f87dd7fa44d353306e8de88eae6d990b0def620071b34",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated BetterTouchTool to version 6.763.
  - Updated Elephas to version 12.0001.
  - Updated Firefox Nightly to the August 30, 2026 build.
  - Updated Postman to version 12.26.0.
  - Refreshed download locations and verification checksums for each updated application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->