### PR TITLE
Patch policies: Hide skipped install from global feed, factor policy refresh into Last fetched

### DIFF
--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -300,6 +300,33 @@ describe("HostHeader", () => {
       expect(screen.queryByText("Last MDM check-in:")).not.toBeInTheDocument();
     });
 
+    it("shows the MDM check-in row even when last fetched is unavailable", async () => {
+      const { user } = renderWithSetup(
+        <HostHeader
+          summaryData={{
+            ...defaultSummaryData,
+            detail_updated_at: undefined,
+            policy_updated_at: undefined,
+            last_mdm_checked_in_at: LAST_CHECK_IN,
+          }}
+          showRefetchSpinner={false}
+          onRefetchHost={jest.fn()}
+          renderActionsDropdown={renderActionDropdown}
+          hostMdmEnrollmentStatus="On (manual)"
+        />
+      );
+
+      await user.hover(screen.getByText(/Last fetched/i));
+
+      expect(await screen.findByText("Last MDM check-in:")).toBeInTheDocument();
+      expect(
+        screen.getByText(internationalTimeFormat(new Date(LAST_CHECK_IN)))
+      ).toBeInTheDocument();
+      // Empty bold next to "Last fetched:" would look broken; render an
+      // explicit fallback instead.
+      expect(screen.getByText("unavailable")).toBeInTheDocument();
+    });
+
     it("uses the more recent of detail_updated_at and policy_updated_at as 'Last fetched' (#51820)", async () => {
       const DETAIL_UPDATED_AT = "2024-04-27T12:00:00Z";
       const POLICY_UPDATED_AT = "2024-04-27T13:30:00Z"; // 90 min newer

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -300,6 +300,36 @@ describe("HostHeader", () => {
       expect(screen.queryByText("Last MDM check-in:")).not.toBeInTheDocument();
     });
 
+    it("uses the more recent of detail_updated_at and policy_updated_at as 'Last fetched' (#51820)", async () => {
+      const DETAIL_UPDATED_AT = "2024-04-27T12:00:00Z";
+      const POLICY_UPDATED_AT = "2024-04-27T13:30:00Z"; // 90 min newer
+      const { user } = renderWithSetup(
+        <HostHeader
+          summaryData={{
+            ...defaultSummaryData,
+            detail_updated_at: DETAIL_UPDATED_AT,
+            policy_updated_at: POLICY_UPDATED_AT,
+            last_mdm_checked_in_at: LAST_CHECK_IN,
+          }}
+          showRefetchSpinner={false}
+          onRefetchHost={jest.fn()}
+          renderActionsDropdown={renderActionDropdown}
+          hostMdmEnrollmentStatus="On (manual)"
+        />
+      );
+
+      await user.hover(screen.getByText(/Last fetched/i));
+
+      expect(
+        await screen.findByText(
+          internationalTimeFormat(new Date(POLICY_UPDATED_AT))
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(internationalTimeFormat(new Date(DETAIL_UPDATED_AT)))
+      ).not.toBeInTheDocument();
+    });
+
     it("renders last fetched without a check-in tooltip when the platform reports no check-in field at all", async () => {
       // lodash `pick` drops the key entirely for platforms whose API response
       // omits it, so the header gets `undefined` rather than "---".

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -167,6 +167,24 @@ const HostHeader = ({
   const hasMdmCheckIn =
     !!lastMdmCheckIn && lastMdmCheckIn !== DEFAULT_EMPTY_CELL_VALUE;
 
+  // "Last fetched" is the most recent of the osquery detail refresh and the
+  // policy refresh, so a patch-when-closed skip driven by a fresh policy
+  // re-eval doesn't look older than the page itself.
+  const detailUpdatedAtMs = Date.parse(summaryData.detail_updated_at);
+  const policyUpdatedAtMs = Date.parse(summaryData.policy_updated_at);
+  const detailValid = Number.isFinite(detailUpdatedAtMs);
+  const policyValid = Number.isFinite(policyUpdatedAtMs);
+  let lastFetchedAt: string | undefined;
+  if (detailValid && policyValid) {
+    lastFetchedAt = new Date(
+      Math.max(detailUpdatedAtMs, policyUpdatedAtMs)
+    ).toISOString();
+  } else if (detailValid) {
+    lastFetchedAt = summaryData.detail_updated_at;
+  } else if (policyValid) {
+    lastFetchedAt = summaryData.policy_updated_at;
+  }
+
   const withTooltip = (content: React.ReactNode) => {
     if (!hasMdmCheckIn) {
       return content;
@@ -180,9 +198,8 @@ const HostHeader = ({
               Last fetched:
               <b>
                 {" "}
-                {internationalTimeFormat(
-                  new Date(summaryData.detail_updated_at)
-                )}
+                {lastFetchedAt &&
+                  internationalTimeFormat(new Date(lastFetchedAt))}
               </b>
             </span>
             <br />
@@ -201,18 +218,14 @@ const HostHeader = ({
     );
   };
 
-  // eslint-disable-next-line no-nested-ternary
-  const lastFetched = summaryData.detail_updated_at ? (
-    hasMdmCheckIn ? (
-      humanLastSeen(summaryData.detail_updated_at)
-    ) : (
-      <HumanTimeDiffWithFleetLaunchCutoff
-        timeString={summaryData.detail_updated_at}
-      />
-    )
-  ) : (
-    ": unavailable"
-  );
+  let lastFetched: React.ReactNode = ": unavailable";
+  if (lastFetchedAt && hasMdmCheckIn) {
+    lastFetched = humanLastSeen(lastFetchedAt);
+  } else if (lastFetchedAt) {
+    lastFetched = (
+      <HumanTimeDiffWithFleetLaunchCutoff timeString={lastFetchedAt} />
+    );
+  }
 
   const renderDeviceStatusTag = () => {
     if (!hostMdmDeviceStatus || hostMdmDeviceStatus === "unlocked") return null;

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -198,8 +198,9 @@ const HostHeader = ({
               Last fetched:
               <b>
                 {" "}
-                {lastFetchedAt &&
-                  internationalTimeFormat(new Date(lastFetchedAt))}
+                {lastFetchedAt
+                  ? internationalTimeFormat(new Date(lastFetchedAt))
+                  : "unavailable"}
               </b>
             </span>
             <br />

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -436,6 +436,7 @@ export const HOST_SUMMARY_DATA: (keyof IHost)[] = [
   "issues",
   "platform",
   "detail_updated_at",
+  "policy_updated_at",
   "team_name",
   "display_name", // Not rendered on my device page
   "maintenance_window", // Not rendered on my device page

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1316,6 +1316,13 @@ func (a ActivityTypeInstalledSoftware) HostIDs() []uint {
 	return []uint{a.HostID}
 }
 
+// HostOnly hides patch-when-closed skips from the global activity feed; they
+// stay on the host activity feed. Skips fire on every policy re-eval while the
+// app is open, which is too noisy globally.
+func (a ActivityTypeInstalledSoftware) HostOnly() bool {
+	return a.SkippedInstall
+}
+
 func (a ActivityTypeInstalledSoftware) WasFromAutomation() bool {
 	return a.PolicyID != nil || a.FromSetupExperience
 }

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -374,3 +374,15 @@ func TestMDMEnrolledActivityHostIDOmission(t *testing.T) {
 		assert.EqualValues(t, 42, got["host_id"])
 	})
 }
+
+func TestInstalledSoftwareHostOnly(t *testing.T) {
+	t.Run("patch-when-closed skip is host-only", func(t *testing.T) {
+		act := ActivityTypeInstalledSoftware{SkippedInstall: true}
+		assert.True(t, act.HostOnly())
+	})
+
+	t.Run("regular install is not host-only", func(t *testing.T) {
+		act := ActivityTypeInstalledSoftware{SkippedInstall: false}
+		assert.False(t, act.HostOnly())
+	})
+}


### PR DESCRIPTION
## Issue
Closes #51820

## Description
- Bug fix (root cause): patch-when-closed installs re-evaluate every policy tick while the app is open, so every skip lands as an `installed_software` row with `SkippedInstall=true`. Added `HostOnly()` on `ActivityTypeInstalledSoftware` — the insert path already flips `host_only=true` for anything satisfying `types.ActivityHostOnly`, the global feed query already filters `WHERE host_only = false`, and the host feed joins `activity_host_past` with no such filter. Result: skips stay on the host activity feed and drop out of global.
- UX (Last fetched): host details showed `detail_updated_at` only, which lags policy refreshes. A patch skip fires on a fresh policy re-eval, so the skip activity's timestamp looked newer than the page's own "Last fetched." Now use `max(detail_updated_at, policy_updated_at)` for the header timestamp and the tooltip. Falls back to whichever one is valid, then `unavailable`. Added `policy_updated_at` to `HOST_SUMMARY_DATA` so it reaches the header.

## Screenrecording
- Global vs host activity feed after a skipped install, and Last fetched updating on a policy-only refresh

https://fleetdm.zoom.us/clips/share/CEDOSNRASEaX6mtlvE_I_A

### Global activity hidden

<img width="769" height="709" alt="Screenshot 2026-09-01 at 10 18 39 AM" src="https://github.com/user-attachments/assets/314b99f8-7bfc-441a-8577-ca45f564bcbe" />

### Host activity shows all skips

<img width="834" height="764" alt="Screenshot 2026-09-01 at 10 18 28 AM" src="https://github.com/user-attachments/assets/1df758fd-b24f-46e0-9590-98d461f61e1c" />

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host details to show the most recent available fetch time from osquery or policy data.
  * Displays “unavailable” when no valid fetch time exists.
  * Corrected installed software activity placement so skipped installations appear only in host activity feeds.

* **Tests**
  * Added coverage for timestamp selection, unavailable states, and host-only software activity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->