### PR TITLE
Fix flaky TestIntegrationsUpdatesExpiredSignatures test

### DIFF
--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update/filestore"
-	"github.com/fleetdm/fleet/v4/pkg/race"
 	"github.com/fleetdm/fleet/v4/pkg/secure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/go-tuf/verify"
 	"github.com/urfave/cli/v2"
 )
 
@@ -463,13 +463,10 @@ func TestRollback(t *testing.T) {
 // behavior depends on which of the roles has the expired signature).
 func TestIntegrationsUpdatesExpiredSignatures(t *testing.T) {
 	// Not t.Parallel() due to modifications to environment and global variables.
-	if race.Enabled {
-		// Because execution is slower and thus sleep time would need to be higher.
-		t.Skip("Skipping test when race is enabled")
-	}
-
 	setPassphrases(t)
-	const timeToExpire = 5 * time.Second
+	// Long enough that a slow test setup cannot expire the metadata early (expiration is
+	// checked with a fake clock below), but shorter than the default expiration durations.
+	const timeToExpire = 1 * time.Hour
 
 	for _, tc := range []struct {
 		name                      string
@@ -572,7 +569,11 @@ func TestIntegrationsUpdatesExpiredSignatures(t *testing.T) {
 			err = updater.UpdateMetadata()
 			require.NoError(t, err)
 
-			time.Sleep(timeToExpire + 1*time.Second)
+			// Move go-tuf's clock past the expiration instead of sleeping.
+			oldIsExpired := verify.IsExpired
+			t.Cleanup(func() { verify.IsExpired = oldIsExpired })
+			fakeNow := time.Now().Add(timeToExpire + 1*time.Minute)
+			verify.IsExpired = func(expires time.Time) bool { return !fakeNow.Before(expires) }
 
 			// Expect UpdateMetadata (client.Update) to fail when the signature has expired.
 			err = updater.UpdateMetadata()


### PR DESCRIPTION
Uses a fake clock instead of sleeping.

Fixes the following flaky test:
```
=== FAIL: ee/fleetctl TestIntegrationsUpdatesExpiredSignatures/root_expired (5.95s)
Generated root key with ID: 084ccb3fc2c03074a1604401a4573e3b1a7c1cb1e230c01402b48daec2a76261
Generated targets key with ID: fed777abbce2fa9ac99634b22fe060d4c2633db58457d9bc3cc9c746ad631fe1
Generated snapshot key with ID: c6919ace2c91f2137bcc6308cb18942510ea217f9973aaff8aa413d58be007c7
Generated timestamp key with ID: 37e762338e1839f7cdb3a37f9c1487090a5623fa7c3599a9455b63cb19924ef0
    updates_test.go:548: 
        	Error Trace:	/home/runner/work/fleet/fleet/ee/fleetctl/updates_test.go:548
        	Error:      	Received unexpected error:
        	            	commit repo: tuf: insufficient signatures for root.json: expired at 2026-09-01 21:42:02 +0000 UTC
        	Test:       	TestIntegrationsUpdatesExpiredSignatures/root_expired
    --- FAIL: TestIntegrationsUpdatesExpiredSignatures/root_expired (5.95s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for expired update signatures.
  * Updated expiration checks to use deterministic simulated time, reducing reliance on real-time delays and improving test reliability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->