### PR TITLE
Fix SSO tooltip style on Fleet Desktop settings page

### DIFF
--- a/changes/52231-fleet-desktop-sso-tooltip-style
+++ b/changes/52231-fleet-desktop-sso-tooltip-style
@@ -1,0 +1,1 @@
+- Fixed the "Single sign-on (SSO)" tooltip on the Fleet Desktop settings page so the underline no longer sits flush against the label text, and so the tooltip style matches whether the option is selectable.

--- a/frontend/pages/admin/OrgSettingsPage/_styles.scss
+++ b/frontend/pages/admin/OrgSettingsPage/_styles.scss
@@ -123,3 +123,14 @@
     @include disabled;
   }
 }
+
+.fleet-desktop {
+  &__sso-radio {
+    // Radio labels use line-height: 1, which leaves no breathing room between
+    // the text and the dashed underline (unlike other underlined tooltips on
+    // this page, e.g. "Browser host", which use the default line-height).
+    .component__tooltip-wrapper__underline {
+      padding-bottom: px-to-rem(3);
+    }
+  }
+}

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -136,7 +136,11 @@ const FleetDesktop = ({
         variant="right-panel"
         content="Customize the Fleet Desktop experience."
       />
-      <form onSubmit={onFormSubmit} autoComplete="off">
+      <form
+        className="fleet-desktop"
+        onSubmit={onFormSubmit}
+        autoComplete="off"
+      >
         <InputField
           label="Custom transparency URL"
           onChange={onInputChange}
@@ -193,12 +197,13 @@ const FleetDesktop = ({
             onChange={onEndUserAuthChange}
           />
           <Radio
+            className="fleet-desktop__sso-radio"
             label={
               <TooltipWrapper
-                showArrow
-                underline={false}
-                position="right"
-                tipOffset={12}
+                showArrow={!isIdPConfigured}
+                underline={isIdPConfigured}
+                position={isIdPConfigured ? "bottom-start" : "right"}
+                tipOffset={8}
                 tipContent={
                   isIdPConfigured
                     ? SSO_TOKEN_ROTATION_TOOLTIP


### PR DESCRIPTION
**Related issue:** Resolves #52231

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] QA'd all new/changed functionality manually

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Fleet Desktop SSO tooltip styling with clearer spacing between labels and underlines.
  * Aligned tooltip appearance across selectable and non-selectable states.
  * Updated tooltip positioning and arrow behavior based on identity provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->