### PR TITLE
Cherry-pick #52135: Use hardcoded string for skipped install details

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -41,6 +41,8 @@ import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 import {
   INSTALL_DETAILS_STATUS_ICONS,
+  SKIPPED_INSTALL_DETAILS,
+  SKIPPED_PRE_INSTALL_OUTPUT,
   getInstallDetailsStatusPredicate,
 } from "../constants";
 
@@ -156,8 +158,7 @@ export const StatusMessage = ({
           <span>
             Fleet skipped install of <b>{software_title}</b> ({software_package}
             ) on {formattedHost}
-            {displayTimeStamp}. The app was open. It will update once the user
-            closes it and policy runs again, or update via self service.
+            {displayTimeStamp}. {SKIPPED_INSTALL_DETAILS}
           </span>
         }
       />
@@ -318,7 +319,7 @@ export const SoftwareInstallDetailsModal = ({
       {
         label: "Pre-install query output:",
         value: detailsFromProps.skipped_install
-          ? "Query didn't return result or failed\nThe app was open"
+          ? SKIPPED_PRE_INSTALL_OUTPUT
           : swInstallResult?.pre_install_query_output,
       },
       {

--- a/frontend/components/ActivityDetails/InstallDetails/constants.ts
+++ b/frontend/components/ActivityDetails/InstallDetails/constants.ts
@@ -22,6 +22,13 @@ export const INSTALL_DETAILS_STATUS_ICONS: Record<
   skipped_install: "error-outline",
 } as const;
 
+export const SKIPPED_INSTALL_DETAILS =
+  "The app was open. It will update once the user closes it and policy runs again, or update via self service.";
+
+// A skip stores an empty pre-install query output, so there is nothing to echo back.
+export const SKIPPED_PRE_INSTALL_OUTPUT =
+  "Query didn't return result or failed\nThe app was open";
+
 const INSTALL_DETAILS_STATUS_PREDICATES: Record<
   EnhancedSoftwareInstallUninstallStatus | "skipped_install",
   string

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
@@ -113,6 +113,32 @@ describe("PolicyAutomationActivityDetailsModal", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("explains a patch-when-closed skip instead of showing empty output sections", () => {
+    render(
+      <PolicyAutomationActivityDetailsModal
+        activity={{
+          ...failedSoftwareActivity,
+          details: {
+            policy_id: 123,
+            software_title: "1Password",
+            skipped_install: true,
+          },
+          output: null,
+          pre_install_output: "",
+        }}
+        onCancel={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("Patch skipped (1Password)")).toBeInTheDocument();
+
+    // Shown inline, the same way a failing row shows its output sections.
+    expect(screen.getByText("Pre-install query output")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Query didn't return result or failed/)
+    ).toBeInTheDocument();
+  });
+
   it("omits the details box when there is no output or error", () => {
     render(
       <PolicyAutomationActivityDetailsModal

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -11,6 +11,7 @@ import CustomLink from "components/CustomLink";
 import DataSet from "components/DataSet";
 import Textarea from "components/Textarea";
 import Icon from "components/Icon";
+import { SKIPPED_PRE_INSTALL_OUTPUT } from "components/ActivityDetails/InstallDetails/constants";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import {
@@ -96,7 +97,9 @@ const PolicyAutomationActivityDetailsModal = ({
           <>
             {renderOutputSection(
               "Pre-install query output",
-              activity.pre_install_output
+              activity.details?.skipped_install
+                ? SKIPPED_PRE_INSTALL_OUTPUT
+                : activity.pre_install_output
             )}
             {renderOutputSection("Details", activity.output)}
             {renderOutputSection(

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -7,10 +7,13 @@ import { createCustomRenderer } from "test/test-utils";
 
 import policiesAPI from "services/entities/policies";
 
+import { SKIPPED_INSTALL_DETAILS } from "components/ActivityDetails/InstallDetails/constants";
+
 import PolicyAutomationsActivitiesTable from "./PolicyAutomationsActivitiesTable";
 import {
   getAutomationRunDisplayName,
   getAutomationStatusIcon,
+  getDetailOutputText,
 } from "./helpers";
 
 jest.mock("services/entities/policies");
@@ -167,6 +170,23 @@ describe("getAutomationStatusIcon", () => {
     expect(
       getAutomationStatusIcon(mockActivity({ status: "success" }))
     ).toEqual({ name: "success-outline" });
+  });
+});
+
+describe("getDetailOutputText", () => {
+  it("explains a patch-when-closed skip rather than returning empty text", () => {
+    expect(
+      getDetailOutputText(
+        mockActivity({
+          status: "error",
+          details: {
+            policy_id: 123,
+            software_title: "1Password",
+            skipped_install: true,
+          },
+        })
+      )
+    ).toBe(SKIPPED_INSTALL_DETAILS);
   });
 });
 

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -1,5 +1,6 @@
 import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
+import { SKIPPED_INSTALL_DETAILS } from "components/ActivityDetails/InstallDetails/constants";
 import { Colors } from "styles/var/colors";
 
 const withName = (base: string, name?: string) =>
@@ -70,13 +71,16 @@ export const getAutomationStatusIcon = (
 };
 
 /**
- * Text shown in the "Details" column (and the modal's primary block): the
- * remote error response for failures, or the script/install output for the
- * task activities. Empty when neither applies.
+ * Text shown in the "Details" column: the explanation for a deferred patch, the
+ * remote error response for failures, or the script/install output for the task
+ * activities. Empty when none apply.
  */
 export const getDetailOutputText = (
   activity: IPolicyAutomationActivity
 ): string => {
+  if (activity.details?.skipped_install) {
+    return SKIPPED_INSTALL_DETAILS;
+  }
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/fleetdm/fleet/pull/52135 into the 4.91.0 RC branch.

Fills the Details column for a "Patch skipped" row in the policy Automation runs table, which showed `---`, and gives its details modal the pre-install query output for that state. The copy is shared with the install details modal rather than duplicated. Frontend only.

For full details see the original PR: https://github.com/fleetdm/fleet/pull/52135

- [x] QA'd all new/changed functionality manually
  - Tested on this specific branch based off 4.91