### PR TITLE
Swap buford for nanopush, send APNs pushes with expiration, push type, and topic headers

### DIFF
--- a/changes/40693-apns-push-reliability.md
+++ b/changes/40693-apns-push-reliability.md
@@ -1,0 +1,1 @@
+- Improved Apple MDM push reliability: APNs notifications are now sent with a 7-day expiration and the documented MDM headers, so Apple stores and retries delivery to offline devices.

--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -4,14 +4,16 @@ package main
 // (newMux) over HTTP via httptest. The wire contract these tests pin —
 // request/response shapes, header semantics, error bodies, SSE stream
 // behavior — is documented on pushHandler, parsePushHeaders, apnsPushError,
-// and eventsSSEHandler in handlers.go. TestE2EBufordCompatibility verifies
-// the contract through the actual buford client `fleet serve` uses in
-// production.
+// and eventsSSEHandler in handlers.go. TestE2ENanopushProvider verifies the
+// contract through the actual nanopush provider `fleet serve` uses in
+// production; TestE2EBufordCompatibility keeps the legacy buford client
+// covered while it remains in-tree.
 
 import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,6 +32,8 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -256,8 +260,8 @@ func waitStreamClosed(t *testing.T, c *sseClient, timeout time.Duration) {
 
 // pushRaw sends a push the way a spec-correct APNS client would, declaring
 // apns-push-type: mdm by default. Pass an empty string value in headers to
-// omit that header instead (Fleet's buford client sends no apns-* headers at
-// all today — TestE2EPushTypeHeader covers that path explicitly).
+// omit that header instead (Fleet sent no apns-* headers before the nanopush
+// swap — TestE2EPushTypeHeader keeps that path covered).
 func pushRaw(t *testing.T, baseURL, token string, payload []byte, headers map[string]string) *http.Response {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/3/device/"+token, bytes.NewReader(payload))
@@ -305,7 +309,7 @@ func requireAPNSErrorBody(t *testing.T, resp *http.Response) string {
 		Timestamp *int64 `json:"timestamp"`
 	}
 	require.NoError(t, json.Unmarshal(bodyBytes, &body),
-		"non-200 responses must have a JSON body: buford's parseErrorResponse returns a JSON-decode error to the caller otherwise")
+		"non-200 responses must have a JSON body: nanopush's newError (and buford's parseErrorResponse) return a JSON-decode error to the caller otherwise")
 	if resp.StatusCode == http.StatusGone {
 		assert.NotNil(t, body.Timestamp, "410 Unregistered must carry the unix-millis timestamp of when the token died")
 	} else {
@@ -402,8 +406,8 @@ func TestE2EPushWithPastExpirationDiscarded(t *testing.T) {
 	srv, node := newTestServerWithNode(t)
 	const token = "aabbccddee04" // nolint:gosec // test token
 
-	// apns-expiration is unix SECONDS (buford's Headers.Expiration marshals
-	// seconds); 1 is 1970, long past. Device offline → discard, don't store.
+	// apns-expiration is unix SECONDS (nanopush sends exp.Unix()); 1 is 1970,
+	// long past. Device offline → discard, don't store.
 	resp := pushOffline(t, srv.URL, token, []byte(`{"mdm":"stale"}`), map[string]string{"apns-expiration": "1"}, node)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "a discarded push is still a successful push (APNS semantics)")
 
@@ -465,8 +469,8 @@ func TestE2EPushTypeHeader(t *testing.T) {
 	const token = "aabbccddee0c" // nolint:gosec // test token
 
 	t.Run("absent header is accepted", func(t *testing.T) {
-		// Fleet's buford path sends no apns-push-type header at all, so
-		// header-less pushes must keep working.
+		// Fleet sent no apns-push-type header before the nanopush swap, so
+		// header-less pushes must keep working for older clients.
 		resp := pushRaw(t, srv.URL, token, []byte(`{"mdm":"m"}`), map[string]string{"apns-push-type": ""})
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
@@ -482,8 +486,9 @@ func TestE2EPushTypeHeader(t *testing.T) {
 }
 
 func TestE2EPayloadWithNewlineIsFramedSafely(t *testing.T) {
-	// PushMagic comes from the device's TokenUpdate and buford builds the
-	// body by string concatenation, so a payload can contain a raw newline.
+	// PushMagic comes from the device's TokenUpdate and the push providers
+	// build the body by string concatenation, so a payload can contain a raw
+	// newline.
 	// Emitted as-is it would end the SSE event early and corrupt every frame
 	// after it; the server must split it across data: lines instead.
 	srv := newTestServer(t)
@@ -741,10 +746,10 @@ func TestE2EDisconnectedStreamIsReapedByKeepalive(t *testing.T) {
 	waitConnected(t, srv.URL, 0)
 }
 
-// TestE2EBufordCompatibility drives the mock through the actual buford
-// client library — the same code path `fleet serve` uses to talk to Apple
-// (server/mdm/nanomdm/push/buford wraps bufordpush.Service). If these pass,
-// pointing Fleet's push provider at the mock works.
+// TestE2EBufordCompatibility drives the mock through the buford client
+// library — the code path `fleet serve` used before the nanopush swap
+// (server/mdm/nanomdm/push/buford wraps bufordpush.Service). Kept while
+// buford remains in-tree so older clients stay covered.
 func TestE2EBufordCompatibility(t *testing.T) {
 	srv := newTestServer(t)
 	svc := bufordpush.NewService(fleethttp.NewClient(), srv.URL)
@@ -766,5 +771,55 @@ func TestE2EBufordCompatibility(t *testing.T) {
 			"error must decode as a buford push error, not a JSON parse failure — the mock must always send the JSON error body")
 		assert.Equal(t, bufordpush.ErrBadDeviceToken, apnsErr.Reason)
 		assert.Equal(t, http.StatusBadRequest, apnsErr.Status)
+	})
+}
+
+// TestE2ENanopushProvider drives the mock through the actual nanopush
+// provider — the code path `fleet serve` uses to talk to Apple — with the
+// same options production sets (expiration, custom client), so the mock is
+// proven against the headers Fleet really sends (apns-expiration,
+// apns-push-type: mdm, apns-topic).
+func TestE2ENanopushProvider(t *testing.T) {
+	srv := newTestServer(t)
+	factory := nanopush.NewFactory(
+		nanopush.WithNewClient(func(*tls.Certificate) (*http.Client, error) {
+			return fleethttp.NewClient(), nil
+		}),
+		nanopush.WithExpiration(7*24*time.Hour),
+		nanopush.WithPushServerURL(srv.URL),
+	)
+	prov, err := factory.NewPushProvider(nil)
+	require.NoError(t, err)
+
+	t.Run("successful push round-trips to a client", func(t *testing.T) {
+		const token = "aabbccddee0e" // nolint:gosec // test token
+		pushInfo := &mdm.Push{PushMagic: "pushmagicXYZ", Topic: "com.apple.mgmt.External.test"}
+		require.NoError(t, pushInfo.SetTokenString(token))
+
+		resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
+		require.NoError(t, err)
+		require.Len(t, resp, 1)
+		require.NoError(t, resp[token].Err)
+		assert.NotEmpty(t, resp[token].Id, "apns-id must round-trip through the provider")
+
+		c := sseConnect(t, srv.URL, token)
+		assert.JSONEq(t, `{"mdm":"pushmagicXYZ"}`, nextPing(t, c, 5*time.Second))
+	})
+
+	t.Run("error body decodes as JSONPushError", func(t *testing.T) {
+		const token = "aabbccddee0f" // nolint:gosec // test token
+		// an over-limit payload is the easiest error reachable through the
+		// provider: tokens are hex-encoded by the transport so they can't be
+		// made invalid from here
+		pushInfo := &mdm.Push{PushMagic: strings.Repeat("x", maxPayloadBytes), Topic: "com.apple.mgmt.External.test"}
+		require.NoError(t, pushInfo.SetTokenString(token))
+
+		resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
+		require.NoError(t, err)
+		require.Len(t, resp, 1)
+		var jsonErr *nanopush.JSONPushError
+		require.ErrorAs(t, resp[token].Err, &jsonErr,
+			"error must decode as a nanopush JSONPushError, not a JSON parse failure — the mock must always send the JSON error body")
+		assert.Equal(t, "PayloadTooLarge", jsonErr.Reason)
 	})
 }

--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -796,7 +796,7 @@ func TestE2ENanopushProvider(t *testing.T) {
 		pushInfo := &mdm.Push{PushMagic: "pushmagicXYZ", Topic: "com.apple.mgmt.External.test"}
 		require.NoError(t, pushInfo.SetTokenString(token))
 
-		resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
+		resp, err := prov.Push(t.Context(), []*mdm.Push{pushInfo})
 		require.NoError(t, err)
 		require.Len(t, resp, 1)
 		require.NoError(t, resp[token].Err)
@@ -814,7 +814,7 @@ func TestE2ENanopushProvider(t *testing.T) {
 		pushInfo := &mdm.Push{PushMagic: strings.Repeat("x", maxPayloadBytes), Topic: "com.apple.mgmt.External.test"}
 		require.NoError(t, pushInfo.SetTokenString(token))
 
-		resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
+		resp, err := prov.Push(t.Context(), []*mdm.Push{pushInfo})
 		require.NoError(t, err)
 		require.Len(t, resp, 1)
 		var jsonErr *nanopush.JSONPushError

--- a/cmd/apple-apns-mock/handlers.go
+++ b/cmd/apple-apns-mock/handlers.go
@@ -212,10 +212,10 @@ func pingEvent(payload []byte) string {
 }
 
 // pushHandler serves POST /3/device/{token}, the same shape as
-// api.push.apple.com. It accepts what Fleet's buford client sends — a raw JSON
-// body and no apns-* headers — plus the spec headers parsePushHeaders models,
-// and applies APNs payload limits. The payload is forwarded verbatim, not
-// parsed.
+// api.push.apple.com. It accepts what Fleet's nanopush client sends — a raw
+// JSON body with apns-expiration, apns-push-type: mdm, and apns-topic — as
+// well as requests with no apns-* headers at all (legacy clients), and
+// applies APNs payload limits. The payload is forwarded verbatim, not parsed.
 func pushHandler(w http.ResponseWriter, r *http.Request, c *coordinator, logger *slog.Logger) {
 	// parsePushHeaders returns its headers even on failure so the error
 	// response echoes the client's apns-id, like real APNS does.
@@ -261,10 +261,12 @@ func pushHandler(w http.ResponseWriter, r *http.Request, c *coordinator, logger 
 	logger.DebugContext(r.Context(), "push accepted", "token", token, "apns-id", headers.PushID, "payload_size", len(payload), "expiration", expiration)
 }
 
-// pushHeaders holds the apns-* request headers the mock models. Fleet sends
-// none of them today, so every field has an "absent" behavior; this struct
-// is the extension point for future headers (apns-priority,
-// apns-collapse-id, ...).
+// pushHeaders holds the apns-* request headers the mock models. Every field
+// keeps an "absent" behavior so clients that send no apns-* headers still
+// work; this struct is the extension point for future headers
+// (apns-priority, apns-collapse-id, ...). apns-topic is accepted but not
+// modeled: Fleet deployments use a single topic and pending pushes are keyed
+// by token alone.
 type pushHeaders struct {
 	PushID     string     // apns-id: echoed back if given (else a generated UUID); non-UUID → 400 BadMessageId
 	PushType   string     // apns-push-type: absent or "mdm" accepted; anything else → 400 InvalidPushType (this mock only models MDM wake-ups)
@@ -304,10 +306,10 @@ func parsePushHeaders(r *http.Request) (*pushHeaders, *apnsError) {
 }
 
 // apnsPushError writes the error shape real APNs returns: an apns-id header
-// and a {"reason":...} JSON body. The body is load-bearing — buford's
-// parseErrorResponse surfaces a JSON-decode error instead of the reason on
-// anything else. A 410 Unregistered, if ever modeled, must add a "timestamp"
-// field; Apple omits it on every other error.
+// and a {"reason":...} JSON body. The body is load-bearing — nanopush's
+// newError surfaces a JSON-decode error instead of the reason on anything
+// else. A 410 Unregistered, if ever modeled, must add a "timestamp" field;
+// Apple omits it on every other error.
 func apnsPushError(w http.ResponseWriter, headers *pushHeaders, err *apnsError) {
 	w.Header().Set("Content-Type", "application/json")
 	if headers != nil {

--- a/cmd/fleet/mdm_apple.go
+++ b/cmd/fleet/mdm_apple.go
@@ -14,7 +14,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
-	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/buford"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
 	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	scepdepot "github.com/fleetdm/fleet/v4/server/mdm/scep/depot"
 	"github.com/fleetdm/fleet/v4/server/service"
@@ -54,14 +54,19 @@ func initAppleMDMStorages(mds *mysql.Datastore, initFatal func(err error, msg st
 // initAppleMDMPushService chooses the push service implementation: a no-op
 // pusher when FLEET_DEV_MDM_APPLE_DISABLE_PUSH=1 (development mode), or a
 // real APNs pusher built around the NanoMDM storage in all other cases.
-func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, logger *slog.Logger) push.Pusher {
+// apnsPushExpiration drives the apns-expiration header so APNs stores and
+// retries delivery to offline devices; zero or negative omits the header,
+// leaving delivery to Apple's undocumented default storage policy.
+func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, apnsPushExpiration time.Duration, logger *slog.Logger) push.Pusher {
 	if dev_mode.Env("FLEET_DEV_MDM_APPLE_DISABLE_PUSH") == "1" {
 		return nopPusher{}
 	}
 	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))
 
-	opts := []buford.Option{
-		buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
+	opts := []nanopush.Option{
+		// keep the fleethttp client: it preserves proxy support and sane
+		// timeouts that nanopush's default bare transport does not have
+		nanopush.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
 			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
 				Certificates: []tls.Certificate{*cert},
 				MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
@@ -69,13 +74,20 @@ func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, logger *slog.Logg
 		}),
 	}
 
+	if apnsPushExpiration > 0 {
+		opts = append(opts, nanopush.WithExpiration(apnsPushExpiration))
+	} else {
+		logger.WarnContext(context.Background(),
+			"mdm.apple_apns_push_expiration is zero or negative; pushes are sent without an apns-expiration header and APNs may not retry delivery to offline devices")
+	}
+
 	devPushServer := dev_mode.Env("FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL")
 	if devPushServer != "" {
 		logger.InfoContext(context.Background(), "using dev push server URL", "url", devPushServer)
-		opts = append(opts, buford.WithPushServerURL(devPushServer))
+		opts = append(opts, nanopush.WithPushServerURL(devPushServer))
 	}
 
-	pushProviderFactory := buford.NewPushProviderFactory(opts...)
+	pushProviderFactory := nanopush.NewFactory(opts...)
 	return nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
 }
 

--- a/cmd/fleet/mdm_apple_test.go
+++ b/cmd/fleet/mdm_apple_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
@@ -44,7 +45,7 @@ func TestInitAppleMDMPushService_DevModeReturnsNopPusher(t *testing.T) {
 	// SetOverride enables dev mode and registers cleanup via t.
 	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_DISABLE_PUSH", "1", t)
 
-	pusher := initAppleMDMPushService(nil, discardLogger())
+	pusher := initAppleMDMPushService(nil, 7*24*time.Hour, discardLogger())
 	require.IsType(t, nopPusher{}, pusher)
 }
 
@@ -52,8 +53,18 @@ func TestInitAppleMDMPushService_DevModeCustomPushServerURL(t *testing.T) {
 	// SetOverride enables dev mode and registers cleanup via t.
 	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL", "http://localhost:8378", t)
 
-	pusher := initAppleMDMPushService(nil, discardLogger())
+	pusher := initAppleMDMPushService(nil, 7*24*time.Hour, discardLogger())
 	require.IsType(t, &nanomdm_pushsvc.PushService{}, pusher)
+}
+
+func TestInitAppleMDMPushService_ZeroExpirationWarnsAndDegrades(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	pusher := initAppleMDMPushService(nil, 0, logger)
+	require.IsType(t, &nanomdm_pushsvc.PushService{}, pusher)
+	require.Contains(t, buf.String(), "apple_apns_push_expiration")
+	require.Contains(t, buf.String(), "level=WARN")
 }
 
 func TestCheckMDMAssetsExist(t *testing.T) {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -360,7 +360,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 
 	mdmStorage, depStorage, scepStorage := initAppleMDMStorages(mds, initFatal)
 
-	mdmPushService := initAppleMDMPushService(mdmStorage, logger)
+	mdmPushService := initAppleMDMPushService(mdmStorage, config.MDM.AppleAPNsPushExpiration, logger)
 	mds.WithPusher(mdmPushService)
 
 	// reconcile Apple MDM and Business Manager configuration with the database

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1052,6 +1052,10 @@ type MDMConfig struct {
 	// AppleDEPSyncPeriodicity is the duration between DEP device syncing
 	// (fetching and setting of DEP profiles).
 	AppleDEPSyncPeriodicity time.Duration `yaml:"apple_dep_sync_periodicity"`
+	// AppleAPNsPushExpiration is the value used for the apns-expiration header
+	// on APNs push notifications, so APNs stores and retries delivery to
+	// offline devices until then. Zero or negative omits the header.
+	AppleAPNsPushExpiration time.Duration `yaml:"apple_apns_push_expiration"`
 	// AppleSCEPChallenge is the SCEP challenge for SCEP enrollment requests.
 	AppleSCEPChallenge string `yaml:"apple_scep_challenge"`
 	// AppleSCEPSignerValidityDays are the days signed client certificates will
@@ -2009,6 +2013,8 @@ func (man Manager) addConfigs() {
 	man.addConfigString("mdm.apple_vpp_app_metadata_api_bearer_token", "", "Apple Connect JWT, used for accessing VPP app metadata directly from Apple")
 	man.addConfigString("mdm.apple_scep_challenge", "", "SCEP static challenge for enrollment")
 	man.addConfigDuration("mdm.apple_dep_sync_periodicity", 1*time.Minute, "How much time to wait for DEP profile assignment")
+	man.addConfigDuration("mdm.apple_apns_push_expiration", 7*24*time.Hour, "How long APNs should store and retry delivering push notifications to offline devices (apns-expiration header); 0 omits the header")
+	man.hideConfig("mdm.apple_apns_push_expiration")
 	man.addConfigString("mdm.windows_wstep_identity_cert", "", "Microsoft WSTEP PEM-encoded certificate path")
 	man.addConfigString("mdm.windows_wstep_identity_key", "", "Microsoft WSTEP PEM-encoded private key path")
 	man.addConfigString("mdm.windows_wstep_identity_cert_bytes", "", "Microsoft WSTEP PEM-encoded certificate bytes")
@@ -2390,6 +2396,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			AppleConnectJWT:                   man.getConfigString("mdm.apple_vpp_app_metadata_api_bearer_token"),
 			AppleSCEPChallenge:                man.getConfigString("mdm.apple_scep_challenge"),
 			AppleDEPSyncPeriodicity:           man.getConfigDuration("mdm.apple_dep_sync_periodicity"),
+			AppleAPNsPushExpiration:           man.getConfigDuration("mdm.apple_apns_push_expiration"),
 			WindowsWSTEPIdentityCert:          man.getConfigString("mdm.windows_wstep_identity_cert"),
 			WindowsWSTEPIdentityKey:           man.getConfigString("mdm.windows_wstep_identity_key"),
 			WindowsWSTEPIdentityCertBytes:     man.getConfigString("mdm.windows_wstep_identity_cert_bytes"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2013,7 +2013,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("mdm.apple_vpp_app_metadata_api_bearer_token", "", "Apple Connect JWT, used for accessing VPP app metadata directly from Apple")
 	man.addConfigString("mdm.apple_scep_challenge", "", "SCEP static challenge for enrollment")
 	man.addConfigDuration("mdm.apple_dep_sync_periodicity", 1*time.Minute, "How much time to wait for DEP profile assignment")
-	man.addConfigDuration("mdm.apple_apns_push_expiration", 7*24*time.Hour, "How long APNs should store and retry delivering push notifications to offline devices (apns-expiration header); 0 omits the header")
+	man.addConfigDuration("mdm.apple_apns_push_expiration", 7*24*time.Hour, "How long APNs should store and retry delivering push notifications to offline devices (apns-expiration header); zero or negative omits the header")
 	man.hideConfig("mdm.apple_apns_push_expiration")
 	man.addConfigString("mdm.windows_wstep_identity_cert", "", "Microsoft WSTEP PEM-encoded certificate path")
 	man.addConfigString("mdm.windows_wstep_identity_key", "", "Microsoft WSTEP PEM-encoded private key path")

--- a/server/mdm/apple/apns_errors.go
+++ b/server/mdm/apple/apns_errors.go
@@ -1,0 +1,27 @@
+package apple_mdm
+
+import (
+	"errors"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
+)
+
+// APNs rejection reasons from the JSON body of a failed push request, as
+// documented in Apple's "Handling notification responses from APNs".
+const (
+	APNSReasonUnregistered           = "Unregistered"
+	APNSReasonExpiredToken           = "ExpiredToken"
+	APNSReasonBadDeviceToken         = "BadDeviceToken"
+	APNSReasonDeviceTokenNotForTopic = "DeviceTokenNotForTopic"
+	APNSReasonTooManyRequests        = "TooManyRequests"
+)
+
+// APNSReason extracts the APNs rejection reason (e.g. "Unregistered",
+// "BadDeviceToken") from a push response error, or "" if the error does not
+// carry one (transport failures, non-APNs errors).
+func APNSReason(err error) string {
+	if jsonErr, ok := errors.AsType[*nanopush.JSONPushError](err); ok {
+		return jsonErr.Reason
+	}
+	return ""
+}

--- a/server/mdm/apple/apns_errors_test.go
+++ b/server/mdm/apple/apns_errors_test.go
@@ -53,7 +53,7 @@ func TestAPNSReason(t *testing.T) {
 }
 
 func TestTurnOffMDMIfAPNSFailed(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	noActivity := func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error { return nil }
 
 	apnsErr := func(err error) *APNSDeliveryError {

--- a/server/mdm/apple/apns_errors_test.go
+++ b/server/mdm/apple/apns_errors_test.go
@@ -1,0 +1,119 @@
+package apple_mdm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPNSReason(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "bare JSONPushError",
+			err:  &nanopush.JSONPushError{Reason: APNSReasonUnregistered, Timestamp: 1725000000000},
+			want: APNSReasonUnregistered,
+		},
+		{
+			name: "wrapped like the provider wraps it",
+			err:  fmt.Errorf("push HTTP status: 410: %w", &nanopush.JSONPushError{Reason: APNSReasonUnregistered}),
+			want: APNSReasonUnregistered,
+		},
+		{
+			name: "double-wrapped",
+			err:  fmt.Errorf("outer: %w", fmt.Errorf("push HTTP status: 400: %w", &nanopush.JSONPushError{Reason: APNSReasonBadDeviceToken})),
+			want: APNSReasonBadDeviceToken,
+		},
+		{
+			name: "transport error",
+			err:  errors.New("dial tcp: connection refused"),
+			want: "",
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, APNSReason(c.err))
+		})
+	}
+}
+
+func TestTurnOffMDMIfAPNSFailed(t *testing.T) {
+	ctx := context.Background()
+	noActivity := func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error { return nil }
+
+	apnsErr := func(err error) *APNSDeliveryError {
+		return &APNSDeliveryError{errorsByUUID: map[string]error{"host-uuid-1": err}}
+	}
+
+	cases := []struct {
+		name            string
+		err             error
+		wantHandled     bool
+		wantTurnOffCall bool
+	}{
+		{
+			name:            "Unregistered turns off MDM",
+			err:             apnsErr(fmt.Errorf("push HTTP status: 410: %w", &nanopush.JSONPushError{Reason: APNSReasonUnregistered, Timestamp: 1725000000000})),
+			wantHandled:     true,
+			wantTurnOffCall: true,
+		},
+		{
+			name:            "BadDeviceToken does not turn off MDM",
+			err:             apnsErr(fmt.Errorf("push HTTP status: 400: %w", &nanopush.JSONPushError{Reason: APNSReasonBadDeviceToken})),
+			wantHandled:     true,
+			wantTurnOffCall: false,
+		},
+		{
+			name:            "TooManyRequests does not turn off MDM",
+			err:             apnsErr(fmt.Errorf("push HTTP status: 429: %w", &nanopush.JSONPushError{Reason: APNSReasonTooManyRequests})),
+			wantHandled:     true,
+			wantTurnOffCall: false,
+		},
+		{
+			name:            "5xx does not turn off MDM",
+			err:             apnsErr(fmt.Errorf("push HTTP status: 503: %w", &nanopush.JSONPushError{Reason: "InternalServerError"})),
+			wantHandled:     true,
+			wantTurnOffCall: false,
+		},
+		{
+			name:            "transport error does not turn off MDM",
+			err:             apnsErr(errors.New("dial tcp: connection refused")),
+			wantHandled:     true,
+			wantTurnOffCall: false,
+		},
+		{
+			name:            "non-APNs error is not handled",
+			err:             errors.New("some datastore error"),
+			wantHandled:     false,
+			wantTurnOffCall: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.MDMTurnOffFunc = func(ctx context.Context, uuid string) ([]*fleet.User, []fleet.ActivityDetails, error) {
+				return nil, nil, nil
+			}
+
+			handled, err := turnOffMDMIfAPNSFailed(ctx, ds, c.err, slog.New(slog.DiscardHandler), noActivity)
+			require.NoError(t, err)
+			require.Equal(t, c.wantHandled, handled)
+			require.Equal(t, c.wantTurnOffCall, ds.MDMTurnOffFuncInvoked)
+		})
+	}
+}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1840,8 +1840,11 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	return nil
 }
 
-// turnOffMDMIfAPNSFailed checks if the error is an APNSDeliveryError and turns off MDM for the failed devices.
-// Returns a boolean value to indicate whether or not MDM was turned off.
+// turnOffMDMIfAPNSFailed turns off MDM for any device whose push was rejected
+// by APNs with an Unregistered reason (dead token). It returns true whenever
+// err is an APNSDeliveryError — even when no device was turned off — signaling
+// the caller that only push delivery failed (commands remain durably queued)
+// so processing can continue.
 func turnOffMDMIfAPNSFailed(ctx context.Context, ds fleet.Datastore, err error, logger *slog.Logger, newActivityFn NewActivityFunc) (bool,
 	error,
 ) {
@@ -1851,7 +1854,10 @@ func turnOffMDMIfAPNSFailed(ctx context.Context, ds fleet.Datastore, err error, 
 	}
 
 	for uuid, err := range e.errorsByUUID {
-		if strings.Contains(err.Error(), "device token is inactive") {
+		// nanopush surfaces APNs' structured rejection reason; buford rendered
+		// this same condition as "device token is inactive". If the push
+		// provider ever changes, this classification must change with it.
+		if APNSReason(err) == APNSReasonUnregistered {
 			logger.InfoContext(ctx, "turning off MDM for device with inactive device token", "uuid", uuid)
 			users, activities, err := ds.MDMTurnOff(ctx, uuid)
 			if err != nil {

--- a/server/mdm/nanomdm/push/nanopush/provider.go
+++ b/server/mdm/nanomdm/push/nanopush/provider.go
@@ -81,6 +81,12 @@ func (p *Provider) do(ctx context.Context, pushInfo *mdm.Push) *push.Response {
 		exp := time.Now().Add(p.expiration)
 		req.Header.Set("apns-expiration", strconv.FormatInt(exp.Unix(), 10))
 	}
+	req.Header.Set("apns-push-type", "mdm")
+	if pushInfo.Topic != "" {
+		// an empty topic is invalid; omitting the header instead lets APNs
+		// infer the topic from the client certificate's UID
+		req.Header.Set("apns-topic", pushInfo.Topic)
+	}
 	r, err := p.client.Do(req)
 	var goAwayErr http2.GoAwayError
 	if errors.As(err, &goAwayErr) {

--- a/server/mdm/nanomdm/push/nanopush/provider_test.go
+++ b/server/mdm/nanomdm/push/nanopush/provider_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/stretchr/testify/require"
@@ -131,6 +133,61 @@ func testPushDevices(t *testing.T, input [][]string) {
 			}
 		}
 	}
+}
+
+// TestPushHeaders pins the apns-* request headers the provider sends: the
+// expiration window when configured, the mdm push type, and the enrollment
+// topic when present.
+func TestPushHeaders(t *testing.T) {
+	const (
+		token = "c2732227a1d8021cfaf781d71fb2f908c61f5861079a00954a5453f1d0281433" // nolint:gosec // test device token
+		topic = "com.example.apns-topic"
+	)
+
+	newPushInfo := func(topic string) *mdm.Push {
+		pushInfo := &mdm.Push{PushMagic: "47250C9C-1B37-4381-98A9-0B8315A441C7", Topic: topic}
+		require.NoError(t, pushInfo.SetTokenString(token))
+		return pushInfo
+	}
+
+	push := func(t *testing.T, expiration time.Duration, pushInfo *mdm.Push) http.Header {
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+		}))
+		defer server.Close()
+
+		prov := &Provider{baseURL: server.URL, client: http.DefaultClient, expiration: expiration}
+		resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
+		require.NoError(t, err)
+		require.NoError(t, resp[token].Err)
+		return got
+	}
+
+	t.Run("expiration, push type and topic set", func(t *testing.T) {
+		expiration := 7 * 24 * time.Hour
+		before := time.Now().Add(expiration).Unix()
+		headers := push(t, expiration, newPushInfo(topic))
+		after := time.Now().Add(expiration).Unix()
+
+		require.Equal(t, "mdm", headers.Get("apns-push-type"))
+		require.Equal(t, topic, headers.Get("apns-topic"))
+		exp, err := strconv.ParseInt(headers.Get("apns-expiration"), 10, 64)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, exp, before)
+		require.LessOrEqual(t, exp, after)
+	})
+
+	t.Run("zero expiration omits the header", func(t *testing.T) {
+		headers := push(t, 0, newPushInfo(topic))
+		require.Empty(t, headers.Values("apns-expiration"))
+		require.Equal(t, "mdm", headers.Get("apns-push-type"))
+	})
+
+	t.Run("empty topic omits the header", func(t *testing.T) {
+		headers := push(t, time.Hour, newPushInfo(""))
+		require.Empty(t, headers.Values("apns-topic"))
+	})
 }
 
 type errorDoer struct{}

--- a/server/mdm/nanomdm/push/nanopush/provider_test.go
+++ b/server/mdm/nanomdm/push/nanopush/provider_test.go
@@ -158,7 +158,7 @@ func TestPushHeaders(t *testing.T) {
 		defer server.Close()
 
 		prov := &Provider{baseURL: server.URL, client: http.DefaultClient, expiration: expiration}
-		resp, err := prov.Push(context.Background(), []*mdm.Push{pushInfo})
+		resp, err := prov.Push(t.Context(), []*mdm.Push{pushInfo})
 		require.NoError(t, err)
 		require.NoError(t, resp[token].Err)
 		return got

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -86,6 +86,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/tokenpki"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
 	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	scepserver "github.com/fleetdm/fleet/v4/server/mdm/scep/server"
 	mdmtesting "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
@@ -22384,8 +22385,10 @@ func (s *integrationMDMTestSuite) TestIOSiPadOSRefetch() {
 		case "pushmagic" + failedMdmDeviceTokenInactive.SerialNumber:
 			return map[string]*push.Response{
 				pushObject.Token.String(): {
-					Id:  failedPushUUID,
-					Err: errors.New("device token is inactive"),
+					Id: failedPushUUID,
+					// same shape the nanopush provider returns on a 410
+					Err: fmt.Errorf("push HTTP status: 410: %w",
+						&nanopush.JSONPushError{Reason: "Unregistered", Timestamp: time.Now().UnixMilli()}),
 				},
 			}, nil
 		case "pushmagic" + failedMdmDevice.SerialNumber:

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -8,14 +8,14 @@
 // https://github.com/fleetdm/fleet/issues/22941
 // and can still be useful for debugging purposes.
 //
-// Usage (through the full Fleet push stack — nanomdm push service + buford):
+// Usage (through the full Fleet push stack — nanomdm push service + nanopush):
 //
 //	go run ./tools/mdm/apple/apnspush/main.go -mysql localhost:3306 -server-private-key <key> HOST_UUID1 HOST_UUID2 ...
 //
 // Direct mode: resolves the device token and push magic from the DB, then
-// sends a raw request to APNS itself — no buford, no nanomdm push
-// provider — and dumps Apple's raw response (status, headers, body) so the
-// actual APNS behavior can be inspected:
+// sends a raw request to APNS itself — no nanomdm push provider — and dumps
+// Apple's raw response (status, headers, body) so the actual APNS behavior
+// can be inspected:
 //
 //	go run ./tools/mdm/apple/apnspush/main.go -direct -mysql localhost:3306 -server-private-key <key> HOST_UUID1 ...
 //	... -direct -url https://api.development.push.apple.com ...  # APNS sandbox
@@ -40,13 +40,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
-	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/buford"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
 	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	"github.com/fleetdm/fleet/v4/server/service"
 )
@@ -54,9 +55,9 @@ import (
 func main() {
 	mysqlAddr := flag.String("mysql", "localhost:3306", "mysql address")
 	serverPrivateKey := flag.String("server-private-key", "", "fleet server's private key (to decrypt MDM assets)")
-	direct := flag.Bool("direct", false, "send raw requests directly to APNS, bypassing buford and the nanomdm push service, and dump the raw responses")
+	direct := flag.Bool("direct", false, "send raw requests directly to APNS, bypassing the nanomdm push service and provider, and dump the raw responses")
 	apnsURL := flag.String("url", "https://api.push.apple.com", "APNS base URL for -direct mode (e.g. https://api.development.push.apple.com for the sandbox, or a mock server)")
-	expiration := flag.Int64("expiration", -1, "apns-expiration header value (unix seconds) for -direct mode; -1 omits the header like Fleet does, 0 means deliver-now-or-discard")
+	expiration := flag.Int64("expiration", -1, "apns-expiration header value (unix seconds) for -direct mode; -1 omits the header, 0 means deliver-now-or-discard")
 	fake := flag.Bool("fake", false, "for -direct mode: UUIDs not found in nano_enrollments are pushed anyway, deriving the mdmtest scheme (token=hex(\"token\"+UUID), magic=\"pushmagic\"+UUID) instead of being skipped")
 	pushType := flag.String("type", "", "apns-push-type header value for -direct mode; if empty, the header is omitted.")
 
@@ -113,11 +114,15 @@ func main() {
 		return
 	}
 
-	pushProviderFactory := buford.NewPushProviderFactory(buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
-		return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{ // nolint:gosec // complains about TLS min version too low
-			Certificates: []tls.Certificate{*cert},
-		})), nil
-	}))
+	pushProviderFactory := nanopush.NewFactory(
+		nanopush.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
+			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{ // nolint:gosec // complains about TLS min version too low
+				Certificates: []tls.Certificate{*cert},
+			})), nil
+		}),
+		// same default expiration the Fleet server uses (mdm.apple_apns_push_expiration)
+		nanopush.WithExpiration(7*24*time.Hour),
+	)
 
 	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))
 	pusher := nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
