### PR TITLE
Document how iOS/iPadOS self-service authentication works

### DIFF
--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -131,10 +131,7 @@ Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrade
 
 ### How iOS/iPadOS hosts authenticate
 
-iOS and iPadOS hosts don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request one of two ways:
-
-1. Certificate (used when available): if the device presents its MDM-issued identity (SCEP) certificate over mTLS, Fleet matches the certificate's serial number to the host and confirms it belongs to the UUID in the URL.
-2. Host UUID (fallback): if no client certificate is presented, Fleet falls back to authenticating by the UUID in the URL.
+iOS and iPadOS hosts don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request via host UUID in the URL.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -129,14 +129,12 @@ Then, add connect hide script to this policy via [policy automations](https://fl
 
 Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrades don't touch the plist the script updates.
 
-### How iOS and iPadOS devices authenticate
+### How iOS/iPadOS hosts authenticate
 
-iOS and iPadOS don't run the Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados) whose URL embeds the host's UUID (`$FLEET_VAR_HOST_UUID`) rather than a device token. Fleet authenticates the request one of two ways:
+iOS and iPadOS don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request one of two ways:
 
-- **Certificate (used when available):** if the device presents its MDM-issued identity (SCEP) certificate over mTLS, Fleet matches the certificate's serial number to the host and confirms it belongs to the UUID in the URL.
-- **Device UUID (fallback):** if no client certificate is presented, Fleet falls back to authenticating by the UUID in the URL alone.
-
-Token authentication isn't available on iOS and iPadOS — Fleet requires certificate or UUID authentication instead.
+1. Certificate (used when available): if the device presents its MDM-issued identity (SCEP) certificate over mTLS, Fleet matches the certificate's serial number to the host and confirms it belongs to the UUID in the URL.
+2. Host UUID (fallback): if no client certificate is presented, Fleet falls back to authenticating by the UUID in the URL.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -129,6 +129,15 @@ Then, add connect hide script to this policy via [policy automations](https://fl
 
 Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrades don't touch the plist the script updates.
 
+### How iOS and iPadOS devices authenticate
+
+iOS and iPadOS don't run the Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados) whose URL embeds the host's UUID (`$FLEET_VAR_HOST_UUID`) rather than a device token. Fleet authenticates the request one of two ways:
+
+- **Certificate (used when available):** if the device presents its MDM-issued identity (SCEP) certificate over mTLS, Fleet matches the certificate's serial number to the host and confirms it belongs to the UUID in the URL.
+- **Device UUID (fallback):** if no client certificate is presented, Fleet falls back to authenticating by the UUID in the URL alone.
+
+Token authentication isn't available on iOS and iPadOS — Fleet requires certificate or UUID authentication instead.
+
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">
 <meta name="authorFullName" value="Mo Zhu">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -137,7 +137,7 @@ This UUID-based authentication only works for iOS and iPadOS hosts and is suppor
 - [Reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error)
 - [Download device's MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile)
 
-Because iOS and iPadOS hosts authenticate this way, Fleet also strips identifying details, like UUID, hardware serial, and MDM profile data, from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
+Because iOS and iPadOS hosts authenticate by UUID, Fleet also strips identifying details, like UUID, hardware serial, and MDM profile data, from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -133,9 +133,11 @@ Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrade
 
 iOS and iPadOS hosts don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request via host UUID in the URL.
 
-This UUID-based authentication only works for iOS and iPadOS hosts and is support for all [device-authenticated API routes] except the following (neither of which applies to iOS/iPadOS hosts):
+This UUID-based authentication only works for iOS and iPadOS hosts and is supported for all [device-authenticated API routes](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#device-authenticated-routes) except the following (neither of which applies to iOS/iPadOS hosts):
 - [Reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error)
 - [Download device's MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile)
+
+Because iOS and iPadOS hosts authenticate this way, Fleet also strips identifying details — like UUID, hardware serial, and MDM profile data — from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -133,6 +133,8 @@ Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrade
 
 iOS and iPadOS hosts don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request via host UUID in the URL.
 
+This UUID-based authentication only works for iOS and iPadOS hosts — macOS and Windows hosts must use a device token or certificate. It works the same way across most [device-authenticated API routes](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#device-authenticated-routes), with a few exceptions that still require a device token or certificate: [reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error) and [downloading the MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile), neither of which applies to iOS/iPadOS hosts.
+
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">
 <meta name="authorFullName" value="Mo Zhu">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -137,7 +137,7 @@ This UUID-based authentication only works for iOS and iPadOS hosts and is suppor
 - [Reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error)
 - [Download device's MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile)
 
-Because iOS and iPadOS hosts authenticate this way, Fleet also strips identifying details — like UUID, hardware serial, and MDM profile data — from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
+Because iOS and iPadOS hosts authenticate this way, Fleet also strips identifying details, like UUID, hardware serial, and MDM profile data, from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -133,7 +133,9 @@ Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrade
 
 iOS and iPadOS hosts don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request via host UUID in the URL.
 
-This UUID-based authentication only works for iOS and iPadOS hosts — macOS and Windows hosts must use a device token or certificate. It works the same way across most [device-authenticated API routes](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#device-authenticated-routes), with a few exceptions that still require a device token or certificate: [reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error) and [downloading the MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile), neither of which applies to iOS/iPadOS hosts.
+This UUID-based authentication only works for iOS and iPadOS hosts and is support for all [device-authenticated API routes] except the following (neither of which applies to iOS/iPadOS hosts):
+- [Reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error)
+- [Download device's MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile)
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -137,7 +137,7 @@ This UUID-based authentication only works for iOS and iPadOS hosts and is suppor
 - [Reporting an agent error](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#report-an-agent-error)
 - [Download device's MDM manual enrollment profile](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#download-devices-mdm-manual-enrollment-profile)
 
-Because iOS and iPadOS hosts authenticate by UUID, Fleet also strips identifying details, like UUID, hardware serial, and MDM profile data, from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
+Because iOS and iPadOS hosts authenticate by UUID, Fleet also strips identifying details, like hardware serial and configuration profile data, from the [Get host by Fleet Desktop token](https://fleetdm.com/docs/rest-api/rest-api#get-host-by-fleet-desktop-token) response for those hosts.
 
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">

--- a/articles/fleet-desktop.md
+++ b/articles/fleet-desktop.md
@@ -131,7 +131,7 @@ Fleet's agent (fleetd) upgrades won't re-show the menu bar icon, because upgrade
 
 ### How iOS/iPadOS hosts authenticate
 
-iOS and iPadOS don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request one of two ways:
+iOS and iPadOS hosts don't run a Fleet Desktop app. Instead, end users reach a self-service page through a [Web Clip configuration profile](https://fleetdm.com/guides/software-self-service#deploy-self-service-on-ios-and-ipados). Fleet authenticates the request one of two ways:
 
 1. Certificate (used when available): if the device presents its MDM-issued identity (SCEP) certificate over mTLS, Fleet matches the certificate's serial number to the host and confirms it belongs to the UUID in the URL.
 2. Host UUID (fallback): if no client certificate is presented, Fleet falls back to authenticating by the UUID in the URL.

--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -92,6 +92,8 @@ You can also download the configuration profile (`.mobileconfig`) and change val
 
 Download example Web Clip profile from [our repository](https://github.com/fleetdm/fleet/tree/main/docs/solutions/ios-ipados/configuration-profiles/fleet-self-service.mobileconfig).
 
+See [how iOS and iPadOS devices authenticate](https://fleetdm.com/guides/fleet-desktop#how-ios-and-ipados-devices-authenticate) for how Fleet verifies requests from the Web Clip above.
+
 ## IT admin experience
 
 How to view, update, install, or uninstall self-service software:

--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -92,7 +92,7 @@ You can also download the configuration profile (`.mobileconfig`) and change val
 
 Download example Web Clip profile from [our repository](https://github.com/fleetdm/fleet/tree/main/docs/solutions/ios-ipados/configuration-profiles/fleet-self-service.mobileconfig).
 
-See [how iOS and iPadOS devices authenticate](https://fleetdm.com/guides/fleet-desktop#how-ios-and-ipados-devices-authenticate) for how Fleet verifies requests from the Web Clip above.
+See [how iOS and iPadOS devices authenticate](https://fleetdm.com/guides/fleet-desktop#how-ios-ipados-devices-authenticate) for how Fleet verifies requests from the Web Clip above.
 
 ## IT admin experience
 

--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -92,7 +92,7 @@ You can also download the configuration profile (`.mobileconfig`) and change val
 
 Download example Web Clip profile from [our repository](https://github.com/fleetdm/fleet/tree/main/docs/solutions/ios-ipados/configuration-profiles/fleet-self-service.mobileconfig).
 
-See [how iOS and iPadOS devices authenticate](https://fleetdm.com/guides/fleet-desktop#how-ios-ipados-devices-authenticate) for how Fleet verifies requests from the Web Clip above.
+See [how iOS and iPadOS devices authenticate](https://fleetdm.com/guides/fleet-desktop#how-ios-ipados-devices-authenticate) for how Fleet verifies requests from the Web Clip.
 
 ## IT admin experience
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4545,9 +4545,9 @@ Returns a subset of information about the host specified by `token`. To get all 
 
 This is the API route used by the **My device** page in Fleet Desktop to display information about the host to the end user.
 
-This endpoint doesn't require API token authentication. Authentication on macOS, Windows, and Linux is enforced by generating a [random UUID that rotates hourly](https://fleetdm.com/guides/fleet-desktop#secure-fleet-desktop). For iOS and iPadOS, this is the host's hardware UUID. Hardware UUID authentication only works for iOS and iPadOS hosts — macOS, Windows, and Linux hosts must present the rotating token or a client certificate.
+This endpoint doesn't require API token authentication. Authentication on macOS, Windows, and Linux is enforced by generating a [random UUID that rotates hourly](https://fleetdm.com/guides/fleet-desktop#secure-fleet-desktop). For iOS/iPadOS, this is the host's hardware UUID.
 
-For iOS and iPadOS hosts authenticated this way, Fleet omits identifying details from the response: `uuid`, `hardware_serial`, `primary_mac`, `hostname`, `computer_name`, `display_name`, `display_text`, `team_name`, `labels`, and MDM profile data all come back empty, and the `license` object's `organization` and `device_count` are stripped.
+For iOS/iPadOS hosts, Fleet omits identifying details from the response: `uuid`, `hardware_serial`, `primary_mac`, `hostname`, `computer_name`, `display_name`, `display_text`, `team_name`, `labels`, and MDM profile data all come back empty, and the `license` object's `organization` and `device_count` are stripped.
 
 
 ##### Parameters

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4545,7 +4545,9 @@ Returns a subset of information about the host specified by `token`. To get all 
 
 This is the API route used by the **My device** page in Fleet Desktop to display information about the host to the end user.
 
-This endpoint doesn't require API token authentication. Authentication on macOS, Windows, and Linux is enforced by generating a [random UUID that rotates hourly](https://fleetdm.com/guides/fleet-desktop#secure-fleet-desktop). For iOS and iPadOS, this is the host's hardware UUID.
+This endpoint doesn't require API token authentication. Authentication on macOS, Windows, and Linux is enforced by generating a [random UUID that rotates hourly](https://fleetdm.com/guides/fleet-desktop#secure-fleet-desktop). For iOS and iPadOS, this is the host's hardware UUID. Hardware UUID authentication only works for iOS and iPadOS hosts — macOS, Windows, and Linux hosts must present the rotating token or a client certificate.
+
+For iOS and iPadOS hosts authenticated this way, Fleet omits identifying details from the response: `uuid`, `hardware_serial`, `primary_mac`, `hostname`, `computer_name`, `display_name`, `display_text`, `team_name`, `labels`, and MDM profile data all come back empty, and the `license` object's `organization` and `device_count` are stripped.
 
 
 ##### Parameters


### PR DESCRIPTION
- iOS/iPadOS use UUID. Show exactly which routes support UUID auth and explain the stripping of data for iOS/iPadOS hosts.
  - @noahtalerman: I don't think we have this documented anywhere...
- @noahtalerman: We'll want to update the section in the Fleet Desktop guide to call out SSO auth as a way for customers to add an extra layer of authentication ([shipping in 4.92](https://github.com/fleetdm/fleet/issues/47116)). 
  - Once this PR merges in, I'll ping @rachaelshaw to get `main` merged into the 4.92 docs branch so that we can add this in to the 4.92 docs. 