### PR TITLE
Keep enrollment error detail on the server log line

### DIFF
--- a/changes/enroll-error-detail
+++ b/changes/enroll-error-detail
@@ -1,0 +1,1 @@
+- Stopped returning internal error details to osquery and Orbit when enrollment fails. Agents now receive only the stage that failed; the underlying reason is logged by the Fleet server.

--- a/server/service/enroll_error_test.go
+++ b/server/service/enroll_error_test.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrollError(t *testing.T) {
+	t.Parallel()
+
+	dbErr := errors.New("Error 1406 (22001): Data too long for column 'osquery_host_id'")
+
+	t.Run("detail moves to the log line", func(t *testing.T) {
+		t.Parallel()
+		ctx := logging.NewContext(t.Context(), &logging.LoggingContext{})
+		err := enrollError(ctx, dbErr, "save host in enroll agent")
+
+		require.EqualError(t, err, "save host in enroll agent")
+		require.NotContains(t, err.Error(), "osquery_host_id")
+		logCtx, _ := logging.FromContext(ctx)
+		require.Contains(t, logCtx.Extras, dbErr.Error())
+	})
+
+	t.Run("cancellation keeps its identity", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(logging.NewContext(t.Context(), &logging.LoggingContext{}))
+		cancel()
+		err := enrollError(ctx, context.Canceled, "save host in enroll agent")
+
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotContains(t, err.Error(), "osquery_host_id")
+	})
+}

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -331,9 +331,8 @@ func (s *integrationLoggerTestSuite) TestEnrollOsqueryLogsErrors() {
 	require.Len(t, records, 1)
 	assert.Equal(t, slog.LevelInfo, records[0].Level)
 	attrs := testutils.RecordAttrs(&records[0])
-	errStr := fmt.Sprint(attrs["err"])
-	assert.Contains(t, errStr, "enroll failed:")
-	assert.Contains(t, errStr, "no matching secret found")
+	assert.Contains(t, fmt.Sprint(attrs["err"]), "enroll failed")
+	assert.Contains(t, fmt.Sprint(attrs["internal"]), "no matching secret found")
 }
 
 func (s *integrationLoggerTestSuite) TestSetupExperienceEULAMetadataDoesNotLogErrorIfNotFound() {

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -332,6 +332,7 @@ func (s *integrationLoggerTestSuite) TestEnrollOsqueryLogsErrors() {
 	assert.Equal(t, slog.LevelInfo, records[0].Level)
 	attrs := testutils.RecordAttrs(&records[0])
 	assert.Contains(t, fmt.Sprint(attrs["err"]), "enroll failed")
+	assert.NotContains(t, fmt.Sprint(attrs["err"]), "no matching secret found")
 	assert.Contains(t, fmt.Sprint(attrs["internal"]), "no matching secret found")
 }
 

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -122,8 +122,7 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 				"device_id", deviceID, "host_uuid", hostUUID)
 			return "", "", "", fleet.NewOrbitIDPAuthRequiredError()
 		}
-		recordErrorDetail(ctx, err)
-		return "", "", "", ctxerr.New(ctx, "getting windows mdm enrollment for EUA token")
+		return "", "", "", enrollError(ctx, err, "getting windows mdm enrollment for EUA token")
 	}
 
 	// Fetch or create the mdm_idp_accounts row for this email.
@@ -131,19 +130,16 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 	// that may have been populated by SCIM provisioning.
 	acct, err := svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 	if err != nil && !fleet.IsNotFound(err) {
-		recordErrorDetail(ctx, err)
-		return "", "", "", ctxerr.New(ctx, "getting mdm idp account by email for EUA token")
+		return "", "", "", enrollError(ctx, err, "getting mdm idp account by email for EUA token")
 	}
 	if fleet.IsNotFound(err) {
 		if err := svc.ds.InsertMDMIdPAccount(ctx, &fleet.MDMIdPAccount{Email: upn, Username: upn}); err != nil {
-			recordErrorDetail(ctx, err)
-			return "", "", "", ctxerr.New(ctx, "inserting mdm idp account for EUA token")
+			return "", "", "", enrollError(ctx, err, "inserting mdm idp account for EUA token")
 		}
 		// Re-fetch to get the UUID assigned by the DB.
 		acct, err = svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 		if err != nil {
-			recordErrorDetail(ctx, err)
-			return "", "", "", ctxerr.New(ctx, "re-fetching mdm idp account after insert for EUA token")
+			return "", "", "", enrollError(ctx, err, "re-fetching mdm idp account after insert for EUA token")
 		}
 	}
 	if acct == nil {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -122,7 +122,8 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 				"device_id", deviceID, "host_uuid", hostUUID)
 			return "", "", "", fleet.NewOrbitIDPAuthRequiredError()
 		}
