### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/airtame/darwin.json
+++ b/ee/maintained-apps/outputs/airtame/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.15.0",
+      "version": "4.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application' AND version_compare(bundle_short_version, '4.15.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.airtame.airtame-application' AND version_compare(bundle_short_version, '4.16.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.airtame.airtame-application' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-4.15.0.dmg",
+      "installer_url": "https://downloads-cdn.airtame.com/app/latest/mac/Airtame-4.16.0.dmg",
       "install_script_ref": "4e4b470a",
       "uninstall_script_ref": "7c597d39",
-      "sha256": "73b70be70c598354d5d4cbec5e2ad69e8d64131cc0ff1c20de9e8eeffbcc392d",
+      "sha256": "90b41d06290be8d80903f7be7d571a9eda2cf9325db4539c486632f784585236",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/windows.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.290.1948",
+      "version": "1.2.291.1949",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Grammarly for Windows' AND publisher = 'Grammarly Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Grammarly for Windows' AND publisher = 'Grammarly Inc.' AND version_compare(version, '1.2.290.1948') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Grammarly for Windows' AND publisher = 'Grammarly Inc.' AND version_compare(version, '1.2.291.1949') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'grammarly desktop.exe');"
       },
-      "installer_url": "https://download-windows.grammarly.com/versions/1.2.290.1948/GrammarlyInstaller.exe",
+      "installer_url": "https://download-windows.grammarly.com/versions/1.2.291.1949/GrammarlyInstaller.exe",
       "install_script_ref": "d8c4db10",
       "uninstall_script_ref": "4314e220",
-      "sha256": "34143a1e7af8f49a5e1e2e525413cf184e172551cf1e2ae3849d66f206f3f3f9",
+      "sha256": "b2dc32aceefb8bf3f78f0b586021c2f0615db0466d648ee0fbd46d0702d1bc80",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.40",
+      "version": "1.2.41",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.40') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.41') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.hive.app' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.40/Hive-1.2.40-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.41/Hive-1.2.41-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "4f9ae976d1d9c9b77da6e769d10386b6427b020870c789cca7fc1f07d16f4f84",
+      "sha256": "ed16f28f7d5110447749f9ca1c0a9d4b76de4b10e057bb180c1392da8136e736",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postgresql-16/windows.json
+++ b/ee/maintained-apps/outputs/postgresql-16/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "16.15-1",
+      "version": "16.15-2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'PostgreSQL 16' AND publisher = 'PostgreSQL Global Development Group';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PostgreSQL 16' AND publisher = 'PostgreSQL Global Development Group' AND version_compare(version, '16.15-1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PostgreSQL 16' AND publisher = 'PostgreSQL Global Development Group' AND version_compare(version, '16.15-2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'postgresql 16.exe');"
       },
-      "installer_url": "https://get.enterprisedb.com/postgresql/postgresql-16.15-1-windows-x64.exe",
+      "installer_url": "https://get.enterprisedb.com/postgresql/postgresql-16.15-2-windows-x64.exe",
       "install_script_ref": "df91c112",
       "uninstall_script_ref": "4f8b3295",
-      "sha256": "de926fefad00e313e212cd438c0f04bf033e200099ad56c012724efcebed79f2",
+      "sha256": "378b35a317ae6c96aaf37af2f81652ccc15dd6fdae31e17ef5ef20b6adf442d8",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/pritunl/darwin.json
+++ b/ee/maintained-apps/outputs/pritunl/darwin.json
@@ -4,7 +4,7 @@
       "version": "1.3.4729.52",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4686.95') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4729.52') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.electron.pritunl' AND a.bundle_executable != '');"
       },
       "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4729.52/Pritunl.pkg.zip",

