### PR TITLE
Give dev's shared webpack chunks fixed names

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,6 +177,30 @@ const config = {
   },
 };
 
+if (process.env.NODE_ENV !== "production") {
+  // Default splitChunks names shared chunks after their contents, so the names
+  // shift as the sharing topology does — 404ing against go-bindata -debug's
+  // asset list, which is frozen when generate-dev runs.
+  config.optimization.splitChunks = {
+    cacheGroups: {
+      defaultVendors: {
+        test: /[\\/]node_modules[\\/]/,
+        name: "vendors",
+        chunks: "async",
+        priority: -10,
+        reuseExistingChunk: true,
+      },
+      default: {
+        name: "common",
+        chunks: "async",
+        minChunks: 2,
+        priority: -20,
+        reuseExistingChunk: true,
+      },
+    },
+  };
+}
+
 if (process.env.NODE_ENV === "production") {
   config.output.filename = "[name]-[contenthash].js";
   // Route chunks need a content hash too, so the Go asset handler serves them


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #47830

Summary in comment below.

Main "con" is that we don't get the full prod optimization in dev (which IMHO is fine, and it's still better than what we had prior to code splitting anyways).

To test, make sure you run:
- `make generate-dev`
- `make build` (after `make generate-dev` finishes)
- `./build/fleet serve ...`

## Testing

- [x] QA'd all new/changed functionality manually

#### Before

Dashboard page breaking:

<img width="1110" height="1170" alt="image (1)" src="https://github.com/user-attachments/assets/a20b512f-b891-4342-8d6c-b33243c98a01" />


#### After

Dev build:

<img width="2553" height="559" alt="Screenshot 2026-09-01 at 9 28 51 AM" src="https://github.com/user-attachments/assets/9d39c231-e2ba-4ad4-a512-1727e8618e95" />

Prod build (unchanged):

<img width="2554" height="628" alt="Screenshot 2026-09-01 at 9 27 38 AM" src="https://github.com/user-attachments/assets/1eb6b15b-16aa-49be-8701-0916a79aa004" />


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development build behavior by assigning stable names to shared application chunks.
  * Production builds remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->