### PR TITLE
another attempt to fix flakiness in mock APNS

### DIFF
--- a/cmd/apple-apns-mock/coordinator.go
+++ b/cmd/apple-apns-mock/coordinator.go
@@ -265,17 +265,11 @@ func (c *coordinator) dispatch(ctx context.Context, msg pushMsg) {
 		}
 	}
 
-	switch c.reg.deliver(msg.Token, p) {
-	case delivered:
-		c.reg.deliveredLive.Add(1)
-	case bufferFull:
-		c.reg.coalesced.Add(1)
-	case notHeld:
+	if c.reg.deliver(msg.Token, p) == notHeld && !inline {
 		// The stream closed between holds and deliver. An inline push is
 		// deliver-or-discard, so only a claimed one goes back.
-		if !inline {
-			_ = c.requeue(ctx, msg.Token, p)
-		}
+		time.Sleep(5 * time.Millisecond)
+		_ = c.requeue(ctx, msg.Token, p)
 	}
 }
 
@@ -449,7 +443,6 @@ func (c *coordinator) resyncBatch(tokens []string) int {
 			continue
 		}
 		if c.reg.deliver(token, p) == delivered {
-			c.reg.deliveredLive.Add(1)
 			recovered++
 		}
 	}

--- a/cmd/apple-apns-mock/coordinator.go
+++ b/cmd/apple-apns-mock/coordinator.go
@@ -268,7 +268,6 @@ func (c *coordinator) dispatch(ctx context.Context, msg pushMsg) {
 	if c.reg.deliver(msg.Token, p) == notHeld && !inline {
 		// The stream closed between holds and deliver. An inline push is
 		// deliver-or-discard, so only a claimed one goes back.
-		time.Sleep(5 * time.Millisecond)
 		_ = c.requeue(ctx, msg.Token, p)
 	}
 }

--- a/cmd/apple-apns-mock/coordinator_test.go
+++ b/cmd/apple-apns-mock/coordinator_test.go
@@ -69,8 +69,9 @@ func waitAnnouncementsHandled(t *testing.T, c *coordinator) {
 	const marker = "ffffff"
 	sub, _ := c.reg.subscribe(marker, 0)
 
-	// Inline, so the marker needs no pending key. ping is queued after the bump
-	// after the ping is queued, so wait on the counter, not on sub.ch.
+	// Inline, so the marker needs no pending key. Wait for it to reach the stream so we
+	// know this node's subscription has processed all earlier announcements (Redis delivers
+	// to a subscriber in publish order).
 	require.NoError(t, c.publish(t.Context(), pushMsg{Token: marker, Inline: []byte(`{"mdm":"marker"}`)}))
 	waitPing(t, sub, 5*time.Second)
 
@@ -226,10 +227,9 @@ func TestCoordinatorClaimIsExactlyOnce(t *testing.T) {
 
 	expectNoPingOn(t, sub1, 200*time.Millisecond)
 	expectNoPingOn(t, sub2, 200*time.Millisecond)
-	waitFor(t, func() bool {
-		return assert.EqualValues(t, 1, c1.reg.claimMisses.Load()+c2.reg.claimMisses.Load(),
-			"the instance that lost the race records a claim miss")
-	})
+	waitFor(t, func() bool { return c1.reg.claimMisses.Load()+c2.reg.claimMisses.Load() == 1 })
+	assert.EqualValues(t, 1, c1.reg.claimMisses.Load()+c2.reg.claimMisses.Load(),
+		"the instance that lost the race records a claim miss")
 }
 
 func TestCoordinatorReconnectElsewhereMovesToken(t *testing.T) {

--- a/cmd/apple-apns-mock/coordinator_test.go
+++ b/cmd/apple-apns-mock/coordinator_test.go
@@ -68,12 +68,11 @@ func waitAnnouncementsHandled(t *testing.T, c *coordinator) {
 	t.Helper()
 	const marker = "ffffff"
 	sub, _ := c.reg.subscribe(marker, 0)
-	before := c.reg.deliveredLive.Load()
 
-	// Inline, so the marker needs no pending key. deliveredLive is bumped
+	// Inline, so the marker needs no pending key. ping is queued after the bump
 	// after the ping is queued, so wait on the counter, not on sub.ch.
 	require.NoError(t, c.publish(t.Context(), pushMsg{Token: marker, Inline: []byte(`{"mdm":"marker"}`)}))
-	waitFor(t, func() bool { return c.reg.deliveredLive.Load() > before })
+	waitPing(t, sub, 5*time.Second)
 
 	c.reg.unsubscribe(marker, sub)
 	c.reg.deliveredLive.Add(-1) // the marker is not a delivery under test
@@ -227,8 +226,10 @@ func TestCoordinatorClaimIsExactlyOnce(t *testing.T) {
 
 	expectNoPingOn(t, sub1, 200*time.Millisecond)
 	expectNoPingOn(t, sub2, 200*time.Millisecond)
-	assert.EqualValues(t, 1, c1.reg.claimMisses.Load()+c2.reg.claimMisses.Load(),
-		"the instance that lost the race records a claim miss")
+	waitFor(t, func() bool {
+		return assert.EqualValues(t, 1, c1.reg.claimMisses.Load()+c2.reg.claimMisses.Load(),
+			"the instance that lost the race records a claim miss")
+	})
 }
 
 func TestCoordinatorReconnectElsewhereMovesToken(t *testing.T) {

--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -126,8 +126,8 @@ func waitSubscribed(t *testing.T, coord *coordinator) {
 		}
 	}, 10*time.Second, time.Millisecond, "node never received its own announcement")
 
-	// Detach before restoring the counters: a duplicate marker still in
-	// flight then finds no stream and touches nothing.
+	// both counters move under the shard lock, and unsubscribe takes that lock,
+	// so a duplicate marker either counted before the restore or finds no stream
 	coord.reg.unsubscribe(marker, sub)
 	coord.reg.deliveredLive.Store(live)
 	coord.reg.coalesced.Store(coalesced)

--- a/cmd/apple-apns-mock/registry.go
+++ b/cmd/apple-apns-mock/registry.go
@@ -165,12 +165,13 @@ func (r *registry) deliver(token string, p *ping) deliverResult {
 	if e == nil || e.sub == nil {
 		return notHeld
 	}
-	select {
-	case e.sub.ch <- p:
-		return delivered
-	default:
+	if len(e.sub.ch) == cap(e.sub.ch) {
+		r.coalesced.Add(1)
 		return bufferFull
 	}
+	r.deliveredLive.Add(1)
+	e.sub.ch <- p // deliver is the only sender and holds the lock, so this cannot block
+	return delivered
 }
 
 // holds reports whether this node has a live stream for the token. Every


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Not user facing.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery when subscription buffers are full, including more consistent coalescing behavior.
  * Improved recovery when a notification stream closes during delivery.
  * Made synchronization and resynchronization behavior more reliable during live notification processing.

* **Tests**
  * Improved test stability by waiting for observable notification events and claim outcomes rather than relying on timing-sensitive counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->