### PR TITLE
Fix dropdown CSS regression from route-based code splitting

### DIFF
--- a/changes/52239-dropdown-css-route-splitting
+++ b/changes/52239-dropdown-css-route-splitting
@@ -1,0 +1,1 @@
+- Fixed a bug where a dropdown could render unstyled or with low-contrast selected-value text on some pages, caused by route-based code splitting scoping `react-select`'s base CSS to a per-page chunk instead of loading it globally.

--- a/changes/52239-dropdown-css-route-splitting
+++ b/changes/52239-dropdown-css-route-splitting
@@ -1,1 +1,0 @@
-- Fixed a bug where a dropdown could render unstyled or with low-contrast selected-value text on some pages, caused by route-based code splitting scoping `react-select`'s base CSS to a per-page chunk instead of loading it globally.

--- a/frontend/index.jsx
+++ b/frontend/index.jsx
@@ -6,6 +6,11 @@ import "regenerator-runtime/runtime";
 
 import "./public-path";
 import routes from "./router";
+// Base layout/positioning CSS for react-select v1 (used by the Dropdown
+// component). Imported here — in the main entry, never code-split — so it's
+// always loaded, and evaluated before index.scss so Fleet's dark-mode
+// .Select-value-label override (same specificity) wins the cascade tie.
+import "react-select/dist/react-select.css";
 import "./index.scss";
 import { initTheme } from "./utilities/theme";
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52239

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

## Summary

#52038 (route-based code splitting) broke `Dropdown` (react-select v1) on pages that don't happen to co-load `SelectTargetsInput.jsx` in the same chunk:

1. `react-select`'s base layout CSS was only ever imported as a side effect inside `SelectTargetsInput.jsx`. Pre-#52038, everything shared one `bundle.css`, so it always loaded. Post-#52038, pages whose route chunk doesn't also pull in `SelectTargetsInput` never load it — `Dropdown` renders unstyled (block-stacked layout, chevron in the wrong spot).
2. Importing the CSS directly inside `Dropdown.jsx` fixes the layout but creates a new bug: since `Dropdown.jsx` is itself lazily loaded per route, the CSS lands in each per-route async chunk instead of the main bundle. Those chunks' `<link>` tags load *after* `bundle.css`. `react-select`'s own hardcoded `.Select-value-label` color and Fleet's dark-mode override have identical specificity, so the later-loading stylesheet wins the tie — now the unthemed color wins, and selected values render low-contrast.

Fix: import `react-select/dist/react-select.css` once from `frontend/index.jsx` (the main entry, never code-split), ordered before `import "./index.scss"` so Fleet's `.Select-value-label` override (pulled in via `index.scss`'s glob-import of component styles) is evaluated after it and reliably wins the specificity tie.

Root-caused and verified against compiled `assets/bundle.css` cascade order (see #52239 for full repro/investigation notes). Not yet manually re-QA'd in a running dev instance since the split from the original branch — flagging that explicitly rather than checking the box above.