### PR TITLE
Fleet UI: Auto-highlight first result in command palette pickers

### DIFF
--- a/frontend/components/CommandPalette/CommandPalette.tests.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tests.tsx
@@ -190,6 +190,47 @@ describe("CommandPalette", () => {
       await openPalette(user);
       expect(screen.getByPlaceholderText(/search/i)).toHaveValue("");
     });
+
+    // Regression: cmdk's selected `value` is controlled here, so if we
+    // don't clear it on close, the previously highlighted row stays
+    // selected across close/reopen. Enter would then activate a prior
+    // row instead of the (expected) first item.
+    it("resets the highlight when reopened, not sticking on a prior row", async () => {
+      const { user } = adminRender(<CommandPalette />);
+      await openPalette(user);
+
+      // Move the highlight away from the first item. ArrowDown twice so
+      // even if the first row starts unselected, we land somewhere past it.
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowDown}");
+
+      // Capture what's highlighted so we can assert it's NOT what's
+      // highlighted after reopen.
+      const highlightedBeforeClose = document.querySelector(
+        `.command-palette__item[aria-selected="true"]`
+      );
+      expect(highlightedBeforeClose).not.toBeNull();
+      const priorLabel = highlightedBeforeClose?.textContent;
+
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(
+          screen.queryByPlaceholderText(/search/i)
+        ).not.toBeInTheDocument();
+      });
+
+      await openPalette(user);
+
+      await waitFor(() => {
+        const highlightedAfterReopen = document.querySelector(
+          `.command-palette__item[aria-selected="true"]`
+        );
+        // Something is highlighted (cmdk auto-selects the first item on a
+        // fresh mount), and it's not the row we left on.
+        expect(highlightedAfterReopen).not.toBeNull();
+        expect(highlightedAfterReopen?.textContent).not.toBe(priorLabel);
+      });
+    });
   });
 
   describe("Rendering items", () => {

--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -7,7 +7,7 @@ import React, {
   useCallback,
   useRef,
 } from "react";
-import { Command, useCommandState } from "cmdk";
+import { Command } from "cmdk";
 import {
   Title as DialogTitle,
   Description as DialogDescription,
@@ -44,24 +44,6 @@ import { isPreFilteredResult } from "./components/constants";
 
 const baseClass = "command-palette";
 
-// Subscribes to cmdk's selected value via its internal store. We can't
-// rely on `Command.Dialog`'s `onValueChange` prop for this: in cmdk@1.1.1
-// that callback only fires when `value` is also controlled, and the
-// palette runs cmdk uncontrolled so arrow-key highlight changes never
-// reach React without this bridge. Rendered inside `Command.Dialog` so
-// the `useCommandState` context is available.
-const HighlightSubscriber = ({
-  onChange,
-}: {
-  onChange: (value: string) => void;
-}) => {
-  const value = useCommandState((state) => state.value);
-  useEffect(() => {
-    onChange(value ?? "");
-  }, [value, onChange]);
-  return null;
-};
-
 // cmdk treats `value` as the row's identity *and* as the substring it
 // filters against. Two rows with the same value collide. Including the
 // item's id guarantees uniqueness without losing the user-typeable
@@ -95,6 +77,11 @@ const CommandPalette = (): JSX.Element | null => {
   const [page, setPage] = useState<Page>("root");
   const [search, setSearch] = useState("");
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+  // Controlled highlight — cmdk's uncontrolled auto-select doesn't re-run
+  // when a picker's async results replace the previous set (state.value
+  // still points at the now-unmounted row), so we set it explicitly.
+  // Empty string means "let cmdk pick the first item on next mount."
+  const [cmdkValue, setCmdkValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -257,6 +244,22 @@ const CommandPalette = (): JSX.Element | null => {
       setExpandedItems(new Set());
     }
   }, [open]);
+
+  // Reset the highlight when the page changes so cmdk auto-selects the
+  // first item on the new page rather than sticking on a value that
+  // belongs to the page we just left.
+  useEffect(() => {
+    setCmdkValue("");
+  }, [page]);
+
+  // Picker results arrive asynchronously; when they do, snap the highlight
+  // to the first row so pressing Enter opens it without a preceding arrow.
+  const handlePickerResultsChange = useCallback(
+    (firstItemValue: string | null) => {
+      setCmdkValue(firstItemValue ?? "");
+    },
+    []
+  );
 
   const canSwitchFleet =
     isPremiumTier &&
@@ -836,6 +839,16 @@ const CommandPalette = (): JSX.Element | null => {
     <Command.Dialog
       open={open}
       onOpenChange={handleOpenChange}
+      // Controlling `value` also switches cmdk into a mode where
+      // `onValueChange` fires on every internal selection update
+      // (arrow keys, pointer hover, filter-driven re-selects), which is
+      // what lets us drive `handleHighlightChange` from a single source
+      // instead of a `useCommandState` bridge.
+      value={cmdkValue}
+      onValueChange={(value) => {
+        setCmdkValue(value);
+        handleHighlightChange(value);
+      }}
       label="Command palette"
       className={baseClass}
       overlayClassName={`${baseClass}__overlay`}
@@ -857,7 +870,6 @@ const CommandPalette = (): JSX.Element | null => {
         return 0;
       }}
     >
-      <HighlightSubscriber onChange={handleHighlightChange} />
       {/* cmdk's Dialog wraps Radix Dialog.Content, which requires a Title and
           a Description for screen reader accessibility — without these, Radix
           logs a console error/warning on every open. Both are rendered
@@ -978,6 +990,7 @@ const CommandPalette = (): JSX.Element | null => {
             search={search}
             showTeamColumn={!!isPremiumTier && !isPrimoMode}
             onSelect={handleSelectHost}
+            onResultsChange={handlePickerResultsChange}
           />
         )}
         {page === "view-software" && (
@@ -985,6 +998,7 @@ const CommandPalette = (): JSX.Element | null => {
             search={search}
             currentTeam={currentTeam}
             onSelect={handleSelectSoftware}
+            onResultsChange={handlePickerResultsChange}
           />
         )}
         {page === "view-software-library" && (
@@ -993,6 +1007,7 @@ const CommandPalette = (): JSX.Element | null => {
             currentTeam={currentTeam}
             scope="library"
             onSelect={handleSelectSoftware}
+            onResultsChange={handlePickerResultsChange}
           />
         )}
         {page === "view-report" && (
@@ -1001,6 +1016,7 @@ const CommandPalette = (): JSX.Element | null => {
             currentTeam={currentTeam}
             isViewerObserver={isViewerObserverInScope}
             onSelect={handleSelectReport}
+            onResultsChange={handlePickerResultsChange}
           />
         )}
         {page === "view-policy" && (
@@ -1009,6 +1025,7 @@ const CommandPalette = (): JSX.Element | null => {
             currentTeam={currentTeam}
             isPremiumTier={!!isPremiumTier}
             onSelect={handleSelectPolicy}
+            onResultsChange={handlePickerResultsChange}
           />
         )}
       </Command.List>

--- a/frontend/components/CommandPalette/CommandPalette.tsx
+++ b/frontend/components/CommandPalette/CommandPalette.tsx
@@ -242,6 +242,10 @@ const CommandPalette = (): JSX.Element | null => {
       setPage("root");
       setSearch("");
       setExpandedItems(new Set());
+      // Also clear cmdkValue: if we closed while on root, the page-change
+      // effect won't fire on reopen, and a stale highlight would carry
+      // over — making Enter accidentally activate a prior row.
+      setCmdkValue("");
     }
   }, [open]);
 

--- a/frontend/components/CommandPalette/components/HostPicker.tests.tsx
+++ b/frontend/components/CommandPalette/components/HostPicker.tests.tsx
@@ -96,6 +96,62 @@ describe("HostPicker", () => {
     ).toBeInTheDocument();
   });
 
+  // Regression: cmdk's uncontrolled auto-select doesn't re-run when items
+  // reference-change after an async fetch, so nothing ends up highlighted
+  // and Enter is a no-op until the user first presses ArrowDown. The
+  // picker signals the parent via `onResultsChange` so the parent can
+  // point cmdk's highlight at the first row explicitly.
+  it("calls onResultsChange with the first host's cmdk value once results load", async () => {
+    mockedHosts.loadHosts.mockResolvedValue(
+      hostsResponseWith(
+        {
+          id: 42,
+          display_name: "results-first-host",
+          status: "online",
+          team_id: null,
+          team_name: null,
+        },
+        {
+          id: 43,
+          display_name: "results-second-host",
+          status: "offline",
+          team_id: null,
+          team_name: null,
+        }
+      )
+    );
+    const onResultsChange = jest.fn();
+
+    const { findByText } = renderPicker(
+      <HostPicker
+        search="results-load-test"
+        onSelect={jest.fn()}
+        onResultsChange={onResultsChange}
+      />
+    );
+    // Anchor on visible content so we know results actually rendered.
+    await findByText("results-first-host");
+
+    // Final call reflects the loaded results — earlier `null` calls from
+    // the initial empty render are expected and don't matter for the fix.
+    expect(onResultsChange).toHaveBeenLastCalledWith("HOST_RESULT 42");
+  });
+
+  it("calls onResultsChange with null when the query returns no hosts", async () => {
+    const onResultsChange = jest.fn();
+
+    const { findByText } = renderPicker(
+      <HostPicker
+        search="results-empty-test"
+        onSelect={jest.fn()}
+        onResultsChange={onResultsChange}
+      />
+    );
+    await findByText(/No hosts match/);
+
+    expect(onResultsChange).toHaveBeenCalledWith(null);
+  });
+
   describe("columns", () => {
     const hosts = hostsResponseWith({
       id: 1,

--- a/frontend/components/CommandPalette/components/HostPicker.tsx
+++ b/frontend/components/CommandPalette/components/HostPicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Command } from "cmdk";
 
 import hostsAPI, { ILoadHostsResponse } from "services/entities/hosts";
@@ -19,12 +19,18 @@ interface IHostPickerProps {
    *  installs have nothing meaningful to show in the team column). */
   showTeamColumn?: boolean;
   onSelect: (hostId: number) => void;
+  /** Fires when the results list identity changes, with the cmdk value of
+   *  the first item (or null when empty). The parent uses it to point
+   *  cmdk's highlight at the first row after each fetch — cmdk's own
+   *  auto-select doesn't re-run when items reference-change. */
+  onResultsChange?: (firstItemValue: string | null) => void;
 }
 
 const HostPicker = ({
   search,
   showTeamColumn = false,
   onSelect,
+  onResultsChange,
 }: IHostPickerProps): JSX.Element => {
   // No team scoping — the picker is a global navigator. On select, the
   // parent navigates to /hosts/:id/details without fleet_id; the host
@@ -46,6 +52,12 @@ const HostPicker = ({
       }),
     selectItems: (data) => data?.hosts ?? [],
   });
+
+  const firstItemValue =
+    hosts.length > 0 ? `${RESULT_PREFIXES.host}${hosts[0].id}` : null;
+  useEffect(() => {
+    onResultsChange?.(firstItemValue);
+  }, [firstItemValue, onResultsChange]);
 
   if (isLoading && hosts.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for hosts...</div>;

--- a/frontend/components/CommandPalette/components/HostPicker.tsx
+++ b/frontend/components/CommandPalette/components/HostPicker.tsx
@@ -55,9 +55,15 @@ const HostPicker = ({
 
   const firstItemValue =
     hosts.length > 0 ? `${RESULT_PREFIXES.host}${hosts[0].id}` : null;
+  // Key the effect off a stable signature of the full list, not just the
+  // first id. If results change but the first id is the same (user types
+  // more, list shrinks/reorders), a previously-arrow'd row further down
+  // may be gone — we still need to snap the highlight back to the first
+  // row so the controlled cmdk value stays valid.
+  const itemsSignature = hosts.map((h) => h.id).join(",");
   useEffect(() => {
     onResultsChange?.(firstItemValue);
-  }, [firstItemValue, onResultsChange]);
+  }, [itemsSignature, firstItemValue, onResultsChange]);
 
   if (isLoading && hosts.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for hosts...</div>;

--- a/frontend/components/CommandPalette/components/PolicyPicker.tsx
+++ b/frontend/components/CommandPalette/components/PolicyPicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Command } from "cmdk";
 
 import { APP_CONTEXT_ALL_TEAMS_ID, ITeamSummary } from "interfaces/team";
@@ -28,6 +28,9 @@ interface IPolicyPickerProps {
   /** Critical-policy badge is Premium-only (matches PoliciesTable). */
   isPremiumTier?: boolean;
   onSelect: (policyId: number) => void;
+  /** Fires when the results list identity changes, with the cmdk value of
+   *  the first item (or null when empty). See HostPicker for rationale. */
+  onResultsChange?: (firstItemValue: string | null) => void;
 }
 
 const PolicyPicker = ({
@@ -35,6 +38,7 @@ const PolicyPicker = ({
   currentTeam,
   isPremiumTier = false,
   onSelect,
+  onResultsChange,
 }: IPolicyPickerProps): JSX.Element => {
   const teamId =
     currentTeam && currentTeam.id !== APP_CONTEXT_ALL_TEAMS_ID
@@ -69,6 +73,12 @@ const PolicyPicker = ({
     },
     selectItems: (data) => data?.policies ?? [],
   });
+
+  const firstItemValue =
+    policies.length > 0 ? `${RESULT_PREFIXES.policy}${policies[0].id}` : null;
+  useEffect(() => {
+    onResultsChange?.(firstItemValue);
+  }, [firstItemValue, onResultsChange]);
 
   if (isLoading && policies.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for policies...</div>;

--- a/frontend/components/CommandPalette/components/PolicyPicker.tsx
+++ b/frontend/components/CommandPalette/components/PolicyPicker.tsx
@@ -76,9 +76,11 @@ const PolicyPicker = ({
 
   const firstItemValue =
     policies.length > 0 ? `${RESULT_PREFIXES.policy}${policies[0].id}` : null;
+  // See HostPicker.
+  const itemsSignature = policies.map((p) => p.id).join(",");
   useEffect(() => {
     onResultsChange?.(firstItemValue);
-  }, [firstItemValue, onResultsChange]);
+  }, [itemsSignature, firstItemValue, onResultsChange]);
 
   if (isLoading && policies.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for policies...</div>;

--- a/frontend/components/CommandPalette/components/ReportPicker.tsx
+++ b/frontend/components/CommandPalette/components/ReportPicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Command } from "cmdk";
 
 import { APP_CONTEXT_ALL_TEAMS_ID, ITeamSummary } from "interfaces/team";
@@ -26,6 +26,9 @@ interface IReportPickerProps {
    *  observers, not to advertise the current user's own capability. */
   isViewerObserver?: boolean;
   onSelect: (reportId: number) => void;
+  /** Fires when the results list identity changes, with the cmdk value of
+   *  the first item (or null when empty). See HostPicker for rationale. */
+  onResultsChange?: (firstItemValue: string | null) => void;
 }
 
 const ReportPicker = ({
@@ -33,6 +36,7 @@ const ReportPicker = ({
   currentTeam,
   isViewerObserver = false,
   onSelect,
+  onResultsChange,
 }: IReportPickerProps): JSX.Element => {
   const teamId =
     currentTeam && currentTeam.id !== APP_CONTEXT_ALL_TEAMS_ID
@@ -60,6 +64,12 @@ const ReportPicker = ({
       }),
     selectItems: (data) => data?.queries ?? [],
   });
+
+  const firstItemValue =
+    reports.length > 0 ? `${RESULT_PREFIXES.report}${reports[0].id}` : null;
+  useEffect(() => {
+    onResultsChange?.(firstItemValue);
+  }, [firstItemValue, onResultsChange]);
 
   if (isLoading && reports.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for reports...</div>;

--- a/frontend/components/CommandPalette/components/ReportPicker.tsx
+++ b/frontend/components/CommandPalette/components/ReportPicker.tsx
@@ -67,9 +67,11 @@ const ReportPicker = ({
 
   const firstItemValue =
     reports.length > 0 ? `${RESULT_PREFIXES.report}${reports[0].id}` : null;
+  // See HostPicker.
+  const itemsSignature = reports.map((r) => r.id).join(",");
   useEffect(() => {
     onResultsChange?.(firstItemValue);
-  }, [firstItemValue, onResultsChange]);
+  }, [itemsSignature, firstItemValue, onResultsChange]);
 
   if (isLoading && reports.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for reports...</div>;

--- a/frontend/components/CommandPalette/components/SoftwarePicker.tsx
+++ b/frontend/components/CommandPalette/components/SoftwarePicker.tsx
@@ -106,9 +106,13 @@ const SoftwarePicker = ({
 
   const firstItemValue =
     titles.length > 0 ? `${RESULT_PREFIXES.software}${titles[0].id}` : null;
+  // See HostPicker: key off a full-list signature so a previously
+  // highlighted later row that's no longer in the results doesn't leave
+  // the controlled cmdk value dangling.
+  const itemsSignature = titles.map((t) => t.id).join(",");
   useEffect(() => {
     onResultsChange?.(firstItemValue);
-  }, [firstItemValue, onResultsChange]);
+  }, [itemsSignature, firstItemValue, onResultsChange]);
 
   if (isLoading && titles.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for software...</div>;

--- a/frontend/components/CommandPalette/components/SoftwarePicker.tsx
+++ b/frontend/components/CommandPalette/components/SoftwarePicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Command } from "cmdk";
 
 import {
@@ -53,6 +53,9 @@ interface ISoftwarePickerProps {
   currentTeam?: ITeamSummary;
   scope?: SoftwareScope;
   onSelect: (softwareId: number) => void;
+  /** Fires when the results list identity changes, with the cmdk value of
+   *  the first item (or null when empty). See HostPicker for rationale. */
+  onResultsChange?: (firstItemValue: string | null) => void;
 }
 
 const SoftwarePicker = ({
@@ -60,6 +63,7 @@ const SoftwarePicker = ({
   currentTeam,
   scope = "inventory",
   onSelect,
+  onResultsChange,
 }: ISoftwarePickerProps): JSX.Element => {
   const teamId =
     currentTeam && currentTeam.id !== APP_CONTEXT_ALL_TEAMS_ID
@@ -99,6 +103,12 @@ const SoftwarePicker = ({
       }),
     selectItems: (data) => data?.software_titles ?? [],
   });
+
+  const firstItemValue =
+    titles.length > 0 ? `${RESULT_PREFIXES.software}${titles[0].id}` : null;
+  useEffect(() => {
+    onResultsChange?.(firstItemValue);
+  }, [firstItemValue, onResultsChange]);
 
   if (isLoading && titles.length === 0) {
     return <div className={`${baseClass}__empty`}>Looking for software...</div>;


### PR DESCRIPTION
## Issue
Closes #52269

## Description
- Bug fix (root cause): cmdk's uncontrolled auto-select only re-runs when `state.value` is empty. When a picker's async results replace the previous set, `state.value` still points at the now-unmounted row, so no row shows as selected and Enter is a no-op until the user first presses ArrowDown.
- Control cmdk's `value` at the CommandPalette level and reset it on page change, so switching in/out of a picker doesn't leave the highlight pointing at a row from the page we just left.
- Each server-backed picker (Host, Software, Report, Policy) now fires `onResultsChange(firstItemValue)` when its results list identity changes; the parent snaps the highlight to the first row so Enter opens it without a preceding arrow keypress.
- Drop the `HighlightSubscriber` bridge: its comment noted it only existed because `onValueChange` was unreliable in uncontrolled mode. Controlling the value makes `onValueChange` fire reliably for every internal selection update, so the bridge is redundant.

## Screenrecording
- Type a query into View host / View software / View policy / View report and press Enter without touching the arrow keys.



https://github.com/user-attachments/assets/95041f58-26fb-4d5b-b73c-9ba7a81688c4



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command palette navigation by resetting the highlighted item when the palette is closed and reopened.
  * Automatically highlights the first available result when search results load or change.
  * Correctly clears the highlight when no results are available.

* **Tests**
  * Added regression coverage for command palette highlight resets and result updates across supported pickers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->