### PR TITLE
fix all go lints

### DIFF
--- a/cmd/android-amapi-mock/middleware.go
+++ b/cmd/android-amapi-mock/middleware.go
@@ -17,14 +17,14 @@ func simulateLatencyAndErrors(latencyMean time.Duration, errorRate float64, next
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Add random latency (50%-150% of mean)
 		if latencyMean > 0 {
-			jitter := time.Duration(float64(latencyMean) * (0.5 + rand.Float64())) // #nosec G404 -- load testing
+			jitter := time.Duration(float64(latencyMean) * (0.5 + rand.Float64())) //nolint:gosec // load testing
 			time.Sleep(jitter)
 		}
 
 		// Occasionally return errors
-		if errorRate > 0 && rand.Float64() < errorRate { // #nosec G404 -- load testing
+		if errorRate > 0 && rand.Float64() < errorRate { //nolint:gosec // load testing
 			w.Header().Set("Content-Type", "application/json")
-			if rand.Float64() < 0.5 { // #nosec G404 -- load testing
+			if rand.Float64() < 0.5 { //nolint:gosec // load testing
 				w.WriteHeader(http.StatusTooManyRequests)
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"error": map[string]any{

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -433,13 +433,14 @@ func TestHostVitalsLabelMembershipCronIDP(t *testing.T) {
 		Value: new("Engineering"),
 	})
 	require.NoError(t, err)
+	raw := json.RawMessage(criteria)
 
 	// Create a global and a team1-scoped IdP host vitals label.
 	globalLabel, err := ds.NewLabel(ctx, &fleet.Label{
 		Name:                "idp-cron-global",
 		LabelType:           fleet.LabelTypeRegular,
 		LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
-		HostVitalsCriteria:  new(json.RawMessage(criteria)),
+		HostVitalsCriteria:  &raw,
 	})
 	require.NoError(t, err)
 	team1Label, err := ds.NewLabel(ctx, &fleet.Label{
@@ -447,7 +448,7 @@ func TestHostVitalsLabelMembershipCronIDP(t *testing.T) {
 		TeamID:              &team1.ID,
 		LabelType:           fleet.LabelTypeRegular,
 		LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
-		HostVitalsCriteria:  new(json.RawMessage(criteria)),
+		HostVitalsCriteria:  &raw,
 	})
 	require.NoError(t, err)
 

--- a/ee/server/googleworkspace/google_workspace.go
+++ b/ee/server/googleworkspace/google_workspace.go
@@ -274,9 +274,9 @@ func rawJSON(v any) string {
 func mapUser(u *directory.User) *fleet.ScimUser {
 	active := !u.Suspended && !u.Archived
 	su := &fleet.ScimUser{
-		ExternalID: new(u.Id),
+		ExternalID: &u.Id,
 		UserName:   u.PrimaryEmail,
-		Active:     new(active),
+		Active:     &active,
 	}
 	if u.Name != nil {
 		if gn := strings.TrimSpace(u.Name.GivenName); gn != "" {

--- a/ee/server/service/request_certificate.go
+++ b/ee/server/service/request_certificate.go
@@ -144,7 +144,7 @@ func (svc *Service) RequestCertificate(ctx context.Context, p fleet.RequestCerti
 			svc.logger.ErrorContext(ctx, "Failed to convert PKCS7 envelope to PEM certificate", "ca_id", ca.ID, "err", err)
 			return nil, ctxerr.Wrap(ctx, err, "converting PKCS7 envelope to PEM certificate")
 		}
-		return new(pemCert), nil
+		return &pemCert, nil
 	}
 
 	// Wrap the certificate in a PEM block for easier consumption by the client. TODO: If we ever

--- a/orbit/pkg/table/ai_tools/internal/agents/agents_test.go
+++ b/orbit/pkg/table/ai_tools/internal/agents/agents_test.go
@@ -74,7 +74,7 @@ func writeExec(t *testing.T, path string) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- test fixture: simulates an executable agent binary
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture: simulates an executable agent binary
 		t.Fatal(err)
 	}
 }

--- a/orbit/pkg/table/ai_tools/internal/fsutil/fsutil_test.go
+++ b/orbit/pkg/table/ai_tools/internal/fsutil/fsutil_test.go
@@ -58,10 +58,10 @@ func TestStatPerms(t *testing.T) {
 	}
 
 	ww := filepath.Join(dir, "ww")
-	if err := os.WriteFile(ww, []byte("x"), 0o666); err != nil { // #nosec G306 -- test fixture: intentionally world-writable to exercise WorldWritable detection
+	if err := os.WriteFile(ww, []byte("x"), 0o666); err != nil { //nolint:gosec // test fixture: intentionally world-writable to exercise WorldWritable detection
 		t.Fatal(err)
 	}
-	if err := os.Chmod(ww, 0o666); err != nil { // #nosec G302 -- test fixture: intentionally world-writable to exercise WorldWritable detection
+	if err := os.Chmod(ww, 0o666); err != nil { //nolint:gosec // test fixture: intentionally world-writable to exercise WorldWritable detection
 		t.Fatal(err)
 	}
 	if p := Stat(ww); !p.WorldWritable {

--- a/orbit/pkg/table/ai_tools/internal/instructions/instructions_test.go
+++ b/orbit/pkg/table/ai_tools/internal/instructions/instructions_test.go
@@ -97,7 +97,7 @@ func TestWorldWritableFlag(t *testing.T) {
 	home := t.TempDir()
 	p := filepath.Join(home, "CLAUDE.md")
 	write(t, p, "rules", 0o666)
-	if err := os.Chmod(p, 0o666); err != nil { // #nosec G302 -- test fixture: intentionally world-writable to exercise world_writable detection
+	if err := os.Chmod(p, 0o666); err != nil { //nolint:gosec // test fixture: intentionally world-writable to exercise world_writable detection
 		t.Fatal(err)
 	}
 	for _, in := range Scan(homes.Home{Dir: home, Username: "t"}) {

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -597,11 +597,12 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 			CustomHostVitalID: &id,
 		})
 		require.NoError(t, err)
+		raw := json.RawMessage(criteria)
 		label, err := ds.NewLabel(ctx, &fleet.Label{
 			Name:                "chv-del-label",
 			LabelType:           fleet.LabelTypeRegular,
 			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
-			HostVitalsCriteria:  new(json.RawMessage(criteria)),
+			HostVitalsCriteria:  &raw,
 		})
 		require.NoError(t, err)
 

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -3265,6 +3265,7 @@ func testUpdateLabelMembershipByHostCriteriaIDP(t *testing.T, ds *Datastore) {
 		Value: new("Engineering"),
 	})
 	require.NoError(t, err)
+	raw := json.RawMessage(criteria)
 
 	newIDPLabel := func(name string, teamID *uint) *fleet.Label {
 		lbl, err := ds.NewLabel(ctx, &fleet.Label{
@@ -3272,7 +3273,7 @@ func testUpdateLabelMembershipByHostCriteriaIDP(t *testing.T, ds *Datastore) {
 			TeamID:              teamID,
 			LabelType:           fleet.LabelTypeRegular,
 			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
-			HostVitalsCriteria:  new(json.RawMessage(criteria)),
+			HostVitalsCriteria:  &raw,
 		})
 		require.NoError(t, err)
 		return lbl
@@ -3355,6 +3356,7 @@ func testUpdateLabelMembershipByHostCriteriaCustomHostVital(t *testing.T, ds *Da
 		CustomHostVitalID: &vitalA.ID,
 	})
 	require.NoError(t, err)
+	raw := json.RawMessage(criteria)
 
 	newCHVLabel := func(name string, teamID *uint) *fleet.Label {
 		lbl, err := ds.NewLabel(ctx, &fleet.Label{
@@ -3362,7 +3364,7 @@ func testUpdateLabelMembershipByHostCriteriaCustomHostVital(t *testing.T, ds *Da
 			TeamID:              teamID,
 			LabelType:           fleet.LabelTypeRegular,
 			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
-			HostVitalsCriteria:  new(json.RawMessage(criteria)),
+			HostVitalsCriteria:  &raw,
 		})
 		require.NoError(t, err)
 		return lbl

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -884,7 +884,6 @@ func testListAvailableAppsSharedName(t *testing.T, ds *Datastore) {
 }
 
 func testSoftwareTitleRenamingWindows(t *testing.T, ds *Datastore) {
-
 	ctx := context.Background()
 
 	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
@@ -937,7 +936,7 @@ func testSoftwareTitleRenamingWindows(t *testing.T, ds *Datastore) {
 		Version:              "1.0",
 		UserID:               user.ID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(maintained3.ID),
+		FleetMaintainedAppID: &maintained3.ID,
 	})
 	require.NoError(t, err)
 	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
@@ -951,7 +950,7 @@ func testSoftwareTitleRenamingWindows(t *testing.T, ds *Datastore) {
 		Version:              "1.0",
 		UserID:               user.ID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(maintained4.ID),
+		FleetMaintainedAppID: &maintained4.ID,
 	})
 	require.NoError(t, err)
 
@@ -1687,7 +1686,7 @@ func testGetWindowsFMAMatches(t *testing.T, ds *Datastore) {
 		BundleIdentifier:     "com.granola.app",
 		UserID:               user.ID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(darwinApp.ID),
+		FleetMaintainedAppID: &darwinApp.ID,
 	})
 	require.NoError(t, err)
 
@@ -1754,7 +1753,7 @@ func testWindowsFMANameOnIngest(t *testing.T, ds *Datastore) {
 		Version:              "7.373.2",
 		UserID:               user.ID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(maintained.ID),
+		FleetMaintainedAppID: &maintained.ID,
 	})
 	require.NoError(t, err)
 
@@ -2079,7 +2078,7 @@ func testWindowsFMAMultiTeamInstallersShareTitle(t *testing.T, ds *Datastore) {
 		Version:              "1.0.0",
 		UserID:               user.ID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(app.ID),
+		FleetMaintainedAppID: &app.ID,
 	})
 	require.NoError(t, err)
 	require.Equal(t, titleID, teamTitleID, "both teams' installers should share one title")
@@ -2530,7 +2529,7 @@ func addWindowsFMAWithInstaller(t *testing.T, ds *Datastore, userID uint, name, 
 		Version:              "1.0.0",
 		UserID:               userID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(app.ID),
+		FleetMaintainedAppID: &app.ID,
 	})
 	require.NoError(t, err)
 

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -2204,8 +2204,8 @@ func testUpdateStatusGuardsTerminalStates(t *testing.T, ds *Datastore) {
 			HostUUID:                        hostUUID,
 			Name:                            "sw-" + string(termStatus),
 			Status:                          termStatus,
-			SoftwareInstallerID:             new(installerID),
-			HostSoftwareInstallsExecutionID: new(execID),
+			SoftwareInstallerID:             &installerID,
+			HostSoftwareInstallsExecutionID: &execID,
 		}
 		insertRow(row)
 		updated, err := ds.MaybeUpdateSetupExperienceSoftwareInstallStatus(ctx, hostUUID, execID, fleet.SetupExperienceStatusFailure)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -5399,7 +5399,8 @@ func (a *hostSoftwareTitleAssembler) addRecord(
 	}
 
 	if icon, ok := a.iconsBySoftwareTitleID[softwareTitleRecord.ID]; ok {
-		softwareTitleRecord.IconUrl = new(icon.IconUrl())
+		iconURL := icon.IconUrl()
+		softwareTitleRecord.IconUrl = &iconURL
 	}
 
 	if displayName, ok := a.displayNames[softwareTitleRecord.ID]; ok {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -1946,7 +1946,7 @@ func testBatchSetSoftwareInstallersMultipleCustomPackages(t *testing.T, ds *Data
 	})
 	require.NoError(t, err)
 	fma := santa("santaFMA", "2026.8")
-	fma.FleetMaintainedAppID = new(maintainedApp.ID)
+	fma.FleetMaintainedAppID = &maintainedApp.ID
 	_, err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
 		santa("santaA", "2026.2"),
 		fma,
@@ -2645,7 +2645,7 @@ func testGetSoftwareInstallersPendingDeletion(t *testing.T, ds *Datastore) {
 			URL:                  "https://example.com/maintained1",
 			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
 			BundleIdentifier:     "fleet.maintained1",
-			FleetMaintainedAppID: new(maintainedApp.ID),
+			FleetMaintainedAppID: &maintainedApp.ID,
 		},
 	})
 	require.NoError(t, err)
@@ -5508,7 +5508,7 @@ func testInsertFleetMaintainedAppVersion(t *testing.T, ds *Datastore) {
 			LabelScope: fleet.LabelScopeIncludeAny,
 			ByName:     map[string]fleet.LabelIdent{lbl.Name: {LabelID: lbl.ID, LabelName: lbl.Name}},
 		},
-		FleetMaintainedAppID: new(maintainedApp.ID),
+		FleetMaintainedAppID: &maintainedApp.ID,
 	})
 	require.NoError(t, err)
 
@@ -5833,7 +5833,7 @@ func testGetSoftwareInstallerMetadataByStorageID(t *testing.T, ds *Datastore) {
 		PackageIDs: []string{"PROD-CODE"}, UpgradeCode: "UP-CODE",
 		InstallerFile: newFile("v1"), StorageID: "hash-meta-1", Filename: "foo.msi", Extension: "msi",
 		Version: "1.0", UserID: user.ID, TeamID: &team.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(maintainedApp.ID),
+		FleetMaintainedAppID: &maintainedApp.ID,
 	})
 	require.NoError(t, err)
 
@@ -7173,7 +7173,7 @@ func testSoftwareTitlePins(t *testing.T, ds *Datastore) {
 		Version:              "1.0",
 		UserID:               user.ID,
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 	})
 	require.NoError(t, err)
 
@@ -7234,7 +7234,7 @@ func testSetFleetMaintainedAppActiveInstallerPin(t *testing.T, ds *Datastore) {
 		Title: "testpkg", Source: "apps", Platform: "darwin",
 		InstallScript: "echo install", UninstallScript: "echo uninstall",
 		InstallerFile: tfr, StorageID: "storageid1", Filename: "test.pkg", Version: "1.0",
-		UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{}, FleetMaintainedAppID: new(fma.ID),
+		UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{}, FleetMaintainedAppID: &fma.ID,
 		PatchQuery: v1Query,
 	})
 	require.NoError(t, err)
@@ -7483,7 +7483,7 @@ func testGetSoftwareInstallDetailsPatchWhenClosed(t *testing.T, ds *Datastore) {
 			TeamID:               &team.ID,
 			UserID:               user.ID,
 			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-			FleetMaintainedAppID: new(app.ID),
+			FleetMaintainedAppID: &app.ID,
 		})
 		require.NoError(t, err)
 		return installerID, titleID
