### PR TITLE
Document actual policy check/automation cadence

### DIFF
--- a/articles/automations.md
+++ b/articles/automations.md
@@ -14,9 +14,11 @@ You can automatically send activites to a webhook URL or a [log destination](htt
 
 Policy automations are triggered if a policy fails on a host. 
 
-Policies run every 1 hour ([configurable](https://fleetdm.com/docs/configuration/fleet-server-configuration#osquery-policy-update-interval)) and run in ascending order by policy ID after the ID is turned into a string ("100" runs before "53", which runs before "7"). 
+Policies run every 1 hour ([configurable](https://fleetdm.com/docs/configuration/fleet-server-configuration#osquery-policy-update-interval)) by default, and run in ascending order by policy ID after the ID is turned into a string ("100" runs before "53", which runs before "7"). 
 
-Automations are fired for scheduled policy runs. Running a live policy doesn't trigger automations.
+Several events can trigger a policy check sooner than this interval: a manual host refetch, a calendar event, a software install or uninstall completing, VPP app install verification, and an MDM check-in all ask the host to check in and run its policies again right away. Because of this, a policy can be evaluated far more often than once an hour, especially on a host with frequent software installs or MDM activity.
+
+Automations are fired for scheduled policy runs, including the ones triggered early by the events above. Running a live policy doesn't trigger automations.
 
 ### Calendar
 

--- a/articles/automations.md
+++ b/articles/automations.md
@@ -16,7 +16,7 @@ Policy automations are triggered if a policy fails on a host.
 
 Policies run every 1 hour ([configurable](https://fleetdm.com/docs/configuration/fleet-server-configuration#osquery-policy-update-interval)) by default, and run in ascending order by policy ID after the ID is turned into a string ("100" runs before "53", which runs before "7"). 
 
-Several events can trigger a policy check sooner than this interval: a manual host refetch, a calendar event, a software install or uninstall completing, VPP app install verification, and an MDM check-in all ask the host to check in and run its policies again right away. Because of this, a policy can be evaluated far more often than once an hour, especially on a host with frequent software installs or MDM activity.
+Several events can trigger a policy check sooner than this interval: a manual host refetch, a calendar event, a software install or uninstall completing, Apple App Store (VPP) app install verification, and an MDM check-in all ask the host to check in and run its policies again right away. Because of this, a policy can be evaluated far more often than once an hour, especially on a host with frequent software installs or MDM activity.
 
 Automations are fired for scheduled policy runs, including the ones triggered early by the events above. Running a live policy doesn't trigger automations.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3456,7 +3456,7 @@ the `software` table.
 - `detail_updated_at`: the last time Fleet updated host data (this includes updates to host associated tables, e.g. `host_users`). This only changes when the host's detail queries run, which is less frequent than policy queries, so it lags behind events (like a policy automation) that were triggered by a policy check alone.
 - `label_updated_at`: the last time Fleet updated the label membership for the host
 - `last_enrolled_at`: the last time the host enrolled to Fleet.
-- `policy_updated_at`: the last time we updated the policy results for the host. Policies can be checked, and policy automations triggered, much more often than the [policy update interval](https://fleetdm.com/docs/configuration/fleet-server-configuration#osquery-policy-update-interval): a manual host refetch, a calendar event, a software install or uninstall completing, VPP app install verification, and an MDM check-in can all trigger an early policy check on top of the regular schedule. The Fleet UI's host details page shows the later of `detail_updated_at` and `policy_updated_at` as "Last fetched," so it reflects the most recent time Fleet actually heard from the host.
+- `policy_updated_at`: the last time we updated the policy results for the host. Policies can be checked, and policy automations triggered, much more often than the policy update interval ([learn more](https://fleetdm.com/guides/automations#policy-automations)).
 - `seen_time`: the last time the host contacted the fleet server, regardless of what operation it was for.
 - `software_updated_at`: the last time software changed for the host in any way.
 - `last_restarted_at`: the last time that the host was restarted.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3453,10 +3453,10 @@ the `software` table.
 
 - `created_at`: the time the row in the database was created, which usually corresponds to the first enrollment of the host.
 - `updated_at`: the last time the row in the database for the `hosts` table was updated.
-- `detail_updated_at`: the last time Fleet updated host data (this includes updates to host associated tables, e.g. `host_users`).
+- `detail_updated_at`: the last time Fleet updated host data (this includes updates to host associated tables, e.g. `host_users`). This only changes when the host's detail queries run, which is less frequent than policy queries, so it lags behind events (like a policy automation) that were triggered by a policy check alone.
 - `label_updated_at`: the last time Fleet updated the label membership for the host
 - `last_enrolled_at`: the last time the host enrolled to Fleet.
-- `policy_updated_at`: the last time we updated the policy results for the host
+- `policy_updated_at`: the last time we updated the policy results for the host. Policies can be checked, and policy automations triggered, much more often than the [policy update interval](https://fleetdm.com/docs/configuration/fleet-server-configuration#osquery-policy-update-interval): a manual host refetch, a calendar event, a software install or uninstall completing, VPP app install verification, and an MDM check-in can all trigger an early policy check on top of the regular schedule. The Fleet UI's host details page shows the later of `detail_updated_at` and `policy_updated_at` as "Last fetched," so it reflects the most recent time Fleet actually heard from the host.
 - `seen_time`: the last time the host contacted the fleet server, regardless of what operation it was for.
 - `software_updated_at`: the last time software changed for the host in any way.
 - `last_restarted_at`: the last time that the host was restarted.
@@ -3650,7 +3650,6 @@ To filter Windows hosts using `os_name` and `os_version`, set `os_name` to the f
       "mdm": {
         "encryption_key_available": false,
         "enrollment_status": "Pending",
-        "is_personal_enrollment": false,
         "dep_profile_error": true,
         "name": "Fleet",
         "server_url": "https://example.fleetdm.com/mdm/apple/mdm",
@@ -4221,7 +4220,6 @@ Returns the information of the specified host.
     "mdm": {
       "encryption_key_available": true,
       "enrollment_status": "On (manual)",
-      "is_personal_enrollment": false,
       "name": "Fleet",
       "connected_to_fleet": true,
       "server_url": "https://acme.com/mdm/apple/mdm",
@@ -4291,8 +4289,6 @@ Returns the information of the specified host.
 > - `scripts_enabled: null` means this agent is not a fleetd agent, or this agent is version <=1.23.0 which is not collecting the scripts enabled info
 
 > Note: [Get human-device mapping](https://github.com/fleetdm/fleet/blob/62dc32454f6a40e81fe229abdfc370d3bf7a56c6/docs/REST%20API/rest-api.md?plain=1#L3518) is deprecated as of Fleet 4.67.0. It is maintained for backwards compatibility. Please use the [Get host](#get-host) endpoint to get human-device mapping.
-
-> Note: `mdm.is_personal_enrollment` reports whether the last MDM enrollment Fleet recorded for the host was personal (BYOD). Unlike `mdm.enrollment_status`, it is not cleared when the host unenrolls, so it stays `true` for an unenrolled Android or Apple mobile host. On macOS and Windows, MDM state is re-reported by the agent, which resets the field once the enrollment profile is gone.
 
 > Note: For iOS, iPadOS, and Android hosts with ⁠`mdm.enrollment_status` set to "On (personal)", ⁠`hardware_serial` and ⁠`uuid` represent a temporary enrollment ID. For Android work profile, this is what Google calls an [enterprise-specific ID](https://developer.android.com/work/versions/android-12#:~:text=An%20enrollment%2Dspecific%20ID%20provides%20a%20unique%20ID%20that%20identifies%20the%20work%20profile%20enrollment%20in%20a%20particular%20organization%2C%20and%20will%20remain%20stable%20across%20factory%20resets).
 
@@ -4486,7 +4482,6 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
     "mdm": {
       "encryption_key_available": false,
       "enrollment_status": null,
-      "is_personal_enrollment": false,
       "name": "",
       "server_url": null,
       "device_status": "unlocked",
@@ -4718,7 +4713,6 @@ X-Client-Cert-Serial: <fleet_identity_scep_cert_serial>
     "mdm": {
       "encryption_key_available": true,
       "enrollment_status": "On (manual)",
-      "is_personal_enrollment": false,
       "name": "Fleet",
       "connected_to_fleet": true,
       "server_url": "https://acme.com/mdm/apple/mdm",
@@ -6846,7 +6840,6 @@ If `mdm_id`, `mdm_name`, `mdm_enrollment_status`, `os_settings`, or `os_settings
       "mdm": {
         "encryption_key_available": false,
         "enrollment_status": null,
-        "is_personal_enrollment": false,
         "name": "",
         "server_url": null
       }

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3650,6 +3650,7 @@ To filter Windows hosts using `os_name` and `os_version`, set `os_name` to the f
       "mdm": {
         "encryption_key_available": false,
         "enrollment_status": "Pending",
+        "is_personal_enrollment": false,
         "dep_profile_error": true,
         "name": "Fleet",
         "server_url": "https://example.fleetdm.com/mdm/apple/mdm",
@@ -4220,6 +4221,7 @@ Returns the information of the specified host.
     "mdm": {
       "encryption_key_available": true,
       "enrollment_status": "On (manual)",
+      "is_personal_enrollment": false,
       "name": "Fleet",
       "connected_to_fleet": true,
       "server_url": "https://acme.com/mdm/apple/mdm",
@@ -4289,6 +4291,8 @@ Returns the information of the specified host.
 > - `scripts_enabled: null` means this agent is not a fleetd agent, or this agent is version <=1.23.0 which is not collecting the scripts enabled info
 
 > Note: [Get human-device mapping](https://github.com/fleetdm/fleet/blob/62dc32454f6a40e81fe229abdfc370d3bf7a56c6/docs/REST%20API/rest-api.md?plain=1#L3518) is deprecated as of Fleet 4.67.0. It is maintained for backwards compatibility. Please use the [Get host](#get-host) endpoint to get human-device mapping.
+
+> Note: `mdm.is_personal_enrollment` reports whether the last MDM enrollment Fleet recorded for the host was personal (BYOD). Unlike `mdm.enrollment_status`, it is not cleared when the host unenrolls, so it stays `true` for an unenrolled Android or Apple mobile host. On macOS and Windows, MDM state is re-reported by the agent, which resets the field once the enrollment profile is gone.
 
 > Note: For iOS, iPadOS, and Android hosts with ⁠`mdm.enrollment_status` set to "On (personal)", ⁠`hardware_serial` and ⁠`uuid` represent a temporary enrollment ID. For Android work profile, this is what Google calls an [enterprise-specific ID](https://developer.android.com/work/versions/android-12#:~:text=An%20enrollment%2Dspecific%20ID%20provides%20a%20unique%20ID%20that%20identifies%20the%20work%20profile%20enrollment%20in%20a%20particular%20organization%2C%20and%20will%20remain%20stable%20across%20factory%20resets).
 
@@ -4482,6 +4486,7 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
     "mdm": {
       "encryption_key_available": false,
       "enrollment_status": null,
+      "is_personal_enrollment": false,
       "name": "",
       "server_url": null,
       "device_status": "unlocked",
@@ -4713,6 +4718,7 @@ X-Client-Cert-Serial: <fleet_identity_scep_cert_serial>
     "mdm": {
       "encryption_key_available": true,
       "enrollment_status": "On (manual)",
+      "is_personal_enrollment": false,
       "name": "Fleet",
       "connected_to_fleet": true,
       "server_url": "https://acme.com/mdm/apple/mdm",
@@ -6840,6 +6846,7 @@ If `mdm_id`, `mdm_name`, `mdm_enrollment_status`, `os_settings`, or `os_settings
       "mdm": {
         "encryption_key_available": false,
         "enrollment_status": null,
+        "is_personal_enrollment": false,
         "name": "",
         "server_url": null
       }

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1292,7 +1292,7 @@ module.exports.routes = {
   'GET /learn-more-about/idp-email': 'https://fleetdm.com/docs/rest-api/rest-api#get-human-device-mapping',
   'GET /learn-more-about/enrolling-hosts': '/docs/using-fleet/adding-hosts',
   'GET /learn-more-about/setup-assistant': '/guides/setup-experience',
-  'GET /learn-more-about/policy-automations': '/docs/using-fleet/automations',
+  'GET /learn-more-about/policy-automations': '/docs/using-fleet/automations#policy-automations',
   'GET /install-wine': 'https://github.com/fleetdm/fleet/blob/main/assets/scripts/install-wine.sh',
   'GET /learn-more-about/creating-service-accounts': 'https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts/create?walkthrough_id=iam--create-service-account&pli=1#step_index=1',
   'GET /learn-more-about/google-workspace-domains': 'https://admin.google.com/ac/domains/manage',


### PR DESCRIPTION
Part of the following bug:
- #51820


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the policy automations redirect to preserve the `#policy-automations` section anchor, taking visitors directly to the relevant documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->