### PR TITLE
Fleet UI: Add hover state and pointer cursor to side nav items

### DIFF
--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -455,6 +455,15 @@ $max-width: 2560px;
     &:hover {
       color: $ui-fleet-black-75-over;
     }
+    // TooltipTruncatedText's inner element sets `cursor: default`; inherit so
+    // the whole nav-item label reads as clickable.
+    .component__tooltip-wrapper__element {
+      cursor: inherit;
+    }
+  }
+
+  &:has(a):hover {
+    background-color: $ui-fleet-black-5;
   }
 
   &--active {


### PR DESCRIPTION
## Issue
Closes #52129

## Description
- Bug fix (root cause): `TooltipWrapper__element` sets `cursor: default`, which overrides the `<a>` `cursor: pointer` inside `SideNavItem` when hovering the label. Inherit the cursor within the nav-item anchor so the whole label reads as clickable.
- UX: Add a hover background (`$ui-fleet-black-5`) on the side-nav item, matching the tab hover pattern in `TabNav/_styles.scss`. Scoped with `:has(a)` so disabled `span.link-with-context` items don't pick up the hover.
- Lands via the `side-nav-item` mixin, so the fix reaches the admin settings side panel and every Controls sub-page that uses `SideNav` (OS settings, Setup experience, Variables).

## Screenrecording
- Hover + pointer cursor on side nav items


https://github.com/user-attachments/assets/a5a91738-1e7e-4461-bd2c-a2d1172d29e3



## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved side navigation hover states for linked items.
  * Ensured tooltip-wrapped navigation labels display the appropriate clickable cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->