### PR TITLE
Fleet UI: Wire raw-response panel on two more error toasts

### DIFF
--- a/changes/notify-error-response-parity.md
+++ b/changes/notify-error-response-parity.md
@@ -1,0 +1,1 @@
+- Populated the expandable raw-response panel on the error toasts shown when saving a Microsoft Graph credential fails and when unenrolling MDM returns "already off," so users can see the full backend response instead of just the parsed reason.

--- a/changes/notify-error-response-parity.md
+++ b/changes/notify-error-response-parity.md
@@ -1,1 +1,1 @@
-- Populated the expandable raw-response panel on the error toasts shown when saving a Microsoft Graph credential fails and when unenrolling MDM returns "already off," so users can see the full backend response instead of just the parsed reason.
+- Cleaned up the error toasts shown when a Microsoft Graph credential save fails and when an MDM unenroll returns "already off": the main line is a short, static message and the full backend response is available in the expandable raw-response panel, so the same long reason no longer appears twice in the same toast.

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tests.tsx
@@ -293,6 +293,41 @@ describe("MicrosoftGraphPage", () => {
     ]);
   });
 
+  // A whole-credential failure (verification, licensing, missing private key) is reported without a per-field `name`, so
+  // it can't attach to a field. The toast then shows a static main line and puts the full server response in the
+  // expandable panel, so a long reason (e.g. AADSTS) doesn't render on both lines.
+  it("toasts the whole-credential failure with a static main line and the full response in the panel", async () => {
+    const rejection = {
+      data: {
+        errors: [
+          {
+            name: "microsoft_graph_credentials",
+            reason:
+              "Microsoft Graph returned an error (400): AADSTS90002: Tenant not found.",
+          },
+        ],
+      },
+    };
+    mockedAPI.applyCredentials.mockRejectedValue(rejection);
+    const { user } = renderPage([createMockCredential()]);
+
+    const secretField = await screen.findByLabelText("Client secret");
+    await user.clear(secretField);
+    await user.type(secretField, "some-secret");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(notify.error).toHaveBeenCalledWith(
+        "Couldn't save Microsoft Graph credential.",
+        {
+          response: rejection,
+        }
+      );
+    });
+    // A whole-credential failure has no field, so the per-field batch toast path stays quiet.
+    expect(notify.batch).not.toHaveBeenCalled();
+  });
+
   it("clears the secret error when the identity change that required it is reverted", async () => {
     const { user } = renderPage([createMockCredential()]);
 

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
@@ -285,7 +285,8 @@ const MicrosoftGraphPage = () => {
         );
       } else {
         notify.error(
-          getErrorReason(e) || "Couldn't save Microsoft Graph credential."
+          getErrorReason(e) || "Couldn't save Microsoft Graph credential.",
+          { response: e }
         );
       }
     } finally {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
@@ -284,10 +284,9 @@ const MicrosoftGraphPage = () => {
           messages.map((message) => ({ variant: "error" as const, message }))
         );
       } else {
-        notify.error(
-          getErrorReason(e) || "Couldn't save Microsoft Graph credential.",
-          { response: e }
-        );
+        notify.error("Couldn't save Microsoft Graph credential.", {
+          response: e,
+        });
       }
     } finally {
       setIsSaving(false);

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -61,7 +61,9 @@ const UnenrollMdmModal = ({
       // would send the user in a loop. It also means this page was working from
       // stale data, so refresh it to drop the action.
       if (hasStatusKey(unenrollMdmError) && unenrollMdmError.status === 409) {
-        notify.error(getErrorReason(unenrollMdmError));
+        notify.error(getErrorReason(unenrollMdmError), {
+          response: unenrollMdmError,
+        });
         onSuccess();
         onClose();
       } else {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -6,7 +6,7 @@ import Modal from "components/Modal";
 import { notify } from "components/ToastNotification";
 
 import mdmAPI from "services/entities/mdm";
-import { getErrorReason, hasStatusKey } from "interfaces/errors";
+import { hasStatusKey } from "interfaces/errors";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 import {
   isAutomaticDeviceEnrollment,
@@ -61,9 +61,10 @@ const UnenrollMdmModal = ({
       // would send the user in a loop. It also means this page was working from
       // stale data, so refresh it to drop the action.
       if (hasStatusKey(unenrollMdmError) && unenrollMdmError.status === 409) {
-        notify.error(getErrorReason(unenrollMdmError), {
-          response: unenrollMdmError,
-        });
+        notify.error(
+          "Couldn't turn off MDM. MDM is already off for this host.",
+          { response: unenrollMdmError }
+        );
         onSuccess();
         onClose();
       } else {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -62,7 +62,7 @@ const UnenrollMdmModal = ({
       // stale data, so refresh it to drop the action.
       if (hasStatusKey(unenrollMdmError) && unenrollMdmError.status === 409) {
         notify.error(
-          "Couldn't turn off MDM. MDM is already off for this host.",
+          "Couldn't turn off MDM. This host already has MDM turned off.",
           { response: unenrollMdmError }
         );
         onSuccess();


### PR DESCRIPTION
## Issue
Closes #50846 
Follow-up to #52197 audit — no separate issue.

## Description
- Both call sites already show a parsed backend reason on the toast's main line, but neither passes `{ response: e }`, so the expandable "Raw response" panel is missing entirely. Add the response so the full backend body is disclosable, matching the pattern used elsewhere (e.g. `DeleteCategoryModal`).
- `MicrosoftGraphPage.tsx:287-289` — whole-credential save failure. Adds `{ response: e }` so a failed save's server body is available under the chevron. Also drops `getErrorReason(e)` from the main line: the parsed reason (an AADSTS wall for a bad tenant/client ID) was rendering identically on the main line and inside the JSON panel, which read as duplication. Main line is now the static `Couldn't save Microsoft Graph credential.`; the full server body still lands in the panel.
- `UnenrollMdmModal.tsx:64-67` — 409 "MDM already off" branch. Adds `{ response: unenrollMdmError }` so the specific server response for the conflict is available under the chevron. Main line switches from `getErrorReason(unenrollMdmError)` to the verbatim `CantTurnOffMDMAlreadyTurnedOffMessage` from `server/fleet/errors.go:32`, so the frontend and backend can't drift on the sentence users see for the 409.
- Tests: added a whole-credential failure case to `MicrosoftGraphPage.tests.tsx` covering the else branch (mock rejection whose error `name` doesn't match a per-field name → `getServerFieldErrors` returns empty → `notify.error` called with static main + `{ response }`).

## Screenrecording
- Save an invalid Microsoft Graph credential, then unenroll a host whose MDM is already off; expand the raw-response panel in each toast to show the JSON body appears.

## After
<img width="1000" height="558" alt="Screenshot 2026-08-31 at 3 16 58 PM" src="https://github.com/user-attachments/assets/5b60c82b-6e27-4105-9e5a-7ec39ec7fc51" />

## After

https://github.com/user-attachments/assets/9fb3b114-dc03-4552-8041-1fa45de2ff95

How to repro:
  1. Frontend rebuilt on this branch (or webpack watch picks it up).
  2. Host 1 detail page > Turn off MDM > modal opens.
  3. Keep modal open. In another terminal:
  docker exec fleet-mysql-1 mysql -u root -ptoor -D fleet -e "UPDATE host_mdm SET enrolled = 0 WHERE host_id = 1;"
  4. Click confirm in the modal. Server returns 409, toast fires.
  5. Screenshot with panel expanded.
  6. Reset:
  docker exec fleet-mysql-1 mysql -u root -ptoor -D fleet -e "UPDATE host_mdm SET enrolled = 1 WHERE host_id = 1;"


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Microsoft Graph credential save failures now display a consistent error message, with technical response details available in the expandable alert.
  - MDM unenrollment conflicts now clearly indicate when MDM is already turned off, while retaining the underlying response details for troubleshooting.
  - Error notifications provide clearer, more consistent messaging across these MDM workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->