-		return "", "", "", ctxerr.Wrap(ctx, err, "getting windows mdm enrollment for EUA token")
+		recordErrorDetail(ctx, err)
+		return "", "", "", ctxerr.New(ctx, "getting windows mdm enrollment for EUA token")
 	}
 
 	// Fetch or create the mdm_idp_accounts row for this email.
@@ -130,16 +131,19 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 	// that may have been populated by SCIM provisioning.
 	acct, err := svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 	if err != nil && !fleet.IsNotFound(err) {
-		return "", "", "", ctxerr.Wrap(ctx, err, "getting mdm idp account by email for EUA token")
+		recordErrorDetail(ctx, err)
+		return "", "", "", ctxerr.New(ctx, "getting mdm idp account by email for EUA token")
 	}
 	if fleet.IsNotFound(err) {
 		if err := svc.ds.InsertMDMIdPAccount(ctx, &fleet.MDMIdPAccount{Email: upn, Username: upn}); err != nil {
-			return "", "", "", ctxerr.Wrap(ctx, err, "inserting mdm idp account for EUA token")
+			recordErrorDetail(ctx, err)
+			return "", "", "", ctxerr.New(ctx, "inserting mdm idp account for EUA token")
 		}
 		// Re-fetch to get the UUID assigned by the DB.
 		acct, err = svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 		if err != nil {
-			return "", "", "", ctxerr.Wrap(ctx, err, "re-fetching mdm idp account after insert for EUA token")
+			recordErrorDetail(ctx, err)
+			return "", "", "", ctxerr.New(ctx, "re-fetching mdm idp account after insert for EUA token")
 		}
 	}
 	if acct == nil {
@@ -188,7 +192,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 			// 	3. Orbit tries to re-enroll using old secret.
 			return "", fleet.NewAuthFailedError("invalid secret")
 		}
-		return "", fleet.OrbitError{Message: err.Error()}
+		recordErrorDetail(ctx, err)
+		return "", fleet.OrbitError{Message: "enroll failed"}
 	}
 
 	identifier := hostInfo.OsqueryIdentifier
@@ -198,7 +203,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 
 	identityCert, err := svc.ds.GetHostIdentityCertByName(ctx, identifier)
 	if err != nil && !fleet.IsNotFound(err) {
-		return "", fleet.OrbitError{Message: fmt.Sprintf("loading certificate: %s", err.Error())}
+		recordErrorDetail(ctx, err)
+		return "", fleet.OrbitError{Message: "loading certificate"}
 	}
 
 	// If an identity certificate exists for this host, make sure the request had an HTTP message signature with the matching certificate.
@@ -216,19 +222,22 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 
 	orbitNodeKey, err := server.GenerateRandomText(svc.config.Osquery.NodeKeySize)
 	if err != nil {
-		return "", fleet.OrbitError{Message: "failed to generate orbit node key: " + err.Error()}
+		recordErrorDetail(ctx, err)
+		return "", fleet.OrbitError{Message: "failed to generate orbit node key"}
 	}
 
 	appConfig, err := svc.ds.AppConfig(ctx)
 	if err != nil {
-		return "", fleet.OrbitError{Message: "app config load failed: " + err.Error()}
+		recordErrorDetail(ctx, err)
+		return "", fleet.OrbitError{Message: "app config load failed"}
 	}
 	isEndUserAuthRequired := appConfig.MDM.MacOSSetup.EnableEndUserAuthentication
 	// If the secret is for a team, get the team config as well.
 	if secret.TeamID != nil {
 		team, err := svc.ds.TeamLite(ctx, *secret.TeamID)
 		if err != nil {
-			return "", fleet.OrbitError{Message: "failed to get team config: " + err.Error()}
+			recordErrorDetail(ctx, err)
+			return "", fleet.OrbitError{Message: "failed to get team config"}
 		}
 		isEndUserAuthRequired = team.Config.MDM.MacOSSetup.EnableEndUserAuthentication
 	}