@@ -7567,7 +7567,7 @@ func testSoftwareInstallerAppOpenQueryRoundTrip(t *testing.T, ds *Datastore) {
 			Platform:             "darwin",
 			UserID:               user.ID,
 			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-			FleetMaintainedAppID: new(app.ID),
+			FleetMaintainedAppID: &app.ID,
 			AppOpenQuery:         appOpenQuery,
 		})
 		require.NoError(t, err)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -12612,6 +12612,7 @@ func TestMatchWindowsFMATitle(t *testing.T) {
 		})
 	}
 }
+
 func testHostSWPaginationWithMultipleFMAVersions(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
@@ -12773,7 +12774,7 @@ func testListHostSoftwareFMAReplacedInstallerOutOfScope(t *testing.T, ds *Datast
 		InstallScript:        "exit 0",
 		InstallerFile:        tfr,
 		StorageID:            "storage_v1",
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 		Filename:             "spotify.pkg",
 		Title:                "Spotify",
 		Version:              "1.0",
@@ -12913,7 +12914,7 @@ func testListHostSoftwareFMAReplacedInstallerInScopeShowsActiveMetadata(t *testi
 		InstallScript:        "exit 0",
 		InstallerFile:        tfr,
 		StorageID:            "old_storage",
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 		Filename:             "fma.pkg",
 		Title:                "FMA App",
 		Version:              "1.0",
@@ -13010,7 +13011,7 @@ func testInstalledInstallersSqlPicksActiveInstaller(t *testing.T, ds *Datastore)
 		InstallScript:        "exit 0",
 		InstallerFile:        tfr,
 		StorageID:            "iisql_storage_v1",
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 		Filename:             "iisql.pkg",
 		Title:                "IISql App",
 		Version:              "1.0",
@@ -13099,7 +13100,7 @@ func testListHostSoftwareUninstallFMAReplacedRespectsActiveInstaller(t *testing.
 		UninstallScript:      "exit 0",
 		InstallerFile:        tfr,
 		StorageID:            "uninst_v1",
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 		Filename:             "fma_uninst.pkg",
 		Title:                "FMA Uninst App",
 		Version:              "1.0",
@@ -13217,7 +13218,7 @@ func testListHostSoftwareStmtAvailableSkipsInactiveInstaller(t *testing.T, ds *D
 		InstallScript:        "exit 0",
 		InstallerFile:        tfr,
 		StorageID:            "stmtavail_v1",
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 		Filename:             "stmtavail.pkg",
 		Title:                "StmtAvail App",
 		Version:              "1.0",

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -3166,7 +3166,7 @@ func testGetFleetMaintainedVersionsOrder(t *testing.T, ds *Datastore) {
 				Version:              c.published[0],
 				UserID:               user.ID,
 				ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-				FleetMaintainedAppID: new(app.ID),
+				FleetMaintainedAppID: &app.ID,
 			})
 			require.NoError(t, err)
 
@@ -3213,7 +3213,7 @@ func testMarkFleetMaintainedAppVersionCurrent(t *testing.T, ds *Datastore) {
 		Title: "Marked", Source: "apps", Platform: "darwin",
 		InstallScript: "echo install", UninstallScript: "echo uninstall",
 		InstallerFile: tfr, StorageID: "marked-storage-1", Filename: "marked-1.pkg", Version: "1.0",
-		UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{}, FleetMaintainedAppID: new(app.ID),
+		UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{}, FleetMaintainedAppID: &app.ID,
 	})
 	require.NoError(t, err)
 	newerID, err := ds.InsertFleetMaintainedAppVersion(ctx, olderID, &fleet.UploadSoftwareInstallerPayload{

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -1483,7 +1483,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateAuthorizationForTeamUse
 		var createTeamResp teamResponse
 		s.DoJSON("POST", "/api/latest/fleet/teams", createTeamRequest{
 			TeamPayload: fleet.TeamPayload{
-				Name: new(deleteOtherTeamName),
+				Name: &deleteOtherTeamName,
 			},
 		}, http.StatusOK, &createTeamResp)
 		otherTeamID := createTeamResp.Team.ID

--- a/server/service/integration_core_misc_test.go
+++ b/server/service/integration_core_misc_test.go
@@ -578,7 +578,7 @@ func (s *integrationTestSuite) TestAPIVersion_v1_2022_04() {
 
 	// try to schedule that query on the endpoint that is deprecated
 	// in that version
-	gsParams := fleet.ScheduledQueryPayload{QueryID: new(qr.ID), Interval: new(uint(42))}
+	gsParams := fleet.ScheduledQueryPayload{QueryID: &qr.ID, Interval: new(uint(42))}
 	res := s.DoRaw("POST", "/api/2022-04/fleet/global/schedule", jsonMustMarshal(t, gsParams), http.StatusNotFound)
 	res.Body.Close()
 	// use the correct version for that deprecated API

--- a/server/service/integration_core_queries_test.go
+++ b/server/service/integration_core_queries_test.go
@@ -116,7 +116,7 @@ func (s *integrationTestSuite) TestGlobalSchedule() {
 	require.NoError(t, err)
 
 	// schedule that query
-	gsParams := fleet.ScheduledQueryPayload{QueryID: new(qr.ID), Interval: new(uint(42))}
+	gsParams := fleet.ScheduledQueryPayload{QueryID: &qr.ID, Interval: new(uint(42))}
 	r := globalScheduleQueryResponse{}
 	s.DoJSON("POST", "/api/latest/fleet/schedule", gsParams, http.StatusOK, &r)
 
@@ -517,9 +517,10 @@ func (s *integrationTestSuite) TestScheduledQueriesInPackInvalidOrderKey() {
 
 	// create a pack so the endpoint has a real id to operate on
 	var createPackResp createPackResponse
+	name := strings.ReplaceAll(t.Name(), "/", "_")
 	s.DoJSON("POST", "/api/latest/fleet/packs", &createPackRequest{
 		PackPayload: fleet.PackPayload{
-			Name: new(strings.ReplaceAll(t.Name(), "/", "_")),
+			Name: &name,
 		},
 	}, http.StatusOK, &createPackResp)
 	pack := createPackResp.Pack.Pack

--- a/server/service/integration_core_software_test.go
+++ b/server/service/integration_core_software_test.go
@@ -827,7 +827,7 @@ func (s *integrationTestSuite) TestListVulnerabilities() {
 			CVSSScore:        new(7.5),
 			EPSSProbability:  new(0.5),
 			CISAKnownExploit: new(true),
-			Published:        new(mockTime),
+			Published:        &mockTime,
 			Description:      "Test CVE 2021-12345",
 		},
 		{

--- a/server/service/integration_core_users_test.go
+++ b/server/service/integration_core_users_test.go
@@ -387,7 +387,7 @@ func (s *integrationTestSuite) TestActivityUserEmailPersistsAfterDeletion() {
 	params := fleet.UserPayload{
 		Name:       new("Gonna B Deleted"),
 		Email:      new("goingto@delete.com"),
-		Password:   new(userRawPwd),
+		Password:   &userRawPwd,
 		GlobalRole: new(fleet.RoleObserver),
 	}
 	s.DoJSON("POST", "/api/latest/fleet/users/admin", params, http.StatusOK, &createResp)
@@ -734,7 +734,7 @@ func (s *integrationTestSuite) TestInvites() {
 		Name:        new("Full Name"),
 		Password:    new(test.GoodPassword),
 		Email:       new(inv.Email),
-		InviteToken: new(deletedInviteToken),
+		InviteToken: &deletedInviteToken,
 	}, http.StatusNotFound, &createFromInviteResp)
 }
 
@@ -771,7 +771,7 @@ func (s *integrationTestSuite) TestCreateUserFromInviteErrors() {
 				Name:        new(""),
 				Password:    &test.GoodPassword,
 				Email:       new("a@b.c"),
-				InviteToken: new(invite.Token),
+				InviteToken: &invite.Token,
 			},
 			http.StatusUnprocessableEntity,
 		},
@@ -781,7 +781,7 @@ func (s *integrationTestSuite) TestCreateUserFromInviteErrors() {
 				Name:        new("Name"),
 				Password:    &test.GoodPassword,
 				Email:       new(""),
-				InviteToken: new(invite.Token),
+				InviteToken: &invite.Token,
 			},
 			http.StatusUnprocessableEntity,
 		},
@@ -791,7 +791,7 @@ func (s *integrationTestSuite) TestCreateUserFromInviteErrors() {
 				Name:        new("Name"),
 				Password:    new(""),
 				Email:       new("a@b.c"),
-				InviteToken: new(invite.Token),
+				InviteToken: &invite.Token,
 			},
 			http.StatusUnprocessableEntity,
 		},
@@ -821,7 +821,7 @@ func (s *integrationTestSuite) TestCreateUserFromInviteErrors() {
 				Name:        new("Name"),
 				Password:    new("password"), // no number or symbol
 				Email:       new("a@b.c"),
-				InviteToken: new(invite.Token),
+				InviteToken: &invite.Token,
 			},
 			http.StatusUnprocessableEntity,
 		},
@@ -831,7 +831,7 @@ func (s *integrationTestSuite) TestCreateUserFromInviteErrors() {
 				Name:         new("Name"),
 				Password:     &test.GoodPassword,
 				Email:        new("a@b.c"),
-				InviteToken:  new(invite.Token),
+				InviteToken:  &invite.Token,
 				APIEndpoints: &[]fleet.APIEndpointRef{{Method: "GET", Path: "/api/v1/fleet/config"}},
 			},
 			http.StatusUnprocessableEntity,
@@ -880,7 +880,7 @@ func (s *integrationTestSuite) TestCreateUserFromSSOInvite() {
 			Name:        new("Attacker"),
 			Email:       new(email),
 			Password:    &test.GoodPassword,
-			InviteToken: new(invite.Token),
+			InviteToken: &invite.Token,
 		}, http.StatusUnprocessableEntity, &resp)
 
 		// no user should have been created
@@ -900,7 +900,7 @@ func (s *integrationTestSuite) TestCreateUserFromSSOInvite() {
 			Email:       new(email),
 			Password:    new(""),
 			SSOInvite:   new(true),
-			InviteToken: new(invite.Token),
+			InviteToken: &invite.Token,
 		}, http.StatusUnprocessableEntity, &resp)
 
 		_, err := s.ds.UserByEmail(ctx, email)
@@ -917,7 +917,7 @@ func (s *integrationTestSuite) TestCreateUserFromSSOInvite() {
 			Name:        new("SSO User"),
 			Email:       new(email),
 			SSOInvite:   new(true),
-			InviteToken: new(invite.Token),
+			InviteToken: &invite.Token,
 		}, http.StatusOK, &resp)
 		require.NotNil(t, resp.User)
 		require.True(t, resp.User.SSOEnabled)
@@ -935,7 +935,7 @@ func (s *integrationTestSuite) TestCreateUserFromSSOInvite() {
 			Name:        new("No Password"),
 			Email:       new(email),
 			SSOInvite:   new(true),
-			InviteToken: new(invite.Token),
+			InviteToken: &invite.Token,
 		}, http.StatusUnprocessableEntity, &resp)
 
 		_, err := s.ds.UserByEmail(ctx, email)
