### PR TITLE
[Handbook]: add section about the reviewer always needs to test any community PR

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -138,7 +138,7 @@ If the PR is not something we want to pursue, thank the contributor, explain the
 
 4. **Track the work**: Create an issue using the relevant [work item](https://fleetdm.com/handbook/company/product-groups#work-items) issue template. The issue then moves across the relevant product group's board following the [standard process](https://fleetdm.com/handbook/company/product-groups#how-issues-move).
 
-5. **Testing locally**: When the community PR comes around for engineering to review, the reviewer should always check-out the PR locally, run it and test the behavior is as expected. This is alongside the actual code review.
+5. **Testing locally**: For community PRs, reviewers should complete code review first, then check out the PR locally, run it, and verify expected behavior.
 
 
 #### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -138,6 +138,8 @@ If the PR is not something we want to pursue, thank the contributor, explain the
 
 4. **Track the work**: Create an issue using the relevant [work item](https://fleetdm.com/handbook/company/product-groups#work-items) issue template. The issue then moves across the relevant product group's board following the [standard process](https://fleetdm.com/handbook/company/product-groups#how-issues-move).
 
+5. **Testing locally**: When the community PR comes around for engineering to review, the reviewer should always check-out the PR locally, run it and test the behavior is as expected. This is alongside the actual code review.
+
 
 #### Merge a community pull request
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

This PR adds a call out to the `Review a community pull request` section, that once the community PR comes back to engineering for review, the reviewer is responsible for **always** checking out the PR locally, and running it by exercising the bug behaviour, and verifying it is fixed on the branch.

This change was discussed in backend sync (September 1st), and keeps our quality high in a world where increasing assisted content is being put up in a PR and we can't trust that the community contributor has done this themselves, ensuring it gets at least 1 pass of local testing before merging it in. 


# Checklist for submitter

- [ ] QA'd all new/changed functionality manually