### PR TITLE
Disk encryption settings show disabled controls with a tooltip instead of an empty state when MDM isn't turned on

### DIFF
--- a/changes/52233-disk-encryption-mdm-empty-state
+++ b/changes/52233-disk-encryption-mdm-empty-state
@@ -1,0 +1,1 @@
+- On the disk encryption settings page, replaced the disabled checkboxes and tooltip with an empty state, and a "Learn more" link, when a platform's MDM isn't turned on.

--- a/changes/52233-disk-encryption-mdm-empty-state
+++ b/changes/52233-disk-encryption-mdm-empty-state
@@ -1,1 +1,0 @@
-- On the disk encryption settings page, replaced the disabled checkboxes and tooltip with an empty state, and a "Learn more" link, when a platform's MDM isn't turned on.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tests.tsx
@@ -5,6 +5,7 @@ import { delay, http, HttpResponse } from "msw";
 import PATHS from "router/paths";
 import { IMdmConfig } from "interfaces/config";
 import { DiskEncryptionSettingsPlatform } from "interfaces/platform";
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
 import mockServer from "test/mock-server";
 import {
@@ -447,33 +448,35 @@ describe("DiskEncryption", () => {
     [
       "macos",
       { enabled_and_configured: false },
-      "To make changes, first turn on Apple MDM.",
+      /You must turn on Apple MDM/,
+      `${LEARN_MORE_ABOUT_BASE_LINK}/turn-on-apple-mdm`,
     ],
     [
       "windows",
       { windows_enabled_and_configured: false },
-      "To make changes, first turn on Windows MDM.",
+      /You must turn on Windows MDM/,
+      `${LEARN_MORE_ABOUT_BASE_LINK}/setup-windows-mdm`,
     ],
   ] as const)(
-    "disables the %s tab and explains why when its MDM is turned off",
-    async (platform, mdm, tooltip) => {
+    "shows an empty state instead of the form on the %s tab when its MDM is turned off",
+    async (platform, mdm, infoText, learnMoreUrl) => {
       mockServer.use(createGetTeamHandler());
       mockServer.use(createGetDiskEncryptionSummaryHandler());
-      const { user } = renderDiskEncryption({
+      renderDiskEncryption({
         urlPlatformParam: platform,
         mdm,
       });
 
-      const checkboxes = await screen.findAllByRole("checkbox");
-      checkboxes.forEach((checkbox) => {
-        expect(checkbox).toHaveAttribute("aria-disabled", "true");
-      });
-      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+      expect(
+        await screen.findByText("Turn on MDM to enforce disk encryption")
+      ).toBeInTheDocument();
+      expect(screen.getByText(infoText)).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: "Learn more" });
+      expect(link).toHaveAttribute("href", learnMoreUrl);
+      expect(link).toHaveAttribute("target", "_blank");
 
-      await user.hover(checkboxes[0]);
-      await waitFor(() => {
-        expect(screen.getByText(tooltip)).toBeInTheDocument();
-      });
+      expect(screen.queryByRole("checkbox")).toBeNull();
+      expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
     }
   );
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -27,6 +27,7 @@ import Card from "components/Card";
 import CustomLink from "components/CustomLink";
 import Checkbox from "components/forms/fields/Checkbox";
 import DataError from "components/DataError";
+import EmptyState from "components/EmptyState";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import Spinner from "components/Spinner";
 import SectionHeader from "components/SectionHeader";
@@ -60,26 +61,43 @@ const getPlatformTabPath = (
     fleet_id: teamId,
   });
 
-const MDM_REQUIRED_TOOLTIPS: Partial<
-  Record<DiskEncryptionSettingsPlatform, string>
+const MDM_REQUIRED_EMPTY_STATES: Partial<
+  Record<DiskEncryptionSettingsPlatform, JSX.Element>
 > = {
-  macos: "To make changes, first turn on Apple MDM.",
-  windows: "To make changes, first turn on Windows MDM.",
+  macos: (
+    <EmptyState
+      header="Turn on MDM to enforce disk encryption"
+      info={
+        <>
+          You must turn on Apple MDM to enforce disk encryption for macOS hosts.{" "}
+          <CustomLink
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/turn-on-apple-mdm`}
+            text="Learn more"
+            newTab
+          />
+        </>
+      }
+      variant="form"
+    />
+  ),
+  windows: (
+    <EmptyState
+      header="Turn on MDM to enforce disk encryption"
+      info={
+        <>
+          You must turn on Windows MDM to enforce disk encryption for Windows
+          hosts.{" "}
+          <CustomLink
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-windows-mdm`}
+            text="Learn more"
+            newTab
+          />
+        </>
+      }
+      variant="form"
+    />
+  ),
 };
