### PR TITLE
incremental lint to micromdm/plist

### DIFF
--- a/.golangci-incremental.yml
+++ b/.golangci-incremental.yml
@@ -48,6 +48,13 @@ linters:
           deny:
             - pkg: math/rand$
               desc: Use math/rand/v2 instead
+        no-plist-forks:
+          list-mode: lax
+          deny:
+            - pkg: howett.net/plist
+              desc: Use github.com/micromdm/plist instead
+            - pkg: github.com/groob/plist
+              desc: Use github.com/micromdm/plist instead
     custom:
       nilaway:
         type: module


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, but since the upstream merged our fix and we removed our custom plist_bounds, we should slowly switch all other plist usages to micromdm. It's done as an incremental lint, so there is quite a few touchpoints and `howett.net/plist` does not share identical signatures.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated incremental linting rules to prevent use of unsupported plist packages and guide development toward the approved alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->