@@ -955,7 +955,7 @@ func (s *integrationTestSuite) TestCreateUserFromSSOInvite() {
 			Email:       new(email),
 			Password:    new("weak"), // too short, no number or symbol
 			SSOInvite:   new(true),
-			InviteToken: new(invite.Token),
+			InviteToken: &invite.Token,
 		}, http.StatusUnprocessableEntity, &resp)
 
 		_, err := s.ds.UserByEmail(ctx, email)
@@ -1415,12 +1415,12 @@ func (s *integrationTestSuite) TestModifyUser() {
 	// as the user: set new password without providing current one
 	newRawPwd := test.GoodPassword2
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", u.ID), fleet.UserPayload{
-		NewPassword: new(newRawPwd),
+		NewPassword: &newRawPwd,
 	}, http.StatusUnprocessableEntity, &modResp)
 
 	// as the user: set new password with an invalid current password
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", u.ID), fleet.UserPayload{
-		NewPassword: new(newRawPwd),
+		NewPassword: &newRawPwd,
 		Password:    new("nosuchpwd"),
 	}, http.StatusForbidden, &modResp)
 
@@ -1440,7 +1440,7 @@ func (s *integrationTestSuite) TestModifyUser() {
 	// any other user that is not admin cannot change another user's password)
 	newRawPwd = userRawPwd + "3"
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", u.ID), fleet.UserPayload{
-		NewPassword: new(newRawPwd),
+		NewPassword: &newRawPwd,
 		Password:    new(testUsers["user2"].PlaintextPassword),
 	}, http.StatusForbidden, &modResp)
 
