### PR TITLE
Load react-select's base styles from the app entry

### DIFF
--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsInput/SelectTargetsInput.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsInput/SelectTargetsInput.jsx
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { difference, isEqual, uniqueId } from "lodash";
 import Select from "react-select";
-import "react-select/dist/react-select.css";
 
 import debounce from "utilities/debounce";
 import targetInterface from "interfaces/target";

--- a/frontend/index.jsx
+++ b/frontend/index.jsx
@@ -4,6 +4,11 @@ import { createRoot } from "react-dom/client";
 import "core-js/stable";
 import "regenerator-runtime/runtime";
 
+// Base styles for the legacy react-select v1 Dropdown. Must load before
+// index.scss so Fleet's overrides win, and from the entry so every route has
+// them — route chunks would otherwise only pull them in on some pages.
+import "react-select/dist/react-select.css";
+
 import "./public-path";
 import routes from "./router";
 import "./index.scss";


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #47830

Route code splitting moved react-select's base stylesheet into the packs route chunk, because the only thing importing it was a component that page owns. Every other page using the legacy react-select v1 `Dropdown` — SMTP settings, team settings, certificate authorities, label creation, and others — then rendered its dropdowns unstyled.

## Testing

- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

#### Before

<img width="817" height="708" alt="Screenshot 2026-08-31 at 10 05 36 PM" src="https://github.com/user-attachments/assets/be4dac84-d286-4f3f-a809-0c9f42efcb74" />
<img width="1079" height="480" alt="Screenshot 2026-08-31 at 10 05 48 PM" src="https://github.com/user-attachments/assets/a62f6ee2-92cd-4f97-bef9-460beaefdc27" />
<img width="1094" height="801" alt="Screenshot 2026-08-31 at 10 05 56 PM" src="https://github.com/user-attachments/assets/cf1ce15f-c7c8-4fdd-a3c2-b0ec4ba18e06" />


#### After

<img width="1093" height="413" alt="Screenshot 2026-08-31 at 10 03 19 PM" src="https://github.com/user-attachments/assets/0df41cba-ccd6-4a23-af85-6eaa98590d0e" />
<img width="1100" height="712" alt="Screenshot 2026-08-31 at 10 03 28 PM" src="https://github.com/user-attachments/assets/bf175a71-9ee3-4d33-87ca-3024bb2221b4" />
<img width="786" height="661" alt="Screenshot 2026-08-31 at 10 04 06 PM" src="https://github.com/user-attachments/assets/e15fe941-eb4c-4a8a-aa10-6a90b2943d32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown styling consistency across the application.
  * Ensured target-selection dropdowns display their base styles reliably on every route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->