### PR TITLE
Add VEX exclusions for SSH server vuln in fleetdm/fleet

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -5,6 +5,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/fleet` docker image
 
+### [CVE-2026-56854](https://nvd.nist.gov/vuln/detail/CVE-2026-56854)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The vulnerable code is in the SSH server authentication path of golang.org/x/crypto/ssh (ssh.NewServerConn). Fleet does not run an SSH server; golang.org/x/crypto/ssh is only linked into the fleet binary as an SSH client (go-git SSH transport, skeema/knownhosts, go.step.sm/crypto key parsing) and for terminal password prompts in fleetctl.
+- **Products:** `fleet`,`pkg:golang/golang.org/x/crypto`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-09-01 11:10:45
+
 ### [CVE-2026-42306](https://nvd.nist.gov/vuln/detail/CVE-2026-42306)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleet/CVE-2026-56854.vex.json
+++ b/security/vex/fleet/CVE-2026-56854.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-bc16bdc4aa91ec5dd7baba48a74c08e48081b58c380eb7536b0ac1f590e01fb8",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56854"
+      },
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The vulnerable code is in the SSH server authentication path of golang.org/x/crypto/ssh (ssh.NewServerConn). Fleet does not run an SSH server; golang.org/x/crypto/ssh is only linked into the fleet binary as an SSH client (go-git SSH transport, skeema/knownhosts, go.step.sm/crypto key parsing) and for terminal password prompts in fleetctl.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-09-01T11:10:45.08996Z"
+    }
+  ],
+  "timestamp": "2026-09-01T11:10:45Z"
+}


### PR DESCRIPTION
The reported CVE is a vulnerability in SSH servers. Fleet does not run an SSH server.

Fixes: https://github.com/fleetdm/fleet/actions/runs/33476561533.

New run: https://github.com/fleetdm/fleet/actions/runs/33501703531.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a vulnerability assessment for CVE-2026-56854.
  * Documented that Fleet is not affected because it uses the SSH package only as a client, not through the vulnerable server authentication path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->