@@ -242,7 +251,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		// Try to find an IdP account for this host.
 		idpAccount, err := svc.ds.GetMDMIdPAccountByHostUUID(ctx, hostInfo.HardwareUUID)
 		if err != nil {
-			return "", fleet.OrbitError{Message: "failed to get IdP account: " + err.Error()}
+			recordErrorDetail(ctx, err)
+			return "", fleet.OrbitError{Message: "failed to get IdP account"}
 		}
 		if idpAccount == nil {
 			// Get the host platform.
@@ -285,7 +295,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 					// prompt for end user authentication again. See https://github.com/fleetdm/fleet/issues/46300.
 					previouslyEnrolled, err := svc.ds.HostPreviouslyOrbitEnrolled(ctx, hostInfo, appConfig.MDM.EnabledAndConfigured)
 					if err != nil {
-						return "", fleet.OrbitError{Message: "failed to check for prior orbit enrollment: " + err.Error()}
+						recordErrorDetail(ctx, err)
+						return "", fleet.OrbitError{Message: "failed to check for prior orbit enrollment"}
 					}
 					if !previouslyEnrolled {
 						// Report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
@@ -317,7 +328,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		fleet.WithEnrollOrbitIdentityCert(identityCert),
 	)
 	if err != nil {
-		return "", fleet.OrbitError{Message: "failed to enroll " + err.Error()}
+		recordErrorDetail(ctx, err)
+		return "", fleet.OrbitError{Message: "failed to enroll"}
 	}
 
 	platform := host.FleetPlatform()

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -93,6 +93,18 @@ func (svc *Service) AuthenticateOrbitHost(ctx context.Context, orbitNodeKey stri
 	return host, svc.debugEnabledForHost(ctx, host.ID), nil
 }
 
+// euaTokenError records the underlying error on the log line and returns the
+// uniform OrbitError shape the rest of EnrollOrbit uses, so an EUA token failure
+// is answered with the same status and body as any other enroll failure. A
+// cancelled request is passed through so the transport still answers 499.
+func euaTokenError(ctx context.Context, err error, msg string) error {
+	if errors.Is(err, context.Canceled) {
+		return ctxerr.Wrap(ctx, err, msg)
+	}
+	recordErrorDetail(ctx, err)
+	return fleet.OrbitError{Message: msg}
+}
+
 // processWindowsEUAToken validates a Fleet-signed EUA token from the Windows MSI
 // installer, ensures the IdP account exists, and returns the UPN, device ID,
 // and IdP account UUID. The actual host_mdm_idp_accounts row is written by
@@ -122,7 +134,7 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 				"device_id", deviceID, "host_uuid", hostUUID)
 			return "", "", "", fleet.NewOrbitIDPAuthRequiredError()
 		}
-		return "", "", "", enrollError(ctx, err, "getting windows mdm enrollment for EUA token")
+		return "", "", "", euaTokenError(ctx, err, "getting windows mdm enrollment for EUA token")
 	}
 
 	// Fetch or create the mdm_idp_accounts row for this email.
