### PR TITLE
Upgrade upload/download-artifact actions due to node 20 removal in Sep 23rd

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Build binaries
         run: make
 
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build
           path: build/

--- a/.github/workflows/build-fleetctl-msi.yml
+++ b/.github/workflows/build-fleetctl-msi.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload MSI artifact (test mode)
         if: ${{ inputs.test_mode }}
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleetctl-msi-${{ matrix.arch }}
           path: dist/fleetctl_v${{ steps.extract_version.outputs.msi_version }}_windows_${{ matrix.arch }}.msi

--- a/.github/workflows/build-fleetctl-pkg.yml
+++ b/.github/workflows/build-fleetctl-pkg.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload package artifact (test mode only)
         if: steps.extract_version.outputs.is_test_mode == 'true'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleetctl-test-package
           path: dist/fleetctl_v${{ steps.extract_version.outputs.version }}_mac.pkg

--- a/.github/workflows/build-fleetd-base-msi.yml
+++ b/.github/workflows/build-fleetd-base-msi.yml
@@ -65,7 +65,7 @@ jobs:
           mv fleet-osquery*.msi fleetd-base.msi
 
       - name: Upload fleetd-base.msi for code signing
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows
           path: fleetd-base.msi
@@ -98,7 +98,7 @@ jobs:
           egress-policy: audit
 
       - name: Download signed artifact
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleetd-base-msi
         
@@ -117,7 +117,7 @@ jobs:
           jq -e . >/dev/null 2>&1 <<< $(cat meta.json)
 
       - name: Upload meta.json
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: meta.json
           path: meta.json

--- a/.github/workflows/build-fleetd-base-pkg.yml
+++ b/.github/workflows/build-fleetd-base-pkg.yml
@@ -111,14 +111,14 @@ jobs:
           </plist>' > fleetd-base-manifest.plist
 
       - name: Upload fleetd-base.pkg
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleetd-base.pkg
           path: |
             fleetd-base.pkg
 
       - name: Upload fleetd-base-manifest.plist
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleetd-base-manifest.plist
           path: |

--- a/.github/workflows/build-fleetd_tables.yaml
+++ b/.github/workflows/build-fleetd_tables.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Build binaries
         run: make fleetd-tables-all
 
-      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleetd_tables
           path: fleetd_tables_*

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -75,7 +75,7 @@ jobs:
           ORBIT_COMMIT: ${{ github.sha }}
 
       - name: Upload orbit
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit
           path: |

--- a/.github/workflows/code-sign-windows.yml
+++ b/.github/workflows/code-sign-windows.yml
@@ -49,7 +49,7 @@ jobs:
           egress-policy: audit
 
       - name: Download unsigned artifact
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.download_name }}
 
@@ -105,7 +105,7 @@ jobs:
           subject-path: ${{ inputs.filename }}
 
       - name: Upload signed artifact
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.upload_name }}
           path: ${{ inputs.filename }}

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload fleet logs
         if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleet-logs
           path: |
@@ -223,7 +223,7 @@ jobs:
 
       - name: Upload cloudflared logs
         if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cloudflared.log
           path: cloudflared.log
@@ -255,7 +255,7 @@ jobs:
           make osqueryd-app-tar-gz version=$OSQUERY_VERSION out-path=.
 
       - name: Upload desktop.app.tar.gz and osqueryd.app.tar.gz
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: macos-pre-built-apps
           path: |
@@ -296,7 +296,7 @@ jobs:
 
       - name: Download macos pre-built apps
         id: download
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: macos-pre-built-apps
 
@@ -321,21 +321,21 @@ jobs:
           ./tools/tuf/test/main.sh
 
       - name: Upload PKG installer
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleet-osquery.pkg
           path: |
             fleet-osquery.pkg
 
       - name: Upload DEB installer
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleet-osquery_amd64.deb
           path: |
             fleet-osquery_*_amd64.deb
 
       - name: Upload MSI installer
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleet-osquery.msi
           path: |
@@ -360,7 +360,7 @@ jobs:
 
       - name: Download pkg
         id: download
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleet-osquery.pkg
 
@@ -426,7 +426,7 @@ jobs:
 
       - name: Upload orbit logs
         if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit-logs-macos
           path: |
@@ -448,7 +448,7 @@ jobs:
 
       - name: Download deb
         id: download
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleet-osquery_amd64.deb
 
