### PR TITLE
Prevent run of orbit codesign in forks PRs and pushes to forks

### DIFF
--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -31,6 +31,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ (github.repository == 'fleetdm/fleet') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
This is to reduce noise (this workflow requires credentials, and forks do not inherit them).

I got a notification about this workflow failing when pushing to a fleet fork (https://github.com/fleetdm/fleet/pull/51845)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS Orbit builds to run only for approved repository contexts.
  * Prevented builds from triggering for pull requests originating from forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->