### PR TITLE
Add VEX exclusion for ssh CVE

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -412,6 +412,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-08-17 10:36:56
 
+### [CVE-2026-56854](https://nvd.nist.gov/vuln/detail/CVE-2026-56854)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The vulnerable code is in the SSH server authentication path of golang.org/x/crypto/ssh (ssh.NewServerConn), where source-address restrictions on authorized keys were not enforced. fleetctl does not run an SSH server; golang.org/x/crypto/ssh is only linked into the fleetctl binary as an SSH client (go-git SSH transport, skeema/knownhosts, go.step.sm/crypto key parsing) and for terminal password prompts (golang.org/x/crypto/ssh/terminal).
+- **Products:** `fleetctl`,`pkg:golang/golang.org/x/crypto`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-09-02 09:20:53
+
 ### [CVE-2026-56853](https://nvd.nist.gov/vuln/detail/CVE-2026-56853)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-56854.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56854.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b23f9ebf4163fac0f5f0031a9c17fc8fddc3927441f89be74b7e549f59e4650d",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56854"
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/crypto"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The vulnerable code is in the SSH server authentication path of golang.org/x/crypto/ssh (ssh.NewServerConn), where source-address restrictions on authorized keys were not enforced. fleetctl does not run an SSH server; golang.org/x/crypto/ssh is only linked into the fleetctl binary as an SSH client (go-git SSH transport, skeema/knownhosts, go.step.sm/crypto key parsing) and for terminal password prompts (golang.org/x/crypto/ssh/terminal).",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-09-02T09:20:53.45027Z"
+    }
+  ],
+  "timestamp": "2026-09-02T09:20:53Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/33598060323.

New run: https://github.com/fleetdm/fleet/actions/runs/33614052766.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a vulnerability assessment stating that `fleetctl` and `golang.org/x/crypto` are not affected by CVE-2026-56854 because the vulnerable SSH server authentication path is not executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->