### PR TITLE
Add the daily APNs sweep cron and the legacy pusher rollback lever

### DIFF
--- a/changes/40693-apns-push-reliability.md
+++ b/changes/40693-apns-push-reliability.md
@@ -1,1 +1,1 @@
-- Improved Apple MDM push reliability: APNs notifications are now sent with a 7-day expiration and the documented MDM headers, so Apple stores and retries delivery to offline devices.
+- Improved Apple MDM push reliability: APNs notifications are now sent with a 30-day expiration and the documented MDM headers, so Apple stores and retries delivery to offline devices.

--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -785,7 +785,7 @@ func TestE2ENanopushProvider(t *testing.T) {
 		nanopush.WithNewClient(func(*tls.Certificate) (*http.Client, error) {
 			return fleethttp.NewClient(), nil
 		}),
-		nanopush.WithExpiration(7*24*time.Hour),
+		nanopush.WithExpiration(30*24*time.Hour),
 		nanopush.WithPushServerURL(srv.URL),
 	)
 	prov, err := factory.NewPushProvider(nil)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2064,11 +2064,11 @@ func newMDMAPNsPusher(
 	instanceID string,
 	ds fleet.Datastore,
 	commander *apple_mdm.MDMAppleCommander,
+	interval time.Duration,
 	logger *slog.Logger,
 ) (*schedule.Schedule, error) {
 	const name = string(fleet.CronAppleMDMAPNsPusher)
 
-	interval := 1 * time.Minute
 	if intervalEnv := dev_mode.Env("FLEET_DEV_CUSTOM_APNS_PUSHER_INTERVAL"); intervalEnv != "" {
 		var err error
 		interval, err = time.ParseDuration(intervalEnv)
@@ -2093,6 +2093,37 @@ func newMDMAPNsPusher(
 			}
 
 			return service.SendPushesToPendingDevices(ctx, ds, commander, logger)
+		}),
+	)
+
+	return s, nil
+}
+
+// newMDMAPNsSweepSchedule runs the APNs sweep: one bounded page of enabled
+// enrollments per tick, re-pushing any silent for more than a day, one lap
+// per ~24h. Registered instead of the legacy per-minute pusher unless the
+// FLEET_MDM_APPLE_LEGACY_APNS_PUSHER_INTERVAL rollback lever is set.
+func newMDMAPNsSweepSchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	commander *apple_mdm.MDMAppleCommander,
+	interval time.Duration,
+	logger *slog.Logger,
+) (*schedule.Schedule, error) {
+	const name = string(fleet.CronAppleMDMAPNsSweep)
+
+	if interval <= 0 {
+		logger.WarnContext(ctx, "invalid mdm.apple_apns_sweep_interval, using 1m")
+		interval = 1 * time.Minute
+	}
+
+	logger = logger.With("cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, interval, ds, ds,
+		schedule.WithLogger(logger),
+		schedule.WithJob("apns_sweep", func(ctx context.Context) error {
+			return apple_mdm.SweepAPNsPushes(ctx, ds, commander, logger, interval)
 		}),
 	)
 

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -296,15 +296,37 @@ func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 		return cronMigrateToPerHostPolicy(ctx, deps.instanceID, deps.ds, deps.logger, deps.androidSvc)
 	})
 
