### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/discord/darwin.json
+++ b/ee/maintained-apps/outputs/discord/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.0.409",
+      "version": "0.0.410",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.409') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.410') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.hnc.Discord' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.409/Discord.dmg",
+      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.410/Discord.dmg",
       "install_script_ref": "43ce350f",
       "uninstall_script_ref": "450a6520",
-      "sha256": "caf8473d7f702fd67e09ccda55a05934675a5f464ae9bfca6d4b534f6d6cc511",
+      "sha256": "893ec758b3ae3fdc6f8c9bb197603d41042bff317aaa7d616f8ea64350d93b19",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/kdenlive/darwin.json
+++ b/ee/maintained-apps/outputs/kdenlive/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.04.3",
+      "version": "26.08.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.Kdenlive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.Kdenlive' AND version_compare(bundle_short_version, '26.04.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.Kdenlive' AND version_compare(bundle_short_version, '26.08.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.kde.Kdenlive' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://cdn.download.kde.org/stable/kdenlive/26.04/macOS/kdenlive-26.04.3-arm64.dmg",
+      "installer_url": "https://cdn.download.kde.org/stable/kdenlive/26.08/macOS/kdenlive-26.08.0-arm64.dmg",
       "install_script_ref": "7b5dd185",
       "uninstall_script_ref": "a2f49d83",
-      "sha256": "ea82cd8b81789455c987d9fb0d47ab47fe9495a632bb2d495c31b27e19992802",
+      "sha256": "a49e253d40bb63bb0f23e0335b484ff4b27e5533e178efb4d5ac44398edd401e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/kiro/darwin.json
+++ b/ee/maintained-apps/outputs/kiro/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.0.395",
+      "version": "1.0.411",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop' AND version_compare(bundle_short_version, '1.0.395') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop' AND version_compare(bundle_short_version, '1.0.411') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'dev.kiro.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.395/kiro-ide-1.0.395-stable-darwin-arm64.dmg",
+      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.411/kiro-ide-1.0.411-stable-darwin-arm64.dmg",
       "install_script_ref": "84b6676a",
       "uninstall_script_ref": "4678d87f",
-      "sha256": "1e26f36611adba2de0da4c980d51cbb6a0b5b1ff21dfe4ba9eabc0eca3b0c878",
+      "sha256": "f3ba39d9c61ee3439603724ef7a33df49f63f8ca4d1d43017283a2b5f044af22",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/loopback/darwin.json
+++ b/ee/maintained-apps/outputs/loopback/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.4.10",
+      "version": "2.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.rogueamoeba.Loopback';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rogueamoeba.Loopback' AND version_compare(bundle_short_version, '2.4.10') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rogueamoeba.Loopback' AND version_compare(bundle_short_version, '2.5.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.rogueamoeba.Loopback' AND a.bundle_executable != '');"
       },
       "installer_url": "https://cdn.rogueamoeba.com/loopback/download/Loopback.zip",

--- a/ee/maintained-apps/outputs/origami-studio/darwin.json
+++ b/ee/maintained-apps/outputs/origami-studio/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "226.0.0.0.0",
+      "version": "227.0.0.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.facebook.Origami-Studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.facebook.Origami-Studio' AND version_compare(bundle_short_version, '226.0.0.0.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.facebook.Origami-Studio' AND version_compare(bundle_short_version, '227.0.0.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.facebook.Origami-Studio' AND a.bundle_executable != '');"
       },
       "installer_url": "https://facebook.com/designtools/origami/",

--- a/ee/maintained-apps/outputs/postgresql-15/windows.json
+++ b/ee/maintained-apps/outputs/postgresql-15/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "15.19-1",
+      "version": "15.19-2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'PostgreSQL 15' AND publisher = 'PostgreSQL Global Development Group';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PostgreSQL 15' AND publisher = 'PostgreSQL Global Development Group' AND version_compare(version, '15.19-1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PostgreSQL 15' AND publisher = 'PostgreSQL Global Development Group' AND version_compare(version, '15.19-2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'postgresql 15.exe');"
       },
-      "installer_url": "https://get.enterprisedb.com/postgresql/postgresql-15.19-1-windows-x64.exe",
+      "installer_url": "https://get.enterprisedb.com/postgresql/postgresql-15.19-2-windows-x64.exe",
       "install_script_ref": "de54a369",
       "uninstall_script_ref": "1da159d1",
-      "sha256": "09dc76dc45332e031074df8e5d19d9eac64b2b98b51e279099b7461a5c12a92a",
+      "sha256": "e4e3ca22e20280cc8d27cc8786d436779c82c83aede52d629bb91213f6db669b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postgresql-17/windows.json
+++ b/ee/maintained-apps/outputs/postgresql-17/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "17.11-1",
+      "version": "17.11-2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'PostgreSQL 17' AND publisher = 'PostgreSQL Global Development Group';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PostgreSQL 17' AND publisher = 'PostgreSQL Global Development Group' AND version_compare(version, '17.11-1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PostgreSQL 17' AND publisher = 'PostgreSQL Global Development Group' AND version_compare(version, '17.11-2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'postgresql 17.exe');"
       },
-      "installer_url": "https://get.enterprisedb.com/postgresql/postgresql-17.11-1-windows-x64.exe",
+      "installer_url": "https://get.enterprisedb.com/postgresql/postgresql-17.11-2-windows-x64.exe",
       "install_script_ref": "a335a7d0",
       "uninstall_script_ref": "b5dcc995",
-      "sha256": "f104c552d8495a6f20738c2a03f643164bc64b9985363329e314dec24559f0b7",
+      "sha256": "31f336dfc6d61cb4421e9c665749f6d30c25cb5f68b1c05657eebac9b223f0fe",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.25.7",
+      "version": "12.26.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.25.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.26.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'postman.exe');"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.25.7/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.26.0/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "ebc1f9eaebd88bebfbc2ce94ac218c2d6480f591784c0faf2ca5b28ffef47b90",
+      "sha256": "7d2c896a376bc1b06a6d71b212acff82340b21c1f2262df06d0724e0e40aa2e9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/powerphotos/darwin.json
+++ b/ee/maintained-apps/outputs/powerphotos/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.4.4",
+      "version": "3.4.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.fatcatsoftware.PowerPhotos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.fatcatsoftware.PowerPhotos' AND version_compare(bundle_short_version, '3.4.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.fatcatsoftware.PowerPhotos' AND version_compare(bundle_short_version, '3.4.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.fatcatsoftware.PowerPhotos' AND a.bundle_executable != '');"
       },
       "installer_url": "https://www.fatcatsoftware.com/powerphotos/PowerPhotos.zip",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated macOS app definitions:
    - Discord to 0.0.410
    - Kdenlive to 26.08.0
    - Kiro to 1.0.411
    - Loopback to 2.5.0
    - Origami Studio to 227.0.0.0.0
    - PowerPhotos to 3.4.5
  - Updated Windows app definitions:
    - PostgreSQL 15 to 15.19-2
    - PostgreSQL 17 to 17.11-2
    - Postman to 12.26.0
  - Updated download details and version checks to support the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->