### PR TITLE
Update actions/checkout to v7.0.1 in website, docs, and vulnerability dashboard workflows

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
         fetch-depth: 0

--- a/.github/workflows/deploy-vulnerability-dashboard.yml
+++ b/.github/workflows/deploy-vulnerability-dashboard.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # Keep the token persisted: the "git fetch --prune --unshallow" step below fetches from the
         # GitHub origin, so authenticated access avoids anonymous rate limits and keeps working if

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         egress-policy: audit
 
     - name: Checkout Code
-      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/test-vulnerability-dashboard-changes.yml
+++ b/.github/workflows/test-vulnerability-dashboard-changes.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
Main PR here: https://github.com/fleetdm/fleet/pull/52114.

@eashaw: Putting this on a separate PR for when you get back from OOO.

Follow-up to #52114: updates `actions/checkout` to v7.0.1 in the workflows owned by @eashaw (website, docs, and vulnerability dashboard). These files were split out of #52114 so it wouldn't stay blocked while the CODEOWNER is OOO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code checkout tooling used by deployment, documentation, and testing workflows.
  * Maintained existing workflow triggers, permissions, build steps, and deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->