-	deps.register("failed to register APNs pusher schedule", func() (fleet.CronSchedule, error) {
-		return newMDMAPNsPusher(
-			ctx,
-			deps.instanceID,
-			deps.ds,
-			deps.commander,
-			deps.logger,
-		)
-	})
+	// The APNs sweep replaces the legacy per-minute pending-commands pusher;
+	// the env var runs the legacy cron instead, as a rollback lever. Not
+	// both: the legacy cron's pushes keep last_seen_at fresh, which would
+	// starve the sweep's silence filter.
+	if legacyInterval, legacyEnabled, parseErr := legacyAPNsPusherInterval(os.Getenv); legacyEnabled {
+		if parseErr != nil {
+			deps.logger.WarnContext(ctx, "invalid FLEET_MDM_APPLE_LEGACY_APNS_PUSHER_INTERVAL, using 1m", "err", parseErr)
+		}
+		deps.logger.InfoContext(ctx, "legacy APNs pusher enabled; APNs sweep disabled")
+		deps.register("failed to register APNs pusher schedule", func() (fleet.CronSchedule, error) {
+			return newMDMAPNsPusher(
+				ctx,
+				deps.instanceID,
+				deps.ds,
+				deps.commander,
+				legacyInterval,
+				deps.logger,
+			)
+		})
+	} else {
+		deps.register("failed to register APNs sweep schedule", func() (fleet.CronSchedule, error) {
+			return newMDMAPNsSweepSchedule(
+				ctx,
+				deps.instanceID,
+				deps.ds,
+				deps.commander,
+				deps.config.MDM.AppleAPNsSweepInterval,
+				deps.logger,
+			)
+		})
+	}
 
 	deps.register("failed to register Apple MDM OS updates schedule", func() (fleet.CronSchedule, error) {
 		return newAppleMDMOSUpdatesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
@@ -403,4 +425,24 @@ func registerMiscCrons(ctx context.Context, deps cronSchedulesDeps) {
 	deps.register("failed to register batch activity completion checker schedule", func() (fleet.CronSchedule, error) {
 		return newBatchActivityCompletionCheckerSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
 	})
+}
+
+// legacyAPNsPusherInterval reads FLEET_MDM_APPLE_LEGACY_APNS_PUSHER_INTERVAL,
+// the rollback lever that registers the legacy per-minute APNs pusher instead
+// of the APNs sweep. Returns the interval to use and whether the lever is
+// set; a non-nil error reports an invalid value, with the interval already
+// fallen back to 1m.
+func legacyAPNsPusherInterval(getenv func(string) string) (time.Duration, bool, error) {
+	raw := getenv("FLEET_MDM_APPLE_LEGACY_APNS_PUSHER_INTERVAL")
+	if raw == "" {
+		return 0, false, nil
+	}
+	interval, err := time.ParseDuration(raw)
+	if err == nil && interval <= 0 {
+		err = fmt.Errorf("non-positive interval %q", raw)
+	}
+	if err != nil {
+		return 1 * time.Minute, true, err
+	}
+	return interval, true, nil
 }

--- a/cmd/fleet/cron_registration_test.go
+++ b/cmd/fleet/cron_registration_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVulnerabilityProcessingDisabled(t *testing.T) {
@@ -41,6 +43,38 @@ func TestVulnerabilityProcessingDisabled(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, vulnerabilityProcessingDisabled(tc.cfg))
+		})
+	}
+}
+
+func TestLegacyAPNsPusherInterval(t *testing.T) {
+	cases := []struct {
+		name         string
+		value        string
+		wantInterval time.Duration
+		wantEnabled  bool
+		wantErr      bool
+	}{
+		{"unset registers the sweep", "", 0, false, false},
+		{"valid interval registers the legacy pusher", "2m", 2 * time.Minute, true, false},
+		{"garbage falls back to 1m with an error", "garbage", time.Minute, true, true},
+		{"non-positive falls back to 1m with an error", "-5m", time.Minute, true, true},
+		{"zero falls back to 1m with an error", "0", time.Minute, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			getenv := func(key string) string {
+				require.Equal(t, "FLEET_MDM_APPLE_LEGACY_APNS_PUSHER_INTERVAL", key)
+				return c.value
+			}
+			interval, enabled, err := legacyAPNsPusherInterval(getenv)
+			require.Equal(t, c.wantEnabled, enabled)
+			require.Equal(t, c.wantInterval, interval)
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/cmd/fleet/mdm_apple_test.go
+++ b/cmd/fleet/mdm_apple_test.go
@@ -45,7 +45,7 @@ func TestInitAppleMDMPushService_DevModeReturnsNopPusher(t *testing.T) {
 	// SetOverride enables dev mode and registers cleanup via t.
 	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_DISABLE_PUSH", "1", t)
 
-	pusher := initAppleMDMPushService(nil, 7*24*time.Hour, discardLogger())
+	pusher := initAppleMDMPushService(nil, 30*24*time.Hour, discardLogger())
 	require.IsType(t, nopPusher{}, pusher)
 }
 
@@ -53,7 +53,7 @@ func TestInitAppleMDMPushService_DevModeCustomPushServerURL(t *testing.T) {
 	// SetOverride enables dev mode and registers cleanup via t.
 	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL", "http://localhost:8378", t)
 
-	pusher := initAppleMDMPushService(nil, 7*24*time.Hour, discardLogger())
+	pusher := initAppleMDMPushService(nil, 30*24*time.Hour, discardLogger())
 	require.IsType(t, &nanomdm_pushsvc.PushService{}, pusher)
 }
 

--- a/cmd/fleet/redis.go
+++ b/cmd/fleet/redis.go
@@ -124,6 +124,7 @@ func initRedis(
 	wrappedDS := cached_mysql.New(ds)
 
 	var dsOpts []mysqlredis.Option
+	dsOpts = append(dsOpts, mysqlredis.WithLogger(logger.With("component", "mysqlredis")))
 	if license.DeviceCount > 0 && cfg.License.EnforceHostLimit {
 		dsOpts = append(dsOpts, mysqlredis.WithEnforcedHostLimit(license.DeviceCount))
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -2017,7 +2017,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("mdm.apple_vpp_app_metadata_api_bearer_token", "", "Apple Connect JWT, used for accessing VPP app metadata directly from Apple")
 	man.addConfigString("mdm.apple_scep_challenge", "", "SCEP static challenge for enrollment")
 	man.addConfigDuration("mdm.apple_dep_sync_periodicity", 1*time.Minute, "How much time to wait for DEP profile assignment")
-	man.addConfigDuration("mdm.apple_apns_push_expiration", 7*24*time.Hour, "How long APNs should store and retry delivering push notifications to offline devices (apns-expiration header); zero or negative omits the header")
+	man.addConfigDuration("mdm.apple_apns_push_expiration", 30*24*time.Hour, "How long APNs should store and retry delivering push notifications to offline devices (apns-expiration header, 30 days is APNs' documented maximum); zero or negative omits the header")
 	man.hideConfig("mdm.apple_apns_push_expiration")
 	man.addConfigDuration("mdm.apple_apns_sweep_interval", 1*time.Minute, "Tick interval of the APNs sweep cron, which re-pushes Apple MDM enrollments that have been silent for more than a day")
 	man.hideConfig("mdm.apple_apns_sweep_interval")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1056,6 +1056,10 @@ type MDMConfig struct {
 	// on APNs push notifications, so APNs stores and retries delivery to
 	// offline devices until then. Zero or negative omits the header.
 	AppleAPNsPushExpiration time.Duration `yaml:"apple_apns_push_expiration"`
+	// AppleAPNsSweepInterval is the tick interval of the APNs sweep cron,
+	// which walks enabled enrollments in daily laps and re-pushes any silent
+	// for more than a day.
+	AppleAPNsSweepInterval time.Duration `yaml:"apple_apns_sweep_interval"`
 	// AppleSCEPChallenge is the SCEP challenge for SCEP enrollment requests.
 	AppleSCEPChallenge string `yaml:"apple_scep_challenge"`
 	// AppleSCEPSignerValidityDays are the days signed client certificates will
@@ -2015,6 +2019,8 @@ func (man Manager) addConfigs() {
 	man.addConfigDuration("mdm.apple_dep_sync_periodicity", 1*time.Minute, "How much time to wait for DEP profile assignment")
 	man.addConfigDuration("mdm.apple_apns_push_expiration", 7*24*time.Hour, "How long APNs should store and retry delivering push notifications to offline devices (apns-expiration header); zero or negative omits the header")
 	man.hideConfig("mdm.apple_apns_push_expiration")
+	man.addConfigDuration("mdm.apple_apns_sweep_interval", 1*time.Minute, "Tick interval of the APNs sweep cron, which re-pushes Apple MDM enrollments that have been silent for more than a day")
+	man.hideConfig("mdm.apple_apns_sweep_interval")
 	man.addConfigString("mdm.windows_wstep_identity_cert", "", "Microsoft WSTEP PEM-encoded certificate path")
 	man.addConfigString("mdm.windows_wstep_identity_key", "", "Microsoft WSTEP PEM-encoded private key path")
 	man.addConfigString("mdm.windows_wstep_identity_cert_bytes", "", "Microsoft WSTEP PEM-encoded certificate bytes")
@@ -2397,6 +2403,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			AppleSCEPChallenge:                man.getConfigString("mdm.apple_scep_challenge"),
 			AppleDEPSyncPeriodicity:           man.getConfigDuration("mdm.apple_dep_sync_periodicity"),
 			AppleAPNsPushExpiration:           man.getConfigDuration("mdm.apple_apns_push_expiration"),
+			AppleAPNsSweepInterval:            man.getConfigDuration("mdm.apple_apns_sweep_interval"),
 			WindowsWSTEPIdentityCert:          man.getConfigString("mdm.windows_wstep_identity_cert"),
 			WindowsWSTEPIdentityKey:           man.getConfigString("mdm.windows_wstep_identity_key"),
 			WindowsWSTEPIdentityCertBytes:     man.getConfigString("mdm.windows_wstep_identity_cert_bytes"),

--- a/server/datastore/mysql/apple_mdm_apns_sweep.go
+++ b/server/datastore/mysql/apple_mdm_apns_sweep.go
@@ -1,0 +1,85 @@
+package mysql
+
+import (
+	"context"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/jmoiron/sqlx"
+)
+
+// ListNanoEnrollmentIDsForAPNsSweep walks enabled nano_enrollments in primary
+// key order, one bounded page per call. The inner page bounds the scan; the
+// EXISTS marks eligibility without multiplying page rows (hosts.uuid is not
+// unique — cloned VMs — so a join would corrupt the page length that pageFull
+// is computed from; when duplicates disagree on MDM state, any enrolled one
+// counts, which errs on the side of a spurious idempotent nudge). Both device
+// and user channels are walked: user-channel rows carry device_id too, so
+// they resolve to their host the same way.
+func (ds *Datastore) ListNanoEnrollmentIDsForAPNsSweep(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+	stmt := `
+SELECT
+    page.id,
+    (page.last_seen_at < DATE_SUB(NOW(), INTERVAL ? SECOND)
+     AND EXISTS (
+         SELECT 1
+         FROM hosts h
+         JOIN host_mdm hmdm ON hmdm.host_id = h.id AND hmdm.enrolled = 1
+         WHERE h.uuid = page.device_id
+     )) AS eligible
+FROM (
+    SELECT ne.id, ne.device_id, ne.last_seen_at
+    FROM nano_enrollments ne
+    WHERE ne.enabled = 1 AND ne.id > ?
+    ORDER BY ne.id
+    LIMIT ?
+) page
+ORDER BY page.id`
+
+	var rows []struct {
+		ID       string `db:"id"`
+		Eligible bool   `db:"eligible"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, int(silentFor.Seconds()), afterID, batchSize); err != nil {
+		return nil, "", false, ctxerr.Wrap(ctx, err, "list nano enrollment ids for apns sweep")
+	}
+
+	var eligible []string
+	for _, row := range rows {
+		if row.Eligible {
+			eligible = append(eligible, row.ID)
+		}
+	}
+	var nextCursor string
+	if len(rows) > 0 {
+		nextCursor = rows[len(rows)-1].ID
+	}
+	return eligible, nextCursor, len(rows) >= batchSize, nil
+}
+
+// CountEnabledNanoEnrollments returns the number of nano_enrollments rows
+// with enabled = 1.
+func (ds *Datastore) CountEnabledNanoEnrollments(ctx context.Context) (int, error) {
+	var count int
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &count, `SELECT COUNT(*) FROM nano_enrollments WHERE enabled = 1`)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "count enabled nano enrollments")
+	}
+	return count, nil
+}
+
+// GetMDMAppleAPNsSweepState returns the APNs sweep cron's persisted pass
+// state. The bare mysql.Datastore has no place to persist it, so this returns
+// nil (fresh pass every tick). The mysqlredis wrapper overrides this to back
+// it with Redis.
+func (ds *Datastore) GetMDMAppleAPNsSweepState(_ context.Context) (*fleet.MDMAppleAPNsSweepState, error) {
+	return nil, nil
+}
+
+// SetMDMAppleAPNsSweepState persists the APNs sweep cron's pass state. The
+// bare mysql.Datastore is a no-op; the mysqlredis wrapper backs it with
+// Redis.
+func (ds *Datastore) SetMDMAppleAPNsSweepState(_ context.Context, _ *fleet.MDMAppleAPNsSweepState) error {
+	return nil
+}

--- a/server/datastore/mysql/apple_mdm_apns_sweep_test.go
+++ b/server/datastore/mysql/apple_mdm_apns_sweep_test.go
@@ -1,0 +1,149 @@
+package mysql
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPNsSweep(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	ctx := t.Context()
+
+	newHost := func(i int, platform string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:        fmt.Sprintf("sweep-host-%02d", i),
+			OsqueryHostID:   new(fmt.Sprintf("sweep-osq-%02d", i)),
+			NodeKey:         new(fmt.Sprintf("sweep-node-%02d", i)),
+			UUID:            fmt.Sprintf("sweep-uuid-%02d", i),
+			Platform:        platform,
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+		})
+		require.NoError(t, err)
+		return h
+	}
+	setHostMDMOn := func(h *fleet.Host) {
+		err := ds.SetOrUpdateMDMData(ctx, h.ID, false, true, "https://example.com", true, fleet.WellKnownMDMFleet, "", false)
+		require.NoError(t, err)
+	}
+	setLastSeen := func(enrollmentID string, silentFor time.Duration) {
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx,
+				`UPDATE nano_enrollments SET last_seen_at = DATE_SUB(NOW(), INTERVAL ? SECOND) WHERE id = ?`,
+				int(silentFor.Seconds()), enrollmentID)
+			return err
+		})
+	}
+
+	// silent > 24h, MDM on: eligible (device channel).
+	hEligible := newHost(1, "darwin")
+	nanoEnroll(t, ds, hEligible, false)
+	setHostMDMOn(hEligible)
+	setLastSeen(hEligible.UUID, 25*time.Hour)
+
+	// silent > 24h, MDM on, with a user channel: both enrollments eligible.
+	hEligibleUser := newHost(2, "darwin")
+	nanoEnroll(t, ds, hEligibleUser, true)
+	setHostMDMOn(hEligibleUser)
+	userEnrollmentID := hEligibleUser.UUID + ":" + nanoenroll_useruuid_prefix + hEligibleUser.UUID
+	setLastSeen(hEligibleUser.UUID, 25*time.Hour)
+	setLastSeen(userEnrollmentID, 25*time.Hour)
+
+	// seen recently: walked but not eligible (nanoEnroll sets last_seen_at ~now).
+	hRecent := newHost(3, "ios")
+	nanoEnroll(t, ds, hRecent, false)
+	setHostMDMOn(hRecent)
+
+	// disabled enrollment: not walked at all.
+	hDisabled := newHost(4, "darwin")
+	nanoEnroll(t, ds, hDisabled, false)
+	setHostMDMOn(hDisabled)
+	setLastSeen(hDisabled.UUID, 25*time.Hour)
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE nano_enrollments SET enabled = 0 WHERE id = ?`, hDisabled.UUID)
+		return err
+	})
+
+	// host_mdm says not enrolled (no row at all here): walked but not eligible.
+	hMDMOff := newHost(5, "darwin")
+	nanoEnroll(t, ds, hMDMOff, false)
+	setLastSeen(hMDMOff.UUID, 25*time.Hour)
+
+	// enrollment with no matching hosts row: walked but not eligible.
+	const orphanID = "sweep-uuid-99-orphan"
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		if _, err := q.ExecContext(ctx,
+			`INSERT INTO nano_devices (id, authenticate) VALUES (?, 'auth')`, orphanID); err != nil {
+			return err
+		}
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO nano_enrollments (id, device_id, type, topic, push_magic, token_hex, last_seen_at)
+			VALUES (?, ?, 'Device', 'topic', 'magic', 'aa', DATE_SUB(NOW(), INTERVAL 25 HOUR))`,
+			orphanID, orphanID)
+		return err
+	})
+
+	wantEligible := []string{hEligible.UUID, hEligibleUser.UUID, userEnrollmentID}
+	// enabled rows walked: hEligible, hEligibleUser (device + user), hRecent, hMDMOff, orphan.
+	const enabledRows = 6
+
+	t.Run("eligibility matrix in one page", func(t *testing.T) {
+		eligible, next, pageFull, err := ds.ListNanoEnrollmentIDsForAPNsSweep(ctx, "", 100, 24*time.Hour)
+		require.NoError(t, err)
+		require.ElementsMatch(t, wantEligible, eligible)
+		require.False(t, pageFull)
+		// the cursor advances past every walked row, eligible or not; the
+		// orphan id sorts last among the seeded rows.
+		require.Equal(t, orphanID, next)
+	})
+
+	t.Run("keyset pagination visits every enabled row exactly once", func(t *testing.T) {
+		var allEligible []string
+		cursor := ""
+		pages := 0
+		for {
+			eligible, next, pageFull, err := ds.ListNanoEnrollmentIDsForAPNsSweep(ctx, cursor, 2, 24*time.Hour)
+			require.NoError(t, err)
+			allEligible = append(allEligible, eligible...)
+			pages++
+			require.Less(t, pages, 20, "walk must terminate")
+			if !pageFull {
+				break
+			}
+			require.Greater(t, next, cursor, "cursor must advance")
+			cursor = next
+		}
+		// 6 enabled rows at batch size 2 = 3 full pages, then one empty page
+		// that reports the pass complete.
+		require.Equal(t, enabledRows/2+1, pages)
+		require.ElementsMatch(t, wantEligible, allEligible)
+	})
+
+	t.Run("shorter silence window widens eligibility", func(t *testing.T) {
+		// with a 1-second window even the recently-seen rows qualify,
+		// proving the silentFor parameter drives the filter.
+		eligible, _, _, err := ds.ListNanoEnrollmentIDsForAPNsSweep(ctx, "", 100, time.Second)
+		require.NoError(t, err)
+		require.ElementsMatch(t, append(wantEligible, hRecent.UUID), eligible)
+	})
+
+	t.Run("count enabled only", func(t *testing.T) {
+		count, err := ds.CountEnabledNanoEnrollments(ctx)
+		require.NoError(t, err)
+		require.Equal(t, enabledRows, count)
+	})
+
+	t.Run("bare datastore sweep state is a no-op", func(t *testing.T) {
+		state, err := ds.GetMDMAppleAPNsSweepState(ctx)
+		require.NoError(t, err)
+		require.Nil(t, state)
+		require.NoError(t, ds.SetMDMAppleAPNsSweepState(ctx, &fleet.MDMAppleAPNsSweepState{Cursor: "x", BatchSize: 1}))
+	})
+}

--- a/server/datastore/mysql/apple_mdm_apns_sweep_test.go
+++ b/server/datastore/mysql/apple_mdm_apns_sweep_test.go
@@ -128,7 +128,9 @@ func TestAPNsSweep(t *testing.T) {
 
 	t.Run("shorter silence window widens eligibility", func(t *testing.T) {
 		// with a 1-second window even the recently-seen rows qualify,
-		// proving the silentFor parameter drives the filter.
+		// proving the silentFor parameter drives the filter. Set the
+		// timestamp explicitly rather than relying on nanoEnroll's seed.
+		setLastSeen(hRecent.UUID, 2*time.Second)
 		eligible, _, _, err := ds.ListNanoEnrollmentIDsForAPNsSweep(ctx, "", 100, time.Second)
 		require.NoError(t, err)
 		require.ElementsMatch(t, append(wantEligible, hRecent.UUID), eligible)

--- a/server/datastore/mysqlredis/apns_sweep_state.go
+++ b/server/datastore/mysqlredis/apns_sweep_state.go
@@ -31,6 +31,9 @@ func (d *Datastore) GetMDMAppleAPNsSweepState(ctx context.Context) (*fleet.MDMAp
 	case err == nil:
 		var state fleet.MDMAppleAPNsSweepState
 		if err := json.Unmarshal(raw, &state); err != nil {
+			// complete the self-heal: drop the poisoned key so it doesn't
+			// linger for the next read or a confused operator
+			_, _ = conn.Do("DEL", apnsSweepStateKey)
 			return nil, nil
 		}
 		return &state, nil

--- a/server/datastore/mysqlredis/apns_sweep_state.go
+++ b/server/datastore/mysqlredis/apns_sweep_state.go
@@ -33,6 +33,8 @@ func (d *Datastore) GetMDMAppleAPNsSweepState(ctx context.Context) (*fleet.MDMAp
 		if err := json.Unmarshal(raw, &state); err != nil {
 			// complete the self-heal: drop the poisoned key so it doesn't
 			// linger for the next read or a confused operator
+			d.logger.WarnContext(ctx, "dropping undecodable APNs sweep state key, starting a fresh pass",
+				"key", apnsSweepStateKey, "err", err)
 			_, _ = conn.Do("DEL", apnsSweepStateKey)
 			return nil, nil
 		}

--- a/server/datastore/mysqlredis/apns_sweep_state.go
+++ b/server/datastore/mysqlredis/apns_sweep_state.go
@@ -1,0 +1,65 @@
+package mysqlredis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+// apnsSweepStateKey is the Redis key holding the APNs sweep cron's pass
+// state (keyset cursor + the batch size computed at pass start), as JSON.
+const apnsSweepStateKey = "mdm:apple:apns_sweep_state"
+
+// GetMDMAppleAPNsSweepState returns the APNs sweep cron's persisted pass
+// state, or nil when no pass is in progress.
+//
+// No TTL: loss of this key is harmless — the cron starts a fresh pass from
+// the beginning with a recomputed batch size, and re-pushing an enrollment
+// is a contentless, idempotent nudge. Undecodable state is treated the same
+// way rather than wedging the cron on a poisoned key.
+func (d *Datastore) GetMDMAppleAPNsSweepState(ctx context.Context) (*fleet.MDMAppleAPNsSweepState, error) {
+	conn := redis.ConfigureDoer(d.pool, d.pool.Get())
+	defer conn.Close()
+
+	raw, err := redigo.Bytes(conn.Do("GET", apnsSweepStateKey))
+	switch {
+	case err == nil:
+		var state fleet.MDMAppleAPNsSweepState
+		if err := json.Unmarshal(raw, &state); err != nil {
+			return nil, nil
+		}
+		return &state, nil
+	case errors.Is(err, redigo.ErrNil):
+		return nil, nil
+	default:
+		return nil, ctxerr.Wrap(ctx, err, "get apple MDM APNs sweep state")
+	}
+}
+
+// SetMDMAppleAPNsSweepState persists the APNs sweep cron's pass state. A nil
+// state deletes the key (pass complete; the next tick starts a new pass).
+func (d *Datastore) SetMDMAppleAPNsSweepState(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error {
+	conn := redis.ConfigureDoer(d.pool, d.pool.Get())
+	defer conn.Close()
+
+	if state == nil {
+		if _, err := conn.Do("DEL", apnsSweepStateKey); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete apple MDM APNs sweep state")
+		}
+		return nil
+	}
+
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "marshal apple MDM APNs sweep state")
+	}
+	if _, err := conn.Do("SET", apnsSweepStateKey, raw); err != nil {
+		return ctxerr.Wrap(ctx, err, "set apple MDM APNs sweep state")
+	}
+	return nil
+}

--- a/server/datastore/mysqlredis/apns_sweep_state_test.go
+++ b/server/datastore/mysqlredis/apns_sweep_state_test.go
@@ -1,0 +1,50 @@
+package mysqlredis
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMDMAppleAPNsSweepState(t *testing.T) {
+	pool := redistest.SetupRedis(t, "apns_sweep_state", false, false, false)
+	ds := New(&mock.Store{}, pool)
+	ctx := t.Context()
+
+	// the state key is fixed (not test-prefixed), so clean it up ourselves.
+	cleanup := func() {
+		conn := pool.Get()
+		defer conn.Close()
+		_, err := conn.Do("DEL", apnsSweepStateKey)
+		require.NoError(t, err)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	state, err := ds.GetMDMAppleAPNsSweepState(ctx)
+	require.NoError(t, err)
+	require.Nil(t, state, "unset key reads as no pass in progress")
+
+	want := &fleet.MDMAppleAPNsSweepState{Cursor: "enrollment-uuid-42", BatchSize: 137}
+	require.NoError(t, ds.SetMDMAppleAPNsSweepState(ctx, want))
+	state, err = ds.GetMDMAppleAPNsSweepState(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, state)
+
+	require.NoError(t, ds.SetMDMAppleAPNsSweepState(ctx, nil))
+	state, err = ds.GetMDMAppleAPNsSweepState(ctx)
+	require.NoError(t, err)
+	require.Nil(t, state, "nil set resets the state")
+
+	// a poisoned key self-heals to a fresh pass instead of wedging the cron.
+	conn := pool.Get()
+	_, err = conn.Do("SET", apnsSweepStateKey, "{not json")
+	require.NoError(t, err)
+	conn.Close()
+	state, err = ds.GetMDMAppleAPNsSweepState(ctx)
+	require.NoError(t, err)
+	require.Nil(t, state)
+}

--- a/server/datastore/mysqlredis/apns_sweep_state_test.go
+++ b/server/datastore/mysqlredis/apns_sweep_state_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
+	redigo "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,8 @@ func TestMDMAppleAPNsSweepState(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, state, "nil set resets the state")
 
-	// a poisoned key self-heals to a fresh pass instead of wedging the cron.
+	// a poisoned key self-heals to a fresh pass instead of wedging the cron,
+	// and the bad key is dropped rather than left to linger.
 	conn := pool.Get()
 	_, err = conn.Do("SET", apnsSweepStateKey, "{not json")
 	require.NoError(t, err)
@@ -47,4 +49,10 @@ func TestMDMAppleAPNsSweepState(t *testing.T) {
 	state, err = ds.GetMDMAppleAPNsSweepState(ctx)
 	require.NoError(t, err)
 	require.Nil(t, state)
+
+	conn = pool.Get()
+	exists, err := redigo.Int(conn.Do("EXISTS", apnsSweepStateKey))
+	conn.Close()
+	require.NoError(t, err)
+	require.Zero(t, exists, "poisoned key must be deleted on read")
 }

--- a/server/datastore/mysqlredis/apns_sweep_state_test.go
+++ b/server/datastore/mysqlredis/apns_sweep_state_test.go
@@ -1,6 +1,8 @@
 package mysqlredis
 
 import (
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
@@ -12,7 +14,8 @@ import (
 
 func TestMDMAppleAPNsSweepState(t *testing.T) {
 	pool := redistest.SetupRedis(t, "apns_sweep_state", false, false, false)
-	ds := New(&mock.Store{}, pool)
+	var logBuf strings.Builder
+	ds := New(&mock.Store{}, pool, WithLogger(slog.New(slog.NewTextHandler(&logBuf, nil))))
 	ctx := t.Context()
 
 	// the state key is fixed (not test-prefixed), so clean it up ourselves.
@@ -55,4 +58,6 @@ func TestMDMAppleAPNsSweepState(t *testing.T) {
 	conn.Close()
 	require.NoError(t, err)
 	require.Zero(t, exists, "poisoned key must be deleted on read")
+	require.Contains(t, logBuf.String(), "level=WARN", "self-heal must be visible in logs")
+	require.Contains(t, logBuf.String(), apnsSweepStateKey)
 }

--- a/server/datastore/mysqlredis/mysqlredis.go
+++ b/server/datastore/mysqlredis/mysqlredis.go
@@ -4,6 +4,7 @@
 package mysqlredis
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -27,6 +28,8 @@ type Datastore struct {
 	hostCacheEnabled bool
 	hostCacheTTL     time.Duration
 	hostCacheSF      singleflight.Group
+
+	logger *slog.Logger
 }
 
 // Option is an option that can be passed to New to configure the datastore.
@@ -54,10 +57,18 @@ func WithHostCache(ttl time.Duration) Option {
 	}
 }
 
+// WithLogger sets the logger for the wrapper's own diagnostics; without it
+// they are discarded.
+func WithLogger(logger *slog.Logger) Option {
+	return func(o *Datastore) {
+		o.logger = logger
+	}
+}
+
 // New creates a Datastore that wraps ds and uses pool to execute redis-based
 // operations.
 func New(ds fleet.Datastore, pool fleet.RedisPool, opts ...Option) *Datastore {
-	newDS := &Datastore{Datastore: ds, pool: pool}
+	newDS := &Datastore{Datastore: ds, pool: pool, logger: slog.New(slog.DiscardHandler)}
 	for _, opt := range opts {
 		opt(newDS)
 	}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -2004,3 +2004,12 @@ type ComputedAppleSoftwareUpdateHost struct {
 	AppleSoftwareUpdateHost
 	Resend bool
 }
+
+// MDMAppleAPNsSweepState is the APNs sweep cron's persisted position: the
+// keyset cursor of the enrollment walk plus the batch size computed at the
+// start of the pass, so the size rides along with the cursor instead of
+// being recounted every tick. A nil state means no pass is in progress.
+type MDMAppleAPNsSweepState struct {
+	Cursor    string `json:"cursor"`
+	BatchSize int    `json:"batch_size"`
+}

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -77,6 +77,10 @@ const (
 	// CronMDMAndroidCommandReconciler polls AMAPI for the outcome of Android MDM commands whose Pub/Sub
 	// COMMAND notification never arrived, so they don't stay pending forever. Runs every 24h.
 	CronMDMAndroidCommandReconciler CronScheduleName = "mdm_android_command_reconciler"
+	// CronAppleMDMAPNsSweep walks enabled Apple MDM enrollments in daily laps
+	// and re-pushes any that have been silent for more than a day, so offline
+	// devices always have a stored push waiting at APNs.
+	CronAppleMDMAPNsSweep CronScheduleName = "apple_mdm_apns_sweep"
 )
 
 type CronSchedulesService interface {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -290,6 +290,18 @@ type Datastore interface {
 
 	GetEnrollmentIDsWithPendingMDMAppleCommands(ctx context.Context) ([]string, error)
 
+	// ListNanoEnrollmentIDsForAPNsSweep walks enabled nano_enrollments in
+	// primary key order, one bounded page per call. It returns the enrollment
+	// IDs in the page that are sweep-eligible (silent for longer than
+	// silentFor and belonging to a host with MDM on), the cursor for the next
+	// page, and whether the underlying page was full (pageFull == false means
+	// the pass is complete).
+	ListNanoEnrollmentIDsForAPNsSweep(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) (eligibleIDs []string, nextCursor string, pageFull bool, err error)
+
+	// CountEnabledNanoEnrollments returns the number of nano_enrollments rows
+	// with enabled = 1, used to size sweep batches at the start of each pass.
+	CountEnabledNanoEnrollments(ctx context.Context) (int, error)
+
 	// LabelQueriesForHost returns the (dynamic) label queries that should be executed for the given host.
 	// Results are returned in a map of label id -> query
 	LabelQueriesForHost(ctx context.Context, host *Host) (map[string]string, error)
@@ -2766,6 +2778,15 @@ type Datastore interface {
 	// SetMDMAppleReconcileCursor persists the host_uuid cursor used by the
 	// batched Apple MDM reconciliation cron.
 	SetMDMAppleReconcileCursor(ctx context.Context, cursor string) error
+
+	// GetMDMAppleAPNsSweepState returns the APNs sweep cron's persisted pass
+	// state, or nil when no pass is in progress. The bare mysql.Datastore
+	// always returns nil; the mysqlredis wrapper backs it with Redis.
+	GetMDMAppleAPNsSweepState(ctx context.Context) (*MDMAppleAPNsSweepState, error)
+
+	// SetMDMAppleAPNsSweepState persists the APNs sweep cron's pass state.
+	// A nil state resets it (pass complete).
+	SetMDMAppleAPNsSweepState(ctx context.Context, state *MDMAppleAPNsSweepState) error
 
 	// GetAppleDeclarationReconcileSnapshot is the DDM counterpart of
 	// GetAppleProfileReconcileSnapshot. It returns a consistent snapshot

--- a/server/mdm/apple/apns_sweep.go
+++ b/server/mdm/apple/apns_sweep.go
@@ -14,10 +14,10 @@ const (
 	// apnsSweepSilence is how long an enrollment must have been silent to be
 	// re-armed with a fresh stored push.
 	apnsSweepSilence = 24 * time.Hour
-	// apnsSweepMinBatch avoids near-empty pages on small fleets;
-	// apnsSweepMaxBatch bounds per-tick work on very large ones (a lap then
-	// takes longer than a day, which the pass-start warning surfaces).
-	apnsSweepMinBatch = 50
+	// apnsSweepMinBatch floors pages at one enrollment per tick;
+	// apnsSweepMaxBatch bounds per-tick work on very large fleets (a lap
+	// then takes longer than a day, which the pass-start warning surfaces).
+	apnsSweepMinBatch = 1
 	apnsSweepMaxBatch = 2000
 )
 
@@ -36,11 +36,11 @@ type apnsNotifier interface {
 // gaps, and a spurious nudge costs one empty Idle check-in.
 //
 // The batch size is computed at pass start so one lap completes in roughly a
-// day at the given tick interval, and rides along with the cursor. Below
-// ~72k enrollments the minimum batch size makes laps finish faster than a
-// day; the resulting extra pushes only reach devices that are still silent
-// and offline, where re-arming a fresh stored push is harmless (APNs
-// coalesces them) and extends the expiration hedge.
+// day at the given tick interval, and rides along with the cursor. Fleets
+// smaller than a day's worth of ticks lap faster than a day at one
+// enrollment per tick; the resulting extra pushes only reach devices that
+// are still silent and offline, where re-arming a fresh stored push is
+// harmless (APNs coalesces them) and extends the expiration hedge.
 func SweepAPNsPushes(ctx context.Context, ds fleet.Datastore, commander *MDMAppleCommander,
 	logger *slog.Logger, interval time.Duration,
 ) error {

--- a/server/mdm/apple/apns_sweep.go
+++ b/server/mdm/apple/apns_sweep.go
@@ -36,7 +36,11 @@ type apnsNotifier interface {
 // gaps, and a spurious nudge costs one empty Idle check-in.
 //
 // The batch size is computed at pass start so one lap completes in roughly a
-// day at the given tick interval, and rides along with the cursor.
+// day at the given tick interval, and rides along with the cursor. Below
+// ~72k enrollments the minimum batch size makes laps finish faster than a
+// day; the resulting extra pushes only reach devices that are still silent
+// and offline, where re-arming a fresh stored push is harmless (APNs
+// coalesces them) and extends the expiration hedge.
 func SweepAPNsPushes(ctx context.Context, ds fleet.Datastore, commander *MDMAppleCommander,
 	logger *slog.Logger, interval time.Duration,
 ) error {

--- a/server/mdm/apple/apns_sweep.go
+++ b/server/mdm/apple/apns_sweep.go
@@ -21,7 +21,7 @@ const (
 	apnsSweepMaxBatch = 2000
 )
 
-// apnsNotifier is the slice of MDMAppleCommander the sweep needs; tests
+// apnsNotifier is the subset of MDMAppleCommander the sweep needs; tests
 // substitute a fake.
 type apnsNotifier interface {
 	SendNotifications(ctx context.Context, ids []string) error
@@ -50,6 +50,11 @@ func SweepAPNsPushes(ctx context.Context, ds fleet.Datastore, commander *MDMAppl
 func sweepAPNsPushes(ctx context.Context, ds fleet.Datastore, notifier apnsNotifier,
 	logger *slog.Logger, interval time.Duration,
 ) error {
+	if interval <= 0 {
+		// the cron constructor guards this too; a local clamp keeps the
+		// batch-size division from panicking for any future caller
+		interval = time.Minute
+	}
 	appCfg, err := ds.AppConfig(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "retrieving app config")

--- a/server/mdm/apple/apns_sweep.go
+++ b/server/mdm/apple/apns_sweep.go
@@ -1,0 +1,115 @@
+package apple_mdm
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+const (
+	// apnsSweepSilence is how long an enrollment must have been silent to be
+	// re-armed with a fresh stored push.
+	apnsSweepSilence = 24 * time.Hour
+	// apnsSweepMinBatch avoids near-empty pages on small fleets;
+	// apnsSweepMaxBatch bounds per-tick work on very large ones (a lap then
+	// takes longer than a day, which the pass-start warning surfaces).
+	apnsSweepMinBatch = 50
+	apnsSweepMaxBatch = 2000
+)
+
+// apnsNotifier is the slice of MDMAppleCommander the sweep needs; tests
+// substitute a fake.
+type apnsNotifier interface {
+	SendNotifications(ctx context.Context, ids []string) error
+}
+
+// SweepAPNsPushes runs one tick of the APNs sweep: it walks one page of
+// enabled enrollments behind a persisted cursor and pushes every enrollment
+// that has been silent for more than a day, so every offline device always
+// has a stored push waiting at APNs (see the apns-expiration header set by
+// the push provider). Deliberately not scoped to enrollments with pending
+// commands: any such filter recreates one of the legacy pusher's delivery
+// gaps, and a spurious nudge costs one empty Idle check-in.
+//
+// The batch size is computed at pass start so one lap completes in roughly a
+// day at the given tick interval, and rides along with the cursor.
+func SweepAPNsPushes(ctx context.Context, ds fleet.Datastore, commander *MDMAppleCommander,
+	logger *slog.Logger, interval time.Duration,
+) error {
+	return sweepAPNsPushes(ctx, ds, commander, logger, interval)
+}
+
+func sweepAPNsPushes(ctx context.Context, ds fleet.Datastore, notifier apnsNotifier,
+	logger *slog.Logger, interval time.Duration,
+) error {
+	appCfg, err := ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "retrieving app config")
+	}
+	if !appCfg.MDM.EnabledAndConfigured {
+		return nil
+	}
+
+	state, err := ds.GetMDMAppleAPNsSweepState(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get apns sweep state")
+	}
+	if state != nil && state.BatchSize <= 0 {
+		// same self-heal posture as undecodable state: a non-positive batch
+		// size would error on LIMIT every tick, before the state is ever
+		// rewritten, wedging the cron on the poisoned value.
+		state = nil
+	}
+	if state == nil { // pass start: size batches so one lap takes ~a day
+		count, err := ds.CountEnabledNanoEnrollments(ctx)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "count enabled nano enrollments")
+		}
+		if count == 0 {
+			return nil
+		}
+		ticksPerDay := max(int(24*time.Hour/interval), 1)
+		batch := (count + ticksPerDay - 1) / ticksPerDay
+		if batch > apnsSweepMaxBatch {
+			logger.WarnContext(ctx, "APNs sweep batch size clamped, a full pass will take longer than a day",
+				"computed_batch_size", batch, "max_batch_size", apnsSweepMaxBatch, "enrollments", count)
+			batch = apnsSweepMaxBatch
+		}
+		batch = max(batch, apnsSweepMinBatch)
+		state = &fleet.MDMAppleAPNsSweepState{BatchSize: batch}
+	}
+
+	eligible, next, pageFull, err := ds.ListNanoEnrollmentIDsForAPNsSweep(ctx, state.Cursor, state.BatchSize, apnsSweepSilence)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list nano enrollment ids for apns sweep")
+	}
+
+	if len(eligible) > 0 {
+		if err := notifier.SendNotifications(ctx, eligible); err != nil {
+			var delivery *APNSDeliveryError
+			if !errors.As(err, &delivery) {
+				// provider or push-cert failure: leave the cursor unadvanced
+				// so this page is retried next tick.
+				return ctxerr.Wrap(ctx, err, "apns sweep send notifications")
+			}
+			// Per-enrollment rejections don't stop the lap. The sweep takes
+			// no action on Unregistered (its ids span both channels while
+			// MDM turn-off is host-keyed); the pool self-corrects because
+			// eligibility requires host_mdm.enrolled = 1.
+			for id, pushErr := range delivery.errorsByUUID {
+				logger.InfoContext(ctx, "APNs sweep push rejected",
+					"enrollment_id", id, "reason", APNSReason(pushErr), "err", pushErr)
+			}
+		}
+	}
+
+	if pageFull {
+		state.Cursor = next
+		return ctxerr.Wrap(ctx, ds.SetMDMAppleAPNsSweepState(ctx, state), "advance apns sweep state")
+	}
+	return ctxerr.Wrap(ctx, ds.SetMDMAppleAPNsSweepState(ctx, nil), "reset apns sweep state")
+}

--- a/server/mdm/apple/apns_sweep_test.go
+++ b/server/mdm/apple/apns_sweep_test.go
@@ -71,7 +71,7 @@ func TestSweepAPNsPushes(t *testing.T) {
 			wantWarn  bool
 		}{
 			{"scales to lap in a day", 100_000, time.Minute, 70, false},
-			{"clamped up to the minimum", 10, time.Minute, 50, false},
+			{"floored at one enrollment per tick", 10, time.Minute, 1, false},
 			{"clamped down to the maximum with a warning", 5_000_000, time.Minute, 2000, true},
 			{"slower ticks mean bigger pages", 40_000, time.Hour, 1667, false},
 			{"intervals of a day or more floor at one tick per lap", 100, 25 * time.Hour, 100, false},
@@ -125,7 +125,7 @@ func TestSweepAPNsPushes(t *testing.T) {
 		require.NoError(t, sweepAPNsPushes(ctx, ds, &fakeAPNsNotifier{}, logger, time.Minute))
 		require.True(t, ds.CountEnabledNanoEnrollmentsFuncInvoked, "fresh pass recomputes the batch")
 		require.Empty(t, gotAfterID)
-		require.Equal(t, 50, gotBatch)
+		require.Equal(t, 1, gotBatch)
 	})
 
 	t.Run("mid-pass state is reused without recounting", func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestSweepAPNsPushes(t *testing.T) {
 		require.Equal(t, [][]string{{"e1", "e2"}}, notifier.calls)
 		require.NotNil(t, gotState)
 		require.Equal(t, "e9", gotState.Cursor)
-		require.Equal(t, 50, gotState.BatchSize, "batch size computed at pass start rides along")
+		require.Equal(t, 1, gotState.BatchSize, "batch size computed at pass start rides along")
 	})
 
 	t.Run("short page resets the state", func(t *testing.T) {

--- a/server/mdm/apple/apns_sweep_test.go
+++ b/server/mdm/apple/apns_sweep_test.go
@@ -1,0 +1,213 @@
+package apple_mdm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAPNsNotifier struct {
+	calls [][]string
+	err   error
+}
+
+func (f *fakeAPNsNotifier) SendNotifications(_ context.Context, ids []string) error {
+	f.calls = append(f.calls, ids)
+	return f.err
+}
+
+// sweepTestDS returns a mock datastore with MDM enabled and the sweep
+// methods stubbed to a one-page pass; individual tests override pieces.
+func sweepTestDS() *mock.Store {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
+	}
+	ds.GetMDMAppleAPNsSweepStateFunc = func(ctx context.Context) (*fleet.MDMAppleAPNsSweepState, error) {
+		return nil, nil
+	}
+	ds.CountEnabledNanoEnrollmentsFunc = func(ctx context.Context) (int, error) {
+		return 100, nil
+	}
+	ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+		return nil, "", false, nil
+	}
+	ds.SetMDMAppleAPNsSweepStateFunc = func(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error {
+		return nil
+	}
+	return ds
+}
+
+func TestSweepAPNsPushes(t *testing.T) {
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
+
+	t.Run("no-op when MDM not enabled and configured", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
+		notifier := &fakeAPNsNotifier{}
+		require.NoError(t, sweepAPNsPushes(ctx, ds, notifier, logger, time.Minute))
+		require.Empty(t, notifier.calls)
+		require.False(t, ds.GetMDMAppleAPNsSweepStateFuncInvoked)
+	})
+
+	t.Run("pass start computes clamped batch size", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			count     int
+			interval  time.Duration
+			wantBatch int
+			wantWarn  bool
+		}{
+			{"scales to lap in a day", 100_000, time.Minute, 70, false},
+			{"clamped up to the minimum", 10, time.Minute, 50, false},
+			{"clamped down to the maximum with a warning", 5_000_000, time.Minute, 2000, true},
+			{"slower ticks mean bigger pages", 40_000, time.Hour, 1667, false},
+			{"intervals of a day or more floor at one tick per lap", 100, 25 * time.Hour, 100, false},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				ds := sweepTestDS()
+				ds.CountEnabledNanoEnrollmentsFunc = func(ctx context.Context) (int, error) {
+					return c.count, nil
+				}
+				var gotBatch int
+				ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+					gotBatch = batchSize
+					require.Empty(t, afterID)
+					require.Equal(t, 24*time.Hour, silentFor)
+					return nil, "", false, nil
+				}
+				var buf strings.Builder
+				warnLogger := slog.New(slog.NewTextHandler(&buf, nil))
+
+				require.NoError(t, sweepAPNsPushes(ctx, ds, &fakeAPNsNotifier{}, warnLogger, c.interval))
+				require.Equal(t, c.wantBatch, gotBatch)
+				require.Equal(t, c.wantWarn, strings.Contains(buf.String(), "level=WARN"), buf.String())
+			})
+		}
+	})
+
+	t.Run("zero enrollments ends the tick without a walk", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.CountEnabledNanoEnrollmentsFunc = func(ctx context.Context) (int, error) {
+			return 0, nil
+		}
+		notifier := &fakeAPNsNotifier{}
+		require.NoError(t, sweepAPNsPushes(ctx, ds, notifier, logger, time.Minute))
+		require.False(t, ds.ListNanoEnrollmentIDsForAPNsSweepFuncInvoked)
+		require.Empty(t, notifier.calls)
+	})
+
+	t.Run("poisoned batch size self-heals to a fresh pass", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.GetMDMAppleAPNsSweepStateFunc = func(ctx context.Context) (*fleet.MDMAppleAPNsSweepState, error) {
+			return &fleet.MDMAppleAPNsSweepState{Cursor: "enrollment-42", BatchSize: -5}, nil
+		}
+		var gotAfterID string
+		var gotBatch int
+		ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+			gotAfterID = afterID
+			gotBatch = batchSize
+			return nil, "", false, nil
+		}
+		require.NoError(t, sweepAPNsPushes(ctx, ds, &fakeAPNsNotifier{}, logger, time.Minute))
+		require.True(t, ds.CountEnabledNanoEnrollmentsFuncInvoked, "fresh pass recomputes the batch")
+		require.Empty(t, gotAfterID)
+		require.Equal(t, 50, gotBatch)
+	})
+
+	t.Run("mid-pass state is reused without recounting", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.GetMDMAppleAPNsSweepStateFunc = func(ctx context.Context) (*fleet.MDMAppleAPNsSweepState, error) {
+			return &fleet.MDMAppleAPNsSweepState{Cursor: "enrollment-42", BatchSize: 7}, nil
+		}
+		ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+			require.Equal(t, "enrollment-42", afterID)
+			require.Equal(t, 7, batchSize)
+			return nil, "enrollment-49", true, nil
+		}
+		require.NoError(t, sweepAPNsPushes(ctx, ds, &fakeAPNsNotifier{}, logger, time.Minute))
+		require.False(t, ds.CountEnabledNanoEnrollmentsFuncInvoked)
+	})
+
+	t.Run("full page pushes eligible and advances the cursor", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+			return []string{"e1", "e2"}, "e9", true, nil
+		}
+		var gotState *fleet.MDMAppleAPNsSweepState
+		ds.SetMDMAppleAPNsSweepStateFunc = func(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error {
+			gotState = state
+			return nil
+		}
+		notifier := &fakeAPNsNotifier{}
+		require.NoError(t, sweepAPNsPushes(ctx, ds, notifier, logger, time.Minute))
+		require.Equal(t, [][]string{{"e1", "e2"}}, notifier.calls)
+		require.NotNil(t, gotState)
+		require.Equal(t, "e9", gotState.Cursor)
+		require.Equal(t, 50, gotState.BatchSize, "batch size computed at pass start rides along")
+	})
+
+	t.Run("short page resets the state", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+			return []string{"e1"}, "e1", false, nil
+		}
+		var setInvoked bool
+		var gotState *fleet.MDMAppleAPNsSweepState
+		ds.SetMDMAppleAPNsSweepStateFunc = func(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error {
+			setInvoked = true
+			gotState = state
+			return nil
+		}
+		require.NoError(t, sweepAPNsPushes(ctx, ds, &fakeAPNsNotifier{}, logger, time.Minute))
+		require.True(t, setInvoked)
+		require.Nil(t, gotState)
+	})
+
+	t.Run("per-enrollment rejections are logged and never turn off MDM", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+			return []string{"e1", "e2"}, "e9", true, nil
+		}
+		var setInvoked bool
+		ds.SetMDMAppleAPNsSweepStateFunc = func(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error {
+			setInvoked = true
+			return nil
+		}
+		notifier := &fakeAPNsNotifier{err: &APNSDeliveryError{errorsByUUID: map[string]error{
+			"e1": fmt.Errorf("push HTTP status: 410: %w", &nanopush.JSONPushError{Reason: APNSReasonUnregistered, Timestamp: 1}),
+		}}}
+		var buf strings.Builder
+		infoLogger := slog.New(slog.NewTextHandler(&buf, nil))
+
+		require.NoError(t, sweepAPNsPushes(ctx, ds, notifier, infoLogger, time.Minute))
+		require.True(t, setInvoked, "rejections must not stall the lap")
+		require.False(t, ds.MDMTurnOffFuncInvoked)
+		require.Contains(t, buf.String(), APNSReasonUnregistered)
+		require.Contains(t, buf.String(), "e1")
+	})
+
+	t.Run("provider-level failure leaves the cursor unadvanced", func(t *testing.T) {
+		ds := sweepTestDS()
+		ds.ListNanoEnrollmentIDsForAPNsSweepFunc = func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) ([]string, string, bool, error) {
+			return []string{"e1"}, "e9", true, nil
+		}
+		notifier := &fakeAPNsNotifier{err: errors.New("dial tcp: connection refused")}
+		err := sweepAPNsPushes(ctx, ds, notifier, logger, time.Minute)
+		require.Error(t, err)
+		require.False(t, ds.SetMDMAppleAPNsSweepStateFuncInvoked)
+	})
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -210,6 +210,10 @@ type LabelsSummaryFunc func(ctx context.Context, filter fleet.TeamFilter) ([]*fl
 
 type GetEnrollmentIDsWithPendingMDMAppleCommandsFunc func(ctx context.Context) ([]string, error)
 
+type ListNanoEnrollmentIDsForAPNsSweepFunc func(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) (eligibleIDs []string, nextCursor string, pageFull bool, err error)
+
+type CountEnabledNanoEnrollmentsFunc func(ctx context.Context) (int, error)
+
 type LabelQueriesForHostFunc func(ctx context.Context, host *fleet.Host) (map[string]string, error)
 
 type ListLabelsForHostFunc func(ctx context.Context, hid uint) ([]*fleet.Label, error)
@@ -1576,6 +1580,10 @@ type GetMDMAppleReconcileCursorFunc func(ctx context.Context) (string, error)
 
 type SetMDMAppleReconcileCursorFunc func(ctx context.Context, cursor string) error
 
+type GetMDMAppleAPNsSweepStateFunc func(ctx context.Context) (*fleet.MDMAppleAPNsSweepState, error)
+
+type SetMDMAppleAPNsSweepStateFunc func(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error
+
 type GetAppleDeclarationReconcileSnapshotFunc func(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allDecls []*fleet.AppleDeclarationForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleHostDeclaration, pageFull bool, err error)
 
 type BulkUpsertMDMAppleHostDeclarationsFunc func(ctx context.Context, rows []*fleet.MDMAppleHostDeclaration) error
@@ -2661,6 +2669,12 @@ type DataStore struct {
 
 	GetEnrollmentIDsWithPendingMDMAppleCommandsFunc        GetEnrollmentIDsWithPendingMDMAppleCommandsFunc
 	GetEnrollmentIDsWithPendingMDMAppleCommandsFuncInvoked bool
+
+	ListNanoEnrollmentIDsForAPNsSweepFunc        ListNanoEnrollmentIDsForAPNsSweepFunc
+	ListNanoEnrollmentIDsForAPNsSweepFuncInvoked bool
+
+	CountEnabledNanoEnrollmentsFunc        CountEnabledNanoEnrollmentsFunc
+	CountEnabledNanoEnrollmentsFuncInvoked bool
 
 	LabelQueriesForHostFunc        LabelQueriesForHostFunc
 	LabelQueriesForHostFuncInvoked bool
@@ -4711,6 +4725,12 @@ type DataStore struct {
 	SetMDMAppleReconcileCursorFunc        SetMDMAppleReconcileCursorFunc
 	SetMDMAppleReconcileCursorFuncInvoked bool
 
+	GetMDMAppleAPNsSweepStateFunc        GetMDMAppleAPNsSweepStateFunc
+	GetMDMAppleAPNsSweepStateFuncInvoked bool
+
+	SetMDMAppleAPNsSweepStateFunc        SetMDMAppleAPNsSweepStateFunc
+	SetMDMAppleAPNsSweepStateFuncInvoked bool
+
 	GetAppleDeclarationReconcileSnapshotFunc        GetAppleDeclarationReconcileSnapshotFunc
 	GetAppleDeclarationReconcileSnapshotFuncInvoked bool
 
@@ -6572,6 +6592,20 @@ func (s *DataStore) GetEnrollmentIDsWithPendingMDMAppleCommands(ctx context.Cont
 	s.GetEnrollmentIDsWithPendingMDMAppleCommandsFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetEnrollmentIDsWithPendingMDMAppleCommandsFunc(ctx)
+}
+
+func (s *DataStore) ListNanoEnrollmentIDsForAPNsSweep(ctx context.Context, afterID string, batchSize int, silentFor time.Duration) (eligibleIDs []string, nextCursor string, pageFull bool, err error) {
+	s.mu.Lock()
+	s.ListNanoEnrollmentIDsForAPNsSweepFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListNanoEnrollmentIDsForAPNsSweepFunc(ctx, afterID, batchSize, silentFor)
+}
+
+func (s *DataStore) CountEnabledNanoEnrollments(ctx context.Context) (int, error) {
+	s.mu.Lock()
+	s.CountEnabledNanoEnrollmentsFuncInvoked = true
+	s.mu.Unlock()
+	return s.CountEnabledNanoEnrollmentsFunc(ctx)
 }
 
 func (s *DataStore) LabelQueriesForHost(ctx context.Context, host *fleet.Host) (map[string]string, error) {
@@ -11353,6 +11387,20 @@ func (s *DataStore) SetMDMAppleReconcileCursor(ctx context.Context, cursor strin
 	s.SetMDMAppleReconcileCursorFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetMDMAppleReconcileCursorFunc(ctx, cursor)
+}
+
+func (s *DataStore) GetMDMAppleAPNsSweepState(ctx context.Context) (*fleet.MDMAppleAPNsSweepState, error) {
+	s.mu.Lock()
+	s.GetMDMAppleAPNsSweepStateFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMAppleAPNsSweepStateFunc(ctx)
+}
+
+func (s *DataStore) SetMDMAppleAPNsSweepState(ctx context.Context, state *fleet.MDMAppleAPNsSweepState) error {
+	s.mu.Lock()
+	s.SetMDMAppleAPNsSweepStateFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetMDMAppleAPNsSweepStateFunc(ctx, state)
 }
 
 func (s *DataStore) GetAppleDeclarationReconcileSnapshot(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allDecls []*fleet.AppleDeclarationForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleHostDeclaration, pageFull bool, err error) {

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -122,7 +122,7 @@ func main() {
 			})), nil
 		}),
 		// same default expiration the Fleet server uses (mdm.apple_apns_push_expiration)
-		nanopush.WithExpiration(7*24*time.Hour),
+		nanopush.WithExpiration(30*24*time.Hour),
 	)
 
 	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51648

Adds the daily APNs sweep cron: it walks enabled `nano_enrollments` in bounded pages behind a Redis-persisted cursor and re-pushes any enrollment silent for more than a day, so offline devices always have a stored push waiting at APNs (one lap per ~24h). `FLEET_MDM_APPLE_LEGACY_APNS_PUSHER_INTERVAL` registers the legacy per-minute pusher instead, as a rollback lever; the legacy code stays in-tree until a follow-up removal issue. Two deviations from the issue's draft SQL/state shape: eligibility uses `EXISTS` instead of `LEFT JOIN hosts` (`hosts.uuid` is not unique, a join would corrupt the page-full arithmetic), and the Redis state is a small JSON object (cursor + batch size) rather than a bare string so the batch size computed at pass start rides along. The `(enabled)` index shipped separately (#52353); no changes file (the story entry rode #52265, whose branch this PR is based on until it merges).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually (dev server + real iPhone against production APNs: sweep registered and legacy pusher absent, silence filter verified negatively and positively, backdated enrollment nudged and device checked in unprompted; rollback lever covered by unit tests and exercised in the #51651 load test)

## New Fleet configuration settings

- [x] Setting(s) is/are explicitly excluded from GitOps



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an automated Apple MDM APNs sweep that re-sends notifications to eligible devices silent for more than 24 hours.
  - Sweeps process enrollments progressively and resume safely if interrupted.
  - Added configurable sweep timing, with a one-minute default.
- **Bug Fixes**
  - Individual delivery failures no longer stop processing other eligible devices.
  - Failed batches retain their progress for subsequent attempts.
  - Invalid sweep intervals safely fall back to one minute.
  - APNs push expiration now defaults to 30 days, matching Apple’s documented maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->