### PR TITLE
Scope the software checksum dedupe migration to giflib

### DIFF
--- a/changes/36365-duplicate-software-checksum
+++ b/changes/36365-duplicate-software-checksum
@@ -1,1 +1,1 @@
-- Fixed duplicate software inventory entries (same name, version, and source with the same vulnerabilities but different host counts) that could appear on instances upgraded to Fleet v4.76.0 or later. Existing duplicates are merged during the database migration on upgrade.
+- Fixed duplicate software inventory entries (same name, version, and source with the same vulnerabilities but different host counts) that could appear on instances upgraded to Fleet v4.76.0 or later. Existing duplicate giflib (Homebrew) entries are merged during the database migration on upgrade.

--- a/server/datastore/mysql/migrations/tables/20260810160000_DedupeSoftwareChecksums.go
+++ b/server/datastore/mysql/migrations/tables/20260810160000_DedupeSoftwareChecksums.go
@@ -19,31 +19,34 @@ const canonicalSoftwareChecksum = "UNHEX(MD5(CONCAT_WS(CHAR(0), " +
 	"extension_for, extension_id, name, " +
 	"NULLIF(COALESCE(application_id, ''), ''), NULLIF(COALESCE(upgrade_code, ''), ''))))"
 
+// dedupeSoftwareScope limits the repair to the software the affected customer reported
+// duplicated (giflib from Homebrew, all versions). Other rows the checksum reorder may
+// have left stale are deliberately out of scope.
+const dedupeSoftwareScope = "name = 'giflib' AND source = 'homebrew_packages'"
+
 // softwareChecksumMapping is a duplicate software row and the row it merges into.
 type softwareChecksumMapping struct {
 	StaleID    uint64 `db:"stale_id"`
 	SurvivorID uint64 `db:"survivor_id"`
 }
 