@@ -130,20 +142,20 @@ func (svc *Service) processWindowsEUAToken(ctx context.Context, hostUUID string,
 	// that may have been populated by SCIM provisioning.
 	acct, err := svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 	if err != nil && !fleet.IsNotFound(err) {
-		return "", "", "", enrollError(ctx, err, "getting mdm idp account by email for EUA token")
+		return "", "", "", euaTokenError(ctx, err, "getting mdm idp account by email for EUA token")
 	}
 	if fleet.IsNotFound(err) {
 		if err := svc.ds.InsertMDMIdPAccount(ctx, &fleet.MDMIdPAccount{Email: upn, Username: upn}); err != nil {
-			return "", "", "", enrollError(ctx, err, "inserting mdm idp account for EUA token")
+			return "", "", "", euaTokenError(ctx, err, "inserting mdm idp account for EUA token")
 		}
 		// Re-fetch to get the UUID assigned by the DB.
 		acct, err = svc.ds.GetMDMIdPAccountByEmail(ctx, upn)
 		if err != nil {
-			return "", "", "", enrollError(ctx, err, "re-fetching mdm idp account after insert for EUA token")
+			return "", "", "", euaTokenError(ctx, err, "re-fetching mdm idp account after insert for EUA token")
 		}
 	}
 	if acct == nil {
-		return "", "", "", ctxerr.New(ctx, "mdm idp account not found for EUA token")
+		return "", "", "", fleet.OrbitError{Message: "mdm idp account not found for EUA token"}
 	}
 
 	return upn, deviceID, acct.UUID, nil

--- a/server/service/orbit_eua_test.go
+++ b/server/service/orbit_eua_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -180,6 +181,26 @@ func TestProcessWindowsEUAToken(t *testing.T) {
 		require.Equal(t, testDeviceID, deviceID)
 		require.Equal(t, testAcctUUID, idpAcctUUID)
 		require.True(t, ds.GetMDMIdPAccountByEmailFuncInvoked, "should still fetch idp account even when enrollment has host_uuid")
+	})
+
+	t.Run("a datastore failure returns a generic OrbitError without the underlying detail", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc := newTestServiceWithWSTEP(t, ds)
+		token := makeToken(t, svc, testUPN, testDeviceID)
+
+		ds.MDMWindowsGetEnrolledDeviceWithDeviceIDFunc = func(ctx context.Context, mdmDeviceID string) (*fleet.MDMWindowsEnrolledDevice, error) {
+			return nil, fmt.Errorf("idp_accounts read failed: %w", context.DeadlineExceeded)
+		}
+
+		_, _, _, err := svc.processWindowsEUAToken(context.Background(), testHostUUID, token)
+		require.Error(t, err)
+		// same OrbitError shape as every other EnrollOrbit failure, with a generic
+		// message; the underlying error stays on the log line, not in the response
+		var orbitErr fleet.OrbitError
+		require.ErrorAs(t, err, &orbitErr)
+		require.Equal(t, "getting windows mdm enrollment for EUA token", orbitErr.Message)
+		require.NotContains(t, orbitErr.Message, "idp_accounts")
+		require.NotEqual(t, "END_USER_AUTH_REQUIRED", orbitErr.Message)
 	})
 
 	t.Run("invalid token falls back to END_USER_AUTH_REQUIRED", func(t *testing.T) {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -50,6 +50,14 @@ func newOsqueryError(msg string) *OsqueryError {
 	return NewOsqueryError(msg, false)
 }
 
+// recordErrorDetail keeps error detail on the request log line and off the
+// response, since the enroll endpoints are unauthenticated. Callers must not
+// return an error implementing ErrWithInternal, or the line gets two "internal"
+// attrs.
+func recordErrorDetail(ctx context.Context, err error) {
+	logging.WithExtras(ctx, "internal", err.Error())
+}
+
 func (svc *Service) AuthenticateHost(ctx context.Context, nodeKey string) (*fleet.Host, bool, error) {
 	// skipauth: Authorization is currently for user endpoints only.
 	svc.authz.SkipAuthorization(ctx)
@@ -134,12 +142,14 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 
 	secret, err := svc.ds.VerifyEnrollSecret(ctx, enrollSecret)
 	if err != nil {
-		return "", newOsqueryErrorWithInvalidNode("enroll failed: " + err.Error())
+		recordErrorDetail(ctx, err)
+		return "", newOsqueryErrorWithInvalidNode("enroll failed")
 	}
 
 	identityCert, err := svc.ds.GetHostIdentityCertByName(ctx, hostIdentifier)
 	if err != nil && !fleet.IsNotFound(err) {
-		return "", fleet.OrbitError{Message: fmt.Sprintf("loading certificate: %s", err.Error())}
+		recordErrorDetail(ctx, err)
+		return "", fleet.OrbitError{Message: "loading certificate"}
 	}
 
 	// If an identity certificate exists for this host, make sure the request had an HTTP message signature with the matching certificate.
@@ -157,13 +167,15 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 
 	nodeKey, err := server.GenerateRandomText(svc.config.Osquery.NodeKeySize)
 	if err != nil {
-		return "", newOsqueryErrorWithInvalidNode("generate node key failed: " + err.Error())
+		recordErrorDetail(ctx, err)
+		return "", newOsqueryErrorWithInvalidNode("generate node key failed")
 	}
 
 	hostIdentifier = getHostIdentifier(ctx, svc.logger, svc.config.Osquery.HostIdentifier, hostIdentifier, hostDetails)
 	canEnroll, err := svc.enrollHostLimiter.CanEnrollNewHost(ctx)
 	if err != nil {
-		return "", newOsqueryErrorWithInvalidNode("can enroll host check failed: " + err.Error())
+		recordErrorDetail(ctx, err)
+		return "", newOsqueryErrorWithInvalidNode("can enroll host check failed")
 	}
 	if !canEnroll {
 		deviceCount := "unknown"
@@ -183,7 +195,8 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 
 	appConfig, err := svc.ds.AppConfig(ctx)
 	if err != nil {
-		return "", newOsqueryErrorWithInvalidNode("app config load failed: " + err.Error())
+		recordErrorDetail(ctx, err)
+		return "", newOsqueryErrorWithInvalidNode("app config load failed")
 	}
 
 	host, err := svc.ds.EnrollOsquery(ctx,
@@ -197,12 +210,14 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 		fleet.WithEnrollOsqueryIdentityCert(identityCert),
 	)
 	if err != nil {
-		return "", newOsqueryErrorWithInvalidNode("save enroll failed: " + err.Error())
+		recordErrorDetail(ctx, err)
+		return "", newOsqueryErrorWithInvalidNode("save enroll failed")
 	}
 
 	features, err := svc.HostFeatures(ctx, host)
 	if err != nil {
-		return "", newOsqueryErrorWithInvalidNode("host features load failed: " + err.Error())
+		recordErrorDetail(ctx, err)
+		return "", newOsqueryErrorWithInvalidNode("host features load failed")
 	}
 
 	// Save enrollment details if provided
@@ -219,21 +234,24 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 	if r, ok := hostDetails["os_version"]; ok {
 		err := detailQueries["os_version"].IngestFunc(ctx, svc.logger, host, []map[string]string{r})
 		if err != nil {
-			return "", ctxerr.Wrap(ctx, err, "Ingesting os_version")
+			recordErrorDetail(ctx, err)
+			return "", ctxerr.New(ctx, "Ingesting os_version")
 		}
 		save = true
 	}
 	if r, ok := hostDetails["osquery_info"]; ok {
 		err := detailQueries["osquery_info"].IngestFunc(ctx, svc.logger, host, []map[string]string{r})
 		if err != nil {
-			return "", ctxerr.Wrap(ctx, err, "Ingesting osquery_info")
+			recordErrorDetail(ctx, err)
+			return "", ctxerr.New(ctx, "Ingesting osquery_info")
 		}
 		save = true
 	}
 	if r, ok := hostDetails["system_info"]; ok {
 		err := detailQueries["system_info"].IngestFunc(ctx, svc.logger, host, []map[string]string{r})
 		if err != nil {
-			return "", ctxerr.Wrap(ctx, err, "Ingesting system_info")
+			recordErrorDetail(ctx, err)
+			return "", ctxerr.New(ctx, "Ingesting system_info")
 		}
 		save = true
 	}
@@ -243,7 +261,8 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 			go svc.serialUpdateHost(ctx, host)
 		} else {
 			if err := svc.ds.UpdateHost(ctx, host); err != nil {
-				return "", ctxerr.Wrap(ctx, err, "save host in enroll agent")
+				recordErrorDetail(ctx, err)
+				return "", ctxerr.New(ctx, "save host in enroll agent")
 			}
 		}
 	}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -58,6 +58,17 @@ func recordErrorDetail(ctx context.Context, err error) {
 	logging.WithExtras(ctx, "internal", err.Error())
 }
 
+// enrollError is recordErrorDetail for sites that return a plain error. A
+// cancellation is wrapped rather than replaced so the transport still answers
+// 499 when the client went away.
+func enrollError(ctx context.Context, err error, msg string) error {
+	if errors.Is(err, context.Canceled) {
+		return ctxerr.Wrap(ctx, err, msg)
+	}
+	recordErrorDetail(ctx, err)
+	return ctxerr.New(ctx, msg)
+}
+
 func (svc *Service) AuthenticateHost(ctx context.Context, nodeKey string) (*fleet.Host, bool, error) {
 	// skipauth: Authorization is currently for user endpoints only.
 	svc.authz.SkipAuthorization(ctx)
@@ -234,24 +245,21 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 	if r, ok := hostDetails["os_version"]; ok {
 		err := detailQueries["os_version"].IngestFunc(ctx, svc.logger, host, []map[string]string{r})
 		if err != nil {
-			recordErrorDetail(ctx, err)
-			return "", ctxerr.New(ctx, "Ingesting os_version")
+			return "", enrollError(ctx, err, "Ingesting os_version")
 		}
 		save = true
 	}
 	if r, ok := hostDetails["osquery_info"]; ok {
 		err := detailQueries["osquery_info"].IngestFunc(ctx, svc.logger, host, []map[string]string{r})
 		if err != nil {
-			recordErrorDetail(ctx, err)
-			return "", ctxerr.New(ctx, "Ingesting osquery_info")
+			return "", enrollError(ctx, err, "Ingesting osquery_info")
 		}
 		save = true
 	}
 	if r, ok := hostDetails["system_info"]; ok {
 		err := detailQueries["system_info"].IngestFunc(ctx, svc.logger, host, []map[string]string{r})
 		if err != nil {
-			recordErrorDetail(ctx, err)
-			return "", ctxerr.New(ctx, "Ingesting system_info")
+			return "", enrollError(ctx, err, "Ingesting system_info")
 		}
 		save = true
 	}
@@ -261,8 +269,7 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 			go svc.serialUpdateHost(ctx, host)
 		} else {
 			if err := svc.ds.UpdateHost(ctx, host); err != nil {
-				recordErrorDetail(ctx, err)
-				return "", ctxerr.New(ctx, "save host in enroll agent")
+				return "", enrollError(ctx, err, "save host in enroll agent")
 			}
 		}
 	}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -160,7 +160,7 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 	identityCert, err := svc.ds.GetHostIdentityCertByName(ctx, hostIdentifier)
 	if err != nil && !fleet.IsNotFound(err) {
 		recordErrorDetail(ctx, err)
-		return "", fleet.OrbitError{Message: "loading certificate"}
+		return "", newOsqueryErrorWithInvalidNode("loading certificate")
 	}
 
 	// If an identity certificate exists for this host, make sure the request had an HTTP message signature with the matching certificate.

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -611,6 +611,27 @@ func TestEnrollOsquery(t *testing.T) {
 	assert.NotEmpty(t, nodeKey)
 }
 
+func TestEnrollOsqueryCertLoadError(t *testing.T) {
+	ds := new(mock.Store)
+	ds.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+		return &fleet.EnrollSecret{Secret: "valid_secret", TeamID: new(uint(3))}, nil
+	}
+	ds.GetHostIdentityCertByNameFunc = func(ctx context.Context, name string) (*types.HostIdentityCertificate, error) {
+		return nil, errors.New("connection refused reading host_identity_certificates")
+	}
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	_, err := svc.EnrollOsquery(ctx, "valid_secret", "host123", nil)
+	require.Error(t, err)
+	// the osquery plane must answer with an OsqueryError, not an OrbitError, and
+	// the datastore detail stays out of the message
+	var oqErr *OsqueryError
+	require.ErrorAs(t, err, &oqErr)
+	require.NotContains(t, oqErr.Error(), "connection refused")
+	var orbitErr fleet.OrbitError
+	require.NotErrorAs(t, err, &orbitErr)
+}
+
 func TestEnrollOsqueryEnforceLimit(t *testing.T) {
 	runTest := func(t *testing.T, pool fleet.RedisPool) {
 		const maxHosts = 2


### PR DESCRIPTION
**Related issue:** N/A

Both enroll endpoints put the underlying error text in the response when enrollment failed. The agent now gets the stage that failed, and the reason goes on the request log line as `internal` next to the existing `err`. Covers `EnrollOsquery`, `EnrollOrbit` and the EUA token path it calls.

Went with `logging.WithExtras` rather than giving `OsqueryError` an `Internal()`. `logging.go` logs either `err` or `internal` for a given error, not both, so a type implementing `ErrWithInternal` without any detail attached logs neither, and that would have silenced every existing `OsqueryError`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enrollment failures now return generic error messages without exposing internal details to osquery or Orbit agents.
  * Enrollment responses identify the failed stage, while underlying failure reasons remain available in Fleet logs for troubleshooting.
  * Improved consistency of error handling across enrollment, device information collection, configuration loading, and identity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->