### PR TITLE
Update Windows 10 CIS benchmark policies to v5.0.0

### DIFF
--- a/changes/51293-cis-win10-v5
+++ b/changes/51293-cis-win10-v5
@@ -1,0 +1,1 @@
+* Updated CIS Windows 10 Enterprise benchmark policies from v4.0.0 to v5.0.0.

--- a/ee/cis/win-10/README.md
+++ b/ee/cis/win-10/README.md
@@ -1,22 +1,69 @@
 # Windows 10 Enterprise benchmarks
 
-Fleet's policies have been written against v4.0.0 of the benchmark. You can refer to the [CIS website](https://www.cisecurity.org/cis-benchmarks) for full details about this version.
+Fleet's policies have been written against v5.0.0 of the benchmark. You can refer to the [CIS website](https://www.cisecurity.org/cis-benchmarks) for full details about this version.
 
 For requirements and usage details, see the [CIS Benchmarks](https://fleetdm.com/docs/using-fleet/cis-benchmarks) documentation.
 
 ### Limitations
 
-> With the two exceptions noted below, all items in this version of the benchmark are able to be automated.
+> All Automated items in this version of the benchmark are able to be automated. Fleet does not ship BitLocker (BL) or Next Generation (NG) profile recommendations.
+
+### Important: Group Policy removal does not clear registry values
+
+When a Group Policy entry is removed from `Registry.pol` and `gpupdate /force` is run, Windows does **not** clean up the registry value it previously wrote. This means the osquery-based policy check will continue to report the device as compliant even after the Group Policy is set back to "Not Configured."
+
+This is expected Windows behavior and is consistent with the CIS benchmark audit procedure, which checks the registry value regardless of how it was set. To truly revert a setting, the registry value must be explicitly deleted or changed -- simply removing the Group Policy is not sufficient.
+
+### v5.0.0 update notes
+
+#### Removed (27 policies)
+
+- **All 21 recommendations under 18.10.42 Microsoft Defender Antivirus** -- CIS removed these from v5.0.0 (Ticket #27270). This includes MAPS, Real-Time Protection, Scan, Reporting, MpEngine, Network Inspection System, Features, and Remediation sub-sections. Microsoft Defender Application Guard (18.10.43) and Exploit Guard (18.10.44) policies are retained.
+- **2.3.8 (L1)** Microsoft network client: Digitally sign communications (if server agrees) -- removed by CIS (Ticket #25346).
+- **2.3.9 (L1)** Microsoft network server: Digitally sign communications (if client agrees) -- removed by CIS (Ticket #25347).
+- **2.2 (L1)** Change the time zone -- removed by CIS (Ticket #26345).
+- **18.10.91 (L1)** Allow networking in Windows Sandbox -- removed by CIS (Ticket #26086).
+- **18.10.94.4 (L1)** Select when Preview Builds and Feature Updates are received -- removed by CIS (Ticket #26311).
+- **18.10.16 (L1)** Disable OneSettings Downloads -- removed by CIS (Ticket #26336).
+
+#### Added (2 policies)
+
+- **18.9.17.1 (L1)** Enable / disable CLFS logfile authentication (Ticket #26810).
+- **18.11.1 (L1)** Disable HTTP proxy features: Disable WPAD (Ticket #26860). Requires the CIS.admx/adml Group Policy template from the CIS Build Kits (January 2026 or newer).
+
+#### Level changes
+
+- **2.3.7.1** Interactive logon: Do not require CTRL+ALT+DEL -- moved L1 to L2 (Ticket #26130).
+- **18.10.50** Prevent the usage of OneDrive for file storage -- moved L1 to L2 (Ticket #26332).
+- **18.10.16** Limit Diagnostic Log Collection -- moved L1 to L2 (Ticket #26882).
+- **18.10.16** Limit Dump Collection -- moved L1 to L2 (Ticket #26883).
+- **18.10.16** Enable OneSettings Auditing -- moved L1 to L2 (Ticket #27156).
+- **18.10.57.3.10** Set time limit for active but idle Remote Desktop Services sessions -- moved L2 to L1 (Ticket #27272).
+
+#### Title and query updates
+
+- Bulk title normalization (Ticket #26462): "Domain member:" prefix added, "Microsoft network client/server:" colons added, "Network security:" colon added, "Interactive logon:" colon added, "empty list" changed to "'No One'", "includes" changed to "to include" with expanded principal lists.
+- Firewall logging name policies changed from checking a specific log file path to checking that a path is configured (Tickets #26325, #26326, #26327).
+- Audit Sensitive Privilege Use changed from "Success and Failure" to "Success" (Ticket #25745).
+- 18.9.7 renamed from "Prevent device metadata retrieval from the Internet" to "Prevent automatic download of applications associated with device metadata" (Ticket #26306).
+- "Audit PNP Activity" corrected to "Audit User Account Management" (mislabeled in v4.0.0).
+- Resolution text fixes: corrected ~12 policies where resolution text said "set to an empty list" but the expected value is a specific principal list (e.g., "Administrators").
+
+#### v5.0.0 items not implemented
+
+These items from the v5.0.0 Change History are **not** represented in `cis-policy-queries.yml`:
+
+- Items in the BitLocker (BL) and Next Generation (NG) profiles -- Fleet does not ship these for this benchmark.
+- User section items (19.x) that were removed -- Fleet does not track removals for items it never shipped.
+- **18.10.57.3.10** Set time limit for disconnected sessions (removed by CIS, Ticket #27275) -- was not present in the v4.0.0 YAML.
+- Section renumbering from Windows 11 Release 25H2 Administrative Templates (Ticket #26305) -- section numbers are not stored in the YAML; only policy names and registry paths matter.
 
 ### v4.0.0 update notes
 
 These items from the v4.0.0 Change History are **not** represented in `cis-policy-queries.yml`, with the reason for each:
 
-- **18.6.8 (L1) Ensure 'Require Encryption' is set to 'Enabled'** — listed in the v4.0.0 Change History (Appendix), but the recommendation has no corresponding section in the body of the v4.0.0 document (the `18.6.8 Lanman Workstation` section only contains `18.6.8.1 Enable insecure guest logons`). With no Description/Audit/Remediation in the benchmark, there is no registry location to query, so no policy could be authored. Revisit if a later errata/print of the PDF adds the section.
-- **18.9.26.2 (NG) Ensure 'Configures LSASS to run as a protected process' is set to 'Enabled: Enabled with UEFI Lock'** — the Change History labels this `(L1)`, but the body heading tags it **Next Generation (NG)**, which Fleet does not ship for this benchmark. Note also that starting with the Windows 11 Release 24H2 Administrative Templates the backing registry value moved from `HKLM\SYSTEM\CurrentControlSet\Control\Lsa:RunAsPPL` to `HKLM\SOFTWARE\Policies\Microsoft\Windows\System:RunAsPPL`.
-
-Other v4.0.0 changes were applied to the YAML: 18 new Automated recommendations were added, 2 recommendations were removed (`18.10.66` Only display the private store within the Microsoft Store, and `18.10.42` Turn off Microsoft Defender AntiVirus), `18.10.17` Enable App Installer moved from Level 1 to Level 2, `Enable Certificate Padding` now accepts a `REG_DWORD` or `REG_SZ` value, and the `Log on as a service`, `Create symbolic links`, and MPR-notifications (`18.10.82.1`) titles were updated to their v4.0.0 wording.
-
+- **18.6.8 (L1) Ensure 'Require Encryption' is set to 'Enabled'** -- listed in the v4.0.0 Change History (Appendix), but the recommendation has no corresponding section in the body of the v4.0.0 document (the `18.6.8 Lanman Workstation` section only contains `18.6.8.1 Enable insecure guest logons`). With no Description/Audit/Remediation in the benchmark, there is no registry location to query, so no policy could be authored.
+- **18.9.26.2 (NG) Ensure 'Configures LSASS to run as a protected process' is set to 'Enabled: Enabled with UEFI Lock'** -- the Change History labels this `(L1)`, but the body heading tags it **Next Generation (NG)**, which Fleet does not ship for this benchmark.
 
 ### Checks that require a Group Policy template
 

--- a/ee/cis/win-10/README.md
+++ b/ee/cis/win-10/README.md
@@ -6,7 +6,7 @@ For requirements and usage details, see the [CIS Benchmarks](https://fleetdm.com
 
 ### Limitations
 
-> All Automated items in this version of the benchmark are able to be automated. Fleet does not ship BitLocker (BL) or Next Generation (NG) profile recommendations.
+> All Automated items in this version of the benchmark are covered. Fleet does not ship BitLocker (BL) or Next Generation (NG) profile recommendations.
 
 ### Important: Group Policy removal does not clear registry values
 

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -501,7 +501,7 @@ spec:
     Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path to include 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny access to this computer from the network'
   query: |
-    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyAccessFromNetwork</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
+    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyAccessFromNetwork</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null) AND (regex_match(mdm_command_output,".*(Local account).*",0) is not null);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, english-support-only
   contributors: marcosd4h
@@ -577,7 +577,7 @@ spec:
     Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on through Remote Desktop Services'
   query: |
-    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyRemoteDesktopServicesLogOn</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
+    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyRemoteDesktopServicesLogOn</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null) AND (regex_match(mdm_command_output,".*(Local account).*",0) is not null);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, english-support-only
   contributors: marcosd4h
@@ -3340,7 +3340,7 @@ spec:
     To establish the recommended configuration via GP, set the following UI path to '%SystemRoot%\System32\logfiles\firewall\privatefw.log':
     'Computer Configuration\Policies\Windows Settings\Security Settings\Windows Defender Firewall with Advanced Security\Windows Defender Firewall with Advanced Security - Local Group Policy Object\Windows Defender Firewall Properties\Private Profile\Logging Customize\Name'
   query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\WindowsFirewall\\PrivateProfile\\Logging\LogFilePath' AND data ='%systemroot%\system32\logfiles\firewall\pfirewall.log');
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging\LogFilePath' and data != '');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: RachelElysia
@@ -3511,7 +3511,7 @@ spec:
     To establish the recommended configuration via GP, set the following UI path to a valid log file path:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Windows Defender Firewall with Advanced Security\Windows Defender Firewall with Advanced Security - Local Group Policy Object\Windows Defender Firewall Properties\Public Profile\Logging Customize\Name'
   query: |
-    SELECT * FROM registry WHERE (key = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging\LogFilePath' and data == '%SystemRoot%\System32\logfiles\firewall\publicfw.log');
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging\LogFilePath' and data != '');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: RachelElysia
@@ -4065,10 +4065,10 @@ spec:
       -  4672: Special privileges assigned to new logon.
       -  4673: A privileged service was called.
       -  4674: An operation was attempted on a privileged object.
-      The recommended state for this setting is: 'Success and Failure'.
+      The recommended state for this setting is: 'Success'.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to include Success and Failure:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to include Success:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\Privilege Use\Audit Sensitive Privilege Use'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/Audit/PrivilegeUse_AuditSensitivePrivilegeUse</LocURI></Target></Item></Get></SyncBody>" 

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -364,24 +364,6 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Change the time zone' is set to 'Administrators, LOCAL SERVICE, Users'
-  platforms: win10
-  platform: windows
-  description: |
-    This setting determines which users can change the time zone of the computer. This ability holds no great danger for the computer and may be useful for mobile workers.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Administrators, LOCAL SERVICE, Users':
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Change the time zone'
-  query: |
-    SELECT 1 FROM cis_audit where item = "2.2.9" AND (regex_match(value,".*(?=.*Administrators)(?=.*Users)(?=.*LOCAL SERVICE).*",0) is not null);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, english-support-only
-  contributors: marcosd4h  
----
-apiVersion: v1
-kind: policy
-spec:
   name: CIS - Ensure 'Create a pagefile' is set to 'Administrators'
   platforms: win10
   platform: windows
@@ -400,14 +382,14 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Create a token object' is set to an empty list
+  name: CIS - Ensure 'Create a token object' is set to 'No One'
   platforms: win10
   platform: windows
   description: |
     This policy setting allows a process to create an access token, which may provide elevated rights to access sensitive data.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to an empty list:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'No One':
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Create a token object'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/CreateToken</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -436,7 +418,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Create permanent shared objects' is set to an empty list
+  name: CIS - Ensure 'Create permanent shared objects' is set to 'No One'
   platforms: win10
   platform: windows
   description: |
@@ -445,7 +427,7 @@ spec:
     not necessary to specifically assign this user right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to an empty list:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'No One':
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Create permanent shared objects'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/CreatePermanentSharedObjects</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -505,7 +487,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny access to this computer from the network' includes 'Guest'
+  name: CIS - Ensure 'Deny access to this computer from the network' to include 'Guests, Local account'
   platforms: win10
   platform: windows
   description: |
@@ -516,7 +498,7 @@ spec:
     this computer from the network user right if an account is subject to both policies.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guest'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path to include 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny access to this computer from the network'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyAccessFromNetwork</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
@@ -527,7 +509,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on as a batch job' includes 'Guests'
+  name: CIS - Ensure 'Deny log on as a batch job' to include 'Guests'
   platforms: win10
   platform: windows
   description: |
@@ -535,7 +517,7 @@ spec:
     batch job. A batch job is not a batch (.bat) file, but rather a batch-queue facility. Accounts that use the Task Scheduler to schedule jobs need this user right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path to include 'Guests'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a batch job'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.17" AND (regex_match(value,".*(?=.*Guests).*",0) is not null);
@@ -546,7 +528,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on as a service' includes 'Guests'
+  name: CIS - Ensure 'Deny log on as a service' to include 'Guests'
   platforms: win10
   platform: windows
   description: |
@@ -554,7 +536,7 @@ spec:
     as a service. This user right supersedes the Log on as a service user right if an account is subject to both policies.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path to include 'Guests'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on as a service'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.18" AND (regex_match(value,".*(?=.*Guests).*",0) is not null);
@@ -565,7 +547,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on locally' includes 'Guest'
+  name: CIS - Ensure 'Deny log on locally' to include 'Guests'
   platforms: win10
   platform: windows
   description: |
@@ -585,14 +567,14 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Deny log on through Remote Desktop Services' includes 'Guest'
+  name: CIS - Ensure 'Deny log on through Remote Desktop Services' to include 'Guests, Local account'
   platforms: win10
   platform: windows
   description: |
     This policy setting determines whether users can log on as Remote Desktop clients. This user right supersedes the Allow log on through Remote Desktop Services user right if an account is subject to both policies.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path includes 'Guests, Local account'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Deny log on through Remote Desktop Services'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/DenyRemoteDesktopServicesLogOn</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Guest).*",0) is not null);
@@ -603,14 +585,14 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Enable computer and user accounts to be trusted for delegation' is set to an empty list
+  name: CIS - Ensure 'Enable computer and user accounts to be trusted for delegation' is set to 'No One'
   platforms: win10
   platform: windows
   description: |
     This policy setting allows users to change the Trusted for Delegation setting on a computer object in Active Directory. Abuse of this privilege could allow unauthorized users to impersonate other users on the network.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Enable computer and user accounts to be trusted for delegation'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/EnableDelegation</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -632,7 +614,7 @@ spec:
     right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Force shutdown from a remote system'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/RemoteShutdown</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -650,7 +632,7 @@ spec:
     This policy setting determines which users or processes can generate audit records in the Security log.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'LOCAL SERVICE, NETWORK SERVICE'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Generate security audits'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/GenerateSecurityAudits</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(LOCAL SERVICE|NETWORK SERVICE).*",0) is not null);
@@ -672,7 +654,7 @@ spec:
     they have created to impersonate that client, which could elevate the unauthorized user's permissions to administrative or system levels.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Impersonate a client after authentication'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ImpersonateClient</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Administrators|LOCAL SERVICE|NETWORK SERVICE|([^\w\s]SERVICE)).*",0) is not null);
@@ -692,7 +674,7 @@ spec:
     user right is not required by administrative tools that are supplied with the operating system but might be required by software development tools.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators, Window Manager\Window Manager Group'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Increase scheduling priority'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/IncreaseSchedulingPriority</LocURI></Target></Item></Get></SyncBody>" AND (regex_match(mdm_command_output,".*(Administrators|Window Manager Group).*",0) is not null);
@@ -713,8 +695,8 @@ spec:
     Windows.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Increase scheduling priority'
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Load and unload device drivers'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/LoadUnloadDeviceDrivers</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
   purpose: Informational
@@ -724,14 +706,14 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Lock pages in memory' is set to an empty list
+  name: CIS - Ensure 'Lock pages in memory' is set to 'No One'
   platforms: win10
   platform: windows
   description: |
     This policy setting allows a process to keep data in physical memory, which prevents the system from paging the data to virtual memory on disk. If this user right is assigned, significant degradation of system performance can occur.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Lock pages in memory'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/LockMemory</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -753,7 +735,7 @@ spec:
     after gaining user level access to a computer.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Log on as a batch job'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.28" AND (regex_match(value,".*(?=.*Administrators).*",0) is not null);
@@ -793,7 +775,7 @@ spec:
     This policy setting determines which users can change the auditing options for files and directories and clear the Security log.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Manage auditing and security log'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ManageAuditingAndSecurityLog</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -804,7 +786,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Modify an object label' is set to an empty list
+  name: CIS - Ensure 'Modify an object label' is set to 'No One'
   platforms: win10
   platform: windows
   description: |
@@ -813,7 +795,7 @@ spec:
     can modify the label of an object owned by that user to a lower level without this privilege.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'No One'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Modify an object label'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ModifyObjectLabel</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "";
@@ -833,7 +815,7 @@ spec:
     Configuration. Modification of these values and could lead to a hardware failure that would result in a denial of service condition.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Modify firmware environment values'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ModifyFirmwareEnvironment</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -851,7 +833,7 @@ spec:
     This policy setting allows users to manage the system's volume or disk configuration, which could allow a user to delete a volume and cause data loss as well as a denial-ofservice condition.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Perform volume maintenance tasks'
   query: |
     SELECT 1 FROM cis_audit where item = "2.2.33" AND (regex_match(value,".*(?=.*Administrators).*",0) is not null);
@@ -874,7 +856,7 @@ spec:
     information that could be used to mount an attack on the system.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Profile single process'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/ProfileSingleProcess</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -935,7 +917,7 @@ spec:
     directories user right.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Restore files and directories'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/RestoreFilesAndDirectories</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -973,7 +955,7 @@ spec:
     or threads. This user right bypasses any permissions that are in place to protect objects to give ownership to the specified user.
   resolution: |
     Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to an empty list
+    Ask your system administrator to establish the recommended configuration via GP, ensure that the following UI path is set to 'Administrators'
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\User Rights Assignment\Take ownership of files or other objects'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/UserRights/TakeOwnership</LocURI></Target></Item></Get></SyncBody>" AND mdm_command_output == "Administrators";
@@ -1137,7 +1119,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1162,7 +1145,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1187,7 +1171,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Digitally sign secure channel data (when possible)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1213,7 +1198,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Disable machine account password changes' is set to 'Disabled'
+  name: >
+    CIS - Ensure 'Domain member: Disable machine account password changes' is set to 'Disabled'
   platforms: win10
   platform: windows
   description: |
@@ -1242,7 +1228,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Maximum machine account password age' is set to '30 or fewer days, but not 0'
+  name: >
+    CIS - Ensure 'Domain member: Maximum machine account password age' is set to '30 or fewer days, but not 0'
   platforms: win10
   platform: windows
   description: |
@@ -1272,7 +1259,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Require strong (Windows 2000 or later) session key' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1303,7 +1291,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Interactive logon Do not require CTRL+ALT+DEL' is set to 'Disabled'
+  name: CIS - Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'
   platforms: win10
   platform: windows
   description: |
@@ -1315,7 +1303,7 @@ spec:
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\DisableCAD' AND data == 0);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level2
   contributors: marcosd4h
 ---
 apiVersion: v1
@@ -1458,7 +1446,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network client Digitally sign communications (always)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1476,25 +1465,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network client Digitally sign communications (if server agrees)' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting determines whether the SMB client will attempt to negotiate SMB packet signing.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Microsoft network client: Digitally sign communications (if server agrees)'
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters\\EnableSecuritySignature' AND data != 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure that 'Microsoft network client Send unencrypted password to third-party SMB servers' is set to 'Disabled'
+  name: >
+    CIS - Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'
   platforms: win10
   platform: windows
   description: |
@@ -1512,7 +1484,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'
+  name: >
+    CIS - Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'
   platforms: win10
   platform: windows
   description: |
@@ -1533,7 +1506,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Digitally sign communications (always)' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1553,27 +1527,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Digitally sign communications (if client agrees)' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting determines whether the SMB server will negotiate SMB packet signing with
-    clients that request it. If no signing request comes from the client, a connection will be
-    allowed without a signature if the Microsoft network server: Digitally sign communications (always) setting is not enabled.
-  resolution: |
-    Automatic method:
-    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Microsoft network server: Digitally sign communications (if client agrees)'
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\CurrentControlSet\\Services\\LanManServer\\Parameters\\enablesecuritysignature' AND data != 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure that 'Microsoft network server Disconnect clients when logon hours expire' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -1593,7 +1548,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure that 'Microsoft network server Server SPN target name validation level' is set to 'Accept if provided by client'
+  name: >
+    CIS - Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client'
   platforms: win10
   platform: windows
   description: |
@@ -1949,7 +1905,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Network security Do not store LAN Manager hash value on next password change' is set to 'Enabled'
+  name: >
+    CIS - Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -3239,17 +3196,17 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Windows Firewall: Domain: Logging: Name' is set to '%SystemRoot%\System32\logfiles\firewall\domainfw.log'
+    CIS - Ensure 'Windows Firewall: Domain: Logging: Name' is configured
   platforms: win10
   platform: windows
   description: |
     Use this option to specify the path and name of the file in which Windows Firewall will write its log information.
-    The recommended state for this setting is: %SystemRoot%\System32\logfiles\firewall\domainfw.log.
+    The recommended state for this setting is: configured with a valid log file path.
   resolution: |
-    To establish the recommended configuration via GP, set the following UI path to %SystemRoot%\System32\logfiles\firewall\domainfw.log:
+    To establish the recommended configuration via GP, set the following UI path to a valid log file path:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Windows Defender Firewall with Advanced Security\Windows Defender Firewall with Advanced Security - Local Group Policy Object\Windows Defender Firewall Properties\Domain Profile\Logging Customize\Name'
   query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging\LogFilePath' and data = '%SystemRoot%\System32\logfiles\firewall\domainfw.log');
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging\LogFilePath' and data != '');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: DefensiveDepth
@@ -3372,12 +3329,12 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SystemRoot%\System32\logfiles\firewall\privatefw.log'
+    CIS - Ensure 'Windows Firewall: Private: Logging: Name' is configured
   platforms: win10
   platform: windows
   description: |
     Use this option to specify the path and name of the file in which Windows Firewall will write its log information.
-    The recommended state for this setting is: %SystemRoot%\System32\logfiles\firewall\privatefw.log.
+    The recommended state for this setting is: configured with a valid log file path.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to '%SystemRoot%\System32\logfiles\firewall\privatefw.log':
     'Computer Configuration\Policies\Windows Settings\Security Settings\Windows Defender Firewall with Advanced Security\Windows Defender Firewall with Advanced Security - Local Group Policy Object\Windows Defender Firewall Properties\Private Profile\Logging Customize\Name'
@@ -3543,14 +3500,14 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Windows Firewall: Public: Logging: Name' is set to '%SystemRoot%\System32\logfiles\firewall\publicfw.log'
+    CIS - Ensure 'Windows Firewall: Public: Logging: Name' is configured
   platforms: win10
   platform: windows
   description: |
     Use this option to specify the path and name of the file in which Windows Firewall will write its log information.
-    The recommended state for this setting is: %SystemRoot%\System32\logfiles\firewall\publicfw.log.
+    The recommended state for this setting is: configured with a valid log file path.
   resolution: |
-    To establish the recommended configuration via GP, set the following UI path to %SystemRoot%\System32\logfiles\firewall\publicfw.log:
+    To establish the recommended configuration via GP, set the following UI path to a valid log file path:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Windows Defender Firewall with Advanced Security\Windows Defender Firewall with Advanced Security - Local Group Policy Object\Windows Defender Firewall Properties\Public Profile\Logging Customize\Name'
   query: |
     SELECT * FROM registry WHERE (key = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\WindowsFirewall\\PublicProfile\\Logging\LogFilePath' and data == '%SystemRoot%\System32\logfiles\firewall\publicfw.log');
@@ -3683,7 +3640,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Audit PNP Activity' is set to 'Success'
+  name: CIS - Ensure 'Audit User Account Management' is set to 'Success and Failure'
   platforms: win10
   platform: windows
   description: |
@@ -4085,7 +4042,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Audit Sensitive Privilege Use' is set to 'Success and Failure'
+  name: CIS - Ensure 'Audit Sensitive Privilege Use' is set to 'Success'
   platforms: win10
   platform: windows
   description: |
@@ -4114,7 +4071,7 @@ spec:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\Privilege Use\Audit Sensitive Privilege Use'
   query: |
     SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/Audit/PrivilegeUse_AuditSensitivePrivilegeUse</LocURI></Target></Item></Get></SyncBody>" 
-    AND mdm_command_output = 3;
+    AND mdm_command_output = 1;
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: sharon-fdm
@@ -5510,14 +5467,14 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Prevent device metadata retrieval from the Internet' is set to 'Enabled'
+    CIS - Ensure 'Prevent automatic download of applications associated with device metadata' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
     This policy setting allows you to prevent Windows from retrieving device metadata from the Internet.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\System\Device Installation\Prevent device metadata retrieval from the Internet'
+    'Computer Configuration\Policies\Administrative Templates\System\Device Installation\Prevent automatic download of applications associated with device metadata'
   query: |
     SELECT 1 FROM REGISTRY WHERE (PATH = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Device Metadata\PreventDeviceMetadataFromNetwork' AND data = 1);
   purpose: Informational
@@ -7870,25 +7827,6 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Disable OneSettings Downloads' is set to 'Enabled'
-  platforms: win11
-  platform: windows
-  description: |
-    This policy is meant for Windows 11.
-    This policy setting controls whether Windows attempts to connect with the OneSettings service to download configuration settings.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Data Collection and Preview Builds\Disable OneSettings Downloads'
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection\\DisableOneSettingsDownloads' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
     CIS - Ensure 'Do not show feedback notifications' is set to 'Enabled'
   platforms: win10
   platform: windows
@@ -7919,7 +7857,7 @@ spec:
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection\\EnableOneSettingsAuditing' AND data = 1);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level2
   contributors: marcosd4h
 ---
 apiVersion: v1
@@ -7938,7 +7876,7 @@ spec:
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection\\LimitDiagnosticLogCollection' AND data = 1);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level2
   contributors: marcosd4h
 ---
 apiVersion: v1
@@ -7957,7 +7895,7 @@ spec:
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection\LimitDumpCollection' AND data = 1);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level2
   contributors: marcosd4h
 ---
 apiVersion: v1
@@ -8281,50 +8219,6 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Configure local setting override for reporting to Microsoft MAPS' is set to 'Disabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures a local override for the configuration to join Microsoft Active Protection Service, which Microsoft renamed to Windows Defender Antivirus Cloud Protection Service and then Microsoft Defender Antivirus Cloud Protection Service.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to Disabled:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\MAPS\Configure local setting override for reporting to Microsoft MAPS'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Spynet\\LocalSettingOverrideSpynetReporting' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: artemist-work
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Join Microsoft MAPS' is set to 'Disabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting allows you to join Microsoft Active Protection Service (MAPS), which Microsoft renamed to Windows Defender Antivirus Cloud Protection Service and then Microsoft Defender Antivirus Cloud Protection Service.
-    Microsoft MAPS / Microsoft Defender Antivirus Cloud Protection Service is the online community that helps you choose how to respond to potential threats.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\MAPS\Join Microsoft MAPS'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    -- The registry key is not present when policy is disabled, so query below is returning 1 when policy is disabled and registry value does not exist. It also return 1 in case policy is enabled and its registry value is 1 or 2
-    SELECT 1 WHERE (
-      NOT EXISTS ( SELECT 1 FROM registry WHERE key = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Spynet' COLLATE NOCASE AND name = 'SpynetReporting' )
-    ) OR (
-      NOT EXISTS ( SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Spynet\\SpynetReporting' COLLATE NOCASE AND data != 0 )
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level2
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
     CIS - Ensure 'Configure Attack Surface Reduction Rules' is set to 'Enabled'
   platforms: win10
   platform: windows
@@ -8434,206 +8328,6 @@ spec:
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Messaging\AllowMessageSync' AND data = 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level2
-  contributors: rachelelysia
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Enable file hash computation feature' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This setting determines whether hash values are computed for files scanned by Microsoft Defender.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\MpEngine\Enable file hash computation feature'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 10 Release 1709 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\MpEngine\\EnableFileHashComputation' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Scan all downloaded files and attachments' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures scanning for all downloaded files and attachments.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Real-Time Protection\Scan all downloaded files and attachments'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Turn off real-time protection' is set to 'Disabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures real-time protection prompts for known malware detection.
-    Microsoft Defender Antivirus alerts you when malware or potentially unwanted software attempts to install itself or to run on your computer.
-    The recommended state for this setting is: Disabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Disabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Real-Time Protection\Turn off real- time protection'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Turn on behavior monitoring' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting allows you to configure behavior monitoring for Microsoft Defender Antivirus.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Real-Time Protection\Turn on behavior monitoring'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Turn on script scanning' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting allows script scanning to be turned on/off. Script scanning intercepts scripts then scans them before they are executed on the system.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Real-Time Protection\Turn on script scanning'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Configure Watson events' is set to 'Disabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting allows you to configure whether or not Watson events are sent.
-    The recommended state for this setting is: Disabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Disabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Reporting\Configure Watson events'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Reporting\\DisableGenericRePorts' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level2
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Scan packed executables' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting manages whether or not Microsoft Defender Antivirus scans packed
-    executables. Packed executables are executable files that contain compressed code.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Scan\Scan packed executables'
-    Note: This Group Policy path is provided by the Group Policy template
-    'WindowsDefender.admx/adml' that is included with the Microsoft Windows 8.1 and Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Scan\DisablePackedExeScanning' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Scan removable drives' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting allows you to manage whether or not to scan for malicious software and unwanted software in the contents of removable drives, such as USB flash drives, when running a full scan.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Scan\Scan removable drives'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Scan\\DisableRemovableDriveScanning' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Turn on e-mail scanning' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting allows you to configure e-mail scanning. When e-mail scanning is enabled, the engine will parse the mailbox and mail files, according to their specific format, in order to analyze the mail bodies and attachments. Several e-mail formats are currently supported, for example: pst (Outlook), dbx, mbx, mime (Outlook Express), binhex (Mac).
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Scan\Turn on e-mail scanning'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 8.1 & Server 2012 R2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Scan\\DisableEmailScanning' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: sharon-fdm
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Configure detection for potentially unwanted applications' is set to 'Enabled: Block'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting controls detection and action for Potentially Unwanted Applications (PUA), which are sneaky unwanted application bundlers or their bundled applications, that can deliver adware or malware.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: Block':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Configure detection for potentially unwanted applications'
-    Note: This Group Policy path is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 10 Release 1809 & Server 2019 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\PUAProtection' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
   contributors: rachelelysia
 ---
 apiVersion: v1
@@ -8793,7 +8487,7 @@ spec:
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\OneDrive\\DisableFileSyncNGSC' AND data = 1);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level2
   contributors: sharon-fdm
 ---
 apiVersion: v1
@@ -9179,7 +8873,7 @@ spec:
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services\\MaxIdleTime' AND CAST(data AS INTEGER) <= 900000 AND CAST(data AS
     INTEGER) != 0);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level2
+  tags: compliance, CIS, CIS_Level1
   contributors: artemist-work
 ---
 apiVersion: v1
@@ -9329,7 +9023,7 @@ spec:
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Dsh\AllowNewsAndInterests' AND data = 0);
   purpose: Informational
-  tags: compliance, CIS, CIS_Level1
+  tags: compliance, CIS, CIS_Level2
   contributors: rachelelysia
 ---
 apiVersion: v1
@@ -9660,25 +9354,6 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Allow networking in Windows Sandbox' is set to 'Disabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting enables or disables networking in the Windows Sandbox. Networking is achieved by creating a virtual switch on the host, and connecting the Windows Sandbox to it via a virtual Network Interface Card (NIC).
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Disabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Sandbox\Allow networking in Windows Sandbox'
-    Note: This Group Policy section is provided by the Group Policy template WindowsSandbox.admx/adml that is included with the Microsoft Windows 11 Release 21H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\Sandbox\\AllowNetworking' AND data = 0);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
     CIS - Ensure 'Prevent users from modifying settings' is set to 'Enabled'
   platforms: win10
   platform: windows
@@ -9787,27 +9462,6 @@ spec:
     'Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Update\Manage updates offered from Windows Update\Manage preview builds'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\ManagePreviewBuildsPolicyValue' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: marcosd4h
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: 180 or more days'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting determines when Preview Build or Feature Updates are received.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: 180 or more days':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Windows Update\Manage updates offered from Windows Update\Windows Update for Business\Select when Preview Builds and Feature Updates are received'
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\DeferFeatureUpdates' AND CAST(data AS INTEGER) = 1)
-    AND EXISTS (
-      SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsUpdate\\DeferFeatureUpdatesPeriodInDays' AND CAST(data AS INTEGER) >= 180)
-    );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: marcosd4h
@@ -10355,177 +10009,6 @@ apiVersion: v1
 kind: policy
 spec:
   name: >
-    CIS - Ensure 'Control whether exclusions are visible to local users' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting controls whether Microsoft Defender Antivirus exclusions are visible to local users. When Enabled, only administrators can view and manage exclusions.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Control whether exclusions are visible to local users'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\HideExclusionsFromLocalUsers' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Enable EDR in block mode' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting controls whether Microsoft Defender Antivirus Endpoint Detection and Response (EDR) is enabled in block mode, providing additional protection when a primary antivirus solution is running in passive mode. This capability requires Microsoft Defender for Endpoint Plan 2.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Features\Enable EDR in block mode'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Features\PassiveRemediation' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Convert warn verdict to block' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting controls whether Microsoft Defender Antivirus network protection will convert a warn verdict into a block, preventing the network traffic rather than only warning the user.
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Network Inspection System\Convert warn verdict to block'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\NIS\EnableConvertWarnToBlock' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level2
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Configure real-time protection and Security Intelligence Updates during OOBE' is set to 'Enabled'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures whether Real-time Protection and Security Intelligence Updates are enabled during the Out of Box Experience (OOBE).
-    The recommended state for this setting is: Enabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Real-Time Protection\Configure real-time protection and Security Intelligence Updates during OOBE'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection\OobeEnableRtpAndSigUpdate' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Configure Remote Encryption Protection Mode' is set to 'Enabled: Audit' or higher
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures the Brute-Force Protection / Remote Encryption Protection feature in Microsoft Defender Antivirus, which can detect and respond to attempts to remotely encrypt files. Audit records the activity; Block prevents it.
-    The recommended state for this setting is: Enabled: Audit or higher (Audit or Block).
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: Audit' or higher:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Remediation\Behavioral Network Blocks\Brute-Force Protection\Configure Remote Encryption Protection Mode'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Remediation\Behavioral Network Blocks\Brute Force Protection\BruteForceProtectionConfiguredState' AND (data = 1 OR data = 2));
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Configure Brute-Force Protection aggressiveness' is set to 'Enabled: Medium' or higher
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures how aggressively Brute-Force Protection in Microsoft Defender Antivirus detects and blocks attempts to forcibly sign in to a system.
-    The recommended state for this setting is: Enabled: Medium or higher (Medium or High).
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: Medium' or higher:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Remediation\Behavioral Network Blocks\Brute-Force Protection\Configure Brute-Force Protection aggressiveness'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Remediation\Behavioral Network Blocks\Brute Force Protection\BruteForceProtectionAggressiveness' AND (data = 1 OR data = 2));
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level2
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Configure how aggressively Remote Encryption Protection blocks threats' is set to 'Enabled: Medium' or higher
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures how aggressively Remote Encryption Protection in Microsoft Defender Antivirus blocks malicious IP addresses involved in remote encryption attempts.
-    The recommended state for this setting is: Enabled: Medium or higher (Medium or High).
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: Medium' or higher:
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Remediation\Behavioral Network Blocks\Remote Encryption Protection\Configure how aggressively Remote Encryption Protection blocks threats'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Remediation\Behavioral Network Blocks\Remote Encryption Protection\RemoteEncryptionProtectionAggressiveness' AND (data = 1 OR data = 2));
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level2
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Scan excluded files and directories during quick scans' is set to 'Enabled: 1'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting manages whether Microsoft Defender Antivirus scans excluded files and directories when running a Quick Scan.
-    The recommended state for this setting is: Enabled: 1.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: 1':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Scan\Scan excluded files and directories during quick scans'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Scan\QuickScanIncludeExclusions' AND data = 1);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Trigger a quick scan after X days without any scans' is set to 'Enabled: 7'
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting configures the number of days after the last scan (of any type) before an aggressive Quick Scan is automatically triggered by Microsoft Defender Antivirus.
-    The recommended state for this setting is: Enabled: 7.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to 'Enabled: 7':
-    'Computer Configuration\Policies\Administrative Templates\Windows Components\Microsoft Defender Antivirus\Scan\Trigger a quick scan after X days without any scans'
-    Note: This Group Policy path may not exist by default. It is provided by the Group Policy template WindowsDefender.admx/adml that is included with the Microsoft Windows 11 Release 24H2 Administrative Templates (or newer).
-  query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Scan\DaysUntilAggressiveCatchupQuickScan' AND data = 7);
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
----
-apiVersion: v1
-kind: policy
-spec:
-  name: >
     CIS - Ensure 'Turn on Basic feed authentication over HTTP' is set to 'Disabled'
   platforms: win10
   platform: windows
@@ -10597,3 +10080,49 @@ spec:
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\GameInputSvc\Start' AND data = 4);
   purpose: Informational
   tags: compliance, CIS, CIS_Level2
+
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Enable / disable CLFS logfile authentication' is set to 'Enabled'
+  platforms: win10
+  platform: windows
+  description: |
+    This policy setting configures Common Log File System (CLFS) logfile authentication.
+    Logfile authentication provides the ability for the CLFS driver to detect malicious
+    modifications made to logfiles.
+    The recommended state for this setting is: Enabled.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Enabled':
+    'Computer Configuration\Policies\Administrative Templates\System\Filesystem\Enable / disable CLFS logfile authentication'
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\ClfsAuthenticationChecking' AND CAST(data AS INTEGER) = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Disable HTTP proxy features: Disable WPAD' is set to 'Enabled: Checked'
+  platforms: win10
+  platform: windows
+  description: |
+    This policy setting determines whether Web Proxy Auto-Discovery protocol (WPAD) is
+    disabled on the system. WPAD is used to discover Proxy Auto-Config (PAC) files from
+    the local network.
+    The recommended state for this setting is: Enabled: Checked.
+  resolution: |
+    Automatic method:
+    Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Enabled: Checked':
+    'Computer Configuration\Policies\Administrative Templates\Center for Internet Security (CIS)\Additional Benchmark Settings\Disable HTTP proxy features: Disable WPAD'
+    Note: This Group Policy path is NOT provided by Microsoft. The Group Policy template CIS.admx/adml is included with the CIS Microsoft Windows Build Kits published after January 2026.
+  query: |
+    SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\WinHttp\DisableWpad' AND CAST(data AS INTEGER) = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_group_policy_template_required
+  contributors: sharon-fdm

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -1291,7 +1291,8 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'
+  name: >
+    CIS - Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'
   platforms: win10
   platform: windows
   description: |


### PR DESCRIPTION
> Generated by Claude on behalf of Sharon FDM

**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/51293

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] QA'd all new/changed functionality manually

## Summary

Updates CIS Windows 10 Enterprise benchmark policies from **v4.0.0 to v5.0.0** (published 08/25/2026). Policy count: **502** (was 527).

All line references below are to `ee/cis/win-10/cis-policy-queries.yml` in the post-change file unless noted otherwise.

### Removed (27 policies)

Removed policies are not in the post-change file. Search the **base branch** file for these names to see the original.

- **21 Microsoft Defender Antivirus** (18.10.42) -- entire section removed by CIS (#27270). Search: `Microsoft Defender Antivirus\` in the resolution text. Application Guard and Exploit Guard retained.
- **2.3.8** `Microsoft network client Digitally sign communications (if server agrees)` -- search base branch
- **2.3.9** `Microsoft network server Digitally sign communications (if client agrees)` -- search base branch
- **2.2** `Change the time zone` -- search base branch
- **18.10.91** `Allow networking in Windows Sandbox` -- search base branch
- **18.10.94.4** `Select when Preview Builds and Feature Updates are received` -- search base branch
- **18.10.16** `Disable OneSettings Downloads` -- search base branch

### Added (2 policies)

- **18.9.17.1 (L1)** CLFS logfile authentication -- **L10090**
- **18.11.1 (L1)** Disable WPAD -- **L10112** (requires CIS.admx/adml GP template, not provided by Microsoft)

### Level changes

| Policy | Line | Change |
|--------|------|--------|
| Interactive logon: Do not require CTRL+ALT+DEL | L1294 | L1 -> L2 |
| Prevent the usage of OneDrive for file storage | L8477 | L1 -> L2 |
| Limit Diagnostic Log Collection | L7868 | L1 -> L2 |
| Limit Dump Collection | L7887 | L1 -> L2 |
| Enable OneSettings Auditing | L7849 | L1 -> L2 |
| Set time limit for active but idle RDS sessions | L8865 | L2 -> L1 |

### Query updates

| Policy | Line | Change |
|--------|------|--------|
| Deny access to this computer from the network | L504 | Added `AND (regex_match(...,".*Local account.*",0) is not null)` per v5.0.0 2.2.15 |
| Deny log on through Remote Desktop Services | L580 | Same -- per v5.0.0 2.2.19 |
| Firewall Domain Logging: Name | L3210 | Specific path -> `data != ''` ("is configured") per v5.0.0 9.1.4 |
| Firewall Private Logging: Name | L3343 | Same -- per v5.0.0 9.2.4 |
| Firewall Public Logging: Name | L3514 | Same -- per v5.0.0 9.3.4 |
| Audit Sensitive Privilege Use | L4075 | `mdm_command_output = 3` -> `= 1` (Success only) per v5.0.0 17.8.1 |

### Title normalization (#26462)

**"Domain member:" prefix added** (YAML switched to `>` folded scalar for colon):

| Line | Policy |
|------|--------|
| L1123 | Digitally encrypt or sign secure channel data (always) |
| L1149 | Digitally encrypt secure channel data (when possible) |
| L1175 | Digitally sign secure channel data (when possible) |
| L1202 | Disable machine account password changes |
| L1232 | Maximum machine account password age |
| L1263 | Require strong (Windows 2000 or later) session key |

**"Microsoft network client/server:" colon added** (also `>` folded scalar):

| Line | Policy |
|------|--------|
| L1450 | Microsoft network client: Digitally sign communications (always) |
| L1469 | Microsoft network client: Send unencrypted password to third-party SMB servers |
| L1488 | Microsoft network server: Amount of idle time required before suspending session |
| L1510 | Microsoft network server: Digitally sign communications (always) |
| L1531 | Microsoft network server: Disconnect clients when logon hours expire |
| L1552 | Microsoft network server: Server SPN target name validation level |

**Other colon additions:**

| Line | Policy |
|------|--------|
| L1909 | Network security: Do not store LAN Manager hash value on next password change |
| L1294 | Interactive logon: Do not require CTRL+ALT+DEL |

**"empty list" -> "'No One'":**

| Line | Policy |
|------|--------|
| L385 | Create a token object |
| L421 | Create permanent shared objects |
| L588 | Enable computer and user accounts to be trusted for delegation |
| L709 | Lock pages in memory |
| L789 | Modify an object label |

**"includes" -> "to include"** (with expanded principals):

| Line | Policy |
|------|--------|
| L490 | Deny access to this computer from the network (now: Guests, Local account) |
| L512 | Deny log on as a batch job (Guests) |
| L531 | Deny log on as a service (Guests) |
| L550 | Deny log on locally (Guests) |
| L570 | Deny log on through Remote Desktop Services (now: Guests, Local account) |

### Other name/text updates

| Policy | Line | Change |
|--------|------|--------|
| Audit Sensitive Privilege Use | L4046, L4068, L4071 | Name, description, and resolution all updated to 'Success' (was 'Success and Failure') |
| Audit PNP Activity (mislabeled) | L3643 | Corrected to "Audit User Account Management" |
| Prevent device metadata | L5471 | Renamed to "Prevent automatic download of applications associated with device metadata" |

### Resolution text fixes

"set to an empty list" corrected to actual expected value:

| Policy | Line | Corrected to |
|--------|------|-------------|
| Force shutdown from a remote system | L606 | 'Administrators' |
| Generate security audits | L628 | 'LOCAL SERVICE, NETWORK SERVICE' |
| Impersonate a client after authentication | L646 | 'Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE' |
| Increase scheduling priority | L668 | 'Administrators, Window Manager\Window Manager Group' |
| Load and unload device drivers | L688 | 'Administrators' (also fixed wrong GP path) |
| Log on as a batch job | L727 | 'Administrators' |
| Manage auditing and security log | L771 | 'Administrators' |
| Modify firmware environment values | L809 | 'Administrators' |
| Perform volume maintenance tasks | L829 | 'Administrators' |
| Profile single process | L847 | 'Administrators' |
| Restore files and directories | L909 | 'Administrators' |
| Take ownership of files or other objects | L950 | 'Administrators' |

---

## Testing

### Environment

VM via `ssh fleet-winvm` (DESKTOP-UUIQ1EM). Windows 10 Enterprise, build 26200 (WMI reports Win 11 24H2; registry paths identical). PowerShell 5.1, auditpol, secedit available. osquery not installed.

### Methodology

For each changed policy: set registry to compliant value (PASS), non-compliant value (FAIL), delete it (NOT SET). Verified each state against the osquery SQL condition.

### New policies

| CIS | Line | Registry | PASS | FAIL | NOT SET |
|-----|------|----------|------|------|---------|
| 18.9.17.1 | L10090 | `ClfsAuthenticationChecking` = 1 | OK | OK | OK |
| 18.11.1 | L10112 | `DisableWpad` = 1 | OK | OK | OK |

`WinHttp` key did not exist by default; created with `New-Item`. WPAD registry path works regardless of GP template.

### Updated firewall logging queries

| Line | Profile | Tests | Result |
|------|---------|-------|--------|
| L3210 | Domain | Default path, custom path, deleted | OK, OK, OK |
| L3343 | Private | Custom path, deleted | OK, OK |
| L3514 | Public | Custom path, deleted | OK, OK |

Custom path test confirms "is configured" semantics accept any non-empty value.

### Level-changed policies

| Policy | Line | Registry | PASS | FAIL | NOT SET |
|--------|------|----------|------|------|---------|
| CTRL+ALT+DEL | L1294 | `DisableCAD` = 0 | OK | OK (1) | OK |
| Device metadata (renamed) | L5471 | `PreventDeviceMetadataFromNetwork` = 1 | OK | OK (0) | OK |
| OneSettings Auditing | L7849 | `EnableOneSettingsAuditing` = 1 | OK | OK (0) | OK |
| Limit Diagnostic Log | L7868 | `LimitDiagnosticLogCollection` = 1 | OK | OK (0) | OK |
| Limit Dump Collection | L7887 | `LimitDumpCollection` = 1 | OK | OK (0) | OK |
| OneDrive for file storage | L8477 | `DisableFileSyncNGSC` = 1 | OK | OK (0) | OK |
| RDS idle timeout | L8865 | `MaxIdleTime` <= 900000, != 0 | OK (900000, 60000) | OK (0, 1800000) | OK |

### Title-updated policies (spot-checked registry paths)

| Policy | Line | Registry | Found |
|--------|------|----------|-------|
| Domain member: encrypt or sign | L1123 | `RequireSignOrSeal` | Yes (1) |
| Domain member: Max password age | L1232 | `MaximumPasswordAge` | Yes (30) |
| MS network server: Idle time | L1488 | `AutoDisconnect` | Yes (15) |
| Network security: LM hash | L1909 | `NoLMHash` | Yes (1) |
| MS client: sign always | L1450 | `RequireSecuritySignature` | Not configured (expected on non-domain VM) |

### Audit Sensitive Privilege Use (L4046)

`auditpol /set /subcategory:"Sensitive Privilege Use"` confirmed both "Success" and "Success and Failure" states work. The osquery query uses mdm_bridge (`mdm_command_output = 1`) -- not testable without MDM.

### Not testable

**52 mdm_bridge-based policies** require MDM enrollment. Includes User Rights Assignment ("No One", "to include"), Deny access/RDS query updates, and Audit Sensitive Privilege Use. Validated by code review and Win-11 v5.0.1 parity (PR #45173).

21 cis_audit and 6 security_profile_info policies were unchanged, not retested.

### QA recommendations

1. Retest on **actual Windows 10 Enterprise** (VM is Win 11 24H2 reporting as Win 10).
2. Test mdm_bridge policies on a device with **MDM enrollment** -- especially Deny access (L504) and Deny RDS (L580) which now require both "Guest" AND "Local account".
3. Verify **CIS.admx/adml** GP template availability for Disable WPAD (18.11.1, L10112).
