### PR TITLE
Handbook: fix grammar in release date discussion guidance

### DIFF
--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -200,7 +200,7 @@ When target release dates are changed on the calendar, the release ritual DRI al
 
 ## Discuss release dates
 
-A single Slack thread is created in the #help-releases channel for every release candidate. Only discussions about release dates should be kept within the release candidate's thread.
+A single Slack thread is created in the #help-releases channel for every release candidate. Discussions in the release candidate's thread should be limited to release dates.
 
 
 ## Handle process exceptions for non-released code


### PR DESCRIPTION
Follow-up to #52324. Rewords the sentence so it reads naturally while keeping the same meaning: the release candidate's thread in #help-releases is only for discussing release dates.

Before: "Only discussions about release dates should be kept within the release candidate's thread."
After: "Discussions in the release candidate's thread should be limited to release dates."

🤖 Generated with [Claude Code](https://claude.com/claude-code)