### PR TITLE
Allow Technician role to clear iOS/iPadOS passcodes

### DIFF
--- a/changes/45734-technician-clear-ios-passcode
+++ b/changes/45734-technician-clear-ios-passcode
@@ -1,0 +1,2 @@
+- Added the ability for users with the Technician role to clear passcodes on iOS and iPadOS hosts.
+- Fixed fleet-level admins and maintainers receiving a permission error when clearing passcodes on hosts in their fleets.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -2052,7 +2052,7 @@ func (svc *Service) decryptUploadedABMToken(ctx context.Context, token io.Reader
 }
 
 func (svc *Service) ClearPasscode(ctx context.Context, hostID uint) (*fleet.CommandEnqueueResult, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionRead); err != nil {
+	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 		return nil, err
 	}
 
@@ -2061,7 +2061,12 @@ func (svc *Service) ClearPasscode(ctx context.Context, hostID uint) (*fleet.Comm
 		return nil, ctxerr.Wrap(ctx, err, "host lite")
 	}
 
-	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{TeamID: host.TeamID}, fleet.ActionWrite); err != nil {
+	// The platform is part of the authorization input because the policy grants
+	// technicians passcode clearing on iOS/iPadOS only.
+	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{
+		TeamID:   host.TeamID,
+		Platform: host.Platform,
+	}, fleet.ActionClearPasscode); err != nil {
 		return nil, err
 	}
 

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -371,9 +371,6 @@ func TestClearPasscode(t *testing.T) {
 	}
 
 	t.Run("authorization", func(t *testing.T) {
-		ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
-			return &fleet.Host{ID: hostID, Platform: "ipados"}, nil
-		}
 		ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
 			return &fleet.HostMDM{}, nil
 		}
@@ -381,26 +378,72 @@ func TestClearPasscode(t *testing.T) {
 			return &fleet.NanoMDMEnrollmentDetails{UnlockToken: new("fake-token")}, nil
 		}
 
+		team1 := new(uint(1))
+
 		cases := []struct {
 			desc              string
 			user              *fleet.User
+			hostTeamID        *uint
 			shoudFailWithAuth bool
 		}{
-			{"no role", test.UserNoRoles, true},
-			{"observer", test.UserObserver, true},
-			{"observer+", test.UserObserverPlus, true},
-			{"technician", test.UserTechnician, true},
-			{"gitops", test.UserGitOps, true},
-			{"maintainer", test.UserMaintainer, false},
-			{"admin", test.UserAdmin, false},
+			{"no role", test.UserNoRoles, nil, true},
+			{"observer", test.UserObserver, nil, true},
+			{"observer+", test.UserObserverPlus, nil, true},
+			{"technician", test.UserTechnician, nil, false},
+			{"gitops", test.UserGitOps, nil, true},
+			{"maintainer", test.UserMaintainer, nil, false},
+			{"admin", test.UserAdmin, nil, false},
+			{"team 1 technician", test.UserTeamTechnicianTeam1, team1, false},
+			{"team 1 admin", test.UserTeamAdminTeam1, team1, false},
+			{"team 1 observer", test.UserTeamObserverTeam1, team1, true},
+			{"team 2 technician", test.UserTeamTechnicianTeam2, team1, true},
 		}
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
+				ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
+					return &fleet.Host{ID: hostID, Platform: "ipados", TeamID: c.hostTeamID}, nil
+				}
+
 				ctx := test.UserContext(t.Context(), c.user)
 				_, err := svc.ClearPasscode(ctx, 1)
 				checkAuthErr(t, c.shoudFailWithAuth, err)
 			})
 		}
