### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/pritunl/darwin.json
+++ b/ee/maintained-apps/outputs/pritunl/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.3.4729.52",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4686.95') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4729.52') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.electron.pritunl' AND a.bundle_executable != '');"
       },
       "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4729.52/Pritunl.pkg.zip",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Pritunl for macOS version detection to recognize installations as patched when running version 1.3.4729.52 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->