@@ -1451,7 +1451,7 @@ func (s *integrationTestSuite) TestModifyUser() {
 	modResp = modifyUserResponse{}
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/users/%d", u.ID), fleet.UserPayload{
 		SSOEnabled:  new(false),
-		NewPassword: new(newRawPwd),
+		NewPassword: &newRawPwd,
 		Email:       new("moduser3@example.com"),
 		Name:        new("moduser3"),
 	}, http.StatusOK, &modResp)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -4685,7 +4685,7 @@ func (s *integrationEnterpriseTestSuite) TestLinuxDiskEncryption() {
 
 	team, err := s.ds.NewTeam(context.Background(), &fleet.Team{Name: "A team"})
 	require.NoError(t, err)
-	teamID := new(team.ID)
+	teamID := &team.ID
 	teamHost, err := s.ds.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),
@@ -6827,7 +6827,7 @@ func (s *integrationEnterpriseTestSuite) TestListVulnerabilities() {
 			CVSSScore:        new(float64(7.5)),
 			EPSSProbability:  new(float64(0.5)),
 			CISAKnownExploit: new(true),
-			Published:        new(mockTime),
+			Published:        &mockTime,
 			Description:      "Test CVE 2021-1234",
 		},
 		{
@@ -35322,7 +35322,7 @@ func (s *integrationEnterpriseTestSuite) TestFMAReplacedInstallerLabelScopeListA
 		InstallScript:        "exit 0",
 		InstallerFile:        tfr,
 		StorageID:            "fma_scope_v1",
-		FleetMaintainedAppID: new(fma.ID),
+		FleetMaintainedAppID: &fma.ID,
 		Filename:             "fma_scope.pkg",
 		Title:                t.Name() + " App",
 		Version:              "1.0",

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -590,13 +590,14 @@ func TestApplyLabelSpecsCustomHostVitalCriteria(t *testing.T) {
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}})
 
 	specWithCriteria := func(criteria fleet.HostVitalCriteria) *fleet.LabelSpec {
-		raw, err := json.Marshal(&criteria)
+		marshalled, err := json.Marshal(&criteria)
 		require.NoError(t, err)
+		raw := json.RawMessage(marshalled)
 		return &fleet.LabelSpec{
 			Name:                "custom-vital-spec",
 			LabelType:           fleet.LabelTypeRegular,
 			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
-			HostVitalsCriteria:  new(json.RawMessage(raw)),
+			HostVitalsCriteria:  &raw,
 		}
 	}
 

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -864,10 +864,10 @@ func TestGetOrbitConfigScriptTimeoutFallback(t *testing.T) {
 		}
 
 		ctx = test.HostContext(ctx, &fleet.Host{
-			OsqueryHostID: ptr.String("test"),
+			OsqueryHostID: new("test"),
 			ID:            1,
 			Platform:      "ubuntu",
-			TeamID:        new(team.ID),
+			TeamID:        &team.ID,
 		})
 		return svc, ctx, ds
 	}

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -130,11 +130,12 @@ func (updateSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 	}
 
 	if idVal, ok := r.MultipartForm.Value["installer_id"]; ok && len(idVal) > 0 && idVal[0] != "" {
-		installerID, err := strconv.ParseUint(idVal[0], 10, 32)
+		parsedInstallerID, err := strconv.ParseUint(idVal[0], 10, 32)
 		if err != nil {
 			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("Invalid installer_id: %s", idVal[0])}
 		}
