### PR TITLE
add ACME support for iPhones and iPads

### DIFF
--- a/changes/51974-support-acme-for-ios-ipados
+++ b/changes/51974-support-acme-for-ios-ipados
@@ -1,0 +1,1 @@
+- Added ACME support for valid Apple Business assigned iPhones and iPads.

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -867,6 +867,10 @@ func (c *TestAppleMDMClient) SCEPEnroll() error {
 		return err
 	}
 
+	// the device has a single MDM identity, so a new SCEP cert replaces any
+	// ACME one it previously enrolled with
+	c.acmeCert = nil
+	c.acmeKey = nil
 	c.scepCert = cert
 	c.scepKey = key
 	return nil
@@ -955,6 +959,10 @@ func (c *TestAppleMDMClient) ACMEEnroll() error {
 		return fmt.Errorf("parse x509 ACME certificate: %w", err)
 	}
 
+	// the device has a single MDM identity, so a new ACME cert replaces any
+	// SCEP one it previously enrolled with
+	c.scepCert = nil
+	c.scepKey = nil
 	c.acmeCert = acmeCert
 	// We can reuse the same key we used for the CSR since it's the one that matches the cert
 	c.acmeKey = acmeKey

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2130,9 +2130,6 @@ func (ds *Datastore) GetDeviceInfoForACMERenewal(ctx context.Context, hostUUIDs 
 		return []fleet.DeviceInfoForACMERenewal{}, nil
 	}
 
