### PR TITLE
Cherry-pick #52188: Defer policy membership wipe

### DIFF
--- a/changes/52084-policy-edit-membership-wipe-lock.md
+++ b/changes/52084-policy-edit-membership-wipe-lock.md
@@ -1,0 +1,1 @@
+- Fixed editing a policy on a large fleet stalling policy and software install result ingestion fleet-wide. The `policy_membership` wipe now runs after the policy update commits instead of inside its transaction, so its row locks are no longer held for the whole wipe. An interrupted wipe is completed by the policy membership cron.

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -375,11 +375,49 @@ func (ds *Datastore) ResetPolicy(ctx context.Context, policyID uint) error {
 		if err := resetPolicyAutomationAttempts(ctx, tx, policyID); err != nil {
 			return ctxerr.Wrap(ctx, err, "reset policy automation attempts")
 		}
-		// removeAllMemberships=true, removePolicyStats=true; platform is unused
-		// when removing all memberships, so "" is fine.
-		return cleanupPolicy(ctx, tx, tx, policyID, "", true, true, ds.logger)
+		return markPolicyNeedsFullMembershipCleanup(ctx, tx, policyID)
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "resetting policy")
+	}
+
+	// removeAllMemberships=true, removePolicyStats=true; platform is unused
+	// when removing all memberships, so "" is fine.
+	if err := ds.cleanupPolicyAfterCommit(ctx, policyID, "", true, true); err != nil {
+		return ctxerr.Wrap(ctx, err, "resetting policy")
+	}
+	return nil
+}
+
+// markPolicyNeedsFullMembershipCleanup must be called inside the caller's transaction,
+// so an interrupted cleanup is still retried by the policy_membership cron.
+func markPolicyNeedsFullMembershipCleanup(ctx context.Context, db sqlx.ExecerContext, policyID uint) error {
+	if _, err := db.ExecContext(ctx,
+		`UPDATE policies SET needs_full_membership_cleanup = 1 WHERE id = ?`, policyID,
+	); err != nil {
+		return ctxerr.Wrap(ctx, err, "setting needs_full_membership_cleanup flag")
+	}
+	return nil
+}
+
+// cleanupPolicyAfterCommit runs the membership cleanup in autocommit, so its row locks
+// last one statement instead of accumulating until a transaction commits. Held longer,
+// they stall policy and software install result ingestion fleet-wide.
+func (ds *Datastore) cleanupPolicyAfterCommit(
+	ctx context.Context, policyID uint, platform string,
+	shouldRemoveAllPolicyMemberships bool, removePolicyStats bool,
+) error {
+	db := ds.writer(ctx)
+	if err := cleanupPolicy(
+		ctx, db, db, policyID, platform, shouldRemoveAllPolicyMemberships, removePolicyStats, ds.logger,
+	); err != nil {
+		return err
+	}
+	if shouldRemoveAllPolicyMemberships {
+		if _, err := db.ExecContext(ctx,
+			`UPDATE policies SET needs_full_membership_cleanup = 0 WHERE id = ?`, policyID,
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "clearing needs_full_membership_cleanup flag")
+		}
 	}
 	return nil
 }