-// Vars so tests can lower them to exercise the batching.
-var (
-	dedupeSoftwareBatchSize    = 1000
-	recomputeSoftwareBatchSize = uint64(50000)
-)
+// Var so tests can lower it to exercise the batching.
+var dedupeSoftwareBatchSize = 1000
 
 func Up_20260810160000(tx *sql.Tx) error {
 	// v4.76.0 moved `name` from the front to the back of the software checksum. Rows
 	// created before that upgrade kept their old checksum, so when a host reported the
 	// same software again it no longer matched and a second `software` row was inserted:
 	// the same software twice, with the same CVEs but split host counts. Merge those
-	// duplicates, then recompute every checksum so pre-upgrade rows that have not
+	// duplicates, then recompute the scoped rows' checksums so ones that have not
 	// duplicated yet cannot duplicate later.
 	txx := sqlx.Tx{Tx: tx, Mapper: reflectx.NewMapperFunc("db", sqlx.NameMapper)}
 
-	// A window function maps duplicates to their survivor in one pass; a GROUP BY would
-	// have to join its result back, which has no index. Partitioning by the canonical
-	// checksum rather than the columns it hashes sorts a 16-byte binary key instead of
-	// 11 utf8mb4 strings (~8x faster), and matches exactly the equivalence the recompute
+	// Map each duplicate row to its survivor. The scope filter is served by
+	// idx_sw_name_source_browser, so only the handful of matching rows are read; FORCE
+	// INDEX pins that plan, since mid-migration index statistics are unreliable and
+	// `software` is too large to risk a fallback scan. Rows are duplicates when the
+	// canonical checksum formula agrees, which is exactly the equivalence the recompute
 	// below must not collide under (CONCAT_WS skips NULLs, so distinct column tuples can
 	// share a checksum).
 	var mappings []softwareChecksumMapping
@@ -51,139 +54,113 @@ func Up_20260810160000(tx *sql.Tx) error {
 		SELECT stale_id, survivor_id FROM (
 			SELECT id AS stale_id,
 				MIN(id) OVER (PARTITION BY `+canonicalSoftwareChecksum+`) AS survivor_id
-			FROM software
+			FROM software FORCE INDEX (idx_sw_name_source_browser)
+			WHERE `+dedupeSoftwareScope+`
 		) m WHERE stale_id <> survivor_id`); err != nil {
 		return fmt.Errorf("selecting duplicate software rows: %w", err)
 	}
 
 	logger.Info.Printf("deduplicating software: found %d duplicate software rows\n", len(mappings))
 
-	var recomputeMaxID uint64
-	return withSteps([]migrationStep{
-		// Merge each duplicate onto its survivor. incrementalMigrationStep skips a step
-		// whose total is zero, so instances with no duplicates never touch the large host
-		// software tables.
-		incrementalMigrationStep(
-			func(*sql.Tx) (uint64, error) { return uint64(len(mappings)), nil },
-			mergeDuplicateSoftware(mappings),
-		),
-		// Recompute every checksum to the current formula. The merge made canonical
-		// checksums unique, so this cannot collide on idx_software_checksum. Progress is
-		// counted in id-range batches, which keeps each statement bounded on this large
-		// table.
-		incrementalMigrationStep(
-			func(tx *sql.Tx) (uint64, error) {
-				if err := tx.QueryRow("SELECT COALESCE(MAX(id), 0) FROM software").Scan(&recomputeMaxID); err != nil {
-					return 0, fmt.Errorf("getting max software id: %w", err)
-				}
-				return recomputeMaxID/recomputeSoftwareBatchSize + 1, nil
-			},
-			func(tx *sql.Tx, increment incrementCountFn) error {
-				var recomputed int64
-				for start := uint64(0); start <= recomputeMaxID; start += recomputeSoftwareBatchSize {
-					res, err := tx.Exec(
-						"UPDATE software SET checksum = "+canonicalSoftwareChecksum+
-							" WHERE id >= ? AND id < ? AND checksum <> "+canonicalSoftwareChecksum,
-						start, start+recomputeSoftwareBatchSize,
-					)
-					if err != nil {
-						return fmt.Errorf("recomputing software checksums: %w", err)
-					}
-					n, err := res.RowsAffected()
-					if err != nil {
-						return fmt.Errorf("counting recomputed software checksums: %w", err)
-					}
-					recomputed += n
-					increment()
-				}
-				logger.Info.Printf("deduplicating software: recomputed %d software checksums\n", recomputed)
-				return nil
-			},
-		),
-	}, tx)
+	if err := mergeDuplicateSoftware(tx, mappings); err != nil {
+		return err
+	}
+
+	// Recompute the scoped rows' checksums to the current formula. The merge made
+	// canonical checksums unique within the scope, and the formula hashes the name, so
+	// this cannot collide on idx_software_checksum.
+	res, err := tx.Exec(
+		"UPDATE software FORCE INDEX (idx_sw_name_source_browser) SET checksum = " + canonicalSoftwareChecksum +
+			" WHERE " + dedupeSoftwareScope + " AND checksum <> " + canonicalSoftwareChecksum)
+	if err != nil {
+		return fmt.Errorf("recomputing software checksums: %w", err)
+	}
+	recomputed, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("counting recomputed software checksums: %w", err)
+	}
+	logger.Info.Printf("deduplicating software: recomputed %d software checksums\n", recomputed)
+
+	return nil
 }
 
 // mergeDuplicateSoftware repoints every host reference from each duplicate row onto its
-// survivor, then deletes the duplicates.
-func mergeDuplicateSoftware(mappings []softwareChecksumMapping) executeWithProgressFn {
-	return func(tx *sql.Tx, increment incrementCountFn) error {
-		for start := 0; start < len(mappings); start += dedupeSoftwareBatchSize {
-			end := min(start+dedupeSoftwareBatchSize, len(mappings))
-			batch := mappings[start:end]
+// survivor, then deletes the duplicates. Instances with no duplicates never touch the
+// large host software tables.
+func mergeDuplicateSoftware(tx *sql.Tx, mappings []softwareChecksumMapping) error {
+	for start := 0; start < len(mappings); start += dedupeSoftwareBatchSize {
+		end := min(start+dedupeSoftwareBatchSize, len(mappings))
+		batch := mappings[start:end]
 
-			// One CASE per batch, so each table below is touched once instead of once per
-			// duplicate.
-			var whens strings.Builder
-			caseArgs := make([]any, 0, len(batch)*2)
-			staleIDs := make([]any, 0, len(batch))
-			for _, m := range batch {
-				whens.WriteString(" WHEN ? THEN ?")
-				caseArgs = append(caseArgs, m.StaleID, m.SurvivorID)
-				staleIDs = append(staleIDs, m.StaleID)
-			}
-			mapCase := func(col string) string { return "CASE " + col + whens.String() + " END" }
+		// One CASE per batch, so each table below is touched once instead of once per
+		// duplicate.
+		var whens strings.Builder
+		caseArgs := make([]any, 0, len(batch)*2)
+		staleIDs := make([]any, 0, len(batch))
+		for _, m := range batch {
+			whens.WriteString(" WHEN ? THEN ?")
+			caseArgs = append(caseArgs, m.StaleID, m.SurvivorID)
+			staleIDs = append(staleIDs, m.StaleID)
+		}
+		mapCase := func(col string) string { return "CASE " + col + whens.String() + " END" }
 
-			// Give the survivor a link for every host on a duplicate row. INSERT IGNORE skips
-			// hosts already linked to it; the duplicate links are deleted below.
-			stmt, args, err := sqlx.In(
-				"INSERT IGNORE INTO host_software (host_id, software_id, last_opened_at) "+
-					"SELECT host_id, "+mapCase("software_id")+", last_opened_at "+
-					"FROM host_software WHERE software_id IN (?)",
-				append(append([]any{}, caseArgs...), staleIDs)...)
+		// Give the survivor a link for every host on a duplicate row. INSERT IGNORE skips
+		// hosts already linked to it; the duplicate links are deleted below.
+		stmt, args, err := sqlx.In(
+			"INSERT IGNORE INTO host_software (host_id, software_id, last_opened_at) "+
+				"SELECT host_id, "+mapCase("software_id")+", last_opened_at "+
+				"FROM host_software WHERE software_id IN (?)",
+			append(append([]any{}, caseArgs...), staleIDs)...)
+		if err != nil {
+			return fmt.Errorf("building host_software repoint: %w", err)
+		}
+		if _, err := tx.Exec(stmt, args...); err != nil {
+			return fmt.Errorf("repointing host_software onto surviving software rows: %w", err)
+		}
+
+		// host_software_installed_paths is only indexed on (host_id, software_id), so
+		// filtering it by software_id alone scans this large table. Drive off host_software
+		// instead, which is indexed on software_id and still holds the duplicate links
+		// here, to reach each path row by the full key. STRAIGHT_JOIN and FORCE INDEX pin
+		// that plan, since mid-migration index statistics are unreliable.
+		//
+		// This skips a path row whose host_software link is already missing, which only
+		// happens when a host's paths were not reconciled after its software was (separate
+		// transactions). Such a row is already stale: nothing joining software can see it,
+		// and the host's next detail query deletes it.
+		stmt, args, err = sqlx.In(
+			"UPDATE host_software hs "+
+				"STRAIGHT_JOIN host_software_installed_paths hsip FORCE INDEX (host_id_software_id_idx) "+
+				"  ON hsip.host_id = hs.host_id AND hsip.software_id = hs.software_id "+
+				"SET hsip.software_id = "+mapCase("hs.software_id")+
+				" WHERE hs.software_id IN (?)",
+			append(append([]any{}, caseArgs...), staleIDs)...)
+		if err != nil {
+			return fmt.Errorf("building host_software_installed_paths repoint: %w", err)
+		}
+		if _, err := tx.Exec(stmt, args...); err != nil {
+			return fmt.Errorf("repointing host_software_installed_paths onto surviving software rows: %w", err)
+		}
+
+		// The counts are recomputed by the software host-count crons, and deleting a
+		// software row cascades software_cpe.
+		for _, del := range []struct{ desc, query string }{
+			{"host_software links", "DELETE FROM host_software WHERE software_id IN (?)"},
+			{"kernel host counts", "DELETE FROM kernel_host_counts WHERE software_id IN (?)"},
+			{"software CVEs", "DELETE FROM software_cve WHERE software_id IN (?)"},
+			{"software host counts", "DELETE FROM software_host_counts WHERE software_id IN (?)"},
+			{"software rows", "DELETE FROM software WHERE id IN (?)"},
+		} {
+			stmt, args, err := sqlx.In(del.query, staleIDs)
 			if err != nil {
-				return fmt.Errorf("building host_software repoint: %w", err)
+				return fmt.Errorf("building duplicate %s delete: %w", del.desc, err)
 			}
 			if _, err := tx.Exec(stmt, args...); err != nil {
-				return fmt.Errorf("repointing host_software onto surviving software rows: %w", err)
-			}
-
-			// host_software_installed_paths is only indexed on (host_id, software_id), so
-			// filtering it by software_id alone scans this large table. Drive off host_software
-			// instead, which is indexed on software_id and still holds the duplicate links
-			// here, to reach each path row by the full key. STRAIGHT_JOIN and FORCE INDEX pin
-			// that plan, since mid-migration index statistics are unreliable.
-			//
-			// This skips a path row whose host_software link is already missing, which only
-			// happens when a host's paths were not reconciled after its software was (separate
-			// transactions). Such a row is already stale: nothing joining software can see it,
-			// and the host's next detail query deletes it.
-			stmt, args, err = sqlx.In(
-				"UPDATE host_software hs "+
-					"STRAIGHT_JOIN host_software_installed_paths hsip FORCE INDEX (host_id_software_id_idx) "+
-					"  ON hsip.host_id = hs.host_id AND hsip.software_id = hs.software_id "+
-					"SET hsip.software_id = "+mapCase("hs.software_id")+
-					" WHERE hs.software_id IN (?)",
-				append(append([]any{}, caseArgs...), staleIDs)...)
-			if err != nil {
-				return fmt.Errorf("building host_software_installed_paths repoint: %w", err)
-			}
-			if _, err := tx.Exec(stmt, args...); err != nil {
-				return fmt.Errorf("repointing host_software_installed_paths onto surviving software rows: %w", err)
-			}
-
-			// The counts are recomputed by the software host-count crons, and deleting a
-			// software row cascades software_cpe.
-			for _, del := range []struct{ desc, query string }{
-				{"host_software links", "DELETE FROM host_software WHERE software_id IN (?)"},
-				{"kernel host counts", "DELETE FROM kernel_host_counts WHERE software_id IN (?)"},
-				{"software CVEs", "DELETE FROM software_cve WHERE software_id IN (?)"},
-				{"software host counts", "DELETE FROM software_host_counts WHERE software_id IN (?)"},
-				{"software rows", "DELETE FROM software WHERE id IN (?)"},
-			} {
-				stmt, args, err := sqlx.In(del.query, staleIDs)
-				if err != nil {
-					return fmt.Errorf("building duplicate %s delete: %w", del.desc, err)
-				}
-				if _, err := tx.Exec(stmt, args...); err != nil {
-					return fmt.Errorf("deleting duplicate %s: %w", del.desc, err)
-				}
-			}
-			for range batch {
-				increment()
+				return fmt.Errorf("deleting duplicate %s: %w", del.desc, err)
 			}
 		}
-		return nil
 	}
+	return nil
 }
 
 func Down_20260810160000(tx *sql.Tx) error {

--- a/server/datastore/mysql/migrations/tables/20260810160000_DedupeSoftwareChecksums_test.go
+++ b/server/datastore/mysql/migrations/tables/20260810160000_DedupeSoftwareChecksums_test.go
@@ -15,11 +15,11 @@ import (
 func TestUp_20260810160000(t *testing.T) {
 	db := applyUpToPrev(t)
 
-	// Shrink the batch sizes so this fixture exercises the batching loops (multiple
-	// dedupe batches and multiple recompute id ranges) rather than a single pass.
-	oldDedupe, oldRecompute := dedupeSoftwareBatchSize, recomputeSoftwareBatchSize
-	dedupeSoftwareBatchSize, recomputeSoftwareBatchSize = 2, 1
-	t.Cleanup(func() { dedupeSoftwareBatchSize, recomputeSoftwareBatchSize = oldDedupe, oldRecompute })
+	// Shrink the batch size so this fixture exercises the batching loop (multiple
+	// dedupe batches) rather than a single pass.
+	oldDedupe := dedupeSoftwareBatchSize
+	dedupeSoftwareBatchSize = 2
+	t.Cleanup(func() { dedupeSoftwareBatchSize = oldDedupe })
 
 	ck := func(cols ...string) []byte {
 		sum := md5.Sum([]byte(strings.Join(cols, "\x00"))) //nolint:gosec // matches the software checksum hash
@@ -43,8 +43,8 @@ func TestUp_20260810160000(t *testing.T) {
 		execNoErr(t, db, `INSERT INTO host_software (host_id, software_id) VALUES (?, ?)`, hostID, swID)
 	}
 
-	// 1. Duplicate group: canonical row (host 1) + legacy row (host 2, and host 1 -> a
-	//    collision), plus an install path on the legacy row.
+	// 1. In-scope duplicate group: canonical giflib row (host 1) + legacy row (host 2, and
+	//    host 1 -> a collision), plus an install path on the legacy row.
 	giflibCanon := insertSW("giflib", "5.2.2", canonical("giflib", "5.2.2"))
 	giflibStale := insertSW("giflib", "5.2.2", nameFirst("giflib", "5.2.2"))
 	link(1, giflibCanon)
@@ -63,20 +63,39 @@ func TestUp_20260810160000(t *testing.T) {
 		execNoErr(t, db, `INSERT INTO kernel_host_counts (software_id, os_version_id, team_id, hosts_count) VALUES (?, ?, 0, 1)`, id, id)
 	}
 
-	// 2. Lone legacy row (no twin yet): must be recomputed to canonical so it can't
-	//    re-duplicate when its host reports again.
+	// 2. Second in-scope version with a three-member group (canonical + two
+	//    differently-stale rows). Together with 5.2.2 this makes three duplicate rows, so
+	//    the merge runs over several batches.
+	giflib521Canon := insertSW("giflib", "5.2.1", canonical("giflib", "5.2.1"))
+	giflib521StaleA := insertSW("giflib", "5.2.1", nameFirst("giflib", "5.2.1"))
+	giflib521StaleB := insertSW("giflib", "5.2.1", ck("giflib-other-legacy-formula"))
+	link(10, giflib521Canon)
+	link(11, giflib521StaleA)
+	link(12, giflib521StaleB)
+
+	// 3. In-scope lone legacy row (no twin yet): must be recomputed to canonical so it
+	//    can't re-duplicate when its host reports again.
+	giflib520Stale := insertSW("giflib", "5.2.0", nameFirst("giflib", "5.2.0"))
+	link(13, giflib520Stale)
+
+	// 4. Out of scope: a lone legacy row of another homebrew package. Same staleness as
+	//    giflib 5.2.0, but not the reported software, so it must be left untouched.
 	zlibStale := insertSW("zlib", "1.0", nameFirst("zlib", "1.0"))
 	link(3, zlibStale)
 
-	// 3. Control: an already-canonical row that must be left untouched.
+	// 4b. Out of scope on the source axis: a stale giflib row from another source.
+	giflibDebCk := ck("giflib", "5.2.2", "deb_packages", "", "", "", "", "", "")
+	giflibDeb := execNoErrLastID(t, db,
+		`INSERT INTO software (name, version, source, checksum) VALUES ('giflib', '5.2.2', 'deb_packages', ?)`,
+		giflibDebCk)
+	link(14, giflibDeb)
+
+	// 5. Out of scope: an already-canonical row.
 	openssl := insertSW("openssl", "3.0", canonical("openssl", "3.0"))
 	link(4, openssl)
 
-	// 4. macOS apps. Migration 20251015103505 only recomputed apps rows that have a
-	//    bundle_identifier, so those are already canonical and must not change. Apps
-	//    without one still carry the original apps formula, which left the name out
-	//    entirely; they are stale and must be repaired here or they duplicate as soon as
-	//    their host reports again.
+	// 6. Out of scope: macOS apps rows, canonical and stale (pre-v4.76.0 apps formula,
+	//    which left the name out entirely). Both must be left untouched.
 	appsCanonical := func(name, version, bundleID string) []byte {
 		return ck(version, "apps", bundleID, "", "", "", "", "", name)
 	}
@@ -90,8 +109,8 @@ func TestUp_20260810160000(t *testing.T) {
 	link(8, safariID)
 	link(9, noBundleID)
 
-	// 5. A three-member group (canonical + two differently-stale rows). Together with
-	//    giflib this makes three duplicate rows, so the merge runs over several batches.
+	// 7. Out of scope: a duplicate group of another homebrew package. Same shape as the
+	//    giflib groups, but it must NOT be merged.
 	curlCanon := insertSW("curl", "8.1", canonical("curl", "8.1"))
 	curlStaleA := insertSW("curl", "8.1", nameFirst("curl", "8.1"))
 	curlStaleB := insertSW("curl", "8.1", ck("curl-other-legacy-formula"))
@@ -111,6 +130,11 @@ func TestUp_20260810160000(t *testing.T) {
 		var cksum []byte
 		require.NoError(t, db.QueryRow(`SELECT id, checksum FROM software WHERE name=? AND version=? AND source='homebrew_packages'`, name, version).Scan(&id, &cksum))
 		return id, cksum
+	}
+	getChecksum := func(id int64) []byte {
+		var cksum []byte
+		require.NoError(t, db.QueryRow(`SELECT checksum FROM software WHERE id=?`, id).Scan(&cksum))
+		return cksum
 	}
 	hostsOn := func(swID int64) []int {
 		rows, err := db.Query(`SELECT host_id FROM host_software WHERE software_id=? ORDER BY host_id`, swID)
@@ -155,56 +179,70 @@ func TestUp_20260810160000(t *testing.T) {
 	require.NoError(t, db.QueryRow(`SELECT last_opened_at FROM host_software WHERE host_id = 2 AND software_id = ?`, giflibID).Scan(&lastOpened))
 	require.True(t, lastOpened.Valid, "repointed link should keep last_opened_at")
 
-	// 2. Lone legacy row: same row kept, checksum recomputed to canonical, host retained.
+	// 2. Three-member group collapsed onto the lowest id, with all three hosts kept.
+	require.Equal(t, 1, countSW("giflib", "5.2.1"))
+	giflib521ID, giflib521Ck := getOne("giflib", "5.2.1")
+	require.Equal(t, giflib521Canon, giflib521ID)
+	require.Equal(t, canonical("giflib", "5.2.1"), giflib521Ck)
+	require.Equal(t, []int{10, 11, 12}, hostsOn(giflib521ID))
+	for _, staleID := range []int64{giflib521StaleA, giflib521StaleB} {
+		var n int
+		require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM software WHERE id=?`, staleID).Scan(&n))
+		require.Zerof(t, n, "stale row %d should be deleted", staleID)
+	}
+
+	// 3. In-scope lone legacy row: same row kept, checksum recomputed to canonical, host
+	//    retained.
+	require.Equal(t, 1, countSW("giflib", "5.2.0"))
+	giflib520ID, giflib520Ck := getOne("giflib", "5.2.0")
+	require.Equal(t, giflib520Stale, giflib520ID)
+	require.Equal(t, canonical("giflib", "5.2.0"), giflib520Ck)
+	require.Equal(t, []int{13}, hostsOn(giflib520ID))
+
+	// 4. Out-of-scope lone legacy row: untouched, stale checksum and all.
 	require.Equal(t, 1, countSW("zlib", "1.0"))
 	zlibID, zlibCk := getOne("zlib", "1.0")
 	require.Equal(t, zlibStale, zlibID)