-	// TODO(mna): anyone knows what those TODOs (from Sarah's PRs) were for?
-	// TODO: refactor this to use hw model from host_dep_assignments once we have that fully in place
-	// TODO: confirm we can rely on host_operating_system and operating_systems tables for accurate OS version information
 	stmt := `
 SELECT
 	h.uuid AS host_uuid,
@@ -2147,7 +2144,7 @@ FROM
 WHERE
 	h.uuid IN(?)
 	AND hda.deleted_at IS NULL
-	AND os.name = 'macOS'`
+	AND os.name IN ('macOS', 'iOS', 'iPadOS')`
 
 	stmt, args, err := sqlx.In(stmt, hostUUIDs)
 	if err != nil {

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -39,6 +39,7 @@ func TestMDMShared(t *testing.T) {
 		name string
 		fn   func(t *testing.T, ds *Datastore)
 	}{
+		{"TestGetDeviceInfoForACMERenewal", testGetDeviceInfoForACMERenewal},
 		{"TestListMDMCommandsByHostIdentifier", testListMDMCommandsByHostIdentifier},
 		{"TestMDMCommands", testMDMCommands},
 		{"TestListMDMCommandsWithTeamFilter", testListMDMCommandsWithTeamFilter},
@@ -6152,4 +6153,73 @@ func testListMDMCommandsAndroid(t *testing.T, ds *Datastore) {
 		}
 	}
 	assert.Equal(t, 3, androidCount, "expected 3 Android commands in all-hosts listing")
+}
+
+func testGetDeviceInfoForACMERenewal(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	encTok := uuid.NewString()
+	abmToken, err := ds.InsertABMToken(ctx, &fleet.ABMToken{OrganizationName: "unused", EncryptedToken: []byte(encTok), RenewAt: time.Now().Add(365 * 24 * time.Hour)})
+	require.NoError(t, err)
+
+	newHost := func(name, model, osName, osVersion string, depAssigned bool) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:       name,
+			OsqueryHostID:  ptr.String("osquery-" + name),
+			NodeKey:        ptr.String("nodekey-" + name),
+			UUID:           "uuid-" + name,
+			HardwareSerial: "serial-" + name,
+			HardwareModel:  model,
+			Platform:       "darwin",
+		})
+		require.NoError(t, err)
+		// NewHost does not persist hardware_model
+		require.NoError(t, ds.UpdateHost(ctx, h))
+
+		if osName != "" {
+			require.NoError(t, ds.UpdateHostOperatingSystem(ctx, h.ID, fleet.OperatingSystem{
+				Name:     osName,
+				Version:  osVersion,
+				Platform: "darwin",
+			}))
+		}
+		if depAssigned {
+			require.NoError(t, ds.UpsertMDMAppleHostDEPAssignments(ctx, []fleet.Host{*h}, abmToken.ID, make(map[uint]time.Time)))
+		}
+		return h
+	}
+
+	macOS := newHost("mac", "MacBookPro18,1", "macOS", "14.5.0", true)
+	iOS := newHost("ios", "iPhone14,2", "iOS", "17.5.1", true)
+	iPadOS := newHost("ipad", "iPad13,1", "iPadOS", "17.5.1", true)
+	// not eligible: no DEP assignment
+	noDEP := newHost("nodep", "MacBookPro18,1", "macOS", "14.5.0", false)
+	// not eligible: DEP-assigned but no operating system recorded
+	noOS := newHost("noos", "MacBookPro18,1", "", "", true)
+	// not eligible: DEP-assigned but not an Apple OS
+	otherOS := newHost("other", "ThinkPad", "Ubuntu", "22.04 LTS", true)
+	// not eligible: DEP assignment was deleted
+	deletedDEP := newHost("deleted", "MacBookPro18,1", "macOS", "14.5.0", true)
+	require.NoError(t, ds.DeleteHostDEPAssignments(ctx, abmToken.ID, []string{deletedDEP.HardwareSerial}))
+
+	// no host UUIDs returns an empty result without hitting the DB
+	got, err := ds.GetDeviceInfoForACMERenewal(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// unknown host UUID returns nothing
+	got, err = ds.GetDeviceInfoForACMERenewal(ctx, []string{"no-such-uuid"})
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// only the eligible hosts are returned, with their device info
+	got, err = ds.GetDeviceInfoForACMERenewal(ctx, []string{
+		macOS.UUID, iOS.UUID, iPadOS.UUID, noDEP.UUID, noOS.UUID, otherOS.UUID, deletedDEP.UUID,
+	})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []fleet.DeviceInfoForACMERenewal{
+		{HostUUID: macOS.UUID, HardwareSerial: macOS.HardwareSerial, HardwareModel: "MacBookPro18,1", OSVersion: "14.5.0"},
+		{HostUUID: iOS.UUID, HardwareSerial: iOS.HardwareSerial, HardwareModel: "iPhone14,2", OSVersion: "17.5.1"},
+		{HostUUID: iPadOS.UUID, HardwareSerial: iPadOS.HardwareSerial, HardwareModel: "iPad13,1", OSVersion: "17.5.1"},
+	}, got)
 }

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -6165,8 +6165,8 @@ func testGetDeviceInfoForACMERenewal(t *testing.T, ds *Datastore) {
 	newHost := func(name, model, osName, osVersion string, depAssigned bool) *fleet.Host {
 		h, err := ds.NewHost(ctx, &fleet.Host{
 			Hostname:       name,
-			OsqueryHostID:  ptr.String("osquery-" + name),
-			NodeKey:        ptr.String("nodekey-" + name),
+			OsqueryHostID:  new("osquery-" + name),
+			NodeKey:        new("nodekey-" + name),
 			UUID:           "uuid-" + name,
 			HardwareSerial: "serial-" + name,
 			HardwareModel:  model,

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1550,7 +1550,7 @@ func IsMacIdentifier(modelIdentifier string) (bool, string, int, error) {
 		strings.HasPrefix(modelIdentifier, "iPod") ||
 		strings.HasPrefix(modelIdentifier, "iPad") {
 		// If the model identifier starts with iPhone, iPod, or iPad, we'll return false with no
-		// error; however, other non-Mac Apple devices like AppleTV will return an error
+		// error; however, other non-Mac Apple devices will also return no, except for invalid product family strings
 		return false, "", 0, nil
 	}
 
@@ -1647,7 +1647,12 @@ func IsA11ChipDevice(modelIdentifier string) (bool, error) {
 		family = iPadFamily
 	}
 
-	return major >= a11MajorThreshold[family], nil
+	threshold, ok := a11MajorThreshold[family]
+	if !ok {
+		return false, nil
+	}
+
+	return major >= threshold, nil
 }
 
 // MDMAppleAccountDrivenUserEnrollDeviceInfo is a more minimal version of DeviceInfo sent on Account

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1519,9 +1519,9 @@ type MDMAppleMachineInfo struct {
 	Version                         string `plist:"VERSION"`
 }
 
-// macProductRe matches a macOS model identifier such as "MacBookPro18,3", capturing the
+// appleProductRe matches an Apple product model identifier such as "MacBookPro18,3" or "iPhone10,1", capturing the
 // alphabetic family prefix (group 1) and the numeric major version (group 2).
-var macProductRe = regexp.MustCompile(`^([A-Za-z]+)(\d+),\d+$`)
+var appleProductRe = regexp.MustCompile(`^([A-Za-z]+)(\d+),\d+$`)
 
 // appleSiliconMajorThreshold maps each traditional Mac product family to the first major
 // version number that corresponds to an Apple Silicon model. Any major version equal to or
@@ -1537,6 +1537,14 @@ var appleSiliconMajorThreshold = map[string]int{
 	"iMac": 21,
 }
 
+// a11MajorThreshold maps each device (that we support and know has shipped with A11) to the first major version number.
+var a11MajorThreshold = map[string]int{
+	// iPhone 10,1 was the first iPhone with the A11 Bionic chip (iPhone 8, Late 2017).
+	"iPhone": 10,
+	// iPad 8,1 was the first iPad with the A11 Bionic chip (iPad Pro 11-inch, 2018).
+	"iPad": 8,
+}
+
 func IsMacIdentifier(modelIdentifier string) (bool, string, int, error) {
 	if strings.HasPrefix(modelIdentifier, "iPhone") ||
 		strings.HasPrefix(modelIdentifier, "iPod") ||
@@ -1546,7 +1554,7 @@ func IsMacIdentifier(modelIdentifier string) (bool, string, int, error) {
 		return false, "", 0, nil
 	}
 
-	matches := macProductRe.FindStringSubmatch(modelIdentifier)
+	matches := appleProductRe.FindStringSubmatch(modelIdentifier)
 	if matches == nil {
 		return false, "", 0, fmt.Errorf("unrecognized product identifier format: %q", modelIdentifier)
 	}
@@ -1566,7 +1574,22 @@ func IsMacIdentifier(modelIdentifier string) (bool, string, int, error) {
 		return true, family, major, nil
 	}
 
-	return false, "", 0, fmt.Errorf("failed to detect if model identifier (%q) was mac", modelIdentifier)
+	return false, "", 0, nil
+}
+
+func IsPrefixedIdentifier(modelIdentifier string, prefix string) (bool, string, int, error) {
+	matches := appleProductRe.FindStringSubmatch(modelIdentifier)
+	if matches == nil {
+		return false, "", 0, fmt.Errorf("unrecognized product identifier format: %q", modelIdentifier)
+	}
+
+	if !strings.HasPrefix(modelIdentifier, prefix) {
+		return false, "", 0, nil
+	}
+
+	family := matches[1]
+	major, _ := strconv.Atoi(matches[2])
+	return true, family, major, nil
 }
 
 // IsMacAppleSilicon determines whether the device is an Apple Silicon Mac. If the model identifier
@@ -1597,10 +1620,34 @@ func IsMacAppleSilicon(modelIdentifier string) (bool, error) {
 
 	threshold, ok := appleSiliconMajorThreshold[family]
 	if !ok {
-		return false, fmt.Errorf("unrecognized Mac product family in identifier: %q", modelIdentifier)
+		return false, nil
 	}
 
 	return major >= threshold, nil
+}
+
+func IsA11ChipDevice(modelIdentifier string) (bool, error) {
+	isIPhone, iPhoneFamily, iPhoneMajor, err := IsPrefixedIdentifier(modelIdentifier, "iPhone")
+	if err != nil {
+		return false, err
+	}
+	isIPad, iPadFamily, iPadMajor, err := IsPrefixedIdentifier(modelIdentifier, "iPad")
+	if err != nil {
+		return false, err
+	}
+
+	if !isIPhone && !isIPad {
+		return false, nil
+	}
+
+	major := iPhoneMajor
+	family := iPhoneFamily
+	if isIPad {
+		major = iPadMajor
+		family = iPadFamily
+	}
+
+	return major >= a11MajorThreshold[family], nil
 }
 
 // MDMAppleAccountDrivenUserEnrollDeviceInfo is a more minimal version of DeviceInfo sent on Account

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -1097,91 +1097,107 @@ func TestIsMacIdentifier(t *testing.T) {
 	}
 }
 
-func TestIsMacAppleSilicon(t *testing.T) {
+func TestIsPrefixedIdentifier(t *testing.T) {
 	cases := []struct {
 		product string
-		wantAS  bool
+		prefix  *string
+		want    bool
 		wantErr bool
 	}{
-		// --- MacBookPro ---
-		// x86: last Intel model before Apple Silicon transition
-		{product: "MacBookPro16,1", wantAS: false},
-		{product: "MacBookPro16,4", wantAS: false},
-		// Apple Silicon: first AS model (M1, Late 2020) and later
-		{product: "MacBookPro17,1", wantAS: true},
-		{product: "MacBookPro18,3", wantAS: true},
-		{product: "MacBookPro18,4", wantAS: true},
-
-		// --- MacBookAir ---
-		// x86: last Intel model before Apple Silicon transition
-		{product: "MacBookAir9,1", wantAS: false},
-		// Apple Silicon: first AS model (M1, Late 2020) and later
-		{product: "MacBookAir10,1", wantAS: true},
-		{product: "MacBookAir14,2", wantAS: true},
-
-		// --- Macmini ---
-		// x86: last Intel model before Apple Silicon transition
-		{product: "Macmini8,1", wantAS: false},
-		// Apple Silicon: first AS model (M1, Late 2020) and later
-		{product: "Macmini9,1", wantAS: true},
-		{product: "Macmini9,2", wantAS: true},
-
-		// --- iMac ---
-		// x86: last Intel models before Apple Silicon transition
-		{product: "iMac20,1", wantAS: false},
-		{product: "iMac20,2", wantAS: false},
-		// Apple Silicon: first AS model (M1, Early 2021) and later
-		{product: "iMac21,1", wantAS: true},
-		{product: "iMac21,2", wantAS: true},
-
-		// --- MacBook (no suffix) — all x86, line discontinued before Apple Silicon ---
-		{product: "MacBook10,1", wantAS: false},
-		{product: "MacBook9,1", wantAS: false},
-
-		// --- iMacPro — all x86, discontinued before Apple Silicon ---
-		{product: "iMacPro1,1", wantAS: false},
-
-		// --- MacPro — old numbering, all x86 ---
-		// (the AS Mac Pro uses the "Mac" prefix, e.g. Mac14,8)
-		{product: "MacPro7,1", wantAS: false},
-		{product: "MacPro6,1", wantAS: false},
-
-		// --- Mac (bare prefix) — unified Apple Silicon naming ---
-		// Mac Studio (M1 Ultra, 2022)
-		{product: "Mac13,1", wantAS: true},
-		{product: "Mac13,2", wantAS: true},
-		// Mac Pro (M2 Ultra, 2023)
-		{product: "Mac14,8", wantAS: true},
-		// Mac mini (M4, 2024)
-		{product: "Mac16,10", wantAS: true},
-
-		// --- Non-Mac Apple devices — return false without error ---
-		{product: "iPhone15,2", wantAS: false},
-		{product: "iPhone14,3", wantAS: false},
-		{product: "iPad13,18", wantAS: false},
-		{product: "iPodTouch9,1", wantAS: false},
-
-		// --- Error cases ---
-		// Empty string
+		{product: "MacBookPro18,4", want: false},
+		{product: "iPhone15,2", want: true},
+		{product: "iPad10,1", want: true, prefix: new("iPad")},
+		{product: "iPhone152", wantErr: true},
 		{product: "", wantErr: true},
-		// No comma separator
-		{product: "MacBookPro18", wantErr: true},
-		// Garbage input
-		{product: "not-a-model", wantErr: true},
-		// Non-Mac Apple devices that don't start with iPhone/iPod/iPad return an error
-		{product: "AppleTV6,2", wantErr: true},
-		{product: "AppleTV14,1", wantErr: true},
-		{product: "VirtualMac2,1", wantErr: true},
 	}
-
 	for _, tc := range cases {
 		t.Run(tc.product, func(t *testing.T) {
-			got, err := IsMacAppleSilicon(tc.product)
+			prefix := "iPhone"
+			if tc.prefix != nil {
+				prefix = *tc.prefix
+			}
+			got, _, _, err := IsPrefixedIdentifier(tc.product, prefix)
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tc.wantAS, got)
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMacSiliconAndA11DeviceCheck(t *testing.T) {
+	type asResult struct{ wantAS, wantErr bool }
+	type a11Result struct{ wantA11, wantErr bool }
+
+	cases := []struct {
+		product string
+		as      asResult
+		a11     a11Result
+	}{
+		// --- MacBookPro ---
+		{product: "MacBookPro16,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "MacBookPro16,4", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "MacBookPro17,1", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "MacBookPro18,3", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "MacBookPro18,4", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+
+		// --- MacBookAir ---
+		{product: "MacBookAir9,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "MacBookAir10,1", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "MacBookAir14,2", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+
+		// --- Macmini ---
+		{product: "Macmini8,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "Macmini9,1", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+
+		// --- iMac ---
+		{product: "iMac20,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "iMac20,2", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "iMac21,1", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "iMac21,2", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+
+		// --- Discontinued x86 lines ---
+		{product: "MacBook10,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "iMacPro1,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "MacPro7,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+		{product: "MacPro6,1", as: asResult{wantAS: false}, a11: a11Result{wantA11: false}},
+
+		// --- Mac (bare prefix) — all Apple Silicon ---
+		{product: "Mac13,1", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "Mac13,2", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "Mac14,8", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+		{product: "Mac16,10", as: asResult{wantAS: true}, a11: a11Result{wantA11: false}},
+
+		// --- Non-Mac iOS/iPadOS devices — A11+ capable, not Apple Silicon Macs ---
+		{product: "iPhone10,3", a11: a11Result{wantA11: true}}, // iPhone X — first A11 device
+		{product: "iPhone14,3", a11: a11Result{wantA11: true}},
+		{product: "iPad13,18", a11: a11Result{wantA11: true}},
+		{product: "iPhone8,1", a11: a11Result{wantA11: false}}, // A11 threshold not reached
+
+		// --- Bad  ---
+		{product: "", as: asResult{wantErr: true}, a11: a11Result{wantErr: true}},
+		{product: "MacBookPro18", as: asResult{wantErr: true}, a11: a11Result{wantErr: true}},
+		{product: "not-a-model", as: asResult{wantErr: true}, a11: a11Result{wantErr: true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.product, func(t *testing.T) {
+			gotAS, err := IsMacAppleSilicon(tc.product)
+			if tc.as.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.as.wantAS, gotAS)
+			}
+
+			gotA11, err := IsA11ChipDevice(tc.product)
+			if tc.a11.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.a11.wantA11, gotA11)
 			}
 		})
 	}

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -1079,9 +1079,9 @@ func TestIsMacIdentifier(t *testing.T) {
 		{product: "MacBookPro18", wantErr: true},
 		// Garbage input
 		{product: "not-a-model", wantErr: true},
-		// Non-Mac Apple devices that don't start with iPhone/iPod/iPad return an error
-		{product: "AppleTV6,2", wantErr: true},
-		{product: "AppleTV14,1", wantErr: true},
+		// Non-Mac Apple devices that don't start with iPhone/iPod/iPad also returns silently with valid format
+		{product: "AppleTV6,2", want: false},
+		{product: "AppleTV14,1", want: false},
 	}
 
 	for _, tc := range cases {

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1595,9 +1595,8 @@ func AddEnrollmentRefToFleetURL(fleetURL, reference string) (string, error) {
 // GenerateACMEEnrollmentProfileMobileconfig builds an ACME (hardware-attested) enrollment profile. See
 // GenerateEnrollmentProfileMobileconfig for newEnrollment; the OU marker survives because Fleet's ACME
 // signer reuses the SCEP depot signer, which copies the CSR Subject verbatim.
-//
-// deviceSerial fills both ClientIdentifier and the Subject CN. It was observed for iOS renewals the device did not substitute %SerialNumber% with it's serial number
-// so we fill it in.
+// deviceSerial fills both ClientIdentifier and the Subject CN. We observed that on iOS renewals,
+// the device does not substitute %SerialNumber% with its serial number, so we fill it in.
 func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, deviceSerial, topic string, accessRights int, newEnrollment bool) ([]byte, error) {
 	serverURL, err := ResolveAppleMDMURL(mdmURL)
 	if err != nil {

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1448,7 +1448,7 @@ var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").F
 				{{ end }}<array>
 					<array>
 						<string>CN</string>
-						<string>{{ .SerialTemplate | xml }}</string>
+						<string>{{ .ClientIdentifier | xml }}</string>
 					</array>
 				</array>
 			</array>
@@ -1595,6 +1595,9 @@ func AddEnrollmentRefToFleetURL(fleetURL, reference string) (string, error) {
 // GenerateACMEEnrollmentProfileMobileconfig builds an ACME (hardware-attested) enrollment profile. See
 // GenerateEnrollmentProfileMobileconfig for newEnrollment; the OU marker survives because Fleet's ACME
 // signer reuses the SCEP depot signer, which copies the CSR Subject verbatim.
+//
+// deviceSerial fills both ClientIdentifier and the Subject CN. It was observed for iOS renewals the device did not substitute %SerialNumber% with it's serial number
+// so we fill it in.
 func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, deviceSerial, topic string, accessRights int, newEnrollment bool) ([]byte, error) {
 	serverURL, err := ResolveAppleMDMURL(mdmURL)
 	if err != nil {
@@ -1613,7 +1616,6 @@ func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, devic
 		Topic                  string
 		ServerURL              string
 		ClientIdentifier       string
-		SerialTemplate         string
 		AccessRights           int
 		NewEnrollmentSubjectOU string
 	}{
@@ -1622,7 +1624,6 @@ func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, devic
 		Topic:                  topic,
 		ServerURL:              serverURL,
 		ClientIdentifier:       deviceSerial,
-		SerialTemplate:         `%SerialNumber%`, // Apple replaces this placeholder with the device's serial number during enrollment
 		AccessRights:           accessRights,
 		NewEnrollmentSubjectOU: newEnrollmentSubjectOU(newEnrollment),
 	}); err != nil {

--- a/server/mdm/apple/apple_mdm_test.go
+++ b/server/mdm/apple/apple_mdm_test.go
@@ -559,6 +559,13 @@ func TestEnrollmentProfileNewEnrollmentSubjectOUMarker(t *testing.T) {
 		renewal, err := GenerateACMEEnrollmentProfileMobileconfig("Fleet", "https://example.com", "acme-ident", "SERIAL123", "com.foo.bar", MDMAccessRightAll, false)
 		require.NoError(t, err)
 		require.NotContains(t, string(renewal), FleetEnrollmentSubjectOU)
+
+		// The ACME payload gets no %SerialNumber% substitution from the device, so the CN must be
+		// the literal serial to match the order's permanent-identifier at finalize.
+		for _, profile := range [][]byte{fresh, renewal} {
+			require.NotContains(t, string(profile), "%SerialNumber%")
+			require.Contains(t, string(profile), "<string>CN</string>\n\t\t\t\t\t\t<string>SERIAL123</string>")
+		}
 	})
 }
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2998,7 +2998,7 @@ func (svc *Service) isMDMAppleACMERequired(ctx context.Context, machineInfo *fle
 		return false, nil
 	}
 
-	isSupported, err := isMacACMESupported(machineInfo.Product, machineInfo.OSVersion)
+	isSupported, err := isACMESupported(ctx, svc.logger, machineInfo.Product, machineInfo.OSVersion)
 	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "checking if device is capable of ACME")
 	} else if !isSupported {
@@ -3016,25 +3016,73 @@ func (svc *Service) isMDMAppleACMERequired(ctx context.Context, machineInfo *fle
 	return len(assignments) > 0, nil
 }
 
-// isMacACMESupported checks if the device is supported for ACME enrollment. Fleet only
-// supports ACME enrollment for Apple Silicon Macs running macOS 14 or later. Other Apple devices
-// may support ACME enrollment (e.g., iOS on Apple Silicon), but they are not currently supported by Fleet.
-func isMacACMESupported(modelIdentifier string, osVersion string) (bool, error) {
-	// we only require ACME for Apple Silicon Macs
-	if isMacAppleSilicon, err := fleet.IsMacAppleSilicon(modelIdentifier); err != nil {
-		return false, fmt.Errorf("checking if device is Apple Silicon: %w", err)
-	} else if !isMacAppleSilicon {
-		return false, nil
+// isACMESupported checks if the device is supported for ACME enrollment. Fleet supports:
+// Apple Silicon Macs running macOS 14 or later.
+// iPhones with A11 chip or higher, running iOS 16 or later.
+// iPads with A11 chip or higher, running iPadOS 16.1 or later.
+// Other Apple devices
+// may support ACME enrollment (e.g., tvOS on Apple TV), but they are not currently supported by Fleet.
+func isACMESupported(ctx context.Context, logger *slog.Logger, modelIdentifier string, osVersion string) (bool, error) {
+	if isMac, _, _, _ := fleet.IsMacIdentifier(modelIdentifier); isMac {
+		// we only require ACME for Apple Silicon Macs, if the device is a mac.
+		isMacAppleSilicon, err := fleet.IsMacAppleSilicon(modelIdentifier)
+		if err != nil {
+			return false, fmt.Errorf("checking if device is Apple Silicon: %w", err)
+		} else if !isMacAppleSilicon {
+			return false, nil
+		}
+
+		// we only require ACME for Apple Silicon Macs running macOS 14 or later
+		if isLessThanMacOS14, err := apple_mdm.IsLessThanVersion(osVersion, "14.0"); err != nil {
+			return false, fmt.Errorf("checking if device is less than macOS 14: %w", err)
+		} else if isLessThanMacOS14 {
+			return false, nil
+		}
+		return true, nil
 	}
 
-	// we only require ACME for Apple Silicon Macs running macOS 14 or later
-	if isLessThanMacOS14, err := apple_mdm.IsLessThanVersion(osVersion, "14.0"); err != nil {
-		return false, fmt.Errorf("checking if device is less than macOS 14: %w", err)
-	} else if isLessThanMacOS14 {
-		return false, nil
+	isIPhone, _, _, err := fleet.IsPrefixedIdentifier(modelIdentifier, "iPhone")
+	if err != nil {
+		return false, fmt.Errorf("checking if device is an iPhone: %w", err)
+	}
+	if isIPhone {
+		if isA11, err := fleet.IsA11ChipDevice(modelIdentifier); err != nil {
+			return false, fmt.Errorf("checking if device has A11 chip: %w", err)
+		} else if !isA11 {
+			return false, nil
+		}
+
+		// Check for iOS 16.0 or above for iPhones
+		if isLessThaniOS16, err := apple_mdm.IsLessThanVersion(osVersion, "16.0"); err != nil {
+			return false, fmt.Errorf("checking if device is less than iOS 16: %w", err)
+		} else if isLessThaniOS16 {
+			return false, nil
+		}
+
+		return true, nil
 	}
 
-	return true, nil
+	if isIPad, _, _, err := fleet.IsPrefixedIdentifier(modelIdentifier, "iPad"); err != nil {
+		return false, fmt.Errorf("checking if device is an iPad: %w", err)
+	} else if isIPad {
+		if isA11, err := fleet.IsA11ChipDevice(modelIdentifier); err != nil {
+			return false, fmt.Errorf("checking if device has A11 chip: %w", err)
+		} else if !isA11 {
+			return false, nil
+		}
+
+		// Check for iPadOS 16.1 or above for iPads
+		if isLessThaniPadOS16_1, err := apple_mdm.IsLessThanVersion(osVersion, "16.1"); err != nil {
+			return false, fmt.Errorf("checking if device is less than iPadOS 16.1: %w", err)
+		} else if isLessThaniPadOS16_1 {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
+	logger.InfoContext(ctx, "got unknown product family for ACME support check", "model_identifier", modelIdentifier, "os_version", osVersion)
+	return false, nil
 }
 
 func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardwareSerial string, orgName string, mdmURL string, topic string) ([]byte, error) {
@@ -6516,7 +6564,7 @@ func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEPro
 		}
 		return ctxerr.Wrap(ctx, err, "probe profile for ACME payload")
 	}
-	if res.Platform != "darwin" || !res.HasACMEPayload {
+	if !res.HasACMEPayload {
 		return nil
 	}
 
@@ -7040,7 +7088,7 @@ func RenewSCEPCertificates(
 ) error {
 	renewalDisable, exists := os.LookupEnv("FLEET_MDM_APPLE_SCEP_RENEWAL_DISABLE")
 	if exists && (strings.EqualFold(renewalDisable, "true") || renewalDisable == "1") {
-		logger.InfoContext(ctx, "skipping renewal of macOS SCEP certificates as FLEET_MDM_APPLE_SCEP_RENEWAL_DISABLE is set to true")
+		logger.InfoContext(ctx, "skipping renewal of Apple SCEP certificates as FLEET_MDM_APPLE_SCEP_RENEWAL_DISABLE is set to true")
 		return nil
 	}
 
@@ -7049,12 +7097,12 @@ func RenewSCEPCertificates(
 		return fmt.Errorf("reading app config: %w", err)
 	}
 	if !appConfig.MDM.EnabledAndConfigured {
-		logger.DebugContext(ctx, "skipping renewal of macOS SCEP certificates as MDM is not fully configured")
+		logger.DebugContext(ctx, "skipping renewal of Apple SCEP certificates as MDM is not fully configured")
 		return nil
 	}
 
 	if commander == nil {
-		logger.DebugContext(ctx, "skipping renewal of macOS SCEP certificates as apple_mdm.MDMAppleCommander was not provided")
+		logger.DebugContext(ctx, "skipping renewal of Apple SCEP certificates as apple_mdm.MDMAppleCommander was not provided")
 		return nil
 	}
 
@@ -7123,7 +7171,7 @@ func RenewSCEPCertificates(
 		}
 		logErrs := []any{}
 		for _, info := range di {
-			if ok, err := isMacACMESupported(info.HardwareModel, info.OSVersion); err != nil {
+			if ok, err := isACMESupported(ctx, logger, info.HardwareModel, info.OSVersion); err != nil {
 				logErrs = append(logErrs, "host_uuid", info.HostUUID, "error", err)
 			} else if ok {
 				acmeRequiredByHostUUID[info.HostUUID] = info

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -6564,7 +6564,7 @@ func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEPro
 		}
 		return ctxerr.Wrap(ctx, err, "probe profile for ACME payload")
 	}
-	if !res.HasACMEPayload {
+	if res.Platform != "darwin" || !res.HasACMEPayload {
 		return nil
 	}
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -10239,11 +10239,42 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 				expectACME: false,
 			},
 			{
-				name: "iPhone",
+				name: "iPhone 16.0",
 				mi: fleet.MDMAppleMachineInfo{
-					Product: "iPhone14,3",
-					Serial:  "IPHONESERIAL",
-					UDID:    "iphone-udid",
+					Product:   "iPhone14,3",
+					Serial:    "IPHONESERIAL",
+					UDID:      "iphone-udid",
+					OSVersion: "16.0",
+				},
+				expectACME: true,
+			},
+			{
+				name: "iPhone < 16.0 does not require ACME",
+				mi: fleet.MDMAppleMachineInfo{
+					Product:   "iPhone14,3",
+					Serial:    "IPHONESERIAL",
+					UDID:      "iphone-udid",
+					OSVersion: "15.0",
+				},
+				expectACME: false,
+			},
+			{
+				name: "iPad 16.1",
+				mi: fleet.MDMAppleMachineInfo{
+					Product:   "iPad10,1",
+					Serial:    "IPADSERIAL",
+					UDID:      "ipad-udid",
+					OSVersion: "16.1",
+				},
+				expectACME: true,
+			},
+			{
+				name: "iPad < 16.1 does not require ACME",
+				mi: fleet.MDMAppleMachineInfo{
+					Product:   "iPad10,1",
+					Serial:    "IPADSERIAL",
+					UDID:      "ipad-udid",
+					OSVersion: "16.0",
 				},
 				expectACME: false,
 			},

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -4001,7 +4001,7 @@ func TestMDMCommandAndReportResultsDeclarativeManagementDetail(t *testing.T) {
 }
 
 // TestMaybeQueueCertificateListForACMEProfile verifies the on-demand
-// CertificateList trigger fires only on macOS hosts whose acked profile
+// CertificateList trigger fires on hosts whose acked profile
 // contains an ACME payload, and that it dedups against pending refetches.
 func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 	ctx := context.Background()

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3362,7 +3362,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	})
 	t.Cleanup(func() {
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			_, err := q.ExecContext(t.Context(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
+			_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
 			return err
 		})
 	})

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3290,12 +3290,16 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	s.enableABM(t.Name())
 	s.setSkipWorkerJobs(t)
 
-	// for our tests, we'll crete three DEP-assigned devices: devices[0] will be enrolled via DEP with ACME,
+	// for our tests, we'll crete five DEP-assigned devices: devices[0] will be enrolled via DEP with ACME,
 	// devices[1] will be enrolled with SCEP, and devices[2] will be enrolled via OTA (no ACME).
+	// devices[3] is an iPhone will be DEP enrolled.
+	// devices[4] is an iPad that will do SCEP first, then renew into ACME
 	devices := []godep.Device{
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"},
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "iPhone14,2", OS: "ios", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "iPad10,1", OS: "ios", OpType: "added"},
 	}
 	s.mockDEPResponse(t.Name(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -3345,7 +3349,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	// confirm that the devices were created
 	listHostsRes := listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
-	require.Len(t, listHostsRes.Hosts, 3)
+	require.Len(t, listHostsRes.Hosts, 5)
 	bySerial := make(map[string]*fleet.Host, len(devices))
 	for _, h := range listHostsRes.Hosts {
 		bySerial[h.HardwareSerial] = h.Host
@@ -3431,6 +3435,56 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", otaHostID), getHostRequest{}, http.StatusOK, &hostResp)
 	assert.False(t, hostResp.Host.MDMEnrollmentHardwareAttested)
+
+	// iPhoneDEPDevice enrolls through DEP and should have hardware attestation
+	iphoneDEPDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, mdmtest.WithACMECerts(s.acmeCertCA, s.acmeCertKey))
+	iphoneDEPDevice.SerialNumber = devices[3].SerialNumber
+	iphoneDEPDevice.Model = devices[3].Model
+	iphoneDEPDevice.OSVersion = "16.0"
+	err = iphoneDEPDevice.Enroll()
+	require.NoError(t, err)
+
+	var iphoneHostID uint
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
+		err := sqlx.GetContext(context.Background(), q, &iphoneHostID, stmt, iphoneDEPDevice.SerialNumber)
+		return err
+	})
+
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", iphoneHostID), getHostRequest{}, http.StatusOK, &hostResp)
+	assert.True(t, hostResp.Host.MDMEnrollmentHardwareAttested)
+
+	// Disable Require ACME, SCEP enroll a valid device via DEP, enable Require ACME and ensure renewal gets ACME
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
+		return err
+	})
+
+	iPadDEPDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, mdmtest.WithACMECerts(s.acmeCertCA, s.acmeCertKey))
+	iPadDEPDevice.SerialNumber = devices[4].SerialNumber
+	iPadDEPDevice.Model = devices[4].Model
+	iPadDEPDevice.OSVersion = "16.1"
+	err = iPadDEPDevice.Enroll()
+	require.NoError(t, err)
+
+	var iPadHostID uint
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
+		err := sqlx.GetContext(context.Background(), q, &iPadHostID, stmt, iPadDEPDevice.SerialNumber)
+		return err
+	})
+
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", iPadHostID), getHostRequest{}, http.StatusOK, &hostResp)
+	assert.False(t, hostResp.Host.MDMEnrollmentHardwareAttested)
+
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
+		return err
+	})
+
+	require.NoError(t, iPadDEPDevice.Reenroll())
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", iPadHostID), getHostRequest{}, http.StatusOK, &hostResp)
+	assert.True(t, hostResp.Host.MDMEnrollmentHardwareAttested)
 }
 
 func (s *integrationMDMTestSuite) TestGetDefaultDEPProfile() {

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3298,8 +3298,8 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"},
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
-		{SerialNumber: uuid.New().String(), Model: "iPhone14,2", OS: "ios", OpType: "added"},
-		{SerialNumber: uuid.New().String(), Model: "iPad10,1", OS: "ios", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "iPhone14,2", OS: "ios", OpType: "added", DeviceFamily: "iPhone"},
+		{SerialNumber: uuid.New().String(), Model: "iPad10,1", OS: "ios", OpType: "added", DeviceFamily: "iPad"},
 	}
 	s.mockDEPResponse(t.Name(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -3357,12 +3357,12 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 
 	// set config.mdm.apple_require_hardware_attestation to true
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
+		_, err := q.ExecContext(t.Context(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
 		return err
 	})
 	t.Cleanup(func() {
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
+			_, err := q.ExecContext(t.Context(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
 			return err
 		})
 	})
@@ -3378,7 +3378,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	var expectIdent string
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `SELECT path_identifier FROM acme_enrollments WHERE host_identifier = ?`
-		err := sqlx.GetContext(context.Background(), q, &expectIdent, stmt, appleSiliconDevice.SerialNumber)
+		err := sqlx.GetContext(t.Context(), q, &expectIdent, stmt, appleSiliconDevice.SerialNumber)
 		return err
 	})
 
@@ -3387,7 +3387,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	var acmeHostID uint
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
-		err := sqlx.GetContext(context.Background(), q, &acmeHostID, stmt, appleSiliconDevice.SerialNumber)
+		err := sqlx.GetContext(t.Context(), q, &acmeHostID, stmt, appleSiliconDevice.SerialNumber)
 		return err
 	})
 
@@ -3407,7 +3407,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	var intelHostID uint
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
-		err := sqlx.GetContext(context.Background(), q, &intelHostID, stmt, intelDevice.SerialNumber)
+		err := sqlx.GetContext(t.Context(), q, &intelHostID, stmt, intelDevice.SerialNumber)
 		return err
 	})
 
@@ -3429,7 +3429,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	var otaHostID uint
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
-		err := sqlx.GetContext(context.Background(), q, &otaHostID, stmt, otaAppleSiliconDevice.SerialNumber)
+		err := sqlx.GetContext(t.Context(), q, &otaHostID, stmt, otaAppleSiliconDevice.SerialNumber)
 		return err
 	})
 
@@ -3447,7 +3447,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	var iphoneHostID uint
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
-		err := sqlx.GetContext(context.Background(), q, &iphoneHostID, stmt, iphoneDEPDevice.SerialNumber)
+		err := sqlx.GetContext(t.Context(), q, &iphoneHostID, stmt, iphoneDEPDevice.SerialNumber)
 		return err
 	})
 
@@ -3456,7 +3456,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 
 	// Disable Require ACME, SCEP enroll a valid device via DEP, enable Require ACME and ensure renewal gets ACME
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
+		_, err := q.ExecContext(t.Context(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
 		return err
 	})
 
@@ -3470,7 +3470,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	var iPadHostID uint
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		stmt := `SELECT id FROM hosts WHERE hardware_serial = ?`
-		err := sqlx.GetContext(context.Background(), q, &iPadHostID, stmt, iPadDEPDevice.SerialNumber)
+		err := sqlx.GetContext(t.Context(), q, &iPadHostID, stmt, iPadDEPDevice.SerialNumber)
 		return err
 	})
 
@@ -3478,7 +3478,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	assert.False(t, hostResp.Host.MDMEnrollmentHardwareAttested)
 
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
+		_, err := q.ExecContext(t.Context(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
 		return err
 	})
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51974

I have not tested iPad or iPod items, since I don't own those, but I'm fairly confident the code works for those as expected.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ACME enrollment support for eligible Apple Business-assigned iPhones and iPads.
  - iPhones running iOS 16 or later and iPads running iPadOS 16.1 or later with supported hardware can use ACME.
  - Apple Silicon Macs continue to support ACME on macOS 14 or later.
  - ACME certificates now identify devices using their actual serial numbers.

- **Bug Fixes**
  - Renewing an MDM identity now removes the previous certificate and key to prevent stale credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->