@@ -149,7 +154,7 @@ func pushDirect(ctx context.Context, mdmStorage *mysql.NanoMDMStorage, baseURL s
 		return fmt.Errorf("retrieve push info from DB: %w", err)
 	}
 
-	// Same client the buford path above builds, so -direct exercises the
+	// Same client the full-stack path above builds, so -direct exercises the
 	// transport Fleet actually uses. HTTP/2 comes from ALPN (fleethttp's
 	// transport inherits ForceAttemptHTTP2 from http.DefaultTransport); the
 	// response's Proto is printed below, so a downgrade is visible.

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -116,8 +116,9 @@ func main() {
 
 	pushProviderFactory := nanopush.NewFactory(
 		nanopush.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
-			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{ // nolint:gosec // complains about TLS min version too low
+			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
 				Certificates: []tls.Certificate{*cert},
+				MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
 			})), nil
 		}),
 		// same default expiration the Fleet server uses (mdm.apple_apns_push_expiration)
@@ -158,8 +159,9 @@ func pushDirect(ctx context.Context, mdmStorage *mysql.NanoMDMStorage, baseURL s
 	// transport Fleet actually uses. HTTP/2 comes from ALPN (fleethttp's
 	// transport inherits ForceAttemptHTTP2 from http.DefaultTransport); the
 	// response's Proto is printed below, so a downgrade is visible.
-	client := fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{ // nolint:gosec // complains about TLS min version too low
+	client := fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
 		Certificates: []tls.Certificate{*cert},
+		MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
 	}))
 
 	var failed int


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51647

Swaps the archived buford APNs provider for the in-tree nanopush provider and sends every push with a 7-day `apns-expiration` (new hidden config `mdm.apple_apns_push_expiration`) plus the documented `apns-push-type: mdm` and `apns-topic` headers, so APNs stores and retries delivery to offline devices. Also replaces buford-specific string matching of APNs errors with structured reason classification (`APNSReason`), which later sub-issues of #40693 build on. QA'd on a real iPhone against production APNs: online delivery and offline store-and-forward both verified.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [x] Setting(s) is/are explicitly excluded from GitOps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple MDM push notifications now use production-compatible APNs settings.
  * Push requests include the MDM push type and support configurable expiration windows, defaulting to seven days.
  * APNs topics are applied when available, while certificate-based topic discovery remains supported.

* **Bug Fixes**
  * Improved handling of APNs rejection responses, including reliably disabling MDM for unregistered devices.
  * Added more accurate reporting and processing of APNs push failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->