### PR TITLE
Add VEX exclusion for gRPC CVE

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -324,6 +324,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-03-23 16:44:57
 
+### [CVE-2026-84304](https://nvd.nist.gov/vuln/detail/CVE-2026-84304)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The vulnerability affects the HTTP/2 server transport of gRPC-Go (memory exhaustion via fragmented DATA frames sent by a remote client); fleetctl does not run a gRPC server (grpc is a transitive dependency used by the Fleet server).
+- **Products:** `fleetctl`,`pkg:golang/google.golang.org/grpc`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-09-02 09:20:06
+
 ### [CVE-2026-8376](https://nvd.nist.gov/vuln/detail/CVE-2026-8376)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-84304.vex.json
+++ b/security/vex/fleetctl/CVE-2026-84304.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1133c9b61c4c9df9ca6dfdf3814d6441eef62e8835634a61b4ad428e4f60e02e",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-84304"
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/google.golang.org/grpc"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The vulnerability affects the HTTP/2 server transport of gRPC-Go (memory exhaustion via fragmented DATA frames sent by a remote client); fleetctl does not run a gRPC server (grpc is a transitive dependency used by the Fleet server).",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-09-02T09:20:06.134223Z"
+    }
+  ],
+  "timestamp": "2026-09-02T09:20:06Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/33598413497/job/100146551300.

New run: https://github.com/fleetdm/fleet/actions/runs/33613861048.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added a vulnerability assessment for CVE-2026-84304.
  - `fleetctl` is classified as **not affected** because it does not run the vulnerable gRPC server transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->