-	require.Equal(t, canonical("zlib", "1.0"), zlibCk)
+	require.Equal(t, nameFirst("zlib", "1.0"), zlibCk, "out-of-scope stale row must keep its legacy checksum")
 	require.Equal(t, []int{3}, hostsOn(zlibID))
 
-	// 3. Control: untouched.
+	// 4b. Same name, different source: untouched, stale checksum and all.
+	require.Equal(t, giflibDebCk, getChecksum(giflibDeb), "giflib from another source must keep its legacy checksum")
+	require.Equal(t, []int{14}, hostsOn(giflibDeb))
+
+	// 5. Out-of-scope canonical row: untouched.
 	require.Equal(t, 1, countSW("openssl", "3.0"))
 	opensslID, opensslCk := getOne("openssl", "3.0")
 	require.Equal(t, openssl, opensslID)
 	require.Equal(t, canonical("openssl", "3.0"), opensslCk)
 	require.Equal(t, []int{4}, hostsOn(opensslID))
 
-	// 4. Apps: the bundle-identifier row was already canonical and is untouched; the one
-	//    without a bundle identifier is repaired to the current formula (so it can no
-	//    longer duplicate), keeping its row and host.
-	var safariCk []byte
-	require.NoError(t, db.QueryRow(`SELECT checksum FROM software WHERE id=?`, safariID).Scan(&safariCk))
-	require.Equal(t, appsCanonical("Safari", "17.0", "com.apple.Safari"), safariCk)
-
-	var legacyCk []byte
-	require.NoError(t, db.QueryRow(`SELECT checksum FROM software WHERE id=?`, noBundleID).Scan(&legacyCk))
-	require.NotEqual(t, appsNameExcluded, legacyCk, "pre-v4.76.0 apps row should be repaired")
-	require.Equal(t, appsCanonical("LegacyApp", "1.0", ""), legacyCk)
+	// 6. Apps rows: both untouched, including the stale one.
+	require.Equal(t, appsCanonical("Safari", "17.0", "com.apple.Safari"), getChecksum(safariID))
+	require.Equal(t, appsNameExcluded, getChecksum(noBundleID), "out-of-scope stale apps row must keep its legacy checksum")
 	require.Equal(t, []int{9}, hostsOn(noBundleID))
 