-
-const withMdmRequiredTooltip = (children: JSX.Element, tipContent?: string) =>
-  tipContent ? (
-    <TooltipWrapper
-      tipContent={tipContent}
-      position="top"
-      showArrow
-      underline={false}
-    >
-      {children}
-    </TooltipWrapper>
-  ) : (
-    children
-  );
 
 export type IDiskEncryptionProps = IOSSettingsCommonProps;
 
@@ -247,24 +265,18 @@ const DiskEncryption = ({
     }
   };
 
-  const renderSaveButton = (
-    platform: DiskEncryptionSettingsPlatform,
-    mdmRequiredTip?: string
-  ) => (
+  const renderSaveButton = (platform: DiskEncryptionSettingsPlatform) => (
     <GitOpsModeTooltipWrapper
-      renderChildren={(disableChildren) =>
-        withMdmRequiredTooltip(
-          <Button
-            disabled={disableChildren || isPlatformFormDisabled(platform)}
-            isLoading={isSaving}
-            className={`${baseClass}__save-button`}
-            onClick={() => onSaveDiskEncryption(platform)}
-          >
-            Save
-          </Button>,
-          mdmRequiredTip
-        )
-      }
+      renderChildren={(disableChildren) => (
+        <Button
+          disabled={disableChildren || isPlatformFormDisabled(platform)}
+          isLoading={isSaving}
+          className={`${baseClass}__save-button`}
+          onClick={() => onSaveDiskEncryption(platform)}
+        >
+          Save
+        </Button>
+      )}
     />
   );
 
@@ -326,28 +338,26 @@ const DiskEncryption = ({
     isEnabled: boolean,
     formFields: JSX.Element
   ) => {
-    // GitOps mode has its own tooltip on Save, so only explain the MDM
-    // requirement when that isn't what's disabling the form
-    const mdmRequiredTip =
+    // GitOps mode has its own tooltip on Save, so only show the MDM-required
+    // empty state when that isn't what's disabling the form
+    const mdmRequiredEmptyState =
       gitOpsModeEnabled || isPlatformMdmEnabled[platform]
         ? undefined
-        : MDM_REQUIRED_TOOLTIPS[platform];
+        : MDM_REQUIRED_EMPTY_STATES[platform];
 
     return (
       <>
-        {!isTechnician && (
-          <Card
-            className={`${baseClass}__settings-card`}
-            color="white"
-            borderRadiusSize="large"
-          >
-            {withMdmRequiredTooltip(
-              <div className={`${baseClass}__form-fields`}>{formFields}</div>,
-              mdmRequiredTip
-            )}
-            {renderSaveButton(platform, mdmRequiredTip)}
-          </Card>
-        )}
+        {!isTechnician &&
+          (mdmRequiredEmptyState || (
+            <Card
+              className={`${baseClass}__settings-card`}
+              color="white"
+              borderRadiusSize="large"
+            >
+              <div className={`${baseClass}__form-fields`}>{formFields}</div>
+              {renderSaveButton(platform)}
+            </Card>
+          ))}
         {isEnabled ? (
           <DiskEncryptionTable
             platform={platform}


### PR DESCRIPTION
For the following bug:
- #52233

- [x] QA'd all new/changed functionality manually