@@ -503,7 +503,7 @@ jobs:
 
       - name: Upload orbit logs
         if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit-logs-ubuntu
           path: |
@@ -525,7 +525,7 @@ jobs:
 
       - name: Download msi
         id: download
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleet-osquery.msi
 
@@ -649,7 +649,7 @@ jobs:
 
       - name: Upload Orbit logs
         if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit-logs-windows
           path: C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log

--- a/.github/workflows/fleet-desktop-macos-build.yml
+++ b/.github/workflows/fleet-desktop-macos-build.yml
@@ -245,7 +245,7 @@ jobs:
         run: security delete-keychain build.keychain || true
 
       - name: Upload pkg artifact
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleet_desktop-pkg
           path: ./apps/fleet-desktop-macos/build/dist/fleet_desktop-v*.pkg

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -126,7 +126,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ matrix.os }}-log
         path: |

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ matrix.os }}-log
         path: |

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -102,7 +102,7 @@ jobs:
           tar -czf ../desktop.app.tar.gz ./*
 
       - name: Upload desktop.app.tar.gz
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop.app.tar.gz
           path: desktop.app.tar.gz
@@ -134,7 +134,7 @@ jobs:
           make desktop-windows
 
       - name: Upload fleet-desktop.exe
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows
           path: fleet-desktop.exe
@@ -184,7 +184,7 @@ jobs:
           make desktop-windows-arm64
 
       - name: Upload fleet-desktop.exe
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows-arm64
           path: fleet-desktop.exe
@@ -245,7 +245,7 @@ jobs:
           subject-path: "desktop.tar.gz"
 
       - name: Upload desktop.tar.gz
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop.tar.gz
           path: desktop.tar.gz
@@ -287,7 +287,7 @@ jobs:
           subject-path: 'desktop.tar.gz'
 
       - name: Upload desktop.tar.gz
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: desktop-arm64.tar.gz
           path: desktop.tar.gz

--- a/.github/workflows/generate-nudge-targets.yml
+++ b/.github/workflows/generate-nudge-targets.yml
@@ -47,7 +47,7 @@ jobs:
         run: make nudge-app-tar-gz version=$NUDGE_VERSION out-path=.
 
       - name: Upload nudge.app.tar.gz
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nudge.app.tar.gz
           path: nudge.app.tar.gz

--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -69,7 +69,7 @@ jobs:
           tar -czf ../osqueryd.app.tar.gz ./*
 
       - name: Upload osqueryd.app.tar.gz
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: osqueryd.app.tar.gz
           path: osqueryd.app.tar.gz
@@ -106,7 +106,7 @@ jobs:
           subject-path: "opt/osquery/bin/osqueryd"
 
       - name: Upload osqueryd for linux
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: osqueryd
           path: opt/osquery/bin/osqueryd
@@ -147,7 +147,7 @@ jobs:
           subject-path: "opt/osquery/bin/osqueryd"
 
       - name: Upload osqueryd for linux-arm64
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: osqueryd-arm64
           path: opt/osquery/bin/osqueryd
@@ -186,7 +186,7 @@ jobs:
           subject-path: C:\temp\osquery\osqueryd\osqueryd.exe
 
       - name: Upload osqueryd for Windows
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: osqueryd.exe
           path: C:\temp\osquery\osqueryd\osqueryd.exe
@@ -229,7 +229,7 @@ jobs:
           subject-path: osqueryd.exe
 
       - name: Upload osqueryd for Windows
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: osqueryd-arm64.exe
           path: osqueryd.exe

--- a/.github/workflows/generate-swift-dialog-targets.yml
+++ b/.github/workflows/generate-swift-dialog-targets.yml
@@ -49,7 +49,7 @@ jobs:
         run: make swift-dialog-app-tar-gz version=${SWIFT_DIALOG_VERSION} build=${SWIFT_DIALOG_BUILD} out-path=.
 
       - name: Upload swiftDialog.app.tar.gz
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: swiftDialog.app.tar.gz
           path: swiftDialog.app.tar.gz

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -176,7 +176,7 @@ jobs:
           fi
 
       - name: Upload signed fleetctl binary for .pkg creation
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.check_binary.outputs.exists == 'true'
         with:
           name: fleetctl-signed-macos
@@ -202,7 +202,7 @@ jobs:
           echo "arches=[$(IFS=,; echo "${ARCHES[*]}")]" >> "$GITHUB_OUTPUT"
 
       - name: Upload unsigned Windows fleetctl amd64
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.check_windows_binaries.outputs.windows_amd64_path != ''
         with:
           name: fleetctl-unsigned-windows-amd64
@@ -210,7 +210,7 @@ jobs:
           retention-days: 1
 
       - name: Upload unsigned Windows fleetctl arm64
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.check_windows_binaries.outputs.windows_arm64_path != ''
         with:
           name: fleetctl-unsigned-windows-arm64
@@ -239,7 +239,7 @@ jobs:
           persist-credentials: false
 
       - name: Download signed fleetctl binary
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleetctl-signed-macos
           path: dist/fleetctl_darwin_all
@@ -304,7 +304,7 @@ jobs:
           persist-credentials: false
 
       - name: Download unsigned fleetctl binary
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleetctl-unsigned-windows-${{ matrix.arch }}
 
@@ -376,7 +376,7 @@ jobs:
             "${{ matrix.arch }}"
 
       - name: Upload signed MSI artifact
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fleetctl-msi-${{ matrix.arch }}
           path: dist/fleetctl_v${{ steps.version.outputs.version }}_windows_${{
@@ -403,7 +403,7 @@ jobs:
           egress-policy: audit
 
       - name: Download signed MSI artifacts
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: fleetctl-msi-*
           merge-multiple: true

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -75,7 +75,7 @@ jobs:
           subject-path: "dist/orbit-macos_darwin_all/orbit"
 
       - name: Upload
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit-macos
           path: dist/orbit-macos_darwin_all/orbit
@@ -123,7 +123,7 @@ jobs:
           subject-path: "dist/orbit_linux_amd64_v1/orbit"
 
       - name: Upload
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit-linux
           path: dist/orbit_linux_amd64_v1/orbit
@@ -168,7 +168,7 @@ jobs:
           subject-path: "dist/orbit_linux_arm64_v8.0/orbit"
 
       - name: Upload
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: orbit-linux-arm64
           path: dist/orbit_linux_arm64_v8.0/orbit
@@ -205,7 +205,7 @@ jobs:
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows.yml # v2.4.4
 
       - name: Upload
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows
           path: dist/orbit_windows_amd64_v1/orbit.exe
@@ -260,7 +260,7 @@ jobs:
         run: go run github.com/goreleaser/goreleaser/v2@606c0e724fe9b980cd01090d08cbebff63cd0f72 release --verbose --clean --skip=publish -f orbit/goreleaser-windows-arm64.yml # v2.4.4
 
       - name: Upload
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows-arm64
           path: dist/orbit_windows_arm64_v8.0/orbit.exe

--- a/.github/workflows/release-fleet-desktop-macos.yml
+++ b/.github/workflows/release-fleet-desktop-macos.yml
@@ -171,7 +171,7 @@ jobs:
           persist-credentials: false
 
       - name: Download built pkg artifact
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleet_desktop-pkg
 

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -122,7 +122,7 @@ jobs:
           echo "update_needed=false" >> $GITHUB_OUTPUT
 
       - name: Upload latest TUF meta artifact
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: latest-tuf-meta.json
           path: latest-tuf-meta.json
@@ -251,7 +251,7 @@ jobs:
           mv fleet-osquery*.msi fleetd-base.msi
 
       - name: Upload fleetd-base.msi for code signing
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows
           path: fleetd-base.msi
@@ -297,7 +297,7 @@ jobs:
           persist-credentials: false
 
       - name: Download signed artifact
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: fleetd-base-msi
 
@@ -337,7 +337,7 @@ jobs:
           persist-credentials: false
 
       - name: Download latest-tuf-meta.json artifact
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: latest-tuf-meta.json
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -65,7 +65,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload build reports
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-reports
           path: |
@@ -80,26 +80,26 @@ jobs:
 
       - name: Upload Detekt report
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: detekt-report
           path: android/app/build/reports/detekt/
 
       - name: Upload Lint report
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lint-report
           path: android/app/build/reports/lint-results-*.html
 
       - name: Upload APK
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app-debug
           path: android/app/build/outputs/apk/debug/app-debug.apk
 
       - name: Save coverage
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-coverage
           path: android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Upload instrumented test reports
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: instrumented-test-reports
           path: |
@@ -207,7 +207,7 @@ jobs:
             /tmp/gradle.log
 
       - name: Save coverage
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: instrumented-coverage
           path: android/app/build/reports/coverage/androidTest/debug/connected/report.xml
@@ -312,7 +312,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scep-integration-test-reports
           path: |
@@ -321,7 +321,7 @@ jobs:
             /tmp/gradle.log
 
       - name: Save coverage
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scep-coverage
           path: android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
@@ -373,7 +373,7 @@ jobs:
           persist-credentials: false
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-coverage'
 

--- a/.github/workflows/test-go-activity.yaml
+++ b/.github/workflows/test-go-activity.yaml
@@ -99,7 +99,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Download artifacts
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-coverage'
       - name: Upload to Codecov
@@ -122,7 +122,7 @@ jobs:
           egress-policy: audit
 
       - name: Download artifacts
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-status'
 

--- a/.github/workflows/test-go-suite.yaml
+++ b/.github/workflows/test-go-suite.yaml
@@ -298,7 +298,7 @@ jobs:
 
     - name: Save coverage
       if: always()
-      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}-coverage
         path: ./coverage.txt
@@ -334,7 +334,7 @@ jobs:
 
     - name: Upload test log
       if: always()
-      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}-test-log
         path: /tmp/gotest.log
@@ -342,14 +342,14 @@ jobs:
 
     - name: Upload summary test log
       if: always()
-      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}-summary-test-log
         path: /tmp/summary.txt
 
     - name: Upload JSON test output
       if: always()
-      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}-test-json
         path: /tmp/test-output.json
@@ -366,7 +366,7 @@ jobs:
 
     - name: Upload status indicator
       if: always()
-      uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ env.ARTIFACT_PREFIX }}-status
         path: /tmp/status

--- a/.github/workflows/test-go-windows.yml
+++ b/.github/workflows/test-go-windows.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-go-test-logs
           path: ${{ runner.temp }}\gotest.log

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -195,7 +195,7 @@ jobs:
             ./server/mdm/nanomdm/storage/mysql 2>&1 | tee /tmp/gotest.log
 
       - name: Save coverage
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nanomdm-coverage
           path: ./coverage.txt
@@ -231,7 +231,7 @@ jobs:
 
       - name: Upload test log
         if: always()
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nanomdm-test-log
           path: /tmp/gotest.log
@@ -239,14 +239,14 @@ jobs:
 
       - name: Upload summary test log
         if: always()
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nanomdm-summary-test-log
           path: /tmp/summary.txt
 
       - name: Upload JSON test output
         if: always()
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nanomdm-test-json
           path: /tmp/test-output.json
@@ -271,7 +271,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Download artifacts
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-coverage'
       - name: Upload to Codecov
@@ -294,7 +294,7 @@ jobs:
           egress-policy: audit
 
       - name: Download artifacts
-        uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: '*-status'
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

⚠️ Node 20 is removed from Actions runners on September 23, 2026 ⚠️

Upgrades `actions/download-artifact` to v8.0.1 and `actions/upload-artifact` to v7.0.1 (pinned by commit SHA) across all workflows — 82 `uses:` lines in 26 workflow files.

## Why

These workflows currently emit Node 20 deprecation warnings. Per the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):

- Node 20 reaches EOL in April 2026.
- GitHub-hosted runners default to Node 24 since **June 16, 2026**.
- **Node 20 is removed from Actions runners on September 23, 2026.**

`upload-artifact` v7 and `download-artifact` v8 run on `node24`, silencing the warnings and keeping these workflows working past the removal date.

## Breaking changes reviewed (none affect Fleet)

- `download-artifact` v5 changed the extraction path for single-artifact downloads by ID — no workflow in this repo uses `artifact-ids`; all download by name.
- `download-artifact` v8 now fails on digest mismatch by default (previously a warning) — only fires on corrupted downloads.
- v6+/v7+ of both actions require runner ≥ 2.327.1 for Node 24 — only relevant to self-hosted runners; no workflow here uses `self-hosted`.
- `upload-artifact` v7 / `download-artifact` v8 moved to ESM and added direct (unzipped) upload/download support — transparent to callers.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality (verified no `artifact-ids` usage and no self-hosted runners; grep confirms all 82 pins updated with no stragglers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact upload and download tooling across build, test, signing, and release workflows.
  * Improved the reliability and security of transferring build outputs, test logs, coverage reports, and release artifacts.
  * Artifact names, paths, and workflow behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->