### PR TITLE
Report Android host vitals from the osquery-perf load-test agent

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -4502,6 +4502,7 @@ func main() {
 		androidStatusInterval    = flag.Duration("android_status_interval", 5*time.Minute, "Interval between Android STATUS_REPORT messages (real devices report ~every 24h; lower values stress test Fleet harder)")
 		androidAppCount          = flag.Int("android_app_count", 50, "Number of installed apps each Android device reports")
 		androidNonComplianceProb = flag.Float64("android_non_compliance_prob", 0.05, "Probability of an Android STATUS_REPORT including non-compliance details [0, 1]")
+		androidVitalsChurnProb   = flag.Float64("android_vitals_churn_prob", defaultVitalsChurnProb, "Probability of an Android STATUS_REPORT reporting changed host vitals; 0 reports identical vitals forever, which MySQL stores without writing a row [0, 1]")
 	)
 
 	flag.Parse()
@@ -4563,6 +4564,9 @@ func main() {
 	}
 	if *androidNonComplianceProb < 0 || *androidNonComplianceProb > 1 {
 		log.Fatalf("Argument android_non_compliance_prob must be between 0 and 1, got %f", *androidNonComplianceProb)
+	}
+	if *androidVitalsChurnProb < 0 || *androidVitalsChurnProb > 1 {
+		log.Fatalf("Argument android_vitals_churn_prob must be between 0 and 1, got %f", *androidVitalsChurnProb)
 	}
 
 	// only fail if mdm is turned on for macOS devices and the mdm_apns_url is not specified.
@@ -4701,6 +4705,7 @@ func main() {
 				*androidStatusInterval,
 				*androidAppCount,
 				*androidNonComplianceProb,
+				*androidVitalsChurnProb,
 				stats,
 			)
 			go androidDevice.runLoop()

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -65,16 +65,29 @@ type androidAgent struct {
 	bootloaderVersion   string
 	systemUpdateStatus  string
 
-	// Device settings, security posture and SIM cards. Fleet stores these as host
-	// vitals, and they describe the device rather than the moment, so they are
-	// generated once and reported identically by every message.
+	// Device settings, security posture and eSIM activation. Fleet stores these
+	// as host vitals. Unlike the fields above they describe the device's current
+	// state rather than its identity, so a status report re-rolls them (see
+	// vitalsChurnProb).
 	adbEnabled        bool
 	deviceSecure      bool
 	verifyAppsEnabled bool
 	encryptionStatus  string
 	securityPosture   string
 	postureDetails    []*androidmanagement.PostureDetail
-	telephonyInfos    []*androidmanagement.TelephonyInfo
+
+	// The SIM cards themselves are hardware and stay put; only their eSIM
+	// activation state and config mode move.
+	telephonyInfos []*androidmanagement.TelephonyInfo
+
+	// Whether the applied policy collects these sections at all. AMAPI omits a
+	// section it is not asked for, and Fleet nulls the matching columns when a
+	// device stops reporting one.
+	reportsDeviceSettings  bool
+	reportsSecurityPosture bool
+
+	// vitalsChurnProb is the chance a status report re-rolls the volatile vitals.
+	vitalsChurnProb float64
 
 	// Memory
 	totalRAM             int64
@@ -156,6 +169,24 @@ var androidApps = []struct {
 	{"LastPass", "com.lastpass.lpandroid", "5.21.0.13562"},
 }
 
+// AMAPI's "no data" members for the eSIM-only telephony enums, which every
+// physical SIM reports and Fleet stores as no value at all.
+const (
+	activationStateUnspecified = "ACTIVATION_STATE_UNSPECIFIED"
+	configModeUnspecified      = "CONFIG_MODE_UNSPECIFIED"
+)
+
+// defaultVitalsChurnProb is the share of status reports that re-roll a device's
+// volatile vitals instead of repeating the previous ones.
+//
+// A real device's posture and settings move far more rarely than this, but a
+// load test needs the vitals table to actually see row writes. Fleet's UPDATE
+// overwrites every column on every status report, yet MySQL changes no row,
+// writes no redo or binlog entry and does not advance updated_at when the values
+// are identical — so a fleet whose vitals never move measures none of the write
+// cost a real one generates.
+const defaultVitalsChurnProb = 0.2
+
 // androidManufacturers maps a brand to the Build.MANUFACTURER value real devices
 // of that brand report, which is not always the brand itself.
 var androidManufacturers = map[string]string{
@@ -223,12 +254,11 @@ var androidCarriers = []androidCarrier{
 	{"Telefonica", "+34", 9},
 }
 
-// generateDeviceVitals produces the device-describing vitals AMAPI reports for a
-// single device: settings, software versions, security posture and SIM cards. The
-// distributions are weighted so a simulated fleet is mostly healthy with a
-// realistic minority of devices that are out of date, insecure or compromised —
-// the aggregate shape matters more than any one device.
-func (a *androidAgent) generateDeviceVitals() {
+// generateStableVitals produces the vitals that identify the device and never
+// change over its lifetime: who built it, what it runs, and which SIM cards are
+// in it. The distributions are weighted so a simulated fleet has a realistic
+// spread — the aggregate shape matters more than any one device.
+func (a *androidAgent) generateStableVitals() {
 	a.manufacturer = androidManufacturers[a.brand]
 	a.apiLevel = androidAPILevels[a.androidVersion]
 	a.securityPatchLevel = androidSecurityPatchLevels[rand.IntN(len(androidSecurityPatchLevels))] // #nosec G404 -- load testing only
@@ -236,13 +266,24 @@ func (a *androidAgent) generateDeviceVitals() {
 	a.deviceKernelVersion = fmt.Sprintf("%s.%d-android%s-%d-g%s",
 		androidKernelBases[a.androidVersion], rand.IntN(100), a.androidVersion, 1+rand.IntN(30), randomHexString(12)) // #nosec G404 -- load testing only
 	a.bootloaderVersion = fmt.Sprintf("%s-%s.0-%d", a.hardware, a.androidVersion, 10000000+rand.IntN(9000000)) // #nosec G404 -- load testing only
+	a.telephonyInfos = generateTelephonyInfos()
+}
 
+// generateVolatileVitals rolls the vitals that describe what the device is doing
+// now rather than what it is: settings a user or admin can change, the posture
+// Play Integrity reports, whether an update is pending, eSIM activation, and
+// which sections the applied policy collects at all.
+func (a *androidAgent) generateVolatileVitals() {
 	// Almost every managed device is encrypted; ACTIVE_PER_USER is what modern
-	// file-based encryption reports, ACTIVE what older full-disk encryption does.
-	a.encryptionStatus = "ACTIVE_PER_USER"
-	if rand.Float64() < 0.1 { // #nosec G404 -- load testing only
-		a.encryptionStatus = "ACTIVE"
-	}
+	// file-based encryption reports and ACTIVE what older full-disk encryption
+	// does. The unencrypted states are rare but not absent: they are the only
+	// ones that make Fleet store an encryption_type other than "on".
+	a.encryptionStatus = weightedChoice([]weightedValue{
+		{"ACTIVE_PER_USER", 0.84},
+		{"ACTIVE", 0.1},
+		{"INACTIVE", 0.04},
+		{"UNSUPPORTED", 0.02},
+	})
 	a.adbEnabled = rand.Float64() < 0.05       // #nosec G404 -- load testing only
 	a.deviceSecure = rand.Float64() < 0.95     // #nosec G404 -- load testing only
 	a.verifyAppsEnabled = rand.Float64() < 0.9 // #nosec G404 -- load testing only
@@ -258,7 +299,9 @@ func (a *androidAgent) generateDeviceVitals() {
 		{"AT_RISK", 0.1},
 		{"POTENTIALLY_COMPROMISED", 0.05},
 	})
-	// AMAPI only attaches posture details to a device that is not secure.
+	// AMAPI only attaches posture details to a device that is not secure, so a
+	// device becoming secure again has to drop the details it used to report.
+	a.postureDetails = nil
 	switch a.securityPosture {
 	case "AT_RISK":
 		risk := "UNKNOWN_OS"
@@ -280,7 +323,34 @@ func (a *androidAgent) generateDeviceVitals() {
 		}}
 	}
 
-	a.telephonyInfos = generateTelephonyInfos()
+	// Rolled alongside the rest, which flips a device's collected sections far
+	// more often than an admin would really edit the policy's status reporting
+	// settings. That is deliberate: a section going away is what makes Fleet null
+	// the matching columns, and a fleet that always reports everything never
+	// exercises it.
+	a.reportsDeviceSettings = rand.Float64() < 0.9  // #nosec G404 -- load testing only
+	a.reportsSecurityPosture = rand.Float64() < 0.9 // #nosec G404 -- load testing only
+
+	a.rollSIMActivation()
+}
+
+// rollSIMActivation re-rolls the activation state and config mode of the device's
+// eSIMs. A physical SIM reports neither, so it is left alone; its *_UNSPECIFIED
+// activation state is what marks it as physical.
+func (a *androidAgent) rollSIMActivation() {
+	for _, sim := range a.telephonyInfos {
+		if sim.ActivationState == activationStateUnspecified {
+			continue
+		}
+		sim.ActivationState = "ACTIVATED"
+		if rand.Float64() < 0.05 { // #nosec G404 -- load testing only
+			sim.ActivationState = "NOT_ACTIVATED"
+		}
+		sim.ConfigMode = "ADMIN_CONFIGURED"
+		if rand.Float64() < 0.3 { // #nosec G404 -- load testing only
+			sim.ConfigMode = "USER_CONFIGURED"
+		}
+	}
 }
 
 // generateTelephonyInfos builds the SIM cards a device reports. Most devices have
@@ -306,18 +376,14 @@ func generateTelephonyInfos() []*androidmanagement.TelephonyInfo {
 			// digit is random rather than a real Luhn check digit; nothing in
 			// Fleet validates it.
 			IccId:           "89" + randomDigits(17),
-			ActivationState: "ACTIVATION_STATE_UNSPECIFIED",
-			ConfigMode:      "CONFIG_MODE_UNSPECIFIED",
+			ActivationState: activationStateUnspecified,
+			ConfigMode:      configModeUnspecified,
 		}
 		if eSIM {
+			// Marks the SIM as an eSIM; rollSIMActivation picks the real values
+			// here and on every later re-roll.
 			info.ActivationState = "ACTIVATED"
-			if rand.Float64() < 0.05 { // #nosec G404 -- load testing only
-				info.ActivationState = "NOT_ACTIVATED"
-			}
 			info.ConfigMode = "ADMIN_CONFIGURED"
-			if rand.Float64() < 0.3 { // #nosec G404 -- load testing only
-				info.ConfigMode = "USER_CONFIGURED"
-			}
 		}
 		infos = append(infos, info)
 	}
@@ -444,9 +510,11 @@ func newAndroidAgent(
 		installedApps:        apps,
 		statusReportInterval: statusReportInterval,
 		nonComplianceProb:    nonComplianceProb,
+		vitalsChurnProb:      defaultVitalsChurnProb,
 	}
 	// Depends on the brand, hardware and Android version picked above.
-	agent.generateDeviceVitals()
+	agent.generateStableVitals()
+	agent.generateVolatileVitals()
 
 	return agent
 }
@@ -734,7 +802,7 @@ func (a *androidAgent) lastKnownState(err error) (*proxyDeviceState, bool, error
 // present in one and absent from the other would make a host's vitals appear or
 // disappear as the messages arrive.
 func (a *androidAgent) deviceInfo() androidmanagement.Device {
-	return androidmanagement.Device{
+	device := androidmanagement.Device{
 		Name:                a.deviceName,
 		Ownership:           "COMPANY_OWNED",
 		ApiLevel:            a.apiLevel,
@@ -762,7 +830,17 @@ func (a *androidAgent) deviceInfo() androidmanagement.Device {
 			TotalInternalStorage: a.totalInternalStorage,
 		},
 		MemoryEvents: a.generateMemoryEvents(),
-		DeviceSettings: &androidmanagement.DeviceSettings{
+		// AMAPI only reports telephonyInfos for a fully managed device, which
+		// every simulated device is (COMPANY_OWNED above).
+		NetworkInfo: &androidmanagement.NetworkInfo{
+			TelephonyInfos: a.telephonyInfos,
+		},
+	}
+
+	// A section the applied policy does not collect is absent from the payload
+	// entirely, rather than present and empty.
+	if a.reportsDeviceSettings {
+		device.DeviceSettings = &androidmanagement.DeviceSettings{
 			AdbEnabled:        a.adbEnabled,
 			IsDeviceSecure:    a.deviceSecure,
 			VerifyAppsEnabled: a.verifyAppsEnabled,
@@ -772,17 +850,16 @@ func (a *androidAgent) deviceInfo() androidmanagement.Device {
 			// back as false either way, since it takes the zero value of a
 			// deviceSettings that is present at all.
 			ForceSendFields: []string{"AdbEnabled", "IsDeviceSecure", "VerifyAppsEnabled"},
-		},
-		SecurityPosture: &androidmanagement.SecurityPosture{
+		}
+	}
+	if a.reportsSecurityPosture {
+		device.SecurityPosture = &androidmanagement.SecurityPosture{
 			DevicePosture:  a.securityPosture,
 			PostureDetails: a.postureDetails,
-		},
-		// AMAPI only reports telephonyInfos for a fully managed device, which
-		// every simulated device is (COMPANY_OWNED above).
-		NetworkInfo: &androidmanagement.NetworkInfo{
-			TelephonyInfos: a.telephonyInfos,
-		},
+		}
 	}
+
+	return device
 }
 
 // sendEnrollment sends an ENROLLMENT PubSub message to Fleet.
@@ -793,6 +870,10 @@ func (a *androidAgent) sendEnrollment() error {
 // sendStatusReport sends a STATUS_REPORT PubSub message to Fleet.
 func (a *androidAgent) sendStatusReport(state *proxyDeviceState) error {
 	now := time.Now().UTC()
+
+	if rand.Float64() < a.vitalsChurnProb { // #nosec G404 -- load testing only
+		a.generateVolatileVitals()
+	}
 
 	device := a.deviceInfo()
 	device.AppliedState = "ACTIVE"

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -49,13 +49,30 @@ type androidAgent struct {
 	orbitNodeKey         string // obtained from orbit enrollment, used for certificate API auth
 
 	// Hardware details
-	brand    string
-	model    string
-	hardware string
+	brand        string
+	model        string
+	hardware     string
+	manufacturer string
 
 	// Software
-	androidVersion     string
-	androidBuildNumber string
+	androidVersion      string
+	androidBuildNumber  string
+	apiLevel            int64
+	securityPatchLevel  string
+	deviceKernelVersion string
+	bootloaderVersion   string
+	systemUpdateStatus  string
+
+	// Device settings, security posture and SIM cards. Fleet stores these as host
+	// vitals, and they describe the device rather than the moment, so they are
+	// generated once and reported identically by every message.
+	adbEnabled        bool
+	deviceSecure      bool
+	verifyAppsEnabled bool
+	encryptionStatus  string
+	securityPosture   string
+	postureDetails    []*androidmanagement.PostureDetail
+	telephonyInfos    []*androidmanagement.TelephonyInfo
 
 	// Memory
 	totalRAM             int64
@@ -137,6 +154,175 @@ var androidApps = []struct {
 	{"LastPass", "com.lastpass.lpandroid", "5.21.0.13562"},
 }
 
+// androidManufacturers maps a brand to the Build.MANUFACTURER value real devices
+// of that brand report, which is not always the brand itself.
+var androidManufacturers = map[string]string{
+	"Google":   "Google",
+	"Samsung":  "samsung",
+	"OnePlus":  "OnePlus",
+	"Motorola": "motorola",
+	"Nokia":    "HMD Global",
+}
+
+// androidAPILevels maps the Android release to its SDK level, which AMAPI reports
+// alongside the version.
+var androidAPILevels = map[string]int64{
+	"13": 33,
+	"14": 34,
+	"15": 35,
+}
+
+// androidKernelBases maps the Android release to the Linux kernel line it ships on.
+var androidKernelBases = map[string]string{
+	"13": "5.15",
+	"14": "6.1",
+	"15": "6.6",
+}
+
+// androidSecurityPatchLevels is a small fixed set rather than a freely generated
+// date because Fleet folds the security patch level into hosts.os_version: a
+// distinct value per device would inflate the os_versions aggregation to one row
+// per host, which no real fleet looks like.
+var androidSecurityPatchLevels = []string{"2026-03-01", "2026-04-01", "2026-05-01", "2026-06-01"}
+
+var androidCarriers = []string{"Verizon", "AT&T", "T-Mobile", "Vodafone", "Rogers", "Orange", "Telefonica"}
+
+// generateDeviceVitals produces the device-describing vitals AMAPI reports for a
+// single device: settings, software versions, security posture and SIM cards. The
+// distributions are weighted so a simulated fleet is mostly healthy with a
+// realistic minority of devices that are out of date, insecure or compromised —
+// the aggregate shape matters more than any one device.
+func (a *androidAgent) generateDeviceVitals() {
+	a.manufacturer = androidManufacturers[a.brand]
+	a.apiLevel = androidAPILevels[a.androidVersion]
+	a.securityPatchLevel = androidSecurityPatchLevels[rand.IntN(len(androidSecurityPatchLevels))] // #nosec G404 -- load testing only
+	// e.g. "6.6.42-android15-11-gb1c0ffee1234", the format Android kernels report.
+	a.deviceKernelVersion = fmt.Sprintf("%s.%d-android%s-%d-g%s",
+		androidKernelBases[a.androidVersion], rand.IntN(100), a.androidVersion, 1+rand.IntN(30), randomHexString(12)) // #nosec G404 -- load testing only
+	a.bootloaderVersion = fmt.Sprintf("%s-%s.0-%d", a.hardware, a.androidVersion, 10000000+rand.IntN(9000000)) // #nosec G404 -- load testing only
+
+	// Almost every managed device is encrypted; ACTIVE_PER_USER is what modern
+	// file-based encryption reports, ACTIVE what older full-disk encryption does.
+	a.encryptionStatus = "ACTIVE_PER_USER"
+	if rand.Float64() < 0.1 { // #nosec G404 -- load testing only
+		a.encryptionStatus = "ACTIVE"
+	}
+	a.adbEnabled = rand.Float64() < 0.05       // #nosec G404 -- load testing only
+	a.deviceSecure = rand.Float64() < 0.95     // #nosec G404 -- load testing only
+	a.verifyAppsEnabled = rand.Float64() < 0.9 // #nosec G404 -- load testing only
+	a.systemUpdateStatus = weightedChoice([]weightedValue{
+		{"UP_TO_DATE", 0.7},
+		{"SECURITY_UPDATE_AVAILABLE", 0.15},
+		{"OS_UPDATE_AVAILABLE", 0.1},
+		{"UNKNOWN_UPDATE_AVAILABLE", 0.05},
+	})
+
+	a.securityPosture = weightedChoice([]weightedValue{
+		{"SECURE", 0.85},
+		{"AT_RISK", 0.1},
+		{"POTENTIALLY_COMPROMISED", 0.05},
+	})
+	// AMAPI only attaches posture details to a device that is not secure.
+	switch a.securityPosture {
+	case "AT_RISK":
+		risk := "UNKNOWN_OS"
+		advice := "This device is running an unrecognized version of Android. Update it to a certified build."
+		if rand.Float64() < 0.5 { // #nosec G404 -- load testing only
+			risk = "HARDWARE_BACKED_EVALUATION_FAILED"
+			advice = "This device does not support hardware-backed integrity checks. Replace it with a device that does."
+		}
+		a.postureDetails = []*androidmanagement.PostureDetail{{
+			SecurityRisk: risk,
+			Advice:       []*androidmanagement.UserFacingMessage{{DefaultMessage: advice}},
+		}}
+	case "POTENTIALLY_COMPROMISED":
+		a.postureDetails = []*androidmanagement.PostureDetail{{
+			SecurityRisk: "COMPROMISED_OS",
+			Advice: []*androidmanagement.UserFacingMessage{
+				{DefaultMessage: "This device is running a modified version of Android. Factory reset it."},
+			},
+		}}
+	}
+
+	a.telephonyInfos = generateTelephonyInfos()
+}
+
+// generateTelephonyInfos builds the SIM cards a device reports. Most devices have
+// one, and a dual-SIM device pairs its physical SIM with an eSIM. Only eSIMs
+// report an activation state and config mode; a physical SIM reports the
+// *_UNSPECIFIED sentinels, which Fleet stores as no value at all.
+func generateTelephonyInfos() []*androidmanagement.TelephonyInfo {
+	simCount := 1
+	if rand.Float64() < 0.3 { // #nosec G404 -- load testing only
+		simCount = 2
+	}
+
+	infos := make([]*androidmanagement.TelephonyInfo, 0, simCount)
+	for i := 0; i < simCount; i++ {
+		// The first SIM is usually physical; a second one is always an eSIM.
+		eSIM := i > 0 || rand.Float64() < 0.4 // #nosec G404 -- load testing only
+		info := &androidmanagement.TelephonyInfo{
+			PhoneNumber:     "+1" + randomDigits(10),
+			CarrierName:     androidCarriers[rand.IntN(len(androidCarriers))], // #nosec G404 -- load testing only
+			IccId:           "89" + randomDigits(17),
+			ActivationState: "ACTIVATION_STATE_UNSPECIFIED",
+			ConfigMode:      "CONFIG_MODE_UNSPECIFIED",
+		}
+		if eSIM {
+			info.ActivationState = "ACTIVATED"
+			if rand.Float64() < 0.05 { // #nosec G404 -- load testing only
+				info.ActivationState = "NOT_ACTIVATED"
+			}
+			info.ConfigMode = "ADMIN_CONFIGURED"
+			if rand.Float64() < 0.3 { // #nosec G404 -- load testing only
+				info.ConfigMode = "USER_CONFIGURED"
+			}
+		}
+		infos = append(infos, info)
+	}
+	return infos
+}
+
+// weightedValue is one option of weightedChoice, with the fraction of devices
+// that should get it.
+type weightedValue struct {
+	value  string
+	weight float64
+}
+
+// weightedChoice picks one value according to its weight. The weights are
+// expected to sum to 1; the last value absorbs any rounding shortfall.
+func weightedChoice(values []weightedValue) string {
+	roll := rand.Float64() // #nosec G404 -- load testing only
+	var cumulative float64
+	for _, v := range values {
+		cumulative += v.weight
+		if roll < cumulative {
+			return v.value
+		}
+	}
+	return values[len(values)-1].value
+}
+
+func randomDigits(n int) string {
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(byte('0' + rand.IntN(10))) // #nosec G404 -- load testing only
+	}
+	return sb.String()
+}
+
+func randomHexString(n int) string {
+	const hexVals = "0123456789abcdef"
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteByte(hexVals[rand.IntN(len(hexVals))]) // #nosec G404 -- load testing only
+	}
+	return sb.String()
+}
+
 // newAndroidAgent creates a new Android device simulator.
 func newAndroidAgent(
 	agentIndex int,
@@ -190,7 +376,7 @@ func newAndroidAgent(
 	totalRAM := ramOptions[rand.IntN(len(ramOptions))] * 1024 * 1024 * 1024             // #nosec G404 -- load testing only
 	totalStorage := storageOptions[rand.IntN(len(storageOptions))] * 1024 * 1024 * 1024 // #nosec G404 -- load testing only
 
-	return &androidAgent{
+	agent := &androidAgent{
 		agentIndex:           agentIndex,
 		serverAddress:        serverAddress,
 		enrollSecret:         enrollSecret,
@@ -212,6 +398,10 @@ func newAndroidAgent(
 		statusReportInterval: statusReportInterval,
 		nonComplianceProb:    nonComplianceProb,
 	}
+	// Depends on the brand, hardware and Android version picked above.
+	agent.generateDeviceVitals()
+
+	return agent
 }
 
 // runLoop is the main loop for the Android agent.
@@ -491,11 +681,16 @@ func (a *androidAgent) lastKnownState(err error) (*proxyDeviceState, bool, error
 	return &stale, true, nil
 }
 
-// sendEnrollment sends an ENROLLMENT PubSub message to Fleet.
-func (a *androidAgent) sendEnrollment() error {
-	device := androidmanagement.Device{
+// deviceInfo builds the parts of the AMAPI device payload that describe the
+// device itself, which every message about it carries. Enrollment and status
+// reports must agree here: Fleet writes host vitals from both, so a section
+// present in one and absent from the other would make a host's vitals appear or
+// disappear as the messages arrive.
+func (a *androidAgent) deviceInfo() androidmanagement.Device {
+	return androidmanagement.Device{
 		Name:                a.deviceName,
 		Ownership:           "COMPANY_OWNED",
+		ApiLevel:            a.apiLevel,
 		EnrollmentTokenData: fmt.Sprintf(`{"EnrollSecret": "%s"}`, a.enrollSecret),
 		HardwareInfo: &androidmanagement.HardwareInfo{
 			EnterpriseSpecificId: a.enterpriseSpecificID,
@@ -503,52 +698,61 @@ func (a *androidAgent) sendEnrollment() error {
 			Brand:                a.brand,
 			Model:                a.model,
 			Hardware:             a.hardware,
+			Manufacturer:         a.manufacturer,
 		},
 		SoftwareInfo: &androidmanagement.SoftwareInfo{
-			AndroidVersion:     a.androidVersion,
-			AndroidBuildNumber: a.androidBuildNumber,
+			AndroidVersion:      a.androidVersion,
+			AndroidBuildNumber:  a.androidBuildNumber,
+			SecurityPatchLevel:  a.securityPatchLevel,
+			DeviceKernelVersion: a.deviceKernelVersion,
+			BootloaderVersion:   a.bootloaderVersion,
+			SystemUpdateInfo: &androidmanagement.SystemUpdateInfo{
+				UpdateStatus: a.systemUpdateStatus,
+			},
 		},
 		MemoryInfo: &androidmanagement.MemoryInfo{
 			TotalRam:             a.totalRAM,
 			TotalInternalStorage: a.totalInternalStorage,
 		},
 		MemoryEvents: a.generateMemoryEvents(),
+		DeviceSettings: &androidmanagement.DeviceSettings{
+			AdbEnabled:        a.adbEnabled,
+			IsDeviceSecure:    a.deviceSecure,
+			VerifyAppsEnabled: a.verifyAppsEnabled,
+			EncryptionStatus:  a.encryptionStatus,
+			// Sent unconditionally so a device reporting every setting as false
+			// still arrives as a populated deviceSettings rather than an absent
+			// one, which Fleet reads as "the policy doesn't collect this".
+			ForceSendFields: []string{"AdbEnabled", "IsDeviceSecure", "VerifyAppsEnabled"},
+		},
+		SecurityPosture: &androidmanagement.SecurityPosture{
+			DevicePosture:  a.securityPosture,
+			PostureDetails: a.postureDetails,
+		},
+		// AMAPI only reports telephonyInfos for a fully managed device, which
+		// every simulated device is (COMPANY_OWNED above).
+		NetworkInfo: &androidmanagement.NetworkInfo{
+			TelephonyInfos: a.telephonyInfos,
+		},
 	}
+}
 
-	return a.sendPubSubMessage(android.PubSubEnrollment, device)
+// sendEnrollment sends an ENROLLMENT PubSub message to Fleet.
+func (a *androidAgent) sendEnrollment() error {
+	return a.sendPubSubMessage(android.PubSubEnrollment, a.deviceInfo())
 }
 
 // sendStatusReport sends a STATUS_REPORT PubSub message to Fleet.
 func (a *androidAgent) sendStatusReport(state *proxyDeviceState) error {
 	now := time.Now().UTC()
 
-	device := androidmanagement.Device{
-		Name:         a.deviceName,
-		Ownership:    "COMPANY_OWNED",
-		AppliedState: "ACTIVE",
-		HardwareInfo: &androidmanagement.HardwareInfo{
-			EnterpriseSpecificId: a.enterpriseSpecificID,
-			SerialNumber:         a.serialNumber,
-			Brand:                a.brand,
-			Model:                a.model,
-			Hardware:             a.hardware,
-		},
-		SoftwareInfo: &androidmanagement.SoftwareInfo{
-			AndroidVersion:     a.androidVersion,
-			AndroidBuildNumber: a.androidBuildNumber,
-		},
-		MemoryInfo: &androidmanagement.MemoryInfo{
-			TotalRam:             a.totalRAM,
-			TotalInternalStorage: a.totalInternalStorage,
-		},
-		MemoryEvents:         a.generateMemoryEvents(),
-		ApplicationReports:   a.installedApps,
-		AppliedPolicyVersion: state.PolicyVersion,
-		AppliedPolicyName:    state.PolicyName,
-		LastPolicySyncTime:   now.Format(time.RFC3339),
-		LastStatusReportTime: now.Format(time.RFC3339),
-		EnrollmentTokenData:  fmt.Sprintf(`{"EnrollSecret": "%s"}`, a.enrollSecret),
-	}
+	device := a.deviceInfo()
+	device.AppliedState = "ACTIVE"
+	device.ApplicationReports = a.installedApps
+	device.AppliedPolicyVersion = state.PolicyVersion
+	device.AppliedPolicyName = state.PolicyName
+	device.LastPolicySyncTime = now.Format(time.RFC3339)
+	device.LastStatusReportTime = now.Format(time.RFC3339)
 
 	// Optionally add non-compliance details
 	nonCompliant := rand.Float64() < a.nonComplianceProb // #nosec G404 -- load testing only

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"math/big"
 	"math/rand/v2"
 	"net/http"
 	neturl "net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -179,13 +181,47 @@ var androidKernelBases = map[string]string{
 	"15": "6.6",
 }
 
-// androidSecurityPatchLevels is a small fixed set rather than a freely generated
-// date because Fleet folds the security patch level into hosts.os_version: a
-// distinct value per device would inflate the os_versions aggregation to one row
-// per host, which no real fleet looks like.
-var androidSecurityPatchLevels = []string{"2026-03-01", "2026-04-01", "2026-05-01", "2026-06-01"}
+// androidSecurityPatchLevels is the set of patch levels devices report, resolved
+// once at startup. It is a handful of recent months rather than a freely
+// generated date because Fleet folds the security patch level into
+// hosts.os_version: a distinct value per device would inflate the os_versions
+// aggregation to one row per host, which no real fleet looks like. Deriving them
+// from the clock rather than hardcoding keeps a long-lived load-test harness from
+// reporting patch levels that are years stale, at the cost of the exact
+// os_versions rows differing between runs in different months.
+var androidSecurityPatchLevels = recentSecurityPatchLevels(time.Now().UTC())
 
-var androidCarriers = []string{"Verizon", "AT&T", "T-Mobile", "Vodafone", "Rogers", "Orange", "Telefonica"}
+// recentSecurityPatchLevels returns the monthly Android security bulletin dates
+// for the four months ending at now, newest last. AMAPI reports these as
+// YYYY-MM-DD, and the bulletins land on the first of the month.
+func recentSecurityPatchLevels(now time.Time) []string {
+	const months = 4
+	levels := make([]string, 0, months)
+	for i := months - 1; i >= 0; i-- {
+		levels = append(levels, now.AddDate(0, -i, 0).Format("2006-01")+"-01")
+	}
+	return levels
+}
+
+// androidCarrier is a mobile carrier a simulated SIM can report.
+type androidCarrier struct {
+	name        string
+	dialCode    string
+	nationalLen int
+}
+
+// androidCarriers pairs a carrier with the country calling code and national
+// number length its subscriber numbers use, so a generated phone number and the
+// carrier reported beside it don't contradict each other.
+var androidCarriers = []androidCarrier{
+	{"Verizon", "+1", 10},
+	{"AT&T", "+1", 10},
+	{"T-Mobile", "+1", 10},
+	{"Rogers", "+1", 10},
+	{"Vodafone", "+44", 10},
+	{"Orange", "+33", 9},
+	{"Telefonica", "+34", 9},
+}
 
 // generateDeviceVitals produces the device-describing vitals AMAPI reports for a
 // single device: settings, software versions, security posture and SIM cards. The
@@ -248,9 +284,10 @@ func (a *androidAgent) generateDeviceVitals() {
 }
 
 // generateTelephonyInfos builds the SIM cards a device reports. Most devices have
-// one, and a dual-SIM device pairs its physical SIM with an eSIM. Only eSIMs
-// report an activation state and config mode; a physical SIM reports the
-// *_UNSPECIFIED sentinels, which Fleet stores as no value at all.
+// one, which is usually physical; a second one is always an eSIM, so a dual-SIM
+// device is either physical + eSIM or two eSIMs. Only eSIMs report an activation
+// state and config mode; a physical SIM reports the *_UNSPECIFIED sentinels,
+// which Fleet stores as no value at all.
 func generateTelephonyInfos() []*androidmanagement.TelephonyInfo {
 	simCount := 1
 	if rand.Float64() < 0.3 { // #nosec G404 -- load testing only
@@ -260,10 +297,14 @@ func generateTelephonyInfos() []*androidmanagement.TelephonyInfo {
 	infos := make([]*androidmanagement.TelephonyInfo, 0, simCount)
 	for i := 0; i < simCount; i++ {
 		// The first SIM is usually physical; a second one is always an eSIM.
-		eSIM := i > 0 || rand.Float64() < 0.4 // #nosec G404 -- load testing only
+		eSIM := i > 0 || rand.Float64() < 0.4                       // #nosec G404 -- load testing only
+		carrier := androidCarriers[rand.IntN(len(androidCarriers))] // #nosec G404 -- load testing only
 		info := &androidmanagement.TelephonyInfo{
-			PhoneNumber:     "+1" + randomDigits(10),
-			CarrierName:     androidCarriers[rand.IntN(len(androidCarriers))], // #nosec G404 -- load testing only
+			PhoneNumber: carrier.dialCode + randomDigits(carrier.nationalLen),
+			CarrierName: carrier.name,
+			// 19 digits behind the 89 telecom industry identifier. The trailing
+			// digit is random rather than a real Luhn check digit; nothing in
+			// Fleet validates it.
 			IccId:           "89" + randomDigits(17),
 			ActivationState: "ACTIVATION_STATE_UNSPECIFIED",
 			ConfigMode:      "CONFIG_MODE_UNSPECIFIED",
@@ -291,17 +332,22 @@ type weightedValue struct {
 }
 
 // weightedChoice picks one value according to its weight. The weights are
-// expected to sum to 1; the last value absorbs any rounding shortfall.
+// expected to sum to 1; any rounding shortfall is absorbed by the last value
+// that can actually be picked, so a zero-weight option is never returned.
 func weightedChoice(values []weightedValue) string {
 	roll := rand.Float64() // #nosec G404 -- load testing only
 	var cumulative float64
+	fallback := values[len(values)-1].value
 	for _, v := range values {
+		if v.weight > 0 {
+			fallback = v.value
+		}
 		cumulative += v.weight
 		if roll < cumulative {
 			return v.value
 		}
 	}
-	return values[len(values)-1].value
+	return fallback
 }
 
 func randomDigits(n int) string {
@@ -340,7 +386,9 @@ func newAndroidAgent(
 	deviceID := "fake" + strings.ReplaceAll(uuid.New().String()[:28], "-", "")
 	serialNumber := fmt.Sprintf("AND%s", randomString(10))
 
-	brands := []string{"Google", "Samsung", "OnePlus", "Motorola", "Nokia"}
+	// Drawn from the vitals maps so a brand or release can only be simulated if
+	// the manufacturer / API level / kernel line it needs is defined for it.
+	brands := slices.Sorted(maps.Keys(androidManufacturers))
 	models := []string{"Pixel 8 Pro", "Pixel 7a", "Galaxy S24", "Galaxy A54", "Nord CE 3", "Edge 40", "X30"}
 	hardwareTypes := []string{"qcom", "exynos", "tensor", "dimensity"}
 
@@ -348,8 +396,7 @@ func newAndroidAgent(
 	model := models[rand.IntN(len(models))]                  // #nosec G404 -- load testing only
 	hardware := hardwareTypes[rand.IntN(len(hardwareTypes))] // #nosec G404 -- load testing only
 
-	// Android versions 13-15
-	androidVersions := []string{"13", "14", "15"}
+	androidVersions := slices.Sorted(maps.Keys(androidAPILevels))
 	androidVersion := androidVersions[rand.IntN(len(androidVersions))]                                     // #nosec G404 -- load testing only
 	buildNumber := fmt.Sprintf("TP1A.%d%02d%02d.003", 2024+rand.IntN(2), 1+rand.IntN(12), 1+rand.IntN(28)) // #nosec G404 -- load testing only
 
@@ -720,9 +767,10 @@ func (a *androidAgent) deviceInfo() androidmanagement.Device {
 			IsDeviceSecure:    a.deviceSecure,
 			VerifyAppsEnabled: a.verifyAppsEnabled,
 			EncryptionStatus:  a.encryptionStatus,
-			// Sent unconditionally so a device reporting every setting as false
-			// still arrives as a populated deviceSettings rather than an absent
-			// one, which Fleet reads as "the policy doesn't collect this".
+			// Wire fidelity only: without this, omitempty drops the false
+			// booleans and AMAPI always sends them explicitly. Fleet reads them
+			// back as false either way, since it takes the zero value of a
+			// deviceSettings that is present at all.
 			ForceSendFields: []string{"AdbEnabled", "IsDeviceSecure", "VerifyAppsEnabled"},
 		},
 		SecurityPosture: &androidmanagement.SecurityPosture{

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -176,6 +176,11 @@ const (
 	configModeUnspecified      = "CONFIG_MODE_UNSPECIFIED"
 )
 
+// policyEditProb is the chance a re-roll of a device's volatile vitals also
+// changes which sections its applied policy collects, standing in for an admin
+// editing the policy's status reporting settings.
+const policyEditProb = 0.05
+
 // defaultVitalsChurnProb is the default for --android_vitals_churn_prob: the
 // share of status reports that re-roll a device's volatile vitals instead of
 // repeating the previous ones.
@@ -228,9 +233,13 @@ var androidSecurityPatchLevels = recentSecurityPatchLevels(time.Now().UTC())
 // YYYY-MM-DD, and the bulletins land on the first of the month.
 func recentSecurityPatchLevels(now time.Time) []string {
 	const months = 4
+	// Anchored to the first of the month before subtracting: AddDate normalizes a
+	// day the target month doesn't have, so subtracting a month from the 31st
+	// lands in the month after the one intended and yields a duplicate.
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	levels := make([]string, 0, months)
 	for i := months - 1; i >= 0; i-- {
-		levels = append(levels, now.AddDate(0, -i, 0).Format("2006-01")+"-01")
+		levels = append(levels, firstOfMonth.AddDate(0, -i, 0).Format("2006-01-02"))
 	}
 	return levels
 }
@@ -259,6 +268,13 @@ var androidCarriers = []androidCarrier{
 // change over its lifetime: who built it, what it runs, and which SIM cards are
 // in it. The distributions are weighted so a simulated fleet has a realistic
 // spread — the aggregate shape matters more than any one device.
+//
+// securityPatchLevel is pinned here even though a real device's does move when
+// it installs an update, which is why a simulated device can report
+// SECURITY_UPDATE_AVAILABLE and then UP_TO_DATE without its patch level ever
+// changing. Fleet folds the patch level into hosts.os_version, so churning it
+// would also churn operating_systems and host_operating_system — a much wider
+// blast radius than the vitals table this change is about.
 func (a *androidAgent) generateStableVitals() {
 	a.manufacturer = androidManufacturers[a.brand]
 	a.apiLevel = androidAPILevels[a.androidVersion]
@@ -267,7 +283,25 @@ func (a *androidAgent) generateStableVitals() {
 	a.deviceKernelVersion = fmt.Sprintf("%s.%d-android%s-%d-g%s",
 		androidKernelBases[a.androidVersion], rand.IntN(100), a.androidVersion, 1+rand.IntN(30), randomHexString(12)) // #nosec G404 -- load testing only
 	a.bootloaderVersion = fmt.Sprintf("%s-%s.0-%d", a.hardware, a.androidVersion, 10000000+rand.IntN(9000000)) // #nosec G404 -- load testing only
+
+	// Almost every managed device is encrypted; ACTIVE_PER_USER is what modern
+	// file-based encryption reports and ACTIVE what older full-disk encryption
+	// does. The unencrypted states are rare but not absent: they are the only
+	// ones that make Fleet store an encryption_type other than "on".
+	//
+	// Stable rather than volatile because none of these transitions exist on real
+	// hardware: UNSUPPORTED is a property of the device, and file-based vs
+	// full-disk encryption is fixed at first boot and changes only on a factory
+	// reset.
+	a.encryptionStatus = weightedChoice([]weightedValue{
+		{"ACTIVE_PER_USER", 0.84},
+		{"ACTIVE", 0.1},
+		{"INACTIVE", 0.04},
+		{"UNSUPPORTED", 0.02},
+	})
+
 	a.telephonyInfos = generateTelephonyInfos()
+	a.rollCollectedSections()
 }
 
 // generateVolatileVitals rolls the vitals that describe what the device is doing
@@ -275,16 +309,6 @@ func (a *androidAgent) generateStableVitals() {
 // Play Integrity reports, whether an update is pending, eSIM activation, and
 // which sections the applied policy collects at all.
 func (a *androidAgent) generateVolatileVitals() {
-	// Almost every managed device is encrypted; ACTIVE_PER_USER is what modern
-	// file-based encryption reports and ACTIVE what older full-disk encryption
-	// does. The unencrypted states are rare but not absent: they are the only
-	// ones that make Fleet store an encryption_type other than "on".
-	a.encryptionStatus = weightedChoice([]weightedValue{
-		{"ACTIVE_PER_USER", 0.84},
-		{"ACTIVE", 0.1},
-		{"INACTIVE", 0.04},
-		{"UNSUPPORTED", 0.02},
-	})
 	a.adbEnabled = rand.Float64() < 0.05       // #nosec G404 -- load testing only
 	a.deviceSecure = rand.Float64() < 0.95     // #nosec G404 -- load testing only
 	a.verifyAppsEnabled = rand.Float64() < 0.9 // #nosec G404 -- load testing only
@@ -324,15 +348,25 @@ func (a *androidAgent) generateVolatileVitals() {
 		}}
 	}
 
-	// Rolled alongside the rest, which flips a device's collected sections far
-	// more often than an admin would really edit the policy's status reporting
-	// settings. That is deliberate: a section going away is what makes Fleet null
-	// the matching columns, and a fleet that always reports everything never
-	// exercises it.
-	a.reportsDeviceSettings = rand.Float64() < 0.9  // #nosec G404 -- load testing only
-	a.reportsSecurityPosture = rand.Float64() < 0.9 // #nosec G404 -- load testing only
+	// Which sections are collected belongs to the applied policy, not to the
+	// moment, so it is decided per device in generateStableVitals. Re-rolling it
+	// rarely stands in for an admin editing the policy's status reporting
+	// settings, which is what makes Fleet null the columns of a section the
+	// device used to report. Re-rolling it every time would instead leave every
+	// host flickering between populated and empty vitals, which no real fleet
+	// does and which reads as a Fleet bug in the host UI.
+	if rand.Float64() < policyEditProb { // #nosec G404 -- load testing only
+		a.rollCollectedSections()
+	}
 
 	a.rollSIMActivation()
+}
+
+// rollCollectedSections decides which optional sections the device's applied
+// policy collects. AMAPI omits a section it is not asked for entirely.
+func (a *androidAgent) rollCollectedSections() {
+	a.reportsDeviceSettings = rand.Float64() < 0.9  // #nosec G404 -- load testing only
+	a.reportsSecurityPosture = rand.Float64() < 0.9 // #nosec G404 -- load testing only
 }
 
 // rollSIMActivation re-rolls the activation state and config mode of the device's
@@ -835,7 +869,7 @@ func (a *androidAgent) deviceInfo() androidmanagement.Device {
 		// AMAPI only reports telephonyInfos for a fully managed device, which
 		// every simulated device is (COMPANY_OWNED above).
 		NetworkInfo: &androidmanagement.NetworkInfo{
-			TelephonyInfos: a.telephonyInfos,
+			TelephonyInfos: a.simSnapshot(),
 		},
 	}
 
@@ -862,6 +896,18 @@ func (a *androidAgent) deviceInfo() androidmanagement.Device {
 	}
 
 	return device
+}
+
+// simSnapshot copies the device's SIM cards so a payload is a snapshot of them.
+// rollSIMActivation mutates them in place, and a message that shared the agent's
+// pointers could otherwise be marshaled with a half-updated SIM — an activation
+// state from after the re-roll beside a config mode from before it.
+func (a *androidAgent) simSnapshot() []*androidmanagement.TelephonyInfo {
+	sims := make([]*androidmanagement.TelephonyInfo, 0, len(a.telephonyInfos))
+	for _, sim := range a.telephonyInfos {
+		sims = append(sims, new(*sim))
+	}
+	return sims
 }
 
 // sendEnrollment sends an ENROLLMENT PubSub message to Fleet.

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -476,10 +476,11 @@ func weightedChoice(values []weightedValue) string {
 }
 
 func randomDigits(n int) string {
+	const digitVals = "0123456789"
 	sb := strings.Builder{}
 	sb.Grow(n)
-	for i := 0; i < n; i++ {
-		sb.WriteByte(byte('0' + rand.IntN(10))) // #nosec G404 -- load testing only
+	for range n {
+		sb.WriteByte(digitVals[rand.IntN(len(digitVals))]) // #nosec G404 -- load testing only
 	}
 	return sb.String()
 }
@@ -488,7 +489,7 @@ func randomHexString(n int) string {
 	const hexVals = "0123456789abcdef"
 	sb := strings.Builder{}
 	sb.Grow(n)
-	for i := 0; i < n; i++ {
+	for range n {
 		sb.WriteByte(hexVals[rand.IntN(len(hexVals))]) // #nosec G404 -- load testing only
 	}
 	return sb.String()

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -80,6 +80,11 @@ type androidAgent struct {
 	// activation state and config mode move.
 	telephonyInfos []*androidmanagement.TelephonyInfo
 
+	// The device's radio identifier. A device has one radio, so exactly one of
+	// these is set: IMEI on a GSM device, MEID on a CDMA one.
+	imei string
+	meid string
+
 	// Whether the applied policy collects these sections at all. AMAPI omits a
 	// section it is not asked for, and Fleet nulls the matching columns when a
 	// device stops reporting one.
@@ -301,7 +306,26 @@ func (a *androidAgent) generateStableVitals() {
 	})
 
 	a.telephonyInfos = generateTelephonyInfos()
+	a.imei, a.meid = generateRadioIdentifier(a.telephonyInfos)
 	a.rollCollectedSections()
+}
+
+// generateRadioIdentifier builds the device's hardware radio identifier and
+// returns it as (imei, meid). AMAPI reports whichever the radio uses and never
+// both, so exactly one of the two is non-empty.
+//
+// CDMA is the rare case, and only for a device on a North American carrier:
+// the networks that ran it elsewhere are gone, and the ones that ran it in the
+// US shut it down years ago, leaving only stragglers.
+func generateRadioIdentifier(sims []*androidmanagement.TelephonyInfo) (imei, meid string) {
+	northAmerican := len(sims) > 0 && strings.HasPrefix(sims[0].PhoneNumber, "+1")
+	if northAmerican && rand.Float64() < 0.1 { // #nosec G404 -- load testing only
+		// An MEID is 14 hexadecimal digits, conventionally upper case.
+		return "", strings.ToUpper(randomHexString(14))
+	}
+	// An IMEI is 15 digits: 14 identifying the device plus a Luhn check digit,
+	// which is left random here because nothing in Fleet validates it.
+	return randomDigits(15), ""
 }
 
 // generateVolatileVitals rolls the vitals that describe what the device is doing
@@ -866,9 +890,11 @@ func (a *androidAgent) deviceInfo() androidmanagement.Device {
 			TotalInternalStorage: a.totalInternalStorage,
 		},
 		MemoryEvents: a.generateMemoryEvents(),
-		// AMAPI only reports telephonyInfos for a fully managed device, which
-		// every simulated device is (COMPANY_OWNED above).
+		// AMAPI only reports telephonyInfos, imei and meid for a fully managed
+		// device, which every simulated device is (COMPANY_OWNED above).
 		NetworkInfo: &androidmanagement.NetworkInfo{
+			Imei:           a.imei,
+			Meid:           a.meid,
 			TelephonyInfos: a.simSnapshot(),
 		},
 	}

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -176,8 +176,9 @@ const (
 	configModeUnspecified      = "CONFIG_MODE_UNSPECIFIED"
 )
 
-// defaultVitalsChurnProb is the share of status reports that re-roll a device's
-// volatile vitals instead of repeating the previous ones.
+// defaultVitalsChurnProb is the default for --android_vitals_churn_prob: the
+// share of status reports that re-roll a device's volatile vitals instead of
+// repeating the previous ones.
 //
 // A real device's posture and settings move far more rarely than this, but a
 // load test needs the vitals table to actually see row writes. Fleet's UPDATE
@@ -446,6 +447,7 @@ func newAndroidAgent(
 	statusReportInterval time.Duration,
 	appCount int,
 	nonComplianceProb float64,
+	vitalsChurnProb float64,
 	stats *osquery_perf.Stats,
 ) *androidAgent {
 	enterpriseSpecificID := strings.ToUpper(uuid.New().String())
@@ -510,7 +512,7 @@ func newAndroidAgent(
 		installedApps:        apps,
 		statusReportInterval: statusReportInterval,
 		nonComplianceProb:    nonComplianceProb,
-		vitalsChurnProb:      defaultVitalsChurnProb,
+		vitalsChurnProb:      vitalsChurnProb,
 	}
 	// Depends on the brand, hardware and Android version picked above.
 	agent.generateStableVitals()

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -434,9 +434,9 @@ func generateTelephonyInfos() []*androidmanagement.TelephonyInfo {
 		info := &androidmanagement.TelephonyInfo{
 			PhoneNumber: carrier.dialCode + randomDigits(carrier.nationalLen),
 			CarrierName: carrier.name,
-			// 19 digits behind the 89 telecom industry identifier. The trailing
-			// digit is random rather than a real Luhn check digit; nothing in
-			// Fleet validates it.
+			// 19 digits in total: the 89 telecom major industry identifier plus
+			// 17 more. The last of those is random rather than a real Luhn check
+			// digit, since nothing in Fleet validates it.
 			IccId:           "89" + randomDigits(17),
 			ActivationState: activationStateUnspecified,
 			ConfigMode:      configModeUnspecified,

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -91,8 +91,11 @@ type androidAgent struct {
 	reportsDeviceSettings  bool
 	reportsSecurityPosture bool
 
-	// vitalsChurnProb is the chance a status report re-rolls the volatile vitals.
+	// vitalsChurnProb is the chance a status report re-rolls the volatile vitals,
+	// and policyEditProb the chance such a re-roll also changes which sections
+	// the applied policy collects.
 	vitalsChurnProb float64
+	policyEditProb  float64
 
 	// Memory
 	totalRAM             int64
@@ -181,10 +184,10 @@ const (
 	configModeUnspecified      = "CONFIG_MODE_UNSPECIFIED"
 )
 
-// policyEditProb is the chance a re-roll of a device's volatile vitals also
-// changes which sections its applied policy collects, standing in for an admin
-// editing the policy's status reporting settings.
-const policyEditProb = 0.05
+// defaultPolicyEditProb is the chance a re-roll of a device's volatile vitals
+// also changes which sections its applied policy collects, standing in for an
+// admin editing the policy's status reporting settings.
+const defaultPolicyEditProb = 0.05
 
 // defaultVitalsChurnProb is the default for --android_vitals_churn_prob: the
 // share of status reports that re-roll a device's volatile vitals instead of
@@ -379,7 +382,7 @@ func (a *androidAgent) generateVolatileVitals() {
 	// device used to report. Re-rolling it every time would instead leave every
 	// host flickering between populated and empty vitals, which no real fleet
 	// does and which reads as a Fleet bug in the host UI.
-	if rand.Float64() < policyEditProb { // #nosec G404 -- load testing only
+	if rand.Float64() < a.policyEditProb { // #nosec G404 -- load testing only
 		a.rollCollectedSections()
 	}
 
@@ -572,6 +575,7 @@ func newAndroidAgent(
 		statusReportInterval: statusReportInterval,
 		nonComplianceProb:    nonComplianceProb,
 		vitalsChurnProb:      vitalsChurnProb,
+		policyEditProb:       defaultPolicyEditProb,
 	}
 	// Depends on the brand, hardware and Android version picked above.
 	agent.generateStableVitals()

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -823,7 +823,7 @@ func TestGeneratedVitalsAcrossFleet(t *testing.T) {
 		cdma           int
 	)
 
-	for i := 0; i < deviceCount; i++ {
+	for range deviceCount {
 		agent := newVitalsTestAgent("http://fleet.invalid")
 
 		assert.Equal(t, androidManufacturers[agent.brand], agent.manufacturer)

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -431,6 +431,17 @@ func newVitalsTestAgent(fleetAddress string) *androidAgent {
 	return newAndroidAgent(1, fleetAddress, "secret", "token", "http://proxy.invalid", "LC01", time.Minute, 5, 0, nil)
 }
 
+// newFullVitalsTestAgent is newVitalsTestAgent pinned to the case where every
+// section is collected and nothing is re-rolled, so a test can assert on an exact
+// payload instead of on whichever sections this device happened to draw.
+func newFullVitalsTestAgent(fleetAddress string) *androidAgent {
+	agent := newVitalsTestAgent(fleetAddress)
+	agent.reportsDeviceSettings = true
+	agent.reportsSecurityPosture = true
+	agent.vitalsChurnProb = 0
+	return agent
+}
+
 // The AMAPI enum members a simulated device is allowed to report. These are
 // deliberately not the full documented sets: the *_UNSPECIFIED sentinels (and
 // UPDATE_STATUS_UNKNOWN) are omitted because Fleet's reportedEnum blanks them
@@ -492,7 +503,7 @@ func assertVitalsReported(t *testing.T, agent *androidAgent, device androidmanag
 func TestStatusReportIncludesHostVitals(t *testing.T) {
 	fleetPubSub := &fakeFleet{}
 	srv := fleetPubSub.server(t)
-	agent := newVitalsTestAgent(srv.URL)
+	agent := newFullVitalsTestAgent(srv.URL)
 
 	state := testState()
 	require.NoError(t, agent.sendStatusReport(&state))
@@ -520,7 +531,7 @@ func TestStatusReportIncludesHostVitals(t *testing.T) {
 func TestEnrollmentIncludesHostVitals(t *testing.T) {
 	fleetPubSub := &fakeFleet{}
 	srv := fleetPubSub.server(t)
-	agent := newVitalsTestAgent(srv.URL)
+	agent := newFullVitalsTestAgent(srv.URL)
 
 	require.NoError(t, agent.sendEnrollment())
 	state := testState()
@@ -534,12 +545,146 @@ func TestEnrollmentIncludesHostVitals(t *testing.T) {
 	assertVitalsReported(t, agent, enrolled)
 	assert.Contains(t, enrolled.EnrollmentTokenData, "secret", "the enroll secret is how Fleet finds the team")
 
+	// The agent is pinned to no churn, so even the volatile vitals must match
+	// here: what a message reports is the device's state at that moment, and
+	// nothing changed between these two.
 	assert.Equal(t, enrolled.ApiLevel, reported.ApiLevel)
 	assert.Equal(t, enrolled.HardwareInfo, reported.HardwareInfo)
 	assert.Equal(t, enrolled.SoftwareInfo, reported.SoftwareInfo)
 	assert.Equal(t, enrolled.DeviceSettings, reported.DeviceSettings)
 	assert.Equal(t, enrolled.SecurityPosture, reported.SecurityPosture)
 	assert.Equal(t, enrolled.NetworkInfo, reported.NetworkInfo)
+}
+
+// TestStatusReportsChurnVolatileVitals is the point of splitting the vitals in
+// two. Fleet overwrites every vitals column on every status report, but MySQL
+// changes no row and advances no updated_at when the values are identical, so a
+// device whose vitals never move makes the load test measure none of the write
+// cost of this table. The device's identity must still hold still.
+func TestStatusReportsChurnVolatileVitals(t *testing.T) {
+	fleetPubSub := &fakeFleet{}
+	srv := fleetPubSub.server(t)
+	agent := newVitalsTestAgent(srv.URL)
+	agent.vitalsChurnProb = 1 // re-roll on every report
+
+	state := testState()
+	// Enough reports that a value failing to move is a real failure and not a run
+	// of luck: the least likely of the assertions below (security posture never
+	// leaving SECURE) has a false-failure probability around 1e-10 at this count,
+	// against roughly 1 in 7,000 at 60 reports.
+	const reports = 150
+	for range reports {
+		require.NoError(t, agent.sendStatusReport(&state))
+	}
+
+	messages := fleetPubSub.captured()
+	require.Len(t, messages, reports)
+
+	var (
+		settings       = map[string]int{}
+		postures       = map[string]int{}
+		updates        = map[string]int{}
+		simConfigModes = map[string]int{}
+		hasESIM        bool
+		sectionsGone   int
+	)
+	first := messages[0].device
+	for _, msg := range messages {
+		device := msg.device
+
+		// Device identity must not move.
+		assert.Equal(t, first.ApiLevel, device.ApiLevel)
+		require.NotNil(t, device.HardwareInfo)
+		assert.Equal(t, first.HardwareInfo.Manufacturer, device.HardwareInfo.Manufacturer)
+		assert.Equal(t, first.HardwareInfo.SerialNumber, device.HardwareInfo.SerialNumber)
+		require.NotNil(t, device.SoftwareInfo)
+		assert.Equal(t, first.SoftwareInfo.SecurityPatchLevel, device.SoftwareInfo.SecurityPatchLevel)
+		assert.Equal(t, first.SoftwareInfo.DeviceKernelVersion, device.SoftwareInfo.DeviceKernelVersion)
+		assert.Equal(t, first.SoftwareInfo.BootloaderVersion, device.SoftwareInfo.BootloaderVersion)
+
+		// The SIM cards are hardware; only their eSIM activation moves.
+		require.NotNil(t, device.NetworkInfo)
+		require.Len(t, device.NetworkInfo.TelephonyInfos, len(first.NetworkInfo.TelephonyInfos))
+		for i, sim := range device.NetworkInfo.TelephonyInfos {
+			assert.Equal(t, first.NetworkInfo.TelephonyInfos[i].IccId, sim.IccId)
+			assert.Equal(t, first.NetworkInfo.TelephonyInfos[i].PhoneNumber, sim.PhoneNumber)
+			assert.Equal(t, first.NetworkInfo.TelephonyInfos[i].CarrierName, sim.CarrierName)
+			assert.Contains(t, validActivationStates, sim.ActivationState)
+			assert.Contains(t, validConfigModes, sim.ConfigMode)
+			// A physical SIM reports neither eSIM enum, on this report or any
+			// other, so only an eSIM's can churn.
+			if sim.ActivationState != activationStateUnspecified {
+				hasESIM = true
+				simConfigModes[sim.ConfigMode]++
+			} else {
+				assert.Equal(t, configModeUnspecified, sim.ConfigMode, "a physical SIM must stay physical")
+			}
+		}
+
+		require.NotNil(t, device.SoftwareInfo.SystemUpdateInfo)
+		assert.Contains(t, validUpdateStatuses, device.SoftwareInfo.SystemUpdateInfo.UpdateStatus)
+		updates[device.SoftwareInfo.SystemUpdateInfo.UpdateStatus]++
+
+		if device.DeviceSettings == nil || device.SecurityPosture == nil {
+			sectionsGone++
+		}
+		if ds := device.DeviceSettings; ds != nil {
+			assert.Contains(t, validEncryptionStatuses, ds.EncryptionStatus)
+			settings[fmt.Sprintf("%t/%t/%t/%s", ds.AdbEnabled, ds.IsDeviceSecure, ds.VerifyAppsEnabled, ds.EncryptionStatus)]++
+		}
+		if sp := device.SecurityPosture; sp != nil {
+			assert.Contains(t, validPostures, sp.DevicePosture)
+			// A device that became secure again must drop the details it used to
+			// report, or Fleet would keep a stale risk on a secure host.
+			if sp.DevicePosture == "SECURE" {
+				assert.Empty(t, sp.PostureDetails)
+			} else {
+				assert.NotEmpty(t, sp.PostureDetails)
+			}
+			postures[sp.DevicePosture]++
+		}
+	}
+
+	// Over 60 re-rolls each of these must have taken more than one value, or the
+	// vitals row would be written once and then never change again.
+	assert.Greater(t, len(settings), 1, "device settings never changed across %d reports", reports)
+	assert.Greater(t, len(postures), 1, "security posture never changed across %d reports", reports)
+	assert.Greater(t, len(updates), 1, "system update status never changed across %d reports", reports)
+	assert.Positive(t, sectionsGone, "no report ever omitted a section, so Fleet never nulls a column")
+	if hasESIM {
+		assert.Greater(t, len(simConfigModes), 1, "eSIM config mode never changed across %d reports", reports)
+	}
+}
+
+// TestUncollectedSectionsAreOmitted covers the other side of the vitals write: a
+// policy that does not collect a section makes AMAPI omit it, and Fleet nulls the
+// matching columns. A payload that always carries every section would never
+// exercise that.
+func TestUncollectedSectionsAreOmitted(t *testing.T) {
+	fleetPubSub := &fakeFleet{}
+	srv := fleetPubSub.server(t)
+	agent := newFullVitalsTestAgent(srv.URL)
+	agent.reportsDeviceSettings = false
+	agent.reportsSecurityPosture = false
+
+	require.NoError(t, agent.sendEnrollment())
+	state := testState()
+	require.NoError(t, agent.sendStatusReport(&state))
+
+	messages := fleetPubSub.captured()
+	require.Len(t, messages, 2)
+	for _, msg := range messages {
+		assert.Nil(t, msg.device.DeviceSettings, "an uncollected section must be absent, not empty")
+		assert.Nil(t, msg.device.SecurityPosture, "an uncollected section must be absent, not empty")
+		assert.NotContains(t, string(msg.raw), "deviceSettings")
+		assert.NotContains(t, string(msg.raw), "securityPosture")
+
+		// The sections the policy still collects must be unaffected.
+		require.NotNil(t, msg.device.HardwareInfo)
+		assert.NotEmpty(t, msg.device.HardwareInfo.Manufacturer)
+		require.NotNil(t, msg.device.NetworkInfo)
+		assert.NotEmpty(t, msg.device.NetworkInfo.TelephonyInfos)
+	}
 }
 
 // TestDeviceSettingsBooleansAlwaysOnTheWire guards the ForceSendFields on
@@ -550,7 +695,7 @@ func TestEnrollmentIncludesHostVitals(t *testing.T) {
 func TestDeviceSettingsBooleansAlwaysOnTheWire(t *testing.T) {
 	fleetPubSub := &fakeFleet{}
 	srv := fleetPubSub.server(t)
-	agent := newVitalsTestAgent(srv.URL)
+	agent := newFullVitalsTestAgent(srv.URL)
 	agent.adbEnabled = false
 	agent.deviceSecure = false
 	agent.verifyAppsEnabled = false
@@ -587,6 +732,9 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 		dualSIM        int
 		adbEnabled     int
 		insecure       int
+		unencrypted    int
+		noSettings     int
+		noPosture      int
 	)
 
 	for i := 0; i < deviceCount; i++ {
@@ -677,6 +825,16 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 		if !agent.deviceSecure {
 			insecure++
 		}
+		// The states that make Fleet store an encryption_type meaning "off".
+		if agent.encryptionStatus == "INACTIVE" || agent.encryptionStatus == "UNSUPPORTED" {
+			unencrypted++
+		}
+		if !agent.reportsDeviceSettings {
+			noSettings++
+		}
+		if !agent.reportsSecurityPosture {
+			noPosture++
+		}
 	}
 
 	// The point of the weighting is a fleet that is mostly healthy but not
@@ -700,6 +858,9 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 		{"dual-SIM devices", dualSIM, 74, 166},
 		{"devices with ADB on", adbEnabled, 4, 45},
 		{"devices without a passcode", insecure, 4, 45},
+		{"unencrypted devices", unencrypted, 5, 48},
+		{"devices not collecting deviceSettings", noSettings, 10, 70},
+		{"devices not collecting securityPosture", noPosture, 10, 70},
 	} {
 		assert.GreaterOrEqual(t, band.got, band.low, "%s: %d is below the expected band", band.name, band.got)
 		assert.LessOrEqual(t, band.got, band.high, "%s: %d is above the expected band", band.name, band.got)

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -429,9 +431,15 @@ func newVitalsTestAgent(fleetAddress string) *androidAgent {
 	return newAndroidAgent(1, fleetAddress, "secret", "token", "http://proxy.invalid", "LC01", time.Minute, 5, 0, nil)
 }
 
-// Valid AMAPI enum members for each vitals field, as documented on
-// enterprises.devices. A value outside these sets would be stored verbatim by
-// Fleet and show up as garbage in the host vitals.
+// The AMAPI enum members a simulated device is allowed to report. These are
+// deliberately not the full documented sets: the *_UNSPECIFIED sentinels (and
+// UPDATE_STATUS_UNKNOWN) are omitted because Fleet's reportedEnum blanks them
+// out, so a device reporting one would be reporting nothing. Do not add them
+// back — the point is that a value outside these sets is either garbage Fleet
+// would store verbatim or a value it would silently drop.
+//
+// The two SIM sets keep their *_UNSPECIFIED members: a physical SIM really does
+// report them, and Fleet dropping them is the behavior being exercised.
 var (
 	validEncryptionStatuses = []string{"UNSUPPORTED", "INACTIVE", "ACTIVATING", "ACTIVE", "ACTIVE_DEFAULT_KEY", "ACTIVE_PER_USER"}
 	validUpdateStatuses     = []string{"UP_TO_DATE", "UNKNOWN_UPDATE_AVAILABLE", "SECURITY_UPDATE_AVAILABLE", "OS_UPDATE_AVAILABLE"}
@@ -592,8 +600,10 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 		assert.Contains(t, androidSecurityPatchLevels, agent.securityPatchLevel)
 		assert.Contains(t, agent.deviceKernelVersion, "-android"+agent.androidVersion+"-",
 			"the kernel must name the Android release it ships on")
-		assert.True(t, strings.HasPrefix(agent.deviceKernelVersion, androidKernelBases[agent.androidVersion]+"."),
-			"kernel %q does not start with the %q line", agent.deviceKernelVersion, androidKernelBases[agent.androidVersion])
+		kernelBase := androidKernelBases[agent.androidVersion]
+		require.NotEmpty(t, kernelBase, "Android %q has no kernel line mapping", agent.androidVersion)
+		assert.True(t, strings.HasPrefix(agent.deviceKernelVersion, kernelBase+"."),
+			"kernel %q does not start with the %q line", agent.deviceKernelVersion, kernelBase)
 		assert.Contains(t, agent.bootloaderVersion, agent.hardware)
 
 		assert.Contains(t, validEncryptionStatuses, agent.encryptionStatus)
@@ -620,9 +630,12 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 		require.LessOrEqual(t, len(agent.telephonyInfos), 2, "no simulated device has more than two SIMs")
 		for _, sim := range agent.telephonyInfos {
 			require.NotNil(t, sim)
-			assert.Regexp(t, `^\+1[0-9]{10}$`, sim.PhoneNumber)
 			assert.Regexp(t, `^89[0-9]{17}$`, sim.IccId, "an ICCID is 19 digits starting with 89")
-			assert.Contains(t, androidCarriers, sim.CarrierName)
+			carrierIdx := slices.IndexFunc(androidCarriers, func(c androidCarrier) bool { return c.name == sim.CarrierName })
+			require.GreaterOrEqual(t, carrierIdx, 0, "unknown carrier %q", sim.CarrierName)
+			carrier := androidCarriers[carrierIdx]
+			assert.Regexp(t, fmt.Sprintf(`^\%s[0-9]{%d}$`, carrier.dialCode, carrier.nationalLen), sim.PhoneNumber,
+				"the number must match the country %s operates in", carrier.name)
 			assert.Contains(t, validActivationStates, sim.ActivationState)
 			assert.Contains(t, validConfigModes, sim.ConfigMode)
 			// A physical SIM reports neither eSIM enum, and an eSIM reports both.
@@ -668,24 +681,70 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 
 	// The point of the weighting is a fleet that is mostly healthy but not
 	// uniformly so; a fleet with only one value in any of these gives the vitals
-	// UI and API nothing to distinguish.
-	assert.Greater(t, postures["SECURE"], postures["AT_RISK"], "most devices should be secure")
-	assert.Positive(t, postures["AT_RISK"])
-	assert.Positive(t, postures["POTENTIALLY_COMPROMISED"])
-	assert.Greater(t, updateStatuses["UP_TO_DATE"], updateStatuses["OS_UPDATE_AVAILABLE"])
-	assert.Positive(t, updateStatuses["SECURITY_UPDATE_AVAILABLE"])
-	assert.Positive(t, updateStatuses["OS_UPDATE_AVAILABLE"])
-	assert.Positive(t, dualSIM, "some devices should be dual-SIM")
-	assert.Less(t, dualSIM, deviceCount, "not every device should be dual-SIM")
-	assert.Positive(t, adbEnabled, "a few devices should have ADB on")
-	assert.Less(t, adbEnabled, deviceCount/2, "ADB on should stay rare")
-	assert.Positive(t, insecure, "a few devices should have no passcode")
+	// UI and API nothing to distinguish. Each band is the weight's implied
+	// binomial mean over deviceCount devices, ±5 standard deviations: loose
+	// enough that a false failure is roughly one run in a million, tight enough
+	// that changing a weight is caught rather than shrugged at.
+	for _, band := range []struct {
+		name      string
+		got       int
+		low, high int
+	}{
+		{"SECURE devices", postures["SECURE"], 304, 376},
+		{"AT_RISK devices", postures["AT_RISK"], 10, 70},
+		{"POTENTIALLY_COMPROMISED devices", postures["POTENTIALLY_COMPROMISED"], 4, 45},
+		{"UP_TO_DATE devices", updateStatuses["UP_TO_DATE"], 234, 326},
+		{"SECURITY_UPDATE_AVAILABLE devices", updateStatuses["SECURITY_UPDATE_AVAILABLE"], 24, 96},
+		{"OS_UPDATE_AVAILABLE devices", updateStatuses["OS_UPDATE_AVAILABLE"], 10, 70},
+		{"UNKNOWN_UPDATE_AVAILABLE devices", updateStatuses["UNKNOWN_UPDATE_AVAILABLE"], 4, 45},
+		{"dual-SIM devices", dualSIM, 74, 166},
+		{"devices with ADB on", adbEnabled, 4, 45},
+		{"devices without a passcode", insecure, 4, 45},
+	} {
+		assert.GreaterOrEqual(t, band.got, band.low, "%s: %d is below the expected band", band.name, band.got)
+		assert.LessOrEqual(t, band.got, band.high, "%s: %d is above the expected band", band.name, band.got)
+	}
 
 	// Both SIM kinds must appear, since Fleet stores their enums differently.
 	assert.Positive(t, activations["ACTIVATION_STATE_UNSPECIFIED"], "physical SIMs")
 	assert.Positive(t, activations["ACTIVATED"], "activated eSIMs")
 	assert.Positive(t, configModes["ADMIN_CONFIGURED"])
 	assert.Positive(t, configModes["USER_CONFIGURED"])
+}
+
+// TestVitalsMapsAgree guards the three per-release / per-brand maps against
+// drifting apart: newAndroidAgent draws its brands and Android versions from two
+// of them, and generateDeviceVitals then indexes the third. A release present in
+// one and missing from another would silently report an empty manufacturer or a
+// kernel version like ".47-android16-3-gdeadbeef".
+func TestVitalsMapsAgree(t *testing.T) {
+	require.NotEmpty(t, androidAPILevels)
+	require.NotEmpty(t, androidManufacturers)
+
+	for version := range androidAPILevels {
+		assert.Positive(t, androidAPILevels[version], "Android %q has no API level", version)
+		assert.NotEmpty(t, androidKernelBases[version], "Android %q has no kernel line", version)
+	}
+	for version := range androidKernelBases {
+		assert.Contains(t, androidAPILevels, version, "kernel line for unsimulated Android %q", version)
+	}
+	for brand, manufacturer := range androidManufacturers {
+		assert.NotEmpty(t, manufacturer, "brand %q has no manufacturer", brand)
+	}
+}
+
+// TestRecentSecurityPatchLevels checks the patch levels a device may report are
+// recent bulletin dates, not the hardcoded set that would go stale.
+func TestRecentSecurityPatchLevels(t *testing.T) {
+	got := recentSecurityPatchLevels(time.Date(2026, 3, 17, 4, 5, 6, 0, time.UTC))
+	assert.Equal(t, []string{"2025-12-01", "2026-01-01", "2026-02-01", "2026-03-01"}, got,
+		"four bulletin dates ending at the current month, newest last")
+
+	// The package-level set the agent actually draws from must be usable too.
+	require.NotEmpty(t, androidSecurityPatchLevels)
+	for _, level := range androidSecurityPatchLevels {
+		assert.Regexp(t, `^[0-9]{4}-[0-9]{2}-01$`, level)
+	}
 }
 
 // TestWeightedChoice covers the picker the vitals distributions rely on.
@@ -699,6 +758,14 @@ func TestWeightedChoice(t *testing.T) {
 	t.Run("a zero-weight value is never picked", func(t *testing.T) {
 		for range 100 {
 			assert.Equal(t, "always", weightedChoice([]weightedValue{{"never", 0}, {"always", 1}}))
+		}
+	})
+
+	// The rounding fallback must not resurrect a zero-weight value just because
+	// it happens to be last.
+	t.Run("a zero-weight value is never picked in last position", func(t *testing.T) {
+		for range 100 {
+			assert.Equal(t, "always", weightedChoice([]weightedValue{{"always", 0.9}, {"never", 0}}))
 		}
 	})
 

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -570,9 +570,12 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 	state := testState()
 	// Enough reports that a value failing to move is a real failure and not a run
 	// of luck: the least likely of the assertions below (security posture never
-	// leaving SECURE) has a false-failure probability around 1e-10 at this count,
-	// against roughly 1 in 7,000 at 60 reports.
+	// leaving SECURE) has a false-failure probability around 4e-10 at this count,
+	// against roughly 1 in 7,000 at 60.
 	const reports = 150
+
+	// The churn only happens in a real load test if the default says it should.
+	assert.Positive(t, defaultVitalsChurnProb, "the default must actually re-roll vitals")
 	for range reports {
 		require.NoError(t, agent.sendStatusReport(&state))
 	}
@@ -586,7 +589,6 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 		updates        = map[string]int{}
 		simConfigModes = map[string]int{}
 		hasESIM        bool
-		sectionsGone   int
 	)
 	first := messages[0].device
 	for _, msg := range messages {
@@ -625,12 +627,11 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 		assert.Contains(t, validUpdateStatuses, device.SoftwareInfo.SystemUpdateInfo.UpdateStatus)
 		updates[device.SoftwareInfo.SystemUpdateInfo.UpdateStatus]++
 
-		if device.DeviceSettings == nil || device.SecurityPosture == nil {
-			sectionsGone++
-		}
 		if ds := device.DeviceSettings; ds != nil {
-			assert.Contains(t, validEncryptionStatuses, ds.EncryptionStatus)
-			settings[fmt.Sprintf("%t/%t/%t/%s", ds.AdbEnabled, ds.IsDeviceSecure, ds.VerifyAppsEnabled, ds.EncryptionStatus)]++
+			// Encryption is a stable device property, so it must not move even
+			// though it lives in the same section as the settings that do.
+			assert.Equal(t, agent.encryptionStatus, ds.EncryptionStatus)
+			settings[fmt.Sprintf("%t/%t/%t", ds.AdbEnabled, ds.IsDeviceSecure, ds.VerifyAppsEnabled)]++
 		}
 		if sp := device.SecurityPosture; sp != nil {
 			assert.Contains(t, validPostures, sp.DevicePosture)
@@ -645,12 +646,11 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 		}
 	}
 
-	// Over 60 re-rolls each of these must have taken more than one value, or the
-	// vitals row would be written once and then never change again.
+	// Across every re-roll each of these must have taken more than one value, or
+	// the vitals row would be written once and then never change again.
 	assert.Greater(t, len(settings), 1, "device settings never changed across %d reports", reports)
 	assert.Greater(t, len(postures), 1, "security posture never changed across %d reports", reports)
 	assert.Greater(t, len(updates), 1, "system update status never changed across %d reports", reports)
-	assert.Positive(t, sectionsGone, "no report ever omitted a section, so Fleet never nulls a column")
 	if hasESIM {
 		assert.Greater(t, len(simConfigModes), 1, "eSIM config mode never changed across %d reports", reports)
 	}
@@ -687,6 +687,64 @@ func TestUncollectedSectionsAreOmitted(t *testing.T) {
 	}
 }
 
+// TestSectionGoingAwayNullsItsColumns covers the transition rather than the
+// steady state: a device that reported a section and then stops is what makes
+// Fleet overwrite those columns with NULL, and it only happens if a payload can
+// go from carrying the section to not carrying it.
+func TestSectionGoingAwayNullsItsColumns(t *testing.T) {
+	fleetPubSub := &fakeFleet{}
+	srv := fleetPubSub.server(t)
+	agent := newFullVitalsTestAgent(srv.URL)
+	state := testState()
+
+	require.NoError(t, agent.sendStatusReport(&state))
+
+	// The admin turns the policy's status reporting settings off.
+	agent.reportsDeviceSettings = false
+	agent.reportsSecurityPosture = false
+	require.NoError(t, agent.sendStatusReport(&state))
+
+	// And on again.
+	agent.reportsDeviceSettings = true
+	agent.reportsSecurityPosture = true
+	require.NoError(t, agent.sendStatusReport(&state))
+
+	messages := fleetPubSub.captured()
+	require.Len(t, messages, 3)
+	assert.NotNil(t, messages[0].device.DeviceSettings)
+	assert.NotNil(t, messages[0].device.SecurityPosture)
+	assert.Nil(t, messages[1].device.DeviceSettings, "the section must actually disappear")
+	assert.Nil(t, messages[1].device.SecurityPosture, "the section must actually disappear")
+	assert.NotNil(t, messages[2].device.DeviceSettings, "and come back")
+	assert.NotNil(t, messages[2].device.SecurityPosture, "and come back")
+}
+
+// TestSIMSnapshotIsIndependentOfTheAgent guards the payload against the agent
+// mutating the SIMs it already handed over: rollSIMActivation edits them in
+// place, so a payload sharing those pointers could carry an activation state
+// from after a re-roll beside a config mode from before it.
+func TestSIMSnapshotIsIndependentOfTheAgent(t *testing.T) {
+	agent := newFullVitalsTestAgent("http://fleet.invalid")
+	require.NotEmpty(t, agent.telephonyInfos)
+
+	snapshot := agent.simSnapshot()
+	require.Len(t, snapshot, len(agent.telephonyInfos))
+	for i, sim := range snapshot {
+		assert.Equal(t, agent.telephonyInfos[i], sim, "a snapshot must start out equal")
+		assert.NotSame(t, agent.telephonyInfos[i], sim, "and must not be the agent's own SIM")
+	}
+
+	for _, sim := range agent.telephonyInfos {
+		sim.ActivationState = "NOT_ACTIVATED"
+		sim.ConfigMode = "USER_CONFIGURED"
+		sim.PhoneNumber = "+15550000000"
+	}
+	for i, sim := range snapshot {
+		assert.NotEqual(t, agent.telephonyInfos[i].PhoneNumber, sim.PhoneNumber,
+			"the snapshot must not see a later mutation")
+	}
+}
+
 // TestDeviceSettingsBooleansAlwaysOnTheWire guards the ForceSendFields on
 // DeviceSettings. Without them Go's omitempty drops every false boolean, so a
 // device with ADB off, no passcode and Play Protect off would send
@@ -716,12 +774,12 @@ func TestDeviceSettingsBooleansAlwaysOnTheWire(t *testing.T) {
 	assert.False(t, messages[0].device.DeviceSettings.VerifyAppsEnabled)
 }
 
-// TestGenerateDeviceVitalsAcrossFleet checks the generated values across many
+// TestGeneratedVitalsAcrossFleet checks the generated values across many
 // devices: each one has to be internally consistent, and the fleet as a whole has
 // to cover the branches Fleet's extraction treats differently — a secure device
 // vs. one with posture details, and an eSIM vs. a physical SIM whose
 // *_UNSPECIFIED enums Fleet blanks out.
-func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
+func TestGeneratedVitalsAcrossFleet(t *testing.T) {
 	const deviceCount = 400
 
 	var (
@@ -839,10 +897,14 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 
 	// The point of the weighting is a fleet that is mostly healthy but not
 	// uniformly so; a fleet with only one value in any of these gives the vitals
-	// UI and API nothing to distinguish. Each band is the weight's implied
-	// binomial mean over deviceCount devices, ±5 standard deviations: loose
-	// enough that a false failure is roughly one run in a million, tight enough
-	// that changing a weight is caught rather than shrugged at.
+	// UI and API nothing to distinguish.
+	//
+	// Each band is the weight's implied binomial mean over deviceCount devices
+	// ±5 standard deviations, except that the 5% weights use a lower bound of 1:
+	// at n=400 their 5σ band runs below zero, and a tighter lower bound would
+	// cost more in false failures than it buys. Overall false-failure
+	// probability is about 2e-6, one run in ~400,000; each band is still tight
+	// enough that a changed weight fails it.
 	for _, band := range []struct {
 		name      string
 		got       int
@@ -850,15 +912,15 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 	}{
 		{"SECURE devices", postures["SECURE"], 304, 376},
 		{"AT_RISK devices", postures["AT_RISK"], 10, 70},
-		{"POTENTIALLY_COMPROMISED devices", postures["POTENTIALLY_COMPROMISED"], 4, 45},
+		{"POTENTIALLY_COMPROMISED devices", postures["POTENTIALLY_COMPROMISED"], 1, 45},
 		{"UP_TO_DATE devices", updateStatuses["UP_TO_DATE"], 234, 326},
 		{"SECURITY_UPDATE_AVAILABLE devices", updateStatuses["SECURITY_UPDATE_AVAILABLE"], 24, 96},
 		{"OS_UPDATE_AVAILABLE devices", updateStatuses["OS_UPDATE_AVAILABLE"], 10, 70},
-		{"UNKNOWN_UPDATE_AVAILABLE devices", updateStatuses["UNKNOWN_UPDATE_AVAILABLE"], 4, 45},
+		{"UNKNOWN_UPDATE_AVAILABLE devices", updateStatuses["UNKNOWN_UPDATE_AVAILABLE"], 1, 45},
 		{"dual-SIM devices", dualSIM, 74, 166},
-		{"devices with ADB on", adbEnabled, 4, 45},
-		{"devices without a passcode", insecure, 4, 45},
-		{"unencrypted devices", unencrypted, 5, 48},
+		{"devices with ADB on", adbEnabled, 1, 45},
+		{"devices without a passcode", insecure, 1, 45},
+		{"unencrypted devices", unencrypted, 1, 48},
 		{"devices not collecting deviceSettings", noSettings, 10, 70},
 		{"devices not collecting securityPosture", noPosture, 10, 70},
 	} {
@@ -875,7 +937,7 @@ func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
 
 // TestVitalsMapsAgree guards the three per-release / per-brand maps against
 // drifting apart: newAndroidAgent draws its brands and Android versions from two
-// of them, and generateDeviceVitals then indexes the third. A release present in
+// of them, and generateStableVitals then indexes the third. A release present in
 // one and missing from another would silently report an empty manufacturer or a
 // kernel version like ".47-android16-3-gdeadbeef".
 func TestVitalsMapsAgree(t *testing.T) {
@@ -897,9 +959,36 @@ func TestVitalsMapsAgree(t *testing.T) {
 // TestRecentSecurityPatchLevels checks the patch levels a device may report are
 // recent bulletin dates, not the hardcoded set that would go stale.
 func TestRecentSecurityPatchLevels(t *testing.T) {
-	got := recentSecurityPatchLevels(time.Date(2026, 3, 17, 4, 5, 6, 0, time.UTC))
-	assert.Equal(t, []string{"2025-12-01", "2026-01-01", "2026-02-01", "2026-03-01"}, got,
-		"four bulletin dates ending at the current month, newest last")
+	for _, tc := range []struct {
+		name string
+		now  time.Time
+		want []string
+	}{
+		{
+			name: "mid-month",
+			now:  time.Date(2026, 3, 17, 4, 5, 6, 0, time.UTC),
+			want: []string{"2025-12-01", "2026-01-01", "2026-02-01", "2026-03-01"},
+		},
+		{
+			// Subtracting a month from the 31st without anchoring to the 1st
+			// first rolls forward into the month after the one intended, which
+			// silently collapsed four patch levels into two.
+			name: "the 31st of a month shorter months cannot hold",
+			now:  time.Date(2026, 5, 31, 23, 59, 59, 0, time.UTC),
+			want: []string{"2026-02-01", "2026-03-01", "2026-04-01", "2026-05-01"},
+		},
+		{
+			name: "across a year boundary",
+			now:  time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+			want: []string{"2025-10-01", "2025-11-01", "2025-12-01", "2026-01-01"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := recentSecurityPatchLevels(tc.now)
+			assert.Equal(t, tc.want, got, "four bulletin dates ending at the current month, newest last")
+			assert.Len(t, slices.Compact(slices.Clone(got)), len(got), "duplicate patch levels double a month's weight")
+		})
+	}
 
 	// The package-level set the agent actually draws from must be usable too.
 	require.NotEmpty(t, androidSecurityPatchLevels)

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -492,9 +492,33 @@ func assertVitalsReported(t *testing.T, agent *androidAgent, device androidmanag
 	require.NotNil(t, device.SecurityPosture, "security_posture")
 	assert.Contains(t, validPostures, device.SecurityPosture.DevicePosture)
 
-	require.NotNil(t, device.NetworkInfo, "telephony_infos")
+	require.NotNil(t, device.NetworkInfo, "telephony_infos, imei and meid")
 	require.NotEmpty(t, device.NetworkInfo.TelephonyInfos)
-	assert.Equal(t, "COMPANY_OWNED", device.Ownership, "Fleet drops telephony info for a personally owned device")
+	assert.Equal(t, agent.imei, device.NetworkInfo.Imei)
+	assert.Equal(t, agent.meid, device.NetworkInfo.Meid)
+	assertRadioIdentifier(t, device.NetworkInfo.Imei, device.NetworkInfo.Meid)
+	assert.Equal(t, "COMPANY_OWNED", device.Ownership,
+		"Fleet drops telephony info, imei and meid for a personally owned device")
+}
+
+// assertRadioIdentifier checks that a device reports exactly one radio
+// identifier, in the right format. A device has one radio: reporting both would
+// be a device Fleet stores an imei and a meid for, which cannot exist, and
+// reporting neither leaves both columns NULL.
+func assertRadioIdentifier(t *testing.T, imei, meid string) {
+	t.Helper()
+
+	switch {
+	case imei != "":
+		assert.Empty(t, meid, "a device reports imei or meid, never both")
+		assert.Regexp(t, `^[0-9]{15}$`, imei, "an IMEI is 15 digits")
+	case meid != "":
+		assert.Regexp(t, `^[0-9A-F]{14}$`, meid, "an MEID is 14 upper-case hex digits")
+	default:
+		t.Error("the device reported neither an imei nor a meid, so Fleet stores neither")
+	}
+	assert.LessOrEqual(t, len(imei), fleet.MDMAndroidDeviceVitalMaxLength)
+	assert.LessOrEqual(t, len(meid), fleet.MDMAndroidDeviceVitalMaxLength)
 }
 
 // TestStatusReportIncludesHostVitals is the load-test counterpart of Fleet's
@@ -604,8 +628,11 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 		assert.Equal(t, first.SoftwareInfo.DeviceKernelVersion, device.SoftwareInfo.DeviceKernelVersion)
 		assert.Equal(t, first.SoftwareInfo.BootloaderVersion, device.SoftwareInfo.BootloaderVersion)
 
-		// The SIM cards are hardware; only their eSIM activation moves.
+		// The radio and the SIM cards are hardware; only eSIM activation moves.
 		require.NotNil(t, device.NetworkInfo)
+		assert.Equal(t, first.NetworkInfo.Imei, device.NetworkInfo.Imei)
+		assert.Equal(t, first.NetworkInfo.Meid, device.NetworkInfo.Meid)
+		assertRadioIdentifier(t, device.NetworkInfo.Imei, device.NetworkInfo.Meid)
 		require.Len(t, device.NetworkInfo.TelephonyInfos, len(first.NetworkInfo.TelephonyInfos))
 		for i, sim := range device.NetworkInfo.TelephonyInfos {
 			assert.Equal(t, first.NetworkInfo.TelephonyInfos[i].IccId, sim.IccId)
@@ -793,6 +820,7 @@ func TestGeneratedVitalsAcrossFleet(t *testing.T) {
 		unencrypted    int
 		noSettings     int
 		noPosture      int
+		cdma           int
 	)
 
 	for i := 0; i < deviceCount; i++ {
@@ -830,6 +858,13 @@ func TestGeneratedVitalsAcrossFleet(t *testing.T) {
 					assert.NotEmpty(t, advice.DefaultMessage, "Fleet only keeps the default message")
 				}
 			}
+		}
+
+		assertRadioIdentifier(t, agent.imei, agent.meid)
+		if agent.meid != "" {
+			cdma++
+			assert.True(t, strings.HasPrefix(agent.telephonyInfos[0].PhoneNumber, "+1"),
+				"only a North American device should still be on CDMA, got %q", agent.telephonyInfos[0].PhoneNumber)
 		}
 
 		require.NotEmpty(t, agent.telephonyInfos)
@@ -923,6 +958,7 @@ func TestGeneratedVitalsAcrossFleet(t *testing.T) {
 		{"unencrypted devices", unencrypted, 1, 48},
 		{"devices not collecting deviceSettings", noSettings, 10, 70},
 		{"devices not collecting securityPosture", noPosture, 10, 70},
+		{"CDMA devices reporting an MEID", cdma, 1, 46},
 	} {
 		assert.GreaterOrEqual(t, band.got, band.low, "%s: %d is below the expected band", band.name, band.got)
 		assert.LessOrEqual(t, band.got, band.high, "%s: %d is above the expected band", band.name, band.got)
@@ -933,6 +969,44 @@ func TestGeneratedVitalsAcrossFleet(t *testing.T) {
 	assert.Positive(t, activations["ACTIVATED"], "activated eSIMs")
 	assert.Positive(t, configModes["ADMIN_CONFIGURED"])
 	assert.Positive(t, configModes["USER_CONFIGURED"])
+}
+
+// TestGenerateRadioIdentifier covers the radio identifier directly: a device has
+// one radio, so Fleet must never receive an imei and a meid for the same device.
+func TestGenerateRadioIdentifier(t *testing.T) {
+	t.Run("a non-North-American device is always GSM", func(t *testing.T) {
+		sims := []*androidmanagement.TelephonyInfo{{PhoneNumber: "+447700900000"}}
+		for range 200 {
+			imei, meid := generateRadioIdentifier(sims)
+			assertRadioIdentifier(t, imei, meid)
+			assert.Empty(t, meid, "CDMA never ran on these networks")
+		}
+	})
+
+	t.Run("a North American device is usually GSM and sometimes CDMA", func(t *testing.T) {
+		sims := []*androidmanagement.TelephonyInfo{{PhoneNumber: "+15551234567"}}
+		var gsm, cdma int
+		for range 400 {
+			imei, meid := generateRadioIdentifier(sims)
+			assertRadioIdentifier(t, imei, meid)
+			if meid != "" {
+				cdma++
+			} else {
+				gsm++
+			}
+		}
+		assert.Greater(t, gsm, cdma, "CDMA is the rare case")
+		// p=0.1 over 400 draws: mean 40, and P(zero) is about 1e-18.
+		assert.Positive(t, cdma, "CDMA devices must still occur")
+	})
+
+	// Nothing generates an empty SIM list today, but the generator reads the
+	// first SIM and must not panic if that ever changes.
+	t.Run("no SIMs still yields an identifier", func(t *testing.T) {
+		imei, meid := generateRadioIdentifier(nil)
+		assertRadioIdentifier(t, imei, meid)
+		assert.Empty(t, meid)
+	})
 }
 
 // TestVitalsMapsAgree guards the three per-release / per-brand maps against

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -428,7 +428,7 @@ func (f *fakeFleet) captured() []capturedMessage {
 // newVitalsTestAgent builds a fully generated agent pointed at fleetAddress, using
 // the real constructor so the generated vitals are the ones a load test would send.
 func newVitalsTestAgent(fleetAddress string) *androidAgent {
-	return newAndroidAgent(1, fleetAddress, "secret", "token", "http://proxy.invalid", "LC01", time.Minute, 5, 0, nil)
+	return newAndroidAgent(1, fleetAddress, "secret", "token", "http://proxy.invalid", "LC01", time.Minute, 5, 0, defaultVitalsChurnProb, nil)
 }
 
 // newFullVitalsTestAgent is newVitalsTestAgent pinned to the case where every

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/api/androidmanagement/v1"
 )
 
 // fakeProxy is a stand-in for the android-amapi-mock coordination API.
@@ -359,4 +365,357 @@ func TestPollProxyStateClassifiesFailures(t *testing.T) {
 	require.NotErrorIs(t, err, errProxyDeviceUnknown, "only a 404 means the registration was lost")
 	require.NotErrorIs(t, err, errProxyDeviceDeleted, "only a 410 means the device was deleted")
 	assert.Contains(t, err.Error(), "429", "error should carry the status code")
+}
+
+// fakeFleet stands in for Fleet's PubSub push endpoint, capturing and decoding the
+// AMAPI device payloads the agent sends.
+type fakeFleet struct {
+	mu       sync.Mutex
+	messages []capturedMessage
+}
+
+type capturedMessage struct {
+	notificationType string
+	// raw is the decoded payload before unmarshalling, so a test can assert on
+	// what is actually on the wire and not just on what unmarshals back.
+	raw    []byte
+	device androidmanagement.Device
+}
+
+func (f *fakeFleet) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/fleet/android_enterprise/pubsub", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Message android.PubSubMessage `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		raw, err := base64.StdEncoding.DecodeString(body.Message.Data)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var device androidmanagement.Device
+		if err := json.Unmarshal(raw, &device); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		f.mu.Lock()
+		f.messages = append(f.messages, capturedMessage{
+			notificationType: body.Message.Attributes["notificationType"],
+			raw:              raw,
+			device:           device,
+		})
+		f.mu.Unlock()
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (f *fakeFleet) captured() []capturedMessage {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]capturedMessage(nil), f.messages...)
+}
+
+// newVitalsTestAgent builds a fully generated agent pointed at fleetAddress, using
+// the real constructor so the generated vitals are the ones a load test would send.
+func newVitalsTestAgent(fleetAddress string) *androidAgent {
+	return newAndroidAgent(1, fleetAddress, "secret", "token", "http://proxy.invalid", "LC01", time.Minute, 5, 0, nil)
+}
+
+// Valid AMAPI enum members for each vitals field, as documented on
+// enterprises.devices. A value outside these sets would be stored verbatim by
+// Fleet and show up as garbage in the host vitals.
+var (
+	validEncryptionStatuses = []string{"UNSUPPORTED", "INACTIVE", "ACTIVATING", "ACTIVE", "ACTIVE_DEFAULT_KEY", "ACTIVE_PER_USER"}
+	validUpdateStatuses     = []string{"UP_TO_DATE", "UNKNOWN_UPDATE_AVAILABLE", "SECURITY_UPDATE_AVAILABLE", "OS_UPDATE_AVAILABLE"}
+	validPostures           = []string{"SECURE", "AT_RISK", "POTENTIALLY_COMPROMISED"}
+	validSecurityRisks      = []string{"UNKNOWN_OS", "COMPROMISED_OS", "HARDWARE_BACKED_EVALUATION_FAILED"}
+	validActivationStates   = []string{"ACTIVATION_STATE_UNSPECIFIED", "ACTIVATED", "NOT_ACTIVATED"}
+	validConfigModes        = []string{"CONFIG_MODE_UNSPECIFIED", "ADMIN_CONFIGURED", "USER_CONFIGURED"}
+)
+
+// assertVitalsReported checks that a device payload carries every section Fleet
+// reads host vitals from. A missing section is not an error Fleet can report — it
+// silently stores NULL — so the load test has to assert it here.
+func assertVitalsReported(t *testing.T, agent *androidAgent, device androidmanagement.Device) {
+	t.Helper()
+
+	assert.Equal(t, agent.apiLevel, device.ApiLevel, "api_level")
+	assert.Positive(t, device.ApiLevel, "an unreported api level stores as NULL")
+
+	require.NotNil(t, device.HardwareInfo, "manufacturer lives on hardwareInfo")
+	assert.Equal(t, agent.manufacturer, device.HardwareInfo.Manufacturer)
+	assert.NotEmpty(t, device.HardwareInfo.Manufacturer)
+
+	require.NotNil(t, device.SoftwareInfo, "kernel, bootloader and patch level live on softwareInfo")
+	assert.Equal(t, agent.securityPatchLevel, device.SoftwareInfo.SecurityPatchLevel)
+	assert.Equal(t, agent.deviceKernelVersion, device.SoftwareInfo.DeviceKernelVersion)
+	assert.Equal(t, agent.bootloaderVersion, device.SoftwareInfo.BootloaderVersion)
+	assert.NotEmpty(t, device.SoftwareInfo.SecurityPatchLevel)
+	assert.NotEmpty(t, device.SoftwareInfo.DeviceKernelVersion)
+	assert.NotEmpty(t, device.SoftwareInfo.BootloaderVersion)
+	require.NotNil(t, device.SoftwareInfo.SystemUpdateInfo, "system_update_status")
+	assert.Contains(t, validUpdateStatuses, device.SoftwareInfo.SystemUpdateInfo.UpdateStatus)
+
+	require.NotNil(t, device.DeviceSettings, "adb, passcode, Play Protect and encryption")
+	assert.Equal(t, agent.adbEnabled, device.DeviceSettings.AdbEnabled)
+	assert.Equal(t, agent.deviceSecure, device.DeviceSettings.IsDeviceSecure)
+	assert.Equal(t, agent.verifyAppsEnabled, device.DeviceSettings.VerifyAppsEnabled)
+	assert.Contains(t, validEncryptionStatuses, device.DeviceSettings.EncryptionStatus)
+
+	require.NotNil(t, device.SecurityPosture, "security_posture")
+	assert.Contains(t, validPostures, device.SecurityPosture.DevicePosture)
+
+	require.NotNil(t, device.NetworkInfo, "telephony_infos")
+	require.NotEmpty(t, device.NetworkInfo.TelephonyInfos)
+	assert.Equal(t, "COMPANY_OWNED", device.Ownership, "Fleet drops telephony info for a personally owned device")
+}
+
+// TestStatusReportIncludesHostVitals is the load-test counterpart of Fleet's
+// androidDeviceVitals extraction: a status report that omits any of these sections
+// leaves the host vitals columns NULL, so a load test would never exercise them.
+func TestStatusReportIncludesHostVitals(t *testing.T) {
+	fleetPubSub := &fakeFleet{}
+	srv := fleetPubSub.server(t)
+	agent := newVitalsTestAgent(srv.URL)
+
+	state := testState()
+	require.NoError(t, agent.sendStatusReport(&state))
+
+	messages := fleetPubSub.captured()
+	require.Len(t, messages, 1)
+	assert.Equal(t, string(android.PubSubStatusReport), messages[0].notificationType)
+
+	device := messages[0].device
+	assertVitalsReported(t, agent, device)
+
+	// The status-report-only fields must survive the shared payload refactor.
+	assert.Equal(t, "ACTIVE", device.AppliedState)
+	assert.Equal(t, state.PolicyVersion, device.AppliedPolicyVersion)
+	assert.Equal(t, state.PolicyName, device.AppliedPolicyName)
+	assert.NotEmpty(t, device.LastStatusReportTime)
+	assert.NotEmpty(t, device.LastPolicySyncTime)
+	assert.Len(t, device.ApplicationReports, 5)
+	assert.Contains(t, device.EnrollmentTokenData, "secret")
+}
+
+// TestEnrollmentIncludesHostVitals covers the other write path: Fleet also stores
+// vitals when it first creates the host from an ENROLLMENT message, and the two
+// payloads must agree or a host's vitals would change on its first status report.
+func TestEnrollmentIncludesHostVitals(t *testing.T) {
+	fleetPubSub := &fakeFleet{}
+	srv := fleetPubSub.server(t)
+	agent := newVitalsTestAgent(srv.URL)
+
+	require.NoError(t, agent.sendEnrollment())
+	state := testState()
+	require.NoError(t, agent.sendStatusReport(&state))
+
+	messages := fleetPubSub.captured()
+	require.Len(t, messages, 2)
+	assert.Equal(t, string(android.PubSubEnrollment), messages[0].notificationType)
+
+	enrolled, reported := messages[0].device, messages[1].device
+	assertVitalsReported(t, agent, enrolled)
+	assert.Contains(t, enrolled.EnrollmentTokenData, "secret", "the enroll secret is how Fleet finds the team")
+
+	assert.Equal(t, enrolled.ApiLevel, reported.ApiLevel)
+	assert.Equal(t, enrolled.HardwareInfo, reported.HardwareInfo)
+	assert.Equal(t, enrolled.SoftwareInfo, reported.SoftwareInfo)
+	assert.Equal(t, enrolled.DeviceSettings, reported.DeviceSettings)
+	assert.Equal(t, enrolled.SecurityPosture, reported.SecurityPosture)
+	assert.Equal(t, enrolled.NetworkInfo, reported.NetworkInfo)
+}
+
+// TestDeviceSettingsBooleansAlwaysOnTheWire guards the ForceSendFields on
+// DeviceSettings. Without them Go's omitempty drops every false boolean, so a
+// device with ADB off, no passcode and Play Protect off would send
+// "deviceSettings":{} — which unmarshals the same way for Fleet, but no longer
+// resembles what AMAPI actually pushes.
+func TestDeviceSettingsBooleansAlwaysOnTheWire(t *testing.T) {
+	fleetPubSub := &fakeFleet{}
+	srv := fleetPubSub.server(t)
+	agent := newVitalsTestAgent(srv.URL)
+	agent.adbEnabled = false
+	agent.deviceSecure = false
+	agent.verifyAppsEnabled = false
+
+	require.NoError(t, agent.sendEnrollment())
+
+	messages := fleetPubSub.captured()
+	require.Len(t, messages, 1)
+	payload := string(messages[0].raw)
+	assert.Contains(t, payload, `"adbEnabled":false`)
+	assert.Contains(t, payload, `"isDeviceSecure":false`)
+	assert.Contains(t, payload, `"verifyAppsEnabled":false`)
+
+	// And Fleet still reads them back as the false values they are.
+	require.NotNil(t, messages[0].device.DeviceSettings)
+	assert.False(t, messages[0].device.DeviceSettings.AdbEnabled)
+	assert.False(t, messages[0].device.DeviceSettings.IsDeviceSecure)
+	assert.False(t, messages[0].device.DeviceSettings.VerifyAppsEnabled)
+}
+
+// TestGenerateDeviceVitalsAcrossFleet checks the generated values across many
+// devices: each one has to be internally consistent, and the fleet as a whole has
+// to cover the branches Fleet's extraction treats differently — a secure device
+// vs. one with posture details, and an eSIM vs. a physical SIM whose
+// *_UNSPECIFIED enums Fleet blanks out.
+func TestGenerateDeviceVitalsAcrossFleet(t *testing.T) {
+	const deviceCount = 400
+
+	var (
+		postures       = map[string]int{}
+		updateStatuses = map[string]int{}
+		activations    = map[string]int{}
+		configModes    = map[string]int{}
+		dualSIM        int
+		adbEnabled     int
+		insecure       int
+	)
+
+	for i := 0; i < deviceCount; i++ {
+		agent := newVitalsTestAgent("http://fleet.invalid")
+
+		assert.Equal(t, androidManufacturers[agent.brand], agent.manufacturer)
+		assert.NotEmpty(t, agent.manufacturer, "brand %q has no manufacturer mapping", agent.brand)
+		assert.Equal(t, androidAPILevels[agent.androidVersion], agent.apiLevel)
+		assert.Positive(t, agent.apiLevel, "Android %q has no API level mapping", agent.androidVersion)
+
+		assert.Contains(t, androidSecurityPatchLevels, agent.securityPatchLevel)
+		assert.Contains(t, agent.deviceKernelVersion, "-android"+agent.androidVersion+"-",
+			"the kernel must name the Android release it ships on")
+		assert.True(t, strings.HasPrefix(agent.deviceKernelVersion, androidKernelBases[agent.androidVersion]+"."),
+			"kernel %q does not start with the %q line", agent.deviceKernelVersion, androidKernelBases[agent.androidVersion])
+		assert.Contains(t, agent.bootloaderVersion, agent.hardware)
+
+		assert.Contains(t, validEncryptionStatuses, agent.encryptionStatus)
+		assert.Contains(t, validUpdateStatuses, agent.systemUpdateStatus)
+		assert.Contains(t, validPostures, agent.securityPosture)
+
+		// AMAPI only attaches posture details to a device that is not secure.
+		if agent.securityPosture == "SECURE" {
+			assert.Empty(t, agent.postureDetails, "a secure device reports no posture details")
+		} else {
+			require.NotEmpty(t, agent.postureDetails, "posture %q must explain itself", agent.securityPosture)
+			for _, detail := range agent.postureDetails {
+				require.NotNil(t, detail)
+				assert.Contains(t, validSecurityRisks, detail.SecurityRisk)
+				require.NotEmpty(t, detail.Advice)
+				for _, advice := range detail.Advice {
+					require.NotNil(t, advice)
+					assert.NotEmpty(t, advice.DefaultMessage, "Fleet only keeps the default message")
+				}
+			}
+		}
+
+		require.NotEmpty(t, agent.telephonyInfos)
+		require.LessOrEqual(t, len(agent.telephonyInfos), 2, "no simulated device has more than two SIMs")
+		for _, sim := range agent.telephonyInfos {
+			require.NotNil(t, sim)
+			assert.Regexp(t, `^\+1[0-9]{10}$`, sim.PhoneNumber)
+			assert.Regexp(t, `^89[0-9]{17}$`, sim.IccId, "an ICCID is 19 digits starting with 89")
+			assert.Contains(t, androidCarriers, sim.CarrierName)
+			assert.Contains(t, validActivationStates, sim.ActivationState)
+			assert.Contains(t, validConfigModes, sim.ConfigMode)
+			// A physical SIM reports neither eSIM enum, and an eSIM reports both.
+			if sim.ActivationState == "ACTIVATION_STATE_UNSPECIFIED" {
+				assert.Equal(t, "CONFIG_MODE_UNSPECIFIED", sim.ConfigMode, "a physical SIM has no config mode")
+			} else {
+				assert.NotEqual(t, "CONFIG_MODE_UNSPECIFIED", sim.ConfigMode, "an eSIM reports a config mode")
+			}
+			// Every value is stored in a varchar(255) column.
+			assert.LessOrEqual(t, len(sim.PhoneNumber), fleet.MDMAndroidDeviceVitalMaxLength)
+			assert.LessOrEqual(t, len(sim.CarrierName), fleet.MDMAndroidDeviceVitalMaxLength)
+			assert.LessOrEqual(t, len(sim.IccId), fleet.MDMAndroidDeviceVitalMaxLength)
+
+			activations[sim.ActivationState]++
+			configModes[sim.ConfigMode]++
+		}
+
+		// Nothing generated may exceed the vitals columns' width.
+		for name, value := range map[string]string{
+			"manufacturer":     agent.manufacturer,
+			"patch level":      agent.securityPatchLevel,
+			"kernel version":   agent.deviceKernelVersion,
+			"bootloader":       agent.bootloaderVersion,
+			"encryption":       agent.encryptionStatus,
+			"update status":    agent.systemUpdateStatus,
+			"security posture": agent.securityPosture,
+		} {
+			assert.LessOrEqual(t, len(value), fleet.MDMAndroidDeviceVitalMaxLength, "%s is too long for its column", name)
+		}
+
+		postures[agent.securityPosture]++
+		updateStatuses[agent.systemUpdateStatus]++
+		if len(agent.telephonyInfos) == 2 {
+			dualSIM++
+		}
+		if agent.adbEnabled {
+			adbEnabled++
+		}
+		if !agent.deviceSecure {
+			insecure++
+		}
+	}
+
+	// The point of the weighting is a fleet that is mostly healthy but not
+	// uniformly so; a fleet with only one value in any of these gives the vitals
+	// UI and API nothing to distinguish.
+	assert.Greater(t, postures["SECURE"], postures["AT_RISK"], "most devices should be secure")
+	assert.Positive(t, postures["AT_RISK"])
+	assert.Positive(t, postures["POTENTIALLY_COMPROMISED"])
+	assert.Greater(t, updateStatuses["UP_TO_DATE"], updateStatuses["OS_UPDATE_AVAILABLE"])
+	assert.Positive(t, updateStatuses["SECURITY_UPDATE_AVAILABLE"])
+	assert.Positive(t, updateStatuses["OS_UPDATE_AVAILABLE"])
+	assert.Positive(t, dualSIM, "some devices should be dual-SIM")
+	assert.Less(t, dualSIM, deviceCount, "not every device should be dual-SIM")
+	assert.Positive(t, adbEnabled, "a few devices should have ADB on")
+	assert.Less(t, adbEnabled, deviceCount/2, "ADB on should stay rare")
+	assert.Positive(t, insecure, "a few devices should have no passcode")
+
+	// Both SIM kinds must appear, since Fleet stores their enums differently.
+	assert.Positive(t, activations["ACTIVATION_STATE_UNSPECIFIED"], "physical SIMs")
+	assert.Positive(t, activations["ACTIVATED"], "activated eSIMs")
+	assert.Positive(t, configModes["ADMIN_CONFIGURED"])
+	assert.Positive(t, configModes["USER_CONFIGURED"])
+}
+
+// TestWeightedChoice covers the picker the vitals distributions rely on.
+func TestWeightedChoice(t *testing.T) {
+	t.Run("a certain value is always picked", func(t *testing.T) {
+		for range 20 {
+			assert.Equal(t, "only", weightedChoice([]weightedValue{{"only", 1}}))
+		}
+	})
+
+	t.Run("a zero-weight value is never picked", func(t *testing.T) {
+		for range 100 {
+			assert.Equal(t, "always", weightedChoice([]weightedValue{{"never", 0}, {"always", 1}}))
+		}
+	})
+
+	// rand.Float64 can return a value the cumulative weights don't reach when they
+	// sum to slightly under 1; that must still yield a real value, not "".
+	t.Run("a short weight sum falls back to the last value", func(t *testing.T) {
+		for range 100 {
+			got := weightedChoice([]weightedValue{{"first", 0.1}, {"last", 0.1}})
+			assert.Contains(t, []string{"first", "last"}, got)
+		}
+	})
+
+	t.Run("every value is reachable", func(t *testing.T) {
+		seen := map[string]bool{}
+		for range 1000 {
+			seen[weightedChoice([]weightedValue{{"a", 0.4}, {"b", 0.4}, {"c", 0.2}})] = true
+		}
+		assert.Equal(t, map[string]bool{"a": true, "b": true, "c": true}, seen)
+	})
 }

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -439,6 +439,7 @@ func newFullVitalsTestAgent(fleetAddress string) *androidAgent {
 	agent.reportsDeviceSettings = true
 	agent.reportsSecurityPosture = true
 	agent.vitalsChurnProb = 0
+	agent.policyEditProb = 0
 	return agent
 }
 
@@ -590,6 +591,12 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 	srv := fleetPubSub.server(t)
 	agent := newVitalsTestAgent(srv.URL)
 	agent.vitalsChurnProb = 1 // re-roll on every report
+	// Sections are pinned on: this test is about the values moving, and a device
+	// that stopped reporting a section would leave the assertions below no
+	// samples to compare. TestSectionGoingAwayNullsItsColumns covers that side.
+	agent.reportsDeviceSettings = true
+	agent.reportsSecurityPosture = true
+	agent.policyEditProb = 0
 
 	state := testState()
 	// Enough reports that a value failing to move is a real failure and not a run
@@ -673,6 +680,11 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 		}
 	}
 
+	// Every report must have carried both sections, or the assertions below would
+	// be comparing a handful of samples, or none at all.
+	assert.Equal(t, reports, countValues(settings), "every report must carry deviceSettings")
+	assert.Equal(t, reports, countValues(postures), "every report must carry securityPosture")
+
 	// Across every re-roll each of these must have taken more than one value, or
 	// the vitals row would be written once and then never change again.
 	assert.Greater(t, len(settings), 1, "device settings never changed across %d reports", reports)
@@ -681,6 +693,15 @@ func TestStatusReportsChurnVolatileVitals(t *testing.T) {
 	if hasESIM {
 		assert.Greater(t, len(simConfigModes), 1, "eSIM config mode never changed across %d reports", reports)
 	}
+}
+
+// countValues totals the observations tallied in a value-count map.
+func countValues(counts map[string]int) int {
+	var total int
+	for _, n := range counts {
+		total += n
+	}
+	return total
 }
 
 // TestUncollectedSectionsAreOmitted covers the other side of the vitals write: a


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51204

Fleet ingests Android host vitals from the AMAPI device payloads it receives over Pub/Sub (#52039, #52304), but the osquery-perf Android agent sent none of the sections those vitals come from. Load tests therefore wrote all-NULL `host_mdm_android_device_vitals` rows and never exercised the new columns.

The simulated device now reports every field `androidDeviceVitals` reads:

| AMAPI path | vitals column(s) |
|---|---|
| `apiLevel` | `api_level` |
| `deviceSettings.{adbEnabled,isDeviceSecure,verifyAppsEnabled,encryptionStatus}` | `adb_enabled`, `passcode_protected`, `play_protect_enabled`, `encryption_type` |
| `hardwareInfo.manufacturer` | `manufacturer` |
| `softwareInfo.{securityPatchLevel,deviceKernelVersion,bootloaderVersion,systemUpdateInfo.updateStatus}` | `security_update_version`, `device_kernel_version`, `bootloader_version`, `system_update_status` |
| `securityPosture.{devicePosture,postureDetails}` | `security_posture`, `security_posture_details` (JSON) |
| `networkInfo.telephonyInfos[]` | `telephony_infos` (JSON) |
| `networkInfo.{imei,meid}` | `imei`, `meid` |

Values are weighted so a simulated fleet is mostly healthy with a realistic minority of devices that are out of date, insecure or compromised, rather than 400 identical hosts.

## Stable vs. volatile vitals

The vitals are split in two, because reporting a fixed set forever would have measured almost none of this table's write cost: `SetOrUpdateHostMDMAndroidDeviceVitals` overwrites every column on every status report, but MySQL changes no row, writes no redo or binlog entry and does not advance `updated_at` when the values are identical.

- **Stable** (device identity, never moves): manufacturer, API level, kernel, bootloader, security patch level, SIM cards, IMEI/MEID, encryption status.
- **Volatile** (re-rolled on a share of status reports): ADB/passcode/Play Protect, system update status, security posture and its details, eSIM activation state and config mode.

Encryption status is deliberately stable: `UNSUPPORTED` is a property of the device, and file-based vs. full-disk encryption is fixed at first boot, so none of those transitions exist on real hardware. IMEI and MEID are mutually exclusive — a device has one radio — and MEID only appears on the rare North American device still on CDMA.

Devices also omit the `deviceSettings` and `securityPosture` sections some of the time, the way AMAPI does when the applied policy stops collecting them, which is what exercises Fleet nulling those columns. Which sections a device collects is decided per device rather than per report, so hosts don't flicker between populated and empty vitals.

## Notes for reviewers

- **New flag:** `--android_vitals_churn_prob` (default 0.2) controls how often a status report reports changed vitals, alongside the existing `--android_non_compliance_prob`. Setting it to 0 reproduces the old behaviour of reporting identical vitals forever.
- **Existing load-test baselines shift.** Reporting `securityPatchLevel` means Fleet now derives `os_version` as `Android 15 (2026-06-01)` instead of a bare `Android 15`, so Android hosts produce more `operating_systems` rows than before. This is unavoidable — the patch level *is* the `security_update_version` vital — but it's worth knowing when diffing against an older baseline.
- The security patch level is pinned per device even though a real device's moves when it installs an update, so a simulated device can report `SECURITY_UPDATE_AVAILABLE` and then `UP_TO_DATE` without it changing. Churning it would also churn `hosts.os_version`, `operating_systems` and `host_operating_system` — a much wider blast radius than the vitals table this change is about.
- `sendEnrollment` and `sendStatusReport` now share a `deviceInfo()` payload builder. Fleet writes vitals on both paths (`addNewHost` and `updateHost`), so the two payloads have to agree.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

No changes file: this only touches the load-testing tool, so there is no user-visible change.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

Automated coverage in `cmd/osquery-perf/android_agent_test.go`, all against a fake Fleet Pub/Sub endpoint that decodes the real wire payload:

- both message types carry every vitals section, and the enrollment and status-report payloads agree
- across 150 status reports the device's identity holds still while the volatile vitals move, and posture details are dropped when a device becomes `SECURE` again
- an uncollected section is absent from the payload rather than present and empty, and a section going away and coming back is covered explicitly
- IMEI/MEID are mutually exclusive and correctly formatted, everywhere they are asserted
- 400 generated devices: enum values are real AMAPI members, nothing exceeds `varchar(255)`, values are internally consistent (API level ↔ release, kernel line ↔ release, physical SIM vs. eSIM), and the fleet-wide mix covers both branches Fleet treats differently, with ±5σ bands on each weight
- the SIM snapshot handed to the marshaller is independent of the agent's own SIMs
- the three per-release/per-brand maps agree, and the derived security patch level dates are correct including on the 31st of a month

Manual QA against a live stack is still to do. Repro, with a local Fleet (Android enabled) and `go run ./cmd/android-amapi-mock`:

```sh
go run ./cmd/osquery-perf --os_templates android --host_count 5 \
  --server_url <fleet> --enroll_secret <secret> \
  --android_pubsub_token <token> --android_proxy_address http://localhost:9999 \
  --android_enterprise_id <LCxxx> --android_status_interval 30s \
  --android_vitals_churn_prob 1
```

Then check that `GET /api/v1/fleet/hosts/:id` returns the new vitals fields, that `host_mdm_android_device_vitals` is populated with varied values across hosts, and that `updated_at` advances between status reports (and stops advancing with `--android_vitals_churn_prob 0`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable Android vitals churn for performance testing, allowing status reports to simulate unchanged or changing device data.
  - Android enrollment and status reports now include richer device information, including security posture, system details, radio identifiers, SIM data, settings, and policy-related sections.
  - Reports accurately reflect sections that are added, removed, or omitted over time.
- **Bug Fixes**
  - Improved consistency between enrollment data and subsequent status reports.
  - Ensured serialized device settings and SIM information are represented reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->