-	// 5. Three-member group collapsed onto the lowest id, with all three hosts kept.
-	require.Equal(t, 1, countSW("curl", "8.1"))
-	curlID, curlCk := getOne("curl", "8.1")
-	require.Equal(t, curlCanon, curlID)
-	require.Equal(t, canonical("curl", "8.1"), curlCk)
-	require.Equal(t, []int{5, 6, 7}, hostsOn(curlID))
-	for _, staleID := range []int64{curlStaleA, curlStaleB} {
-		var n int
-		require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM software WHERE id=?`, staleID).Scan(&n))
-		require.Zerof(t, n, "stale row %d should be deleted", staleID)
-	}
+	// 7. Out-of-scope duplicate group: not merged — all three rows, checksums, and host
+	//    links remain exactly as seeded.
+	require.Equal(t, 3, countSW("curl", "8.1"))
+	require.Equal(t, canonical("curl", "8.1"), getChecksum(curlCanon))
+	require.Equal(t, nameFirst("curl", "8.1"), getChecksum(curlStaleA))
+	require.Equal(t, ck("curl-other-legacy-formula"), getChecksum(curlStaleB))
+	require.Equal(t, []int{5}, hostsOn(curlCanon))
+	require.Equal(t, []int{6}, hostsOn(curlStaleA))
+	require.Equal(t, []int{7}, hostsOn(curlStaleB))
 }
 
 // The migration merges rows that share a checksum identity, so the dangerous direction is
 // over-merging: if a column that feeds the checksum were dropped from the partition key,
 // genuinely different software would be collapsed into one row and host data lost. Assert
-// that rows differing in exactly one identity column are always left alone, and that the
-// NULL/” handling for the optional columns matches ComputeRawChecksum.
+// that in-scope (giflib) rows differing in exactly one identity column are always left
+// alone, and that the NULL/” handling for the optional columns matches ComputeRawChecksum.
 func TestUp_20260810160000_DoesNotMergeDistinctSoftware(t *testing.T) {
 	db := applyUpToPrev(t)
 
 	base := map[string]any{
-		"name": "base", "version": "1.0", "source": "deb_packages",
+		"name": "giflib", "version": "1.0", "source": "homebrew_packages",
 		"bundle_identifier": "com.example", "release": "1", "arch": "amd64",
 		"vendor": "vendorA", "extension_for": "chrome", "extension_id": "extA",
 		"application_id": "app-a", "upgrade_code": "upgrade-a",
@@ -231,11 +269,14 @@ func TestUp_20260810160000_DoesNotMergeDistinctSoftware(t *testing.T) {
 		return n == 1
 	}
 
-	// One pair per identity column, each differing only in that column.
+	// One pair per identity column, each differing only in that column. Every pair stays
+	// in scope (name/source from base) except the name and source variants themselves,
+	// which leave it — either way the rows are distinct software and must both survive.
+	// Each pair gets its own version so the pairs are in separate identity groups.
 	pairs := make(map[string][2]int64, len(cols))
 	for _, col := range cols {
 		a := maps.Clone(base)
-		a["name"] = "distinct-" + col // keep each pair in its own identity group
+		a["version"] = "v-" + col
 		b := maps.Clone(a)
 		b[col] = a[col].(string) + "-variant"
 		pairs[col] = [2]int64{insert(a, "a-"+col), insert(b, "b-"+col)}
@@ -243,7 +284,7 @@ func TestUp_20260810160000_DoesNotMergeDistinctSoftware(t *testing.T) {
 
 	// NULL and '' are equivalent for the optional columns, so these two ARE duplicates.
 	nullish := maps.Clone(base)
-	nullish["name"] = "nullish"
+	nullish["version"] = "v-nullish"
 	nullish["application_id"], nullish["upgrade_code"] = nil, nil
 	emptyish := maps.Clone(nullish)
 	emptyish["application_id"], emptyish["upgrade_code"] = "", ""
@@ -257,13 +298,13 @@ func TestUp_20260810160000_DoesNotMergeDistinctSoftware(t *testing.T) {
 	}
 
 	var nullishRows int
-	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM software WHERE name = 'nullish'`).Scan(&nullishRows))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM software WHERE version = 'v-nullish'`).Scan(&nullishRows))
 	require.Equal(t, 1, nullishRows, "NULL and '' optional columns are the same identity and must merge")
 	require.NotEqual(t, exists(nullID), exists(emptyID), "exactly one of the pair survives")
 }
 
-// A fresh install has no software at all. The merge step must be skipped (a zero total)
-// and the recompute must cope with MAX(id) being NULL rather than erroring or looping.
+// A fresh install has no software at all. Both the merge and the recompute must cope with
+// an empty (or giflib-free) software table rather than erroring.
 func TestUp_20260810160000_EmptySoftwareTable(t *testing.T) {
 	db := applyUpToPrev(t)
 


### PR DESCRIPTION
Relates to #36365

Instead of merging every duplicate pair and recomputing every software row's checksum, target only the software reported duplicated (#36365): giflib from homebrew_packages, all versions.

Both statements now read only the matching rows via idx_sw_name_source_browser (FORCE INDEX), so the migration no longer scans the software table, and the progress steps and id-range batching of the recompute are dropped. Other rows left stale by the v4.76.0 checksum reorder are deliberately not repaired.

Tests assert the scope boundary on both axes: same source/different name (zlib, curl) and same name/different source (giflib deb_packages) stay untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected software inventory deduplication for duplicate giflib entries installed through Homebrew.
  * Recomputed affected checksums to ensure canonical inventory records.
  * Preserved unrelated software records and entries from other sources during cleanup.
* **Tests**
  * Expanded migration coverage for duplicate, unique, legacy, and out-of-scope software records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->