### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/airtame/darwin.json
+++ b/ee/maintained-apps/outputs/airtame/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.15.0",
+      "version": "4.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application' AND version_compare(bundle_short_version, '4.15.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application' AND version_compare(bundle_short_version, '4.16.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.airtame.airtame-application' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-4.15.0.dmg",
+      "installer_url": "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-4.16.0.dmg",
       "install_script_ref": "4e4b470a",
       "uninstall_script_ref": "7c597d39",
-      "sha256": "73b70be70c598354d5d4cbec5e2ad69e8d64131cc0ff1c20de9e8eeffbcc392d",
+      "sha256": "90b41d06290be8d80903f7be7d571a9eda2cf9325db4539c486632f784585236",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pritunl/darwin.json
+++ b/ee/maintained-apps/outputs/pritunl/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.3.4729.52",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4686.95') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4729.52') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.electron.pritunl' AND a.bundle_executable != '');"
       },
       "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4729.52/Pritunl.pkg.zip",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Airtame macOS app definition to version 4.16.0, including its installer and verification details.
  * Updated the Pritunl macOS app definition to recognize version 1.3.4729.52 and newer as current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->