### PR TITLE
Fix: MacOS Software Package version resolve logic

### DIFF
--- a/changes/52262-fix-macos-pkg-version-detection-logic.md
+++ b/changes/52262-fix-macos-pkg-version-detection-logic.md
@@ -1,0 +1,1 @@
+* Fixed server side MacOS Package version detection logic where some packages distribution XML structure will resolve with incorrect software version.

--- a/pkg/file/testdata/distribution/distribution-globalprotect.xml
+++ b/pkg/file/testdata/distribution/distribution-globalprotect.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+    <title>GlobalProtect</title>
+    <choices-outline>
+        <line choice="default"/>
+    </choices-outline>
+    <choice id="default">
+        <pkg-ref id="com.paloaltonetworks.globalprotect.pkg"/>
+    </choice>
+    <pkg-ref id="com.paloaltonetworks.globalprotect.pkg" version="6.2.8-948" installKBytes="180866">#gp.pkg</pkg-ref>
+    <pkg-ref id="com.paloaltonetworks.globalprotect.uninstall.pkg" version="0" installKBytes="0">#gp_uninstall.pkg</pkg-ref>
+    <pkg-ref id="com.paloaltonetworks.globalprotect.systemext.pkg" version="0" installKBytes="0">#gp_systemext.pkg</pkg-ref>
+    <pkg-ref id="com.paloaltonetworks.globalprotect.pkg">
+        <bundle-version>
+            <bundle CFBundleShortVersionString="6.2.8" id="com.paloaltonetworks.GlobalProtect.gpsplit" path="Contents/Resources/gpsplit.kext"/>
+        </bundle-version>
+    </pkg-ref>
+</installer-gui-script>

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -532,6 +532,9 @@ func getDistributionInfo(d *distributionXML) (name string, identifier string, ve
 		for _, pkgRef := range d.PkgRefs {
 			if pkgRef.Version != "" {
 				version = pkgRef.Version
+				if version != "0" {
+					break
+				}
 			}
 		}
 	}

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -104,6 +104,13 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			expectedPackageIDs: []string{"org.golang.go"},
 		},
 		{
+			file:               "distribution-globalprotect.xml",
+			expectedName:       "GlobalProtect",
+			expectedVersion:    "6.2.8-948",
+			expectedBundleID:   "com.paloaltonetworks.globalprotect.pkg",
+			expectedPackageIDs: []string{"com.paloaltonetworks.globalprotect.pkg"},
+		},
+		{
 			file:             "distribution-microsoft-teams.xml",
 			expectedName:     "Microsoft Teams",
 			expectedVersion:  "24124.1412.2911.3341",


### PR DESCRIPTION
## Root Cause Analysis

When MacOS pkg distribution XML do not include `<product version="x.x.x"/>` - the fallback logic that was implemented was intended to loop through pkg-ref and stop on the first version found - yet it didn't, and the loop kept on running and using the last version mentioned in the last pkg-ref block found.

Now pkg-ref fallback loop will break if a meaningful version is found, as was originally intended. Added globalprotect test distribution XML with the 'problematic' XML structure to the test list.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52262

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package metadata parsing to ignore placeholder version values and select the correct package version.
  * GlobalProtect installer information now reports the correct name, version, bundle identifier, and package ID.

* **Tests**
  * Added coverage for parsing GlobalProtect installer distribution files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->