### PR TITLE
Differentiate users restricted to specific API endpoints in the users table

### DIFF
--- a/changes/51602-api-endpoint-restricted-users
+++ b/changes/51602-api-endpoint-restricted-users
@@ -1,0 +1,2 @@
+* Renamed the "Role" column to "Permissions" on the Settings > Users page, and added a badge showing how many API endpoints an API-only user is restricted to.
+* Updated the Settings > Users table so the actions dropdown only appears on row hover and clicking anywhere else in a row opens that user's edit page.

--- a/frontend/components/Tag/Tag.stories.tsx
+++ b/frontend/components/Tag/Tag.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Tag> = {
   title: "Components/Tag",
   argTypes: {
     children: { control: "text" },
-    size: { control: "radio", options: ["large", "small"] },
+    size: { control: "radio", options: ["large", "small", "xsmall"] },
     disabled: { control: "boolean" },
     tooltip: { control: "text" },
     className: { control: "text" },
@@ -35,6 +35,13 @@ export const Small: Story = {
   args: {
     children: "Patch",
     size: "small",
+  },
+};
+
+export const XSmall: Story = {
+  args: {
+    children: "16 API endpoints",
+    size: "xsmall",
   },
 };
 

--- a/frontend/components/Tag/Tag.tests.tsx
+++ b/frontend/components/Tag/Tag.tests.tsx
@@ -24,6 +24,12 @@ describe("Tag", () => {
     expect(screen.getByText("Inherited")).toHaveClass("tag--small");
   });
 
+  it("adds the xsmall modifier class when size is set to xsmall", () => {
+    render(<Tag size="xsmall">Inherited</Tag>);
+
+    expect(screen.getByText("Inherited")).toHaveClass("tag--xsmall");
+  });
+
   it("does not wrap the tag in a tooltip when tooltip is omitted", () => {
     const { container } = render(<Tag>Inherited</Tag>);
 

--- a/frontend/components/Tag/Tag.tsx
+++ b/frontend/components/Tag/Tag.tsx
@@ -8,8 +8,9 @@ const baseClass = "tag";
 
 interface ITagBaseProps {
   children: React.ReactNode;
-  /** Default: "large" (28px). Per design, use "small" (24px) sparingly. */
-  size?: "large" | "small";
+  /** Default: "large" (28px). Per design, use "small" (24px) sparingly and
+   * "xsmall" (19px) only inline with table cell text. */
+  size?: "large" | "small" | "xsmall";
   className?: string;
   /** Wraps the tag in a tooltip that shows this content on hover */
   tooltip?: JSX.Element | string;
@@ -51,6 +52,7 @@ const Tag = (props: ITagProps) => {
     [`${baseClass}--clickable`]: props.type === "clickable",
     [`${baseClass}--dismissible`]: props.type === "dismissible",
     [`${baseClass}--small`]: props.size === "small",
+    [`${baseClass}--xsmall`]: props.size === "xsmall",
   });
 
   let content: JSX.Element;

--- a/frontend/components/Tag/Tag.tsx
+++ b/frontend/components/Tag/Tag.tsx
@@ -9,7 +9,7 @@ const baseClass = "tag";
 interface ITagBaseProps {
   children: React.ReactNode;
   /** Default: "large" (28px). Per design, use "small" (24px) sparingly and
-   * "xsmall" (19px) only inline with table cell text. */
+   * "xsmall" (20px) only inline with table cell text. */
   size?: "large" | "small" | "xsmall";
   className?: string;
   /** Wraps the tag in a tooltip that shows this content on hover */

--- a/frontend/components/Tag/_styles.scss
+++ b/frontend/components/Tag/_styles.scss
@@ -20,10 +20,10 @@
   }
 
   &--xsmall {
-    height: 19px;
+    height: 20px;
     padding: 0 $pad-xsmall;
     gap: $pad-xsmall;
-    font-size: $xxx-small;
+    font-size: $xx-small;
   }
 
   &--clickable {

--- a/frontend/components/Tag/_styles.scss
+++ b/frontend/components/Tag/_styles.scss
@@ -19,6 +19,13 @@
     height: 24px;
   }
 
+  &--xsmall {
+    height: 19px;
+    padding: 0 $pad-xsmall;
+    gap: $pad-xsmall;
+    font-size: $xxx-small;
+  }
+
   &--clickable {
     background: none;
     cursor: pointer;

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPageTableConfig.tsx
@@ -74,7 +74,7 @@ export const renderApiUserIndicator = () => {
           />
         </>
       }
-      size="small"
+      size="xsmall"
     >
       API
     </Tag>

--- a/frontend/pages/admin/ManageUsersPage/_styles.scss
+++ b/frontend/pages/admin/ManageUsersPage/_styles.scss
@@ -9,8 +9,7 @@
           &.actions__header {
             padding-left: 0;
           }
-          &.status__header,
-          &.role__header {
+          &.status__header {
             width: 86px; // set to prevent expanding
           }
         }
@@ -19,7 +18,6 @@
       tbody {
         // need specificity to override datatable css
         td.name__cell,
-        td.role__cell,
         td.teams__cell,
         td.status__cell,
         td.email__cell {
@@ -27,8 +25,14 @@
           white-space: nowrap;
         }
 
+        // Wider than its siblings so the role plus the API endpoint count tag
+        // fit on one line
+        td.permissions__cell {
+          max-width: $col-md;
+        }
+
         td.status__cell,
-        td.role__cell {
+        td.permissions__cell {
           white-space: nowrap; // Prevent No access from wrapping
         }
 
@@ -83,8 +87,8 @@
       }
 
       @media (max-width: ($break-mobile-sm - 1)) {
-        .role__header,
-        .role__cell {
+        .permissions__header,
+        .permissions__cell {
           display: none;
           width: 0;
         }
@@ -135,6 +139,15 @@
     .actions-dropdown__help-text {
       @include help-text;
     }
+  }
+}
+
+.users-table {
+  // Not to be confused with .permissions__cell, the react-table <td> this sits in
+  &__permissions-content {
+    display: flex;
+    align-items: center;
+    gap: $pad-small;
   }
 }
 
@@ -292,4 +305,3 @@
     }
   }
 }
-

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useContext, useMemo } from "react";
 import { InjectedRouter } from "react-router";
+import { Row } from "react-table";
 import { useQuery } from "react-query";
 
 import PATHS from "router/paths";
@@ -47,6 +48,10 @@ const EmptyUsersTable = () => (
     info="Expecting to see users? Try again in a few seconds as the system catches up."
   />
 );
+
+interface IRowProps extends Row {
+  original: IUserTableData;
+}
 
 interface IUsersTableProps {
   router: InjectedRouter; // v3
@@ -121,16 +126,27 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
 
   // FUNCTIONS
 
+  const goToEditUser = useCallback(
+    (user: IUserTableData) => {
+      if (user.type === "user" && user.apiId === currentUser?.id) {
+        router.push(PATHS.ACCOUNT);
+        return;
+      }
+      const editPath = PATHS.ADMIN_USERS_EDIT(user.apiId);
+      router.push(
+        user.type === "invite" ? `${editPath}?type=invite` : editPath
+      );
+    },
+    [router, currentUser?.id]
+  );
+
   const onActionSelect = useCallback(
     (value: string, user: IUserTableData) => {
       switch (value) {
-        case "edit": {
-          const editPath = PATHS.ADMIN_USERS_EDIT(user.apiId);
-          router.push(
-            user.type === "invite" ? `${editPath}?type=invite` : editPath
-          );
+        case "edit":
+        case "editMyAccount":
+          goToEditUser(user);
           break;
-        }
         case "delete":
           toggleDeleteUserModal(user);
           break;
@@ -140,16 +156,13 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         case "resetSessions":
           toggleResetSessionsUserModal(user);
           break;
-        case "editMyAccount":
-          router.push(PATHS.ACCOUNT);
-          break;
         default:
           return null;
       }
       return null;
     },
     [
-      router,
+      goToEditUser,
       toggleDeleteUserModal,
       toggleResetPasswordUserModal,
       toggleResetSessionsUserModal,
@@ -347,6 +360,8 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
           isAllPagesSelected={false}
           isClientSidePagination
           renderCount={renderUsersCount}
+          disableMultiRowSelect
+          onClickRow={(row: IRowProps) => goToEditUser(row.original)}
         />
       )}
       {showDeleteUserModal && renderDeleteUserModal()}

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
@@ -28,7 +28,7 @@ const renderPermissionsCell = (row: IUserTableData) => {
     row: { original: IUserTableData };
   }) => JSX.Element;
 
-  render(Cell({ cell: { value: row.role }, row: { original: row } }));
+  render(<Cell cell={{ value: row.role }} row={{ original: row }} />);
 };
 
 const createMockInvite = (overrides?: Partial<IInvite>): IInvite => ({

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { render, screen } from "@testing-library/react";
 
 import createMockUser from "__mocks__/userMock";

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
@@ -21,14 +21,14 @@ const mockEndpoints = (count: number): IApiEndpointRef[] =>
 
 const renderPermissionsCell = (row: IUserTableData) => {
   const column = generateTableHeaders(jest.fn(), true).find(
-    (c) => c.accessor === "permissions"
+    (c) => c.id === "permissions"
   );
   const Cell = column?.Cell as (props: {
     cell: { value: string };
     row: { original: IUserTableData };
   }) => JSX.Element;
 
-  render(Cell({ cell: { value: row.permissions }, row: { original: row } }));
+  render(Cell({ cell: { value: row.role }, row: { original: row } }));
 };
 
 const createMockInvite = (overrides?: Partial<IInvite>): IInvite => ({
@@ -104,7 +104,7 @@ describe("UsersTableConfig - API endpoint restrictions", () => {
 
   it("names the role column 'Permissions'", () => {
     const column = generateTableHeaders(jest.fn(), true).find(
-      (c) => c.accessor === "permissions"
+      (c) => c.id === "permissions"
     );
     expect(column?.title).toBe("Permissions");
     expect(column?.Header).toBe("Permissions");

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tests.tsx
@@ -1,10 +1,35 @@
+import { render, screen } from "@testing-library/react";
+
 import createMockUser from "__mocks__/userMock";
 import { IInvite } from "interfaces/invite";
+import { IApiEndpointRef } from "interfaces/api_endpoint";
 
-import { combineDataSets } from "./UsersTableConfig";
+import {
+  combineDataSets,
+  generateTableHeaders,
+  IUserTableData,
+} from "./UsersTableConfig";
 
 const daysAgo = (days: number): string =>
   new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+const mockEndpoints = (count: number): IApiEndpointRef[] =>
+  Array.from({ length: count }, (_unused, i) => ({
+    method: "GET",
+    path: `/api/v1/fleet/endpoint-${i}`,
+  }));
+
+const renderPermissionsCell = (row: IUserTableData) => {
+  const column = generateTableHeaders(jest.fn(), true).find(
+    (c) => c.accessor === "permissions"
+  );
+  const Cell = column?.Cell as (props: {
+    cell: { value: string };
+    row: { original: IUserTableData };
+  }) => JSX.Element;
+
+  render(Cell({ cell: { value: row.permissions }, row: { original: row } }));
+};
 
 const createMockInvite = (overrides?: Partial<IInvite>): IInvite => ({
   created_at: daysAgo(1),
@@ -54,5 +79,66 @@ describe("UsersTableConfig - combineDataSets", () => {
     const invites = [createMockInvite({ global_role: null, teams: [] })];
     const [row] = combineDataSets([], invites, 99);
     expect(row.status).toBe("No access");
+  });
+});
+
+describe("UsersTableConfig - API endpoint restrictions", () => {
+  it("counts the endpoints a user is restricted to", () => {
+    const users = [
+      createMockUser({ api_only: true, api_endpoints: mockEndpoints(3) }),
+    ];
+    const [row] = combineDataSets(users, [], 99);
+    expect(row.apiEndpointCount).toBe(3);
+  });
+
+  it("counts zero endpoints for a user with unrestricted API access", () => {
+    const users = [createMockUser({ api_only: true })];
+    const [row] = combineDataSets(users, [], 99);
+    expect(row.apiEndpointCount).toBe(0);
+  });
+
+  it("counts zero endpoints for invites", () => {
+    const [row] = combineDataSets([], [createMockInvite()], 99);
+    expect(row.apiEndpointCount).toBe(0);
+  });
+
+  it("names the role column 'Permissions'", () => {
+    const column = generateTableHeaders(jest.fn(), true).find(
+      (c) => c.accessor === "permissions"
+    );
+    expect(column?.title).toBe("Permissions");
+    expect(column?.Header).toBe("Permissions");
+  });
+
+  it("shows a badge with the endpoint count in the Permissions cell", () => {
+    const users = [
+      createMockUser({ api_only: true, api_endpoints: mockEndpoints(16) }),
+    ];
+    const [row] = combineDataSets(users, [], 99);
+
+    renderPermissionsCell(row);
+
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByText("16 API endpoints")).toBeInTheDocument();
+  });
+
+  it("singularizes the badge when the user is restricted to one endpoint", () => {
+    const users = [
+      createMockUser({ api_only: true, api_endpoints: mockEndpoints(1) }),
+    ];
+    const [row] = combineDataSets(users, [], 99);
+
+    renderPermissionsCell(row);
+
+    expect(screen.getByText("1 API endpoint")).toBeInTheDocument();
+  });
+
+  it("omits the badge for a user with unrestricted API access", () => {
+    const users = [createMockUser({ api_only: true })];
+    const [row] = combineDataSets(users, [], 99);
+
+    renderPermissionsCell(row);
+
+    expect(screen.queryByText(/API endpoint/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -22,13 +22,19 @@ import {
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import ActionsDropdown from "../../../../../components/ActionsDropdown";
 
+const baseClass = "users-table";
+
 const renderApiUserIndicator = () => {
   return (
-    <Tag tooltip="This user only has API access." size="small">
+    <Tag tooltip="This user only has API access." size="xsmall">
       API
     </Tag>
   );
 };
+
+const renderApiEndpointCount = (count: number) => (
+  <Tag size="xsmall">{`${count} API endpoint${count === 1 ? "" : "s"}`}</Tag>
+);
 
 interface IHeaderProps {
   column: {
@@ -73,7 +79,7 @@ export interface IUserTableData {
   teams: string;
   teamNames: string[];
   roleGroups: { role: string; names: string[] }[];
-  role: UserRole;
+  permissions: UserRole;
   actions: IDropdownOption[];
   /** Prefixed ID used as a unique react-table row key (e.g. "user-3", "invite-1") */
   id: string;
@@ -81,6 +87,8 @@ export interface IUserTableData {
   apiId: number;
   type: string;
   api_only: boolean;
+  /** Number of API endpoints this user is restricted to; 0 means unrestricted */
+  apiEndpointCount: number;
 }
 
 // The inactivity window is enforced server-side (see UserInactiveAfter in
@@ -106,8 +114,68 @@ const generateInviteStatus = (invite: IInvite): string =>
     ? "No access"
     : "Invite pending";
 
-// NOTE: cellProps come from react-table
-// more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
+const renderRole = (cellProps: ICellProps) => {
+  if (cellProps.cell.value === "GitOps") {
+    return (
+      <TooltipWrapper
+        tipContent={
+          <>
+            The GitOps role is only available for API-only
+            <br />
+            users. This user has no access to the UI.
+          </>
+        }
+      >
+        GitOps
+      </TooltipWrapper>
+    );
+  }
+  if (cellProps.cell.value === "Observer+") {
+    return (
+      <TooltipWrapper
+        tipContent={
+          <>
+            Users with the Observer+ role have access to all of
+            <br />
+            the same functions as an Observer, with the added
+            <br />
+            ability to run any live report against all hosts.
+          </>
+        }
+      >
+        {cellProps.cell.value}
+      </TooltipWrapper>
+    );
+  }
+  if (cellProps.cell.value === ROLE_VARIOUS) {
+    const { roleGroups } = cellProps.row.original;
+    return (
+      <TooltipWrapper
+        tipContent={roleGroups.map(({ role, names }) => (
+          <span key={role}>
+            <b>{role}:</b> {names.join(", ")}
+            <br />
+          </span>
+        ))}
+        underline={false}
+        showArrow
+        position="top"
+        tipOffset={10}
+        fixedPositionStrategy
+      >
+        <TextCell value={ROLE_VARIOUS} grey italic />
+      </TooltipWrapper>
+    );
+  }
+  return (
+    <TextCell
+      value={cellProps.cell.value}
+      grey={greyCell(cellProps.cell.value)}
+      italic={greyCell(cellProps.cell.value)}
+    />
+  );
+};
+
 const generateTableHeaders = (
   actionSelectHandler: (value: string, user: IUserTableData) => void,
   isPremiumTier: boolean | undefined
@@ -133,69 +201,18 @@ const generateTableHeaders = (
       },
     },
     {
-      title: "Role",
-      Header: "Role",
-      accessor: "role",
+      title: "Permissions",
+      Header: "Permissions",
+      accessor: "permissions",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
-        if (cellProps.cell.value === "GitOps") {
-          return (
-            <TooltipWrapper
-              tipContent={
-                <>
-                  The GitOps role is only available for API-only
-                  <br />
-                  users. This user has no access to the UI.
-                </>
-              }
-            >
-              GitOps
-            </TooltipWrapper>
-          );
-        }
-        if (cellProps.cell.value === "Observer+") {
-          return (
-            <TooltipWrapper
-              tipContent={
-                <>
-                  Users with the Observer+ role have access to all of
-                  <br />
-                  the same functions as an Observer, with the added
-                  <br />
-                  ability to run any live report against all hosts.
-                </>
-              }
-            >
-              {cellProps.cell.value}
-            </TooltipWrapper>
-          );
-        }
-        if (cellProps.cell.value === ROLE_VARIOUS) {
-          const { roleGroups } = cellProps.row.original;
-          return (
-            <TooltipWrapper
-              tipContent={roleGroups.map(({ role, names }) => (
-                <span key={role}>
-                  <b>{role}:</b> {names.join(", ")}
-                  <br />
-                </span>
-              ))}
-              underline={false}
-              showArrow
-              position="top"
-              tipOffset={10}
-              fixedPositionStrategy
-            >
-              <TextCell value={ROLE_VARIOUS} grey italic />
-            </TooltipWrapper>
-          );
-        }
+        const { apiEndpointCount } = cellProps.row.original;
+
         return (
-          <TextCell
-            value={cellProps.cell.value}
-            grey={greyCell(cellProps.cell.value)}
-            italic={greyCell(cellProps.cell.value)}
-          />
+          <div className={`${baseClass}__permissions-content`}>
+            {renderRole(cellProps)}
+            {apiEndpointCount > 0 && renderApiEndpointCount(apiEndpointCount)}
+          </div>
         );
       },
     },
@@ -249,15 +266,22 @@ const generateTableHeaders = (
       disableSortBy: true,
       accessor: "actions",
       Cell: (cellProps: IActionsDropdownProps) => (
-        <ActionsDropdown
-          options={cellProps.cell.value}
-          onChange={(value: string) =>
-            actionSelectHandler(value, cellProps.row.original)
-          }
-          placeholder="Actions"
-          menuAlign="right"
-          variant="secondary"
-        />
+        <div
+          role="presentation"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <ActionsDropdown
+            className="row-hover-button"
+            options={cellProps.cell.value}
+            onChange={(value: string) =>
+              actionSelectHandler(value, cellProps.row.original)
+            }
+            placeholder="Actions"
+            menuAlign="right"
+            variant="secondary"
+          />
+        </div>
       ),
     },
   ];
@@ -370,7 +394,7 @@ const enhanceUserData = (
       teams: generateTeam(user.teams, user.global_role),
       teamNames: generateTeamNames(user.teams),
       roleGroups: generateRoleGroups(user.teams),
-      role: generateRole(user.teams, user.global_role),
+      permissions: generateRole(user.teams, user.global_role),
       actions: generateActionDropdownOptions(
         user.id === currentUserId,
         false,
@@ -381,6 +405,7 @@ const enhanceUserData = (
       apiId: user.id,
       type: "user",
       api_only: user.api_only,
+      apiEndpointCount: user.api_endpoints?.length ?? 0,
     };
   });
 };
@@ -394,7 +419,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       teams: generateTeam(invite.teams, invite.global_role),
       teamNames: generateTeamNames(invite.teams),
       roleGroups: generateRoleGroups(invite.teams),
-      role: generateRole(invite.teams, invite.global_role),
+      permissions: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(
         false,
         true,
@@ -405,6 +430,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       apiId: invite.id,
       type: "invite",
       api_only: false, // api only users are created through fleetctl and not invites
+      apiEndpointCount: 0,
     };
   });
 };

--- a/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UsersTable/UsersTableConfig.tsx
@@ -65,6 +65,7 @@ interface IDataColumn {
   title: string;
   Header: ((props: IHeaderProps) => JSX.Element) | string;
   accessor: string;
+  id?: string;
   Cell:
     | ((props: ICellProps) => JSX.Element)
     | ((props: IActionsDropdownProps) => JSX.Element);
@@ -79,7 +80,7 @@ export interface IUserTableData {
   teams: string;
   teamNames: string[];
   roleGroups: { role: string; names: string[] }[];
-  permissions: UserRole;
+  role: UserRole;
   actions: IDropdownOption[];
   /** Prefixed ID used as a unique react-table row key (e.g. "user-3", "invite-1") */
   id: string;
@@ -203,7 +204,11 @@ const generateTableHeaders = (
     {
       title: "Permissions",
       Header: "Permissions",
-      accessor: "permissions",
+      accessor: "role",
+      // react-table derives the cell/header DOM classes and the sort key from
+      // `id`, so this keeps them as `permissions__*` without renaming the
+      // underlying row field.
+      id: "permissions",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
         const { apiEndpointCount } = cellProps.row.original;
@@ -394,7 +399,7 @@ const enhanceUserData = (
       teams: generateTeam(user.teams, user.global_role),
       teamNames: generateTeamNames(user.teams),
       roleGroups: generateRoleGroups(user.teams),
-      permissions: generateRole(user.teams, user.global_role),
+      role: generateRole(user.teams, user.global_role),
       actions: generateActionDropdownOptions(
         user.id === currentUserId,
         false,
@@ -419,7 +424,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       teams: generateTeam(invite.teams, invite.global_role),
       teamNames: generateTeamNames(invite.teams),
       roleGroups: generateRoleGroups(invite.teams),
-      permissions: generateRole(invite.teams, invite.global_role),
+      role: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(
         false,
         true,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51602

- Adds a badge that surfaces how many API endpoints an API-only user has access to.
- Added a smaller badge (Tag.tsx) variant following the Figma spec.
- Changed `Role` column header to `Permissions`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/e0f4ea52-dd33-41d9-9f82-8563829c448d



## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed the Users table’s “Role” column to “Permissions.”
  * API-only users now see a badge showing the number of restricted API endpoints.
  * Clicking a user row opens the edit page, while row actions appear on hover.
  * Added an extra-small tag size for compact table indicators.

* **Bug Fixes**
  * Improved navigation when editing your own account, invited users, and other user types.
  * Prevented action menu interactions from triggering row navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->