-		decoded.InstallerID = new(uint(installerID))
+		installerID := uint(parsedInstallerID)
+		decoded.InstallerID = &installerID
 	}
 
 	installScriptMultipart, ok := r.MultipartForm.Value["install_script"]
@@ -390,11 +391,12 @@ func (uploadSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 	}
 
 	if v, ok := r.MultipartForm.Value["software_title_id"]; ok && len(v) > 0 && v[0] != "" {
-		id, err := strconv.ParseUint(v[0], 10, 32)
+		parsedTitleID, err := strconv.ParseUint(v[0], 10, 32)
 		if err != nil {
 			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("Invalid software_title_id: %s", v[0])}
 		}
-		decoded.TitleID = new(uint(id))
+		titleID := uint(parsedTitleID)
+		decoded.TitleID = &titleID
 	}
 
 	val, ok = r.MultipartForm.Value["install_script"]

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -2072,7 +2072,7 @@ func TestListUsersComputesStatus(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
 
-	now := time.Now()
+	now := time.Now() //nolint:staticcheck // it is referenced.
 	ds.ListUsersFunc = func(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
 		return []*fleet.User{
 			{

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -631,13 +631,13 @@ func checkCVEs(
 								sink.addSoftware(ctx, fleet.SoftwareVulnerability{
 									SoftwareID:        CPEItem.GetID(),
 									CVE:               matches.CVE.ID(),
-									ResolvedInVersion: new(resolvedVersion),
+									ResolvedInVersion: &resolvedVersion,
 								})
 							} else if _, ok := CPEItem.(osCPEWithNVDMeta); ok {
 								sink.addOS(ctx, fleet.OSVulnerability{
 									OSID:              CPEItem.GetID(),
 									CVE:               matches.CVE.ID(),
-									ResolvedInVersion: new(resolvedVersion),
+									ResolvedInVersion: &resolvedVersion,
 								})
 							}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing.

Fixes all issues in `make lint-go` that has been there for some time and was **annoying**

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Not user facing.


## Testing

- [ ] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed certificate requests configured to return PEM data so they now provide the generated certificate content correctly.

- **Maintenance**
  - Improved code quality and static-analysis compatibility across certificate, software, vulnerability, and configuration workflows.
  - Updated test fixtures and linting guidance without changing expected application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->