### PR TITLE
Fleet UI: Put unsupported-extension error reason in the toast raw-response panel

### DIFF
--- a/changes/50846-package-form-toast-shape.md
+++ b/changes/50846-package-form-toast-shape.md
@@ -1,0 +1,1 @@
+- Fixed the error toast shown when selecting a custom package with an unsupported extension so the friendly message stays on the main line and the extension reason appears in the expandable raw-response panel.

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -45,6 +45,15 @@ const selectFileOfSize = async (container: HTMLElement, size: number) => {
   await userEvent.upload(input, file);
 };
 
+const selectFileNamed = async (container: HTMLElement, name: string) => {
+  const file = new File(["installer"], name);
+  const input = container.querySelector("#upload-file") as HTMLInputElement;
+  // Bypass the input's `accept` attribute so we can exercise the client-side
+  // extension-guard path (`getDefaultInstallScript`/`Uninstall`) for files a
+  // drag-and-drop or a browser lenient with MIME sniffing would let through.
+  await userEvent.upload(input, file, { applyAccept: false });
+};
+
 const TARGET_BANNER_COPY = /If multiple packages of the same software target the same host, Fleet will install the one that was added first\./i;
 
 describe("PackageForm", () => {
@@ -150,6 +159,43 @@ describe("PackageForm", () => {
 
       expect(errorSpy).not.toHaveBeenCalled();
       expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+    });
+  });
+
+  describe("Unsupported file extension on add", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    // Regression: the raw Error was passed as the toast response, so the
+    // main line rendered "Error: unsupported file extension: dmg" and the
+    // expandable panel opened on `{}` (Error's own props are non-enumerable).
+    it("shows a friendly toast with the reason in the response payload when the install-script derivation throws", async () => {
+      const errorSpy = jest.spyOn(notify, "error");
+      const { container } = renderForm();
+
+      await selectFileNamed(container, "test.dmg");
+
+      expect(errorSpy).toHaveBeenCalledWith("Couldn't add.", {
+        response: {
+          data: { message: "unsupported file extension: dmg" },
+        },
+      });
+    });
+
+    // .zip passes the install switch (returns "") but trips the uninstall
+    // switch's default, so this covers the second catch block.
+    it("shows a friendly toast with the reason in the response payload when the uninstall-script derivation throws", async () => {
+      const errorSpy = jest.spyOn(notify, "error");
+      const { container } = renderForm();
+
+      await selectFileNamed(container, "test.zip");
+
+      expect(errorSpy).toHaveBeenCalledWith("Couldn't add.", {
+        response: {
+          data: { message: "unsupported file extension: zip" },
+        },
+      });
     });
   });
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -282,7 +282,13 @@ const PackageForm = ({
         try {
           newDefaultInstallScript = getDefaultInstallScript(file.name);
         } catch (e) {
-          notify.error(`${e}`, { response: e });
+          notify.error("Couldn't add software.", {
+            response: {
+              data: {
+                message: e instanceof Error ? e.message : String(e),
+              },
+            },
+          });
           return;
         }
 
@@ -290,7 +296,13 @@ const PackageForm = ({
         try {
           newDefaultUninstallScript = getDefaultUninstallScript(file.name);
         } catch (e) {
-          notify.error(`${e}`, { response: e });
+          notify.error("Couldn't add software.", {
+            response: {
+              data: {
+                message: e instanceof Error ? e.message : String(e),
+              },
+            },
+          });
           return;
         }
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -282,7 +282,7 @@ const PackageForm = ({
         try {
           newDefaultInstallScript = getDefaultInstallScript(file.name);
         } catch (e) {
-          notify.error("Couldn't add software.", {
+          notify.error(ADD_SOFTWARE_ERROR_PREFIX, {
             response: {
               data: {
                 message: e instanceof Error ? e.message : String(e),
@@ -296,7 +296,7 @@ const PackageForm = ({
         try {
           newDefaultUninstallScript = getDefaultUninstallScript(file.name);
         } catch (e) {
-          notify.error("Couldn't add software.", {
+          notify.error(ADD_SOFTWARE_ERROR_PREFIX, {
             response: {
               data: {
                 message: e instanceof Error ? e.message : String(e),


### PR DESCRIPTION
## Issue
Closes #50846

## Description
- Root cause: `PackageForm.onFileSelect` passed a client-side `Error` to `notify.error` as both the main message (`\`${e}\``) and the "raw response" payload (`{ response: e }`). `\`${new Error("...")}\`` prints `Error: <reason>`, so the main line carried the JS toString prefix; `JSON.stringify(errorObj)` returns `"{}"` because `Error`'s own properties are non-enumerable, so the panel opened on an empty object.
- Fixed the two catch blocks around `getDefaultInstallScript` / `getDefaultUninstallScript` (add flow only, `!isEditingSoftware`) to put a friendly one-line message on top and the extension reason inside the panel body, matching the shape `DeleteCategoryModal` and other software toasts use now that the JSON details panel exists.
- Companion to #51338, which hides the panel at the shared renderer when the payload serializes to nothing. This PR fixes the call sites so they use the correct shape in the first place instead of relying on the renderer to swallow the empty panel.

## Screenrecording
- Adding a `.gz` file (not `.tar.gz`) as a custom package: main line reads "Couldn't add software." and the expanded panel shows `{ "message": "unsupported file extension: gz" }`.

### Before

<img width="1035" height="573" alt="Screenshot 2026-08-31 at 1 31 59 PM" src="https://github.com/user-attachments/assets/62774472-1c62-43df-8b4e-97a3de9e42a2" />

### After

<img width="992" height="646" alt="Screenshot 2026-08-31 at 1 34 44 PM" src="https://github.com/user-attachments/assets/9307849c-dbfd-4bc3-a02c-29a81f1d37a2" />

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error notifications when default installation or uninstallation scripts cannot be generated.
  * Error messages are now displayed more clearly and consistently, including for unsupported package file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->