@@ -388,16 +426,25 @@ func (ds *Datastore) ResetPolicy(ctx context.Context, policyID uint) error {
 //
 // Currently, SavePolicy does not allow updating the team of an existing policy.
 func (ds *Datastore) SavePolicy(ctx context.Context, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error {
+	if p == nil {
+		return ctxerr.New(ctx, "save policy: policy is nil")
+	}
+
 	if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		return savePolicy(ctx, tx, ds.logger, p, shouldRemoveAllPolicyMemberships, removePolicyStats)
+		return savePolicy(ctx, tx, p, shouldRemoveAllPolicyMemberships)
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating policy")
 	}
 
+	if err := ds.cleanupPolicyAfterCommit(
+		ctx, p.ID, p.Platform, shouldRemoveAllPolicyMemberships, removePolicyStats,
+	); err != nil {
+		return ctxerr.Wrap(ctx, err, "updating policy")
+	}
 	return nil
 }
 
-func savePolicy(ctx context.Context, db sqlx.ExtContext, logger *slog.Logger, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool, removePolicyStats bool) error {
+func savePolicy(ctx context.Context, db sqlx.ExtContext, p *fleet.Policy, shouldRemoveAllPolicyMemberships bool) error {
 	if p.TeamID == nil && p.SoftwareInstallerID != nil {
 		return ctxerr.Wrap(ctx, errSoftwareTitleIDOnGlobalPolicy, "save policy")
 	}
@@ -445,9 +492,10 @@ func savePolicy(ctx context.Context, db sqlx.ExtContext, logger *slog.Logger, p 
 		return ctxerr.Wrap(ctx, err, "resetting policy automation attempts")
 	}
 
-	return cleanupPolicy(
-		ctx, db, db, p.ID, p.Platform, shouldRemoveAllPolicyMemberships, removePolicyStats, logger,
-	)
+	if shouldRemoveAllPolicyMemberships {
+		return markPolicyNeedsFullMembershipCleanup(ctx, db, p.ID)
+	}
+	return nil
 }
 
 // ResetPolicyAutomationRetryAttemptsForHost marks all prior script and software
@@ -1944,27 +1992,15 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 	// Always run cleanup since labels may have changed even if the main policy
 	// fields didn't (the cleanup function is safe to call and will only delete
 	// memberships that don't match current criteria).
-	dbCtx := ds.writer(ctx)
 	for _, args := range pendingCleanups {
-		if err := cleanupPolicy(
+		if err := ds.cleanupPolicyAfterCommit(
 			ctx,
-			dbCtx,
-			dbCtx,
 			args.policyID,
 			args.platform,
 			args.shouldRemoveAllPolicyMemberships,
 			args.removePolicyStats,
-			ds.logger,
 		); err != nil {
 			return err
-		}
-
-		if args.shouldRemoveAllPolicyMemberships {
-			if _, err := ds.writer(ctx).ExecContext(ctx,
-				`UPDATE policies SET needs_full_membership_cleanup = 0 WHERE id = ?`,
-				args.policyID); err != nil {
-				return ctxerr.Wrap(ctx, err, "clearing needs_full_membership_cleanup flag")
-			}
 		}
 	}
 	return nil
@@ -2307,10 +2343,12 @@ func cleanupPolicyMembershipForPolicy(
 	var afterHostID uint
 	for {
 		var batchHostIDs []uint
+		// Join order is pinned: the optimizer otherwise leads with hosts (range scan +
+		// filesort), making each batch O(#hosts) rather than O(batch size).
 		err := sqlx.SelectContext(ctx, queryerContext, &batchHostIDs, `
 			SELECT pm.host_id
 			FROM policy_membership pm
-			INNER JOIN hosts h ON pm.host_id = h.id
+			STRAIGHT_JOIN hosts h ON pm.host_id = h.id
 			WHERE pm.policy_id = ? AND pm.host_id > ?
 			ORDER BY pm.host_id ASC
 			LIMIT ?`, policyID, afterHostID, policyMembershipDeleteBatchSize)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,6 +101,10 @@ func TestPolicies(t *testing.T) {
 		{"BatchedPolicyMembershipCleanupOnPolicyUpdate", testBatchedPolicyMembershipCleanupOnPolicyUpdate},
 		{"ApplyPolicySpecsNeedsFullMembershipCleanupFlag", testApplyPolicySpecsNeedsFullMembershipCleanupFlag},
 		{"CleanupPolicyMembershipCrashRecovery", testCleanupPolicyMembershipCrashRecovery},
+		{"SavePolicyDefersMembershipCleanup", testSavePolicyDefersMembershipCleanup},
+		{"SavePolicyDoesNotBlockUnrelatedPolicyIngestion", testSavePolicyDoesNotBlockUnrelatedPolicyIngestion},
+		{"SavePolicyNeedsFullMembershipCleanupFlag", testSavePolicyNeedsFullMembershipCleanupFlag},
+		{"ResetPolicyDefersMembershipCleanup", testResetPolicyDefersMembershipCleanup},
 		{"ApplyPolicySpecNoSpuriousStatsReset", testApplyPolicySpecNoSpuriousStatsReset},
 		{"GetPoliciesForConditionalAccessSQLInjection", testGetPoliciesForConditionalAccess},
 		{"RecordPolicyQueryExecutionsDeletedPolicy", testRecordPolicyQueryExecutionsDeletedPolicy},
@@ -7979,6 +7984,304 @@ func testCleanupPolicyMembershipCrashRecovery(t *testing.T, ds *Datastore) {
 			`SELECT needs_full_membership_cleanup FROM policies WHERE id = ?`, pol.ID))
 		assert.Zero(t, flagVal, "flag must be cleared even when no membership rows remain")
 	})
+}
+
+// testSavePolicyDefersMembershipCleanup asserts a transaction boundary, not a row count:
+// with the wipe blocked partway through, the new query must already be visible to another
+// connection. That is impossible while the wipe runs inside the SavePolicy transaction.
+func testSavePolicyDefersMembershipCleanup(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	// One host per batch, so the barrier below lands mid-wipe.
+	orig := policyMembershipDeleteBatchSize
+	policyMembershipDeleteBatchSize = 1
+	t.Cleanup(func() { policyMembershipDeleteBatchSize = orig })
+
+	pol := newTestPolicy(t, ds, user1, "defer cleanup policy", "", nil)
+	hosts := newPolicyTestHosts(t, ds, 8, "defer-cleanup")
+	for _, h := range hosts {
+		_, err := ds.RecordPolicyQueryExecutions(ctx, h, map[uint]*bool{pol.ID: new(false)}, time.Now(), false, nil)
+		require.NoError(t, err)
+	}
+
+	// The cursor pages by ascending host_id, so the wipe reaches this row last.
+	lastHostID := hosts[len(hosts)-1].ID
+	barrier, err := ds.writer(ctx).Connx(ctx)
+	require.NoError(t, err)
+	defer barrier.Close() //nolint:errcheck // test cleanup
+	barrierTx, err := barrier.BeginTxx(ctx, nil)
+	require.NoError(t, err)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { _ = barrierTx.Rollback() }) }
+	t.Cleanup(release)
+	// Released on a timer, not after the assertion: a regression blocks the wipe here and
+	// waiting on it would cost a full innodb_lock_wait_timeout plus retries.
+	barrierTimer := time.AfterFunc(2*time.Second, release)
+	t.Cleanup(func() { barrierTimer.Stop() })
+	var locked int
+	require.NoError(t, barrierTx.GetContext(ctx, &locked,
+		`SELECT 1 FROM policy_membership WHERE policy_id = ? AND host_id = ? FOR UPDATE`, pol.ID, lastHostID))
+
+	const newQuery = "SELECT 1 WHERE 1 = 2;"
+	pol.Query = newQuery
+	saveErr := make(chan error, 1)
+	go func() { saveErr <- ds.SavePolicy(ctx, pol, true, true) }()
+
+	// The committed edit must be visible from another connection while membership rows
+	// for this policy still exist.
+	var sawCommittedEditMidWipe bool
+	require.Eventually(t, func() bool {
+		var row struct {
+			Query string `db:"query"`
+			Flag  bool   `db:"needs_full_membership_cleanup"`
+			Rows  int    `db:"rows"`
+		}
+		if err := sqlx.GetContext(ctx, ds.writer(ctx), &row, `
+			SELECT p.query, p.needs_full_membership_cleanup,
+			       (SELECT COUNT(*) FROM policy_membership WHERE policy_id = p.id) AS `+"`rows`"+`
+			FROM policies p WHERE p.id = ?`, pol.ID); err != nil {
+			return false
+		}
+		if row.Query == newQuery && row.Flag && row.Rows > 0 {
+			sawCommittedEditMidWipe = true
+		}
+		return sawCommittedEditMidWipe
+	}, 8*time.Second, 2*time.Millisecond,
+		"policy edit never became visible to another connection while membership rows remained: "+
+			"the membership wipe is still running inside the SavePolicy transaction")
+
+	release()
+	require.NoError(t, <-saveErr)
+
+	// Final state: fully wiped and the retry flag cleared.
+	var count int
+	require.NoError(t, ds.writer(ctx).Get(&count, `SELECT COUNT(*) FROM policy_membership WHERE policy_id = ?`, pol.ID))
+	assert.Zero(t, count)
+	var flagVal int
+	require.NoError(t, ds.writer(ctx).Get(&flagVal,
+		`SELECT needs_full_membership_cleanup FROM policies WHERE id = ?`, pol.ID))
+	assert.Zero(t, flagVal)
+}
+
+// testSavePolicyDoesNotBlockUnrelatedPolicyIngestion guards the cross-policy reach: the
+// per-batch host issues recompute locks policy_membership by host_id only, so it covers
+// every policy those hosts belong to, not just the one being edited.
+func testSavePolicyDoesNotBlockUnrelatedPolicyIngestion(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	// Batch > 1 so the multi-host recompute (and its blanket FOR UPDATE) actually runs.
+	orig := policyMembershipDeleteBatchSize
+	policyMembershipDeleteBatchSize = 5
+	t.Cleanup(func() { policyMembershipDeleteBatchSize = orig })
+
+	target := newTestPolicy(t, ds, user1, "target policy", "", nil)
+	unrelated := newTestPolicy(t, ds, user1, "unrelated policy", "", nil)
+	hosts := newPolicyTestHosts(t, ds, 40, "cross-policy")
+	for _, h := range hosts {
+		_, err := ds.RecordPolicyQueryExecutions(ctx, h,
+			map[uint]*bool{target.ID: new(false), unrelated.ID: new(true)}, time.Now(), false, nil)
+		require.NoError(t, err)
+	}
+
+	// Stall the wipe so it cannot finish before we probe; otherwise it completes in
+	// milliseconds on a test database and the probe never overlaps it.
+	barrier, err := ds.writer(ctx).Connx(ctx)
+	require.NoError(t, err)
+	defer barrier.Close() //nolint:errcheck // test cleanup
+	barrierTx, err := barrier.BeginTxx(ctx, nil)
+	require.NoError(t, err)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { _ = barrierTx.Rollback() }) }
+	t.Cleanup(release)
+	var locked int
+	require.NoError(t, barrierTx.GetContext(ctx, &locked,
+		`SELECT 1 FROM policy_membership WHERE policy_id = ? AND host_id = ? FOR UPDATE`,
+		target.ID, hosts[len(hosts)-1].ID))
+
+	// A short lock timeout turns "blocked" into a fast, unambiguous error.
+	probe, err := ds.writer(ctx).Connx(ctx)
+	require.NoError(t, err)
+	defer probe.Close() //nolint:errcheck // test cleanup
+	_, err = probe.ExecContext(ctx, `SET SESSION innodb_lock_wait_timeout = 1`)
+	require.NoError(t, err)
+
+	target.Query = "SELECT 1 WHERE 1 = 2;"
+	saveErr := make(chan error, 1)
+	go func() { saveErr <- ds.SavePolicy(ctx, target, true, true) }()
+
+	// Replay the RecordPolicyQueryExecutions upsert for the unrelated policy on a host the
+	// wipe has already passed. Its accumulated locks must not cover this row.
+	var attempts int
+	var lockErrs []error
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		attempts++
+		if _, err := probe.ExecContext(ctx, `
+			INSERT IGNORE INTO policy_membership (updated_at, policy_id, host_id, passes)
+			VALUES (?, ?, ?, ?)
+			ON DUPLICATE KEY UPDATE updated_at = VALUES(updated_at), passes = VALUES(passes)`,
+			time.Now(), unrelated.ID, hosts[0].ID, true); err != nil {
+			lockErrs = append(lockErrs, err)
+		}
+	}
+	require.Positive(t, attempts)
+	release()
+	require.NoError(t, <-saveErr)
+
+	require.Empty(t, lockErrs,
+		"ingestion for an unrelated policy was blocked by a policy edit (%d attempts): %v", attempts, lockErrs)
+	// The unrelated policy keeps its rows; only the edited policy is wiped.
+	var count int
+	require.NoError(t, ds.writer(ctx).Get(&count, `SELECT COUNT(*) FROM policy_membership WHERE policy_id = ?`, unrelated.ID))
+	assert.Equal(t, len(hosts), count)
+	require.NoError(t, ds.writer(ctx).Get(&count, `SELECT COUNT(*) FROM policy_membership WHERE policy_id = ?`, target.ID))
+	assert.Zero(t, count)
+}
+
+// testSavePolicyNeedsFullMembershipCleanupFlag covers the flag lifecycle, which is what
+// makes an interrupted wipe recoverable by the cron.
+func testSavePolicyNeedsFullMembershipCleanupFlag(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	pol := newTestPolicy(t, ds, user1, "flag lifecycle policy", "", nil)
+	hosts := newPolicyTestHosts(t, ds, 3, "flag-lifecycle")
+	for _, h := range hosts {
+		_, err := ds.RecordPolicyQueryExecutions(ctx, h, map[uint]*bool{pol.ID: new(false)}, time.Now(), false, nil)
+		require.NoError(t, err)
+	}
+
+	flag := func() int {
+		var v int
+		require.NoError(t, ds.writer(ctx).Get(&v,
+			`SELECT needs_full_membership_cleanup FROM policies WHERE id = ?`, pol.ID))
+		return v
+	}
+	membership := func() int {
+		var v int
+		require.NoError(t, ds.writer(ctx).Get(&v,
+			`SELECT COUNT(*) FROM policy_membership WHERE policy_id = ?`, pol.ID))
+		return v
+	}
+
+	// A save that does not wipe membership must not queue cron work.
+	pol.Description = "edited description"
+	require.NoError(t, ds.SavePolicy(ctx, pol, false, false))
+	assert.Zero(t, flag(), "flag must not be set when memberships are kept")
+	assert.Equal(t, 3, membership(), "membership must be untouched")
+
+	// A save that wipes membership sets the flag and clears it on success.
+	pol.Query = "SELECT 1 WHERE 1 = 2;"
+	require.NoError(t, ds.SavePolicy(ctx, pol, true, true))
+	assert.Zero(t, flag(), "flag must be cleared after a successful cleanup")
+	assert.Zero(t, membership())
+
+	// An interrupted cleanup leaves the flag set; the cron must finish the job.
+	for _, h := range hosts {
+		_, err := ds.RecordPolicyQueryExecutions(ctx, h, map[uint]*bool{pol.ID: new(false)}, time.Now(), false, nil)
+		require.NoError(t, err)
+	}
+	_, err := ds.writer(ctx).ExecContext(ctx,
+		`UPDATE policies SET needs_full_membership_cleanup = 1 WHERE id = ?`, pol.ID)
+	require.NoError(t, err)
+	require.NoError(t, ds.CleanupPolicyMembership(ctx, time.Now()))
+	assert.Zero(t, flag(), "cron must clear the flag")
+	assert.Zero(t, membership(), "cron must finish the interrupted wipe")
+}
+
+// testResetPolicyDefersMembershipCleanup is the ResetPolicy twin. ResetPolicy issues no
+// UPDATE policies, so it never held the policies-row lock, but it did accumulate the same
+// policy_membership and host_issues locks until commit.
+func testResetPolicyDefersMembershipCleanup(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	orig := policyMembershipDeleteBatchSize
+	policyMembershipDeleteBatchSize = 1
+	t.Cleanup(func() { policyMembershipDeleteBatchSize = orig })
+
+	pol := newTestPolicy(t, ds, user1, "reset defer policy", "", nil)
+	hosts := newPolicyTestHosts(t, ds, 8, "reset-defer")
+	for _, h := range hosts {
+		_, err := ds.RecordPolicyQueryExecutions(ctx, h, map[uint]*bool{pol.ID: new(false)}, time.Now(), false, nil)
+		require.NoError(t, err)
+	}
+
+	// Block the wipe on the last host's row, as above.
+	barrier, err := ds.writer(ctx).Connx(ctx)
+	require.NoError(t, err)
+	defer barrier.Close() //nolint:errcheck // test cleanup
+	barrierTx, err := barrier.BeginTxx(ctx, nil)
+	require.NoError(t, err)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { _ = barrierTx.Rollback() }) }
+	t.Cleanup(release)
+	// Released on a timer, not after the assertion: a regression blocks the wipe here and
+	// waiting on it would cost a full innodb_lock_wait_timeout plus retries.
+	barrierTimer := time.AfterFunc(2*time.Second, release)
+	t.Cleanup(func() { barrierTimer.Stop() })
+	var locked int
+	require.NoError(t, barrierTx.GetContext(ctx, &locked,
+		`SELECT 1 FROM policy_membership WHERE policy_id = ? AND host_id = ? FOR UPDATE`,
+		pol.ID, hosts[len(hosts)-1].ID))
+
+	resetErr := make(chan error, 1)
+	go func() { resetErr <- ds.ResetPolicy(ctx, pol.ID) }()
+
+	// The flag must be committed and visible to another connection mid-wipe.
+	require.Eventually(t, func() bool {
+		var row struct {
+			Flag bool `db:"needs_full_membership_cleanup"`
+			Rows int  `db:"rows"`
+		}
+		if err := sqlx.GetContext(ctx, ds.writer(ctx), &row, `
+			SELECT p.needs_full_membership_cleanup,
+			       (SELECT COUNT(*) FROM policy_membership WHERE policy_id = p.id) AS `+"`rows`"+`
+			FROM policies p WHERE p.id = ?`, pol.ID); err != nil {
+			return false
+		}
+		return row.Flag && row.Rows > 0
+	}, 8*time.Second, 2*time.Millisecond,
+		"ResetPolicy did not commit before wiping membership")
+
+	release()
+	require.NoError(t, <-resetErr)
+
+	var count int
+	require.NoError(t, ds.writer(ctx).Get(&count, `SELECT COUNT(*) FROM policy_membership WHERE policy_id = ?`, pol.ID))
+	assert.Zero(t, count)
+	require.NoError(t, ds.writer(ctx).Get(&count, `SELECT COUNT(*) FROM policy_stats WHERE policy_id = ?`, pol.ID))
+	assert.Zero(t, count)
+	var flagVal int
+	require.NoError(t, ds.writer(ctx).Get(&flagVal,
+		`SELECT needs_full_membership_cleanup FROM policies WHERE id = ?`, pol.ID))
+	assert.Zero(t, flagVal)
+}
+
+// newPolicyTestHosts creates n linux hosts with unique identifiers derived from prefix.
+func newPolicyTestHosts(t *testing.T, ds *Datastore, n int, prefix string) []*fleet.Host {
+	t.Helper()
+	ctx := context.Background()
+	hosts := make([]*fleet.Host, n)
+	for i := range hosts {
+		id := fmt.Sprintf("%s-%d", prefix, i)
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			OsqueryHostID:   &id,
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         &id,
+			UUID:            id,
+			Hostname:        id,
+			Platform:        "linux",
+		})
+		require.NoError(t, err)
+		hosts[i] = h
+	}
+	return hosts
 }
 
 func testTeamPatchPolicy(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
Cherry-pick of #52188 into the 4.91.0 RC. Applied cleanly, no conflicts.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Automated tests and manual QA were completed on #52188. This branch carries the same commit unchanged.
