### PR TITLE
[API] Update description for managed account password retrieval

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6339,7 +6339,7 @@ Rotates the managed local account password for a host.
 
 ### Get host's managed account password
 
-Retrieves the managed account password for a macOS host.
+Retrieves the managed account password for an eligible macOS or Windows host.
 
 The host will only return a password if its managed account password status is "Verified".
 


### PR DESCRIPTION
Moves reference doc changes from #48804 to `docs-v4.93.0`.

Originally documented for `docs-v4.91.0` — feature pushed to this release.

**Related:** #48804