+	})
+
+	t.Run("authorization non-Apple-mobile platforms", func(t *testing.T) {
+		ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
+			return &fleet.Host{ID: hostID, Platform: "android"}, nil
+		}
+
+		// Technicians can only clear passcodes on iOS/iPadOS hosts; Android still
+		// requires full MDM command write.
+		ctx := test.UserContext(t.Context(), test.UserTechnician)
+		_, err := svc.ClearPasscode(ctx, 1)
+		checkAuthErr(t, true, err)
+
+		// Same for macOS: it is not an Apple mobile platform, so technicians are
+		// denied at the authorization gate rather than by platform validation.
+		ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
+			return &fleet.Host{ID: hostID, Platform: "darwin"}, nil
+		}
+		_, err = svc.ClearPasscode(ctx, 1)
+		checkAuthErr(t, true, err)
+
+		ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
+			return &fleet.Host{ID: hostID, Platform: "android"}, nil
+		}
+
+		// Admin passes authorization and fails on Android MDM not being configured,
+		// proving the gate itself lets admins through.
+		ctx = test.UserContext(t.Context(), test.UserAdmin)
+		_, err = svc.ClearPasscode(ctx, 1)
+		require.Error(t, err)
+		var forbiddenError *authz.Forbidden
+		require.NotErrorAs(t, err, &forbiddenError)
+		var badReq *fleet.BadRequestError
+		require.ErrorAs(t, err, &badReq)
+		require.Contains(t, badReq.Message, fleet.AndroidMDMNotConfiguredMessage)
 	})
 
 	t.Run("happy path ipados", func(t *testing.T) {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -2683,39 +2683,97 @@ describe("Host Actions Dropdown", () => {
       expect(screen.queryByText("Clear passcode")).toBeInTheDocument();
     });
 
-    it("does not render for below maintainer", async () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isGlobalTechnician: true,
-            isGlobalAdmin: false,
-            isTeamMaintainer: false,
-            isTeamAdmin: false,
-            isPremiumTier: true,
-            isMacMdmEnabledAndConfigured: true,
-            currentUser: createMockUser(),
+    // Technicians can clear passcodes on iOS/iPadOS hosts, globally or on a host
+    // of their own fleet. Android stays admin/maintainer-only, and roles below
+    // technician never see the action.
+    it.each([
+      {
+        case: "renders for a global technician on an iOS host",
+        currentUser: createMockUser(),
+        isGlobalTechnician: true,
+        hostTeamId: 1,
+        hostPlatform: "ios",
+        hostMdmEnrollmentStatus: "On (company-owned)" as const,
+        expectVisible: true,
+      },
+      {
+        case: "renders for a team technician on an iOS host of their fleet",
+        currentUser: createMockUser({
+          global_role: null,
+          teams: [createMockTeam({ id: 1, role: "technician" })],
+        }),
+        isGlobalTechnician: false,
+        hostTeamId: 1,
+        hostPlatform: "ios",
+        hostMdmEnrollmentStatus: "On (company-owned)" as const,
+        expectVisible: true,
+      },
+      {
+        case: "does not render for an observer on an iOS host",
+        currentUser: createMockUser({ global_role: "observer" }),
+        isGlobalTechnician: false,
+        hostTeamId: 1,
+        hostPlatform: "ios",
+        hostMdmEnrollmentStatus: "On (company-owned)" as const,
+        expectVisible: false,
+      },
+      {
+        case: "does not render for a technician on an Android host",
+        currentUser: createMockUser(),
+        isGlobalTechnician: true,
+        hostTeamId: null,
+        hostPlatform: "android",
+        hostMdmEnrollmentStatus: "On (automatic)" as const,
+        expectVisible: false,
+      },
+    ])(
+      "$case",
+      async ({
+        currentUser,
+        isGlobalTechnician,
+        hostTeamId,
+        hostPlatform,
+        hostMdmEnrollmentStatus,
+        expectVisible,
+      }) => {
+        const render = createCustomRenderer({
+          context: {
+            app: {
+              isPremiumTier: true,
+              isMacMdmEnabledAndConfigured: true,
+              isAndroidMdmEnabledAndConfigured: true,
+              isGlobalTechnician,
+              currentUser,
+            },
           },
-        },
-      });
+        });
 
-      const { user } = render(
-        <HostActionsDropdown
-          hostTeamId={1}
-          onSelect={noop}
-          hostStatus="online"
-          hostPlatform="ios"
-          hostMdmEnrollmentStatus="On (company-owned)"
-          isConnectedToFleetMdm
-          hostMdmDeviceStatus="unlocked"
-          hostScriptsEnabled
-        />
-      );
+        const { user } = render(
+          <HostActionsDropdown
+            hostTeamId={hostTeamId}
+            onSelect={noop}
+            hostStatus="online"
+            hostPlatform={hostPlatform}
+            hostMdmEnrollmentStatus={hostMdmEnrollmentStatus}
+            isConnectedToFleetMdm
+            hostMdmDeviceStatus="unlocked"
+            hostScriptsEnabled
+          />
+        );
 
-      // Global technicians see the Transfer action, but Clear passcode must
-      // still be hidden since it requires maintainer or above.
-      await user.click(screen.getByText("Actions"));
-      expect(screen.queryByText("Clear passcode")).not.toBeInTheDocument();
-    });
+        // A role with no actions at all on the host gets no dropdown to open.
+        const actionsButton = screen.queryByText("Actions");
+        if (actionsButton) {
+          await user.click(actionsButton);
+        }
+
+        if (expectVisible) {
+          expect(screen.queryByText("Clear passcode")).toBeInTheDocument();
+        } else {
+          expect(screen.queryByText("Clear passcode")).not.toBeInTheDocument();
+        }
+      }
+    );
 
     it("does not render for non-iOS hosts", async () => {
       const render = createCustomRenderer({

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -474,20 +474,21 @@ const canClearPasscode = (config: IHostActionConfigOptions) => {
     config.isGlobalMaintainer ||
     config.isTeamAdmin ||
     config.isTeamMaintainer;
-  if (!isAdminOrMaintainer) {
-    return false;
-  }
-
-  // Android: per Figma dev note (#41683) hide Clear passcode whenever any of Lock / Unenroll / Wipe / Clear passcode is pending.
-  if (
-    isAndroid(config.hostPlatform) &&
-    config.hostMdmDeviceStatus &&
-    config.hostMdmDeviceStatus !== "unlocked"
-  ) {
-    return false;
-  }
 
   if (isAndroid(config.hostPlatform)) {
+    // Android clear passcode stays admin/maintainer-only.
+    if (!isAdminOrMaintainer) {
+      return false;
+    }
+
+    // Android: per Figma dev note (#41683) hide Clear passcode whenever any of Lock / Unenroll / Wipe / Clear passcode is pending.
+    if (
+      config.hostMdmDeviceStatus &&
+      config.hostMdmDeviceStatus !== "unlocked"
+    ) {
+      return false;
+    }
+
     return (
       config.isAndroidMdmEnabledAndConfigured &&
       config.isEnrolledInMdm &&
@@ -495,7 +496,15 @@ const canClearPasscode = (config: IHostActionConfigOptions) => {
     );
   }
 
-  // iOS / iPadOS — existing behavior unchanged.
+  // iOS / iPadOS — technicians can also clear passcodes.
+  if (
+    !isAdminOrMaintainer &&
+    !config.isGlobalTechnician &&
+    !config.isTeamTechnician
+  ) {
+    return false;
+  }
+
   if (!isIPadOrIPhone(config.hostPlatform)) {
     return false;
   }

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -17,6 +17,7 @@ create := "create" # only for labels right now
 write_host_label := "write_host_label"
 cancel_host_activity := "cancel_host_activity"
 transfer_host := "transfer_host"
+clear_passcode := "clear_passcode"
 resend := "resend" # only for profiles, and to a single host
 read_secrets := "read_secrets"
 write_members := "write_members"
@@ -1065,6 +1066,43 @@ allow {
   object.type == "mdm_command"
   team_role(subject, object.team_id) == [admin, maintainer, gitops][_]
   action == write
+}
+
+# Global admins, maintainers, and technicians can clear passcodes on iOS/iPadOS
+# hosts (not gitops as this is not something that relates to fleetctl gitops).
+allow {
+  object.type == "mdm_command"
+  {"ios", "ipados"}[object.platform]
+  subject.global_role == [admin, maintainer, technician][_]
+  action == clear_passcode
+}
+
+# Team admins, maintainers, and technicians can clear passcodes on iOS/iPadOS hosts of their teams.
+allow {
+  not is_null(object.team_id)
+  object.type == "mdm_command"
+  {"ios", "ipados"}[object.platform]
+  team_role(subject, object.team_id) == [admin, maintainer, technician][_]
+  action == clear_passcode
+}
+
+# Only global admins and maintainers can clear passcodes on any other platform
+# (Android).
+allow {
+  object.type == "mdm_command"
+  not {"ios", "ipados"}[object.platform]
+  subject.global_role == [admin, maintainer][_]
+  action == clear_passcode
+}
+
+# Only team admins and maintainers can clear passcodes on hosts of their teams
+# on any other platform (Android).
+allow {
+  not is_null(object.team_id)
+  object.type == "mdm_command"
+  not {"ios", "ipados"}[object.platform]
+  team_role(subject, object.team_id) == [admin, maintainer][_]
+  action == clear_passcode
 }
 
 # Global admins, maintainers, technicians, observers and observer_plus can read MDM commands.

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -30,6 +30,7 @@ const (
 	selectiveList      = fleet.ActionSelectiveList
 	cancelHostActivity = fleet.ActionCancelHostActivity
 	transferHost       = fleet.ActionTransferHost
+	clearPasscode      = fleet.ActionClearPasscode
 	create             = fleet.ActionCreate
 	readSecrets        = fleet.ActionReadSecrets
 	writeMembers       = fleet.ActionWriteMembers
@@ -2862,6 +2863,23 @@ func TestAuthorizeMDMCommand(t *testing.T) {
 	team1Command := &fleet.MDMCommandAuthz{
 		TeamID: new(uint(1)),
 	}
+	// Clearing a passcode is only granted to technicians on iOS/iPadOS hosts, so
+	// those rules are exercised against both an Apple mobile host and one that
+	// isn't (Android).
+	globalIOSCommand := &fleet.MDMCommandAuthz{
+		Platform: "ios",
+	}
+	team1IOSCommand := &fleet.MDMCommandAuthz{
+		TeamID:   new(uint(1)),
+		Platform: "ipados",
+	}
+	globalAndroidCommand := &fleet.MDMCommandAuthz{
+		Platform: "android",
+	}
+	team1AndroidCommand := &fleet.MDMCommandAuthz{
+		TeamID:   new(uint(1)),
+		Platform: "android",
+	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalCommand, action: write, allow: false},
 		{user: test.UserNoRoles, object: globalCommand, action: read, allow: false},
@@ -2957,6 +2975,60 @@ func TestAuthorizeMDMCommand(t *testing.T) {
 		{user: test.UserTeamTechnicianTeam2, object: globalCommand, action: read, allow: false},
 		{user: test.UserTeamTechnicianTeam2, object: team1Command, action: write, allow: false},
 		{user: test.UserTeamTechnicianTeam2, object: team1Command, action: read, allow: false},
+
+		// Clearing passcodes is granted to technicians in addition to admins and
+		// maintainers, but not to gitops (unlike the broader write action).
+		{user: test.UserNoRoles, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserNoRoles, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserAdmin, object: globalIOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserAdmin, object: team1IOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserMaintainer, object: globalIOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserMaintainer, object: team1IOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserTechnician, object: globalIOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserTechnician, object: team1IOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserObserver, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserObserver, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserObserverPlus, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserObserverPlus, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserGitOps, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserGitOps, object: team1IOSCommand, action: clearPasscode, allow: false},
+
+		{user: test.UserTeamAdminTeam1, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamAdminTeam1, object: team1IOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserTeamAdminTeam2, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamAdminTeam2, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: team1IOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserTeamMaintainerTeam2, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamTechnicianTeam1, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamTechnicianTeam1, object: team1IOSCommand, action: clearPasscode, allow: true},
+		{user: test.UserTeamTechnicianTeam2, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamTechnicianTeam2, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverTeam1, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverTeam1, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverTeam2, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverTeam2, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverPlusTeam1, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverPlusTeam1, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverPlusTeam2, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamObserverPlusTeam2, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamGitOpsTeam1, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamGitOpsTeam1, object: team1IOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamGitOpsTeam2, object: globalIOSCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamGitOpsTeam2, object: team1IOSCommand, action: clearPasscode, allow: false},
+
+		// On hosts that aren't iOS/iPadOS (Android), clearing a passcode stays
+		// limited to admins and maintainers.
+		{user: test.UserAdmin, object: globalAndroidCommand, action: clearPasscode, allow: true},
+		{user: test.UserMaintainer, object: globalAndroidCommand, action: clearPasscode, allow: true},
+		{user: test.UserTechnician, object: globalAndroidCommand, action: clearPasscode, allow: false},
+		{user: test.UserObserver, object: globalAndroidCommand, action: clearPasscode, allow: false},
+		{user: test.UserGitOps, object: globalAndroidCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamAdminTeam1, object: team1AndroidCommand, action: clearPasscode, allow: true},
+		{user: test.UserTeamMaintainerTeam1, object: team1AndroidCommand, action: clearPasscode, allow: true},
+		{user: test.UserTeamTechnicianTeam1, object: team1AndroidCommand, action: clearPasscode, allow: false},
+		{user: test.UserTeamTechnicianTeam2, object: team1AndroidCommand, action: clearPasscode, allow: false},
 	})
 }
 

--- a/server/fleet/authz.go
+++ b/server/fleet/authz.go
@@ -16,7 +16,8 @@ const (
 	// ActionTransferHost refers to transferring a host between fleets (teams).
 	// This action is permitted for technicians in addition to admin/maintainer/gitops,
 	// so transferring does not require the broader ActionWrite permission.
-	ActionTransferHost = "transfer_host"
+	ActionTransferHost  = "transfer_host"
+	ActionClearPasscode = "clear_passcode"
 	// ActionResend refers to resending an entity on a single host (currently used for configuration profiles).
 	ActionResend = "resend"
 	// ActionReadSecrets refers to reading secrets/credentials of an entity (e.g. CA private keys, API tokens).

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -392,7 +392,8 @@ type CommandEnqueueResult struct {
 // MDMCommandAuthz is used to check user authorization to read/write an
 // MDM command.
 type MDMCommandAuthz struct {
-	TeamID *uint `json:"team_id" renameto:"fleet_id"` // required for authorization by team
+	TeamID   *uint  `json:"team_id" renameto:"fleet_id"` // required for authorization by team
+	Platform string `json:"platform"`                    // Platform of the targeted host
 }
 
 // SetTeamID implements the TeamIDSetter interface.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -23561,6 +23561,14 @@ func (s *integrationMDMTestSuite) TestTechnicianPermissions() {
 	team1MacOSHost, team1MacOSMDMClient := createHostThenEnrollMDM(s.ds, s.server.URL, t)
 	s.Do("POST", "/api/v1/fleet/hosts/transfer",
 		addHostsToTeamRequest{TeamID: &t1.ID, HostIDs: []uint{team1MacOSHost.ID}}, http.StatusOK)
+	// iOS hosts to test clearing passcodes (MDM enrollment sends the unlock token).
+	globalIOSHost, _ := s.createAppleMobileHostThenEnrollMDM("ios")
+	team1IOSHost, _ := s.createAppleMobileHostThenEnrollMDM("ios")
+	s.Do("POST", "/api/v1/fleet/hosts/transfer",
+		addHostsToTeamRequest{TeamID: &t1.ID, HostIDs: []uint{team1IOSHost.ID}}, http.StatusOK)
+	team2IOSHost, _ := s.createAppleMobileHostThenEnrollMDM("ios")
+	s.Do("POST", "/api/v1/fleet/hosts/transfer",
+		addHostsToTeamRequest{TeamID: &t2.ID, HostIDs: []uint{team2IOSHost.ID}}, http.StatusOK)
 	// Add a configuration profile to t1.
 	mcUUID := "a" + uuid.NewString()
 	prof := mcBytesForTest("name-"+mcUUID, "identifier-"+mcUUID, mcUUID)
@@ -23831,6 +23839,14 @@ func (s *integrationMDMTestSuite) TestTechnicianPermissions() {
 		TeamID:  nil,
 		HostIDs: []uint{h1.ID},
 	}, http.StatusOK, &addHostsToTeamResponse{})
+
+	// Attempt to clear the passcode on an iOS host, should allow.
+	var cpResp fleet.ClearPasscodeResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/clear_passcode", globalIOSHost.ID), nil, http.StatusOK, &cpResp)
+
+	// Attempt to lock a host, should fail. Lock, unlock and wipe share the same
+	// authorization, so lock stands in for all three.
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/lock", globalIOSHost.ID), nil, http.StatusForbidden)
 
 	// Attempt to create a global label, should allow.
 	clr := fleet.CreateLabelResponse{}
@@ -24268,6 +24284,13 @@ func (s *integrationMDMTestSuite) TestTechnicianPermissions() {
 	require.Nil(t, teamTechConfigResp.SMTPSettings)
 	require.Nil(t, teamTechConfigResp.SSOSettings)
 	require.Nil(t, teamTechConfigResp.AgentOptions)
+
+	// Attempt to clear the passcode on an iOS host of its team, should allow.
+	var teamCpResp fleet.ClearPasscodeResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/clear_passcode", team1IOSHost.ID), nil, http.StatusOK, &teamCpResp)
+
+	// Attempt to clear the passcode on an iOS host of another team, should fail.
+	s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/clear_passcode", team2IOSHost.ID), nil, http.StatusForbidden)
 
 	// Attempt to create queries in global domain, should allow.
 	tcqr := fleet.CreateQueryResponse{}


### PR DESCRIPTION
Fixes #45734

Adds a narrow clear_passcode authz action on mdm_command granted to admins, maintainers, and technicians (global and fleet-level). The ClearPasscode service authorizes it for iOS/iPadOS hosts only; Android keeps requiring full MDM command write. Also fixes fleet-level admins and maintainers being denied on this endpoint (the first authz gate now uses host list, matching LockHost). Surfaces the Clear passcode action to technicians in the host actions dropdown for iOS/iPadOS hosts.

https://github.com/user-attachments/assets/ddfe4287-7525-467d-861b-2ca86fba693f

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
- 
## Frontend

- [X] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Technicians can clear passcodes on iOS and iPadOS hosts.
  * Team technicians can clear passcodes on Apple mobile hosts within their assigned fleet.
* **Bug Fixes**
  * Fleet-level administrators and maintainers no longer receive permission errors when clearing passcodes on eligible hosts.
  * Passcode clearing remains restricted on Android and macOS according to role permissions.
  * The clear-passcode option is hidden when another device action is already pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->