--- a/ee/maintained-apps/outputs/retcon/darwin.json
+++ b/ee/maintained-apps/outputs/retcon/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'garden.lemon.Retcon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'garden.lemon.Retcon' AND version_compare(bundle_short_version, '1.6.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'garden.lemon.Retcon' AND version_compare(bundle_short_version, '1.6.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'garden.lemon.Retcon' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.lemon.garden/retcon/retcon-1.6.2.dmg",
+      "installer_url": "https://downloads.lemon.garden/retcon/retcon-1.6.3.dmg",
       "install_script_ref": "a7fff0b3",
       "uninstall_script_ref": "2a7db7ed",
-      "sha256": "bc662d787bbe1101428fcf4241a82c20579ef7ed778f24480609090e89842050",
+      "sha256": "09d1f705f03622013562196c4972e44635e70dce324c6aa2d782c1265e1337bd",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/sync/darwin.json
+++ b/ee/maintained-apps/outputs/sync/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.2.61",
+      "version": "2.2.62",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sync.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sync.desktop' AND version_compare(bundle_short_version, '2.2.61') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sync.desktop' AND version_compare(bundle_short_version, '2.2.62') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.sync.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://www10.sync.com/download/apple/Sync-2.2.61.dmg",
+      "installer_url": "https://www10.sync.com/download/apple/Sync-2.2.62.dmg",
       "install_script_ref": "6caa9cd1",
       "uninstall_script_ref": "0beaaab1",
-      "sha256": "8e1d757e4878e8b5df15e80009e82c687c0a0b270f8f3e698a3659d2e9bb7f02",
+      "sha256": "458960bfed82fe409aae2727b4e122caa92388745c9deb74266066f25408a3cd",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "78.0.0",
+      "version": "78.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '78.0.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '78.1.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.webcatalog.jordan' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-78.0.0-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-78.1.0-universal.dmg",
       "install_script_ref": "23e707d7",
       "uninstall_script_ref": "6ca374e8",
-      "sha256": "823a0546ff697df59056ff4cd2be5a209b5e0de8407d318798e35b58567f59ac",
+      "sha256": "f383332084d8f50c33ae147c43a04d8b467d8b47c856c44f6657ecc6085eab1b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/yaak/windows.json
+++ b/ee/maintained-apps/outputs/yaak/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.6.0",
+      "version": "2026.7.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Yaak' AND publisher = 'Yaak';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Yaak' AND publisher = 'Yaak' AND version_compare(version, '2026.6.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Yaak' AND publisher = 'Yaak' AND version_compare(version, '2026.7.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'yaak.exe');"
       },
-      "installer_url": "https://github.com/mountain-loop/yaak/releases/download/v2026.6.0/Yaak_2026.6.0_x64-setup.exe",
+      "installer_url": "https://github.com/mountain-loop/yaak/releases/download/v2026.7.0/Yaak_2026.7.0_x64-setup.exe",
       "install_script_ref": "64dd4e97",
       "uninstall_script_ref": "41feb8b6",
-      "sha256": "8ae03db3915f8da8b1030812f4d2b5233b0b4deb3c28482dcd7a8fe73a3b0bd7",
+      "sha256": "8cd4c0c5c170bb42ceebfd33966607dd7ac1e1d79a8725e9647518c63aea64fb",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zoom/windows.json
+++ b/ee/maintained-apps/outputs/zoom/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.1.43453",
+      "version": "7.1.46825",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Zoom Workplace%' AND publisher = 'Zoom';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Zoom Workplace%' AND publisher = 'Zoom' AND version_compare(version, '7.1.43453') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Zoom Workplace%' AND publisher = 'Zoom' AND version_compare(version, '7.1.46825') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zoom.exe');"
       },
-      "installer_url": "https://zoom.us/client/7.1.5.43453/ZoomInstallerFull.msi?archType=x64",
+      "installer_url": "https://zoom.us/client/7.1.8.46825/ZoomInstallerFull.msi?archType=x64",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "2e978ed3",
-      "sha256": "5c45549aa924ee807215465aec6ca8f743520e2cd0b6ff8698b4a023e5b22204",
+      "sha256": "caa80801ac68d327014da0a6e387f37976d1e405e8a02ea40ce5b73cf47c3302",
       "default_categories": [
         "Communication"
       ],


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated maintained app packages to the latest available versions:
    * Airtame for macOS: 4.16.0
    * Grammarly for Windows: 1.2.291.1949
    * Hive for macOS: 1.2.41
    * PostgreSQL 16 for Windows: 16.15-2
    * Pritunl for macOS: 1.3.4729.52
    * Retcon for macOS: 1.6.3
    * Sync for macOS: 2.2.62
    * WebCatalog for macOS: 78.1.0
    * Yaak for Windows: 2026.7.0
    * Zoom Workplace for Windows: 7.1.46825
  * Updated installer links, version detection, and checksums where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->