### PR TITLE
Handbook: clarify #help-releases threads are only for release date discussions

### DIFF
--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -200,7 +200,7 @@ When target release dates are changed on the calendar, the release ritual DRI al
 
 ## Discuss release dates
 
-A single Slack thread is created in the #help-releases channel for every release candidate. Any discussions about release dates should be kept within the release candidate's thread.
+A single Slack thread is created in the #help-releases channel for every release candidate. Only discussions about release dates should be kept within the release candidate's thread.
 
 
 ## Handle process exceptions for non-released code


### PR DESCRIPTION
Changes "Any" to "Only" in the [Discuss release dates](https://fleetdm.com/handbook/engineering#discuss-release-dates) section, so the handbook states that release candidate threads in #help-releases are only for discussions about release dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)