### PR TITLE
Add in-process retry of transient APNs push failures

### DIFF
--- a/cmd/fleet/mdm_apple.go
+++ b/cmd/fleet/mdm_apple.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
 	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
@@ -88,7 +89,10 @@ func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, apnsPushExpiratio
 	}
 
 	pushProviderFactory := nanopush.NewFactory(opts...)
-	return nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
+	pusher := nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
+	// retry transient push failures in-process; the legacy per-minute
+	// pusher cron was the de facto retry before its removal
+	return apple_mdm.NewRetryingPusher(pusher, logger.With("component", "apple-mdm-push-retry"))
 }
 
 // checkMDMAssetsExist reports whether the named MDM config assets exist in

--- a/cmd/fleet/mdm_apple_test.go
+++ b/cmd/fleet/mdm_apple_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/jmoiron/sqlx"
@@ -54,7 +54,8 @@ func TestInitAppleMDMPushService_DevModeCustomPushServerURL(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL", "http://localhost:8378", t)
 
 	pusher := initAppleMDMPushService(nil, 30*24*time.Hour, discardLogger())
-	require.IsType(t, &nanomdm_pushsvc.PushService{}, pusher)
+	require.IsType(t, &apple_mdm.RetryingPusher{}, pusher)
+	t.Cleanup(pusher.(*apple_mdm.RetryingPusher).Stop)
 }
 
 func TestInitAppleMDMPushService_ZeroExpirationWarnsAndDegrades(t *testing.T) {
@@ -62,7 +63,8 @@ func TestInitAppleMDMPushService_ZeroExpirationWarnsAndDegrades(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
 	pusher := initAppleMDMPushService(nil, 0, logger)
-	require.IsType(t, &nanomdm_pushsvc.PushService{}, pusher)
+	require.IsType(t, &apple_mdm.RetryingPusher{}, pusher)
+	t.Cleanup(pusher.(*apple_mdm.RetryingPusher).Stop)
 	require.Contains(t, buf.String(), "apple_apns_push_expiration")
 	require.Contains(t, buf.String(), "level=WARN")
 }

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1154,6 +1154,10 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		defer cancel()
 		errs <- func() error {
 			cancelFunc()
+			if stopper, ok := mdmPushService.(interface{ Stop() }); ok {
+				// end the APNs retry loop; pending retries defer to the sweep
+				stopper.Stop()
+			}
 			cleanupCronStatsOnShutdown(ctx, ds, logger, instanceID)
 			launcher.GracefulStop()
 			// Flush any pending OTEL data before shutting down

--- a/server/mdm/apple/apns_errors.go
+++ b/server/mdm/apple/apns_errors.go
@@ -14,6 +14,7 @@ const (
 	APNSReasonBadDeviceToken         = "BadDeviceToken"
 	APNSReasonDeviceTokenNotForTopic = "DeviceTokenNotForTopic"
 	APNSReasonTooManyRequests        = "TooManyRequests"
+	APNSReasonPayloadTooLarge        = "PayloadTooLarge"
 
 	// 403-class reasons: certificate or topic problems that retrying a
 	// device token cannot fix.
@@ -25,6 +26,10 @@ const (
 	APNSReasonMissingProviderToken      = "MissingProviderToken"
 	APNSReasonBadTopic                  = "BadTopic"
 	APNSReasonTopicDisallowed           = "TopicDisallowed"
+	// token-auth-only reasons; unreachable with Fleet's certificate-based
+	// APNs auth, classified for completeness
+	APNSReasonUnrelatedKeyIdInToken      = "UnrelatedKeyIdInToken"      //nolint:revive // Apple's spelling
+	APNSReasonBadEnvironmentKeyIdInToken = "BadEnvironmentKeyIdInToken" //nolint:revive // Apple's spelling
 )
 
 // isPermanentAPNSRejection reports whether a per-device push error is a
@@ -36,7 +41,8 @@ func isPermanentAPNSRejection(err error) bool {
 	case APNSReasonUnregistered, APNSReasonExpiredToken, APNSReasonBadDeviceToken, APNSReasonDeviceTokenNotForTopic,
 		APNSReasonBadCertificate, APNSReasonBadCertificateEnvironment, APNSReasonExpiredProviderToken,
 		APNSReasonForbidden, APNSReasonInvalidProviderToken, APNSReasonMissingProviderToken,
-		APNSReasonBadTopic, APNSReasonTopicDisallowed:
+		APNSReasonBadTopic, APNSReasonTopicDisallowed,
+		APNSReasonPayloadTooLarge, APNSReasonUnrelatedKeyIdInToken, APNSReasonBadEnvironmentKeyIdInToken:
 		return true
 	}
 	return false

--- a/server/mdm/apple/apns_errors.go
+++ b/server/mdm/apple/apns_errors.go
@@ -14,7 +14,33 @@ const (
 	APNSReasonBadDeviceToken         = "BadDeviceToken"
 	APNSReasonDeviceTokenNotForTopic = "DeviceTokenNotForTopic"
 	APNSReasonTooManyRequests        = "TooManyRequests"
+
+	// 403-class reasons: certificate or topic problems that retrying a
+	// device token cannot fix.
+	APNSReasonBadCertificate            = "BadCertificate"
+	APNSReasonBadCertificateEnvironment = "BadCertificateEnvironment"
+	APNSReasonExpiredProviderToken      = "ExpiredProviderToken"
+	APNSReasonForbidden                 = "Forbidden"
+	APNSReasonInvalidProviderToken      = "InvalidProviderToken"
+	APNSReasonMissingProviderToken      = "MissingProviderToken"
+	APNSReasonBadTopic                  = "BadTopic"
+	APNSReasonTopicDisallowed           = "TopicDisallowed"
 )
+
+// isPermanentAPNSRejection reports whether a per-device push error is a
+// rejection that retrying cannot fix: dead or mismatched tokens, or
+// certificate/topic problems. Everything else (429, 5xx, transport errors,
+// GOAWAY) is treated as transient.
+func isPermanentAPNSRejection(err error) bool {
+	switch APNSReason(err) {
+	case APNSReasonUnregistered, APNSReasonExpiredToken, APNSReasonBadDeviceToken, APNSReasonDeviceTokenNotForTopic,
+		APNSReasonBadCertificate, APNSReasonBadCertificateEnvironment, APNSReasonExpiredProviderToken,
+		APNSReasonForbidden, APNSReasonInvalidProviderToken, APNSReasonMissingProviderToken,
+		APNSReasonBadTopic, APNSReasonTopicDisallowed:
+		return true
+	}
+	return false
+}
 
 // APNSReason extracts the APNs rejection reason (e.g. "Unregistered",
 // "BadDeviceToken") from a push response error, or "" if the error does not

--- a/server/mdm/apple/apns_errors.go
+++ b/server/mdm/apple/apns_errors.go
@@ -16,6 +16,12 @@ const (
 	APNSReasonTooManyRequests        = "TooManyRequests"
 	APNSReasonPayloadTooLarge        = "PayloadTooLarge"
 
+	// 5xx reasons: transient, but Apple documents retrying them no sooner
+	// than 15 minutes after the failure.
+	APNSReasonInternalServerError = "InternalServerError"
+	APNSReasonServiceUnavailable  = "ServiceUnavailable"
+	APNSReasonShutdown            = "Shutdown"
+
 	// 403-class reasons: certificate or topic problems that retrying a
 	// device token cannot fix.
 	APNSReasonBadCertificate            = "BadCertificate"
@@ -43,6 +49,17 @@ func isPermanentAPNSRejection(err error) bool {
 		APNSReasonForbidden, APNSReasonInvalidProviderToken, APNSReasonMissingProviderToken,
 		APNSReasonBadTopic, APNSReasonTopicDisallowed,
 		APNSReasonPayloadTooLarge, APNSReasonUnrelatedKeyIdInToken, APNSReasonBadEnvironmentKeyIdInToken:
+		return true
+	}
+	return false
+}
+
+// isAPNS5xxRejection reports whether a per-device push error carries one of
+// APNs' 5xx reasons, which Apple documents retrying no sooner than 15
+// minutes after the failure.
+func isAPNS5xxRejection(err error) bool {
+	switch APNSReason(err) {
+	case APNSReasonInternalServerError, APNSReasonServiceUnavailable, APNSReasonShutdown:
 		return true
 	}
 	return false

--- a/server/mdm/apple/apns_errors_test.go
+++ b/server/mdm/apple/apns_errors_test.go
@@ -58,6 +58,7 @@ func TestIsPermanentAPNSRejection(t *testing.T) {
 		APNSReasonBadCertificate, APNSReasonBadCertificateEnvironment, APNSReasonExpiredProviderToken,
 		APNSReasonForbidden, APNSReasonInvalidProviderToken, APNSReasonMissingProviderToken,
 		APNSReasonBadTopic, APNSReasonTopicDisallowed,
+		APNSReasonPayloadTooLarge, APNSReasonUnrelatedKeyIdInToken, APNSReasonBadEnvironmentKeyIdInToken,
 	}
 	for _, reason := range permanent {
 		t.Run(reason, func(t *testing.T) {

--- a/server/mdm/apple/apns_errors_test.go
+++ b/server/mdm/apple/apns_errors_test.go
@@ -52,6 +52,33 @@ func TestAPNSReason(t *testing.T) {
 	}
 }
 
+func TestIsPermanentAPNSRejection(t *testing.T) {
+	permanent := []string{
+		APNSReasonUnregistered, APNSReasonExpiredToken, APNSReasonBadDeviceToken, APNSReasonDeviceTokenNotForTopic,
+		APNSReasonBadCertificate, APNSReasonBadCertificateEnvironment, APNSReasonExpiredProviderToken,
+		APNSReasonForbidden, APNSReasonInvalidProviderToken, APNSReasonMissingProviderToken,
+		APNSReasonBadTopic, APNSReasonTopicDisallowed,
+	}
+	for _, reason := range permanent {
+		t.Run(reason, func(t *testing.T) {
+			err := fmt.Errorf("push HTTP status: 400: %w", &nanopush.JSONPushError{Reason: reason})
+			require.True(t, isPermanentAPNSRejection(err))
+		})
+	}
+
+	transient := map[string]error{
+		"TooManyRequests":      fmt.Errorf("push HTTP status: 429: %w", &nanopush.JSONPushError{Reason: APNSReasonTooManyRequests}),
+		"InternalServerError":  fmt.Errorf("push HTTP status: 500: %w", &nanopush.JSONPushError{Reason: "InternalServerError"}),
+		"transport error":      errors.New("dial tcp: connection refused"),
+		"no structured reason": fmt.Errorf("push HTTP status: 502: %w", &nanopush.JSONPushError{}),
+	}
+	for name, err := range transient {
+		t.Run(name, func(t *testing.T) {
+			require.False(t, isPermanentAPNSRejection(err))
+		})
+	}
+}
+
 func TestTurnOffMDMIfAPNSFailed(t *testing.T) {
 	ctx := t.Context()
 	noActivity := func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error { return nil }

--- a/server/mdm/apple/retrying_pusher.go
+++ b/server/mdm/apple/retrying_pusher.go
@@ -1,0 +1,250 @@
+package apple_mdm
+
+import (
+	"context"
+	"log/slog"
+	mathrand "math/rand/v2"
+	"sync"
+	"time"
+
+	nanomdm_push "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
+)
+
+const (
+	// retryPendingCap bounds the in-memory pending set; on overflow the
+	// oldest entry is dropped (the sweep covers it).
+	retryPendingCap = 10_000
+	// retryFlushBatch bounds how many due retries are re-pushed per flush.
+	retryFlushBatch = 100
+	// retryTick is how often the background loop looks for due retries.
+	retryTick = 5 * time.Second
+	// retryBreakerThreshold consecutive call-level push failures (provider
+	// or APNs outage, not per-device rejections) open the breaker for
+	// retryBreakerCooldown, pausing the retry loop so retries don't pile
+	// onto a down APNs. Fresh enqueue-time pushes are never gated.
+	retryBreakerThreshold = 5
+	retryBreakerCooldown  = 2 * time.Minute
+)
+
+// retryBackoffs are the waits before each successive retry of an enrollment;
+// after the last retry fails the entry is dropped and the daily sweep covers
+// it.
+var retryBackoffs = [...]time.Duration{30 * time.Second, 2 * time.Minute, 8 * time.Minute, 30 * time.Minute}
+
+type retryEntry struct {
+	// attempt counts retries scheduled so far; the wait behind nextAttempt
+	// is retryBackoffs[attempt-1], and the entry is dropped once all of
+	// retryBackoffs have been consumed.
+	attempt     int
+	nextAttempt time.Time
+	queuedAt    time.Time
+}
+
+// RetryingPusher wraps a nanomdm push.Pusher and retries transient per-device
+// push failures in-process with jittered backoff. Lossy by design: pushes are
+// contentless and idempotent, and the APNs sweep bounds worst-case delivery,
+// so a dropped retry (overflow, restart, giving up) only delays delivery,
+// never loses commands. Push returns the inner results unchanged, so
+// synchronous surfaces (lock, wipe, run-command) behave exactly as today.
+type RetryingPusher struct {
+	inner  nanomdm_push.Pusher
+	logger *slog.Logger
+	clock  func() time.Time
+
+	mu                  sync.Mutex
+	pending             map[string]*retryEntry
+	consecutiveFailures int
+	breakerOpenUntil    time.Time
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewRetryingPusher wraps inner and starts the background retry loop; call
+// Stop to end it.
+func NewRetryingPusher(inner nanomdm_push.Pusher, logger *slog.Logger) *RetryingPusher {
+	p := newRetryingPusher(inner, logger)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+	go p.loop(ctx)
+	return p
+}
+
+// newRetryingPusher builds the wrapper without starting the loop, so tests
+// can drive flushes deterministically through a fake clock.
+func newRetryingPusher(inner nanomdm_push.Pusher, logger *slog.Logger) *RetryingPusher {
+	return &RetryingPusher{
+		inner:   inner,
+		logger:  logger,
+		clock:   time.Now,
+		pending: make(map[string]*retryEntry),
+		done:    make(chan struct{}),
+	}
+}
+
+// Stop ends the background retry loop and waits for it to exit. Pending
+// retries are dropped; the sweep covers them.
+func (p *RetryingPusher) Stop() {
+	if p.cancel != nil {
+		p.cancel()
+		<-p.done
+	}
+}
+
+// Push sends through the wrapped pusher and returns its results and error
+// unchanged (both can be non-nil at once: the push service returns partial
+// results). Transient per-device failures are scheduled for background
+// retry; permanent rejections never are — callers already route those (e.g.
+// Unregistered to MDM turn-off).
+func (p *RetryingPusher) Push(ctx context.Context, ids []string) (map[string]*nanomdm_push.Response, error) {
+	res, err := p.inner.Push(ctx, ids)
+
+	now := p.clock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.noteCallResultLocked(ctx, now, err)
+	for _, id := range ids {
+		r, ok := res[id]
+		switch {
+		case !ok || r == nil:
+			// no per-device verdict: a call-level failure (push cert or
+			// push-info retrieval) leaves affected ids out of the map
+			// entirely, and that's a transient failure for each of them. No
+			// call-level error (e.g. the dev nop pusher) means nothing to do.
+			if err != nil {
+				p.scheduleRetryLocked(ctx, id, now)
+			}
+		case r.Err == nil:
+			// an observed success supersedes any pending retry
+			delete(p.pending, id)
+		case isPermanentAPNSRejection(r.Err):
+			// never retried; a pending entry is now known-hopeless too
+			delete(p.pending, id)
+		default:
+			p.scheduleRetryLocked(ctx, id, now)
+		}
+	}
+	return res, err
+}
+
+func (p *RetryingPusher) loop(ctx context.Context) {
+	defer close(p.done)
+	ticker := time.NewTicker(retryTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.flushDue(ctx)
+		}
+	}
+}
+
+// flushDue re-pushes up to retryFlushBatch due entries through the inner
+// pusher and reschedules or drops them based on the outcome.
+func (p *RetryingPusher) flushDue(ctx context.Context) {
+	now := p.clock()
+	p.mu.Lock()
+	if now.Before(p.breakerOpenUntil) {
+		p.mu.Unlock()
+		return
+	}
+	var due []string
+	for id, e := range p.pending {
+		if !e.nextAttempt.After(now) {
+			due = append(due, id)
+			if len(due) >= retryFlushBatch {
+				break
+			}
+		}
+	}
+	p.mu.Unlock()
+	if len(due) == 0 {
+		return
+	}
+
+	res, err := p.inner.Push(ctx, due)
+
+	now = p.clock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.noteCallResultLocked(ctx, now, err)
+	for _, id := range due {
+		r := res[id]
+		if err != nil && r == nil {
+			// call-level failure with no per-device verdict: not the
+			// device's fault, keep the entry due; the breaker bounds how
+			// hard a down APNs is re-attempted.
+			continue
+		}
+		e := p.pending[id]
+		if e == nil {
+			continue
+		}
+		switch {
+		case r == nil || r.Err == nil:
+			delete(p.pending, id)
+		case isPermanentAPNSRejection(r.Err):
+			p.logger.InfoContext(ctx, "dropping APNs retry, rejection is permanent",
+				"enrollment_id", id, "reason", APNSReason(r.Err))
+			delete(p.pending, id)
+		case e.attempt >= len(retryBackoffs):
+			p.logger.InfoContext(ctx, "giving up on APNs retry, the sweep covers it",
+				"enrollment_id", id, "attempts", e.attempt)
+			delete(p.pending, id)
+		default:
+			e.nextAttempt = now.Add(jitteredBackoff(retryBackoffs[e.attempt]))
+			e.attempt++
+		}
+	}
+}
+
+// noteCallResultLocked feeds the circuit breaker with a call-level Push
+// outcome. Requires p.mu held.
+func (p *RetryingPusher) noteCallResultLocked(ctx context.Context, now time.Time, err error) {
+	if err == nil {
+		p.consecutiveFailures = 0
+		return
+	}
+	p.consecutiveFailures++
+	if p.consecutiveFailures >= retryBreakerThreshold && !now.Before(p.breakerOpenUntil) {
+		p.breakerOpenUntil = now.Add(retryBreakerCooldown)
+		p.consecutiveFailures = 0
+		p.logger.WarnContext(ctx, "pausing APNs retries, pushes are failing at the provider level",
+			"cooldown", retryBreakerCooldown.String())
+	}
+}
+
+// scheduleRetryLocked adds id to the pending set at the first backoff step.
+// Duplicates collapse: an already-pending entry keeps its backoff position.
+// Requires p.mu held.
+func (p *RetryingPusher) scheduleRetryLocked(ctx context.Context, id string, now time.Time) {
+	if _, ok := p.pending[id]; ok {
+		return
+	}
+	if len(p.pending) >= retryPendingCap {
+		var oldestID string
+		var oldestQueuedAt time.Time
+		for pid, e := range p.pending {
+			if oldestID == "" || e.queuedAt.Before(oldestQueuedAt) {
+				oldestID, oldestQueuedAt = pid, e.queuedAt
+			}
+		}
+		delete(p.pending, oldestID)
+		p.logger.WarnContext(ctx, "APNs retry set is full, dropping the oldest pending retry",
+			"dropped_enrollment_id", oldestID, "cap", retryPendingCap)
+	}
+	p.pending[id] = &retryEntry{
+		attempt:     1,
+		nextAttempt: now.Add(jitteredBackoff(retryBackoffs[0])),
+		queuedAt:    now,
+	}
+}
+
+// jitteredBackoff spreads d by ±20% so a burst of failures doesn't retry in
+// lockstep.
+func jitteredBackoff(d time.Duration) time.Duration {
+	delta := (mathrand.Float64()*2 - 1) * 0.2 * float64(d) //nolint:gosec // non-security randomness
+	return d + time.Duration(delta)
+}

--- a/server/mdm/apple/retrying_pusher.go
+++ b/server/mdm/apple/retrying_pusher.go
@@ -20,10 +20,12 @@ const (
 	retryFlushBatch = 100
 	// retryTick is how often the background loop looks for due retries.
 	retryTick = 5 * time.Second
-	// retryBreakerThreshold consecutive call-level push failures (provider
-	// or APNs outage, not per-device rejections) open the breaker for
-	// retryBreakerCooldown, pausing the retry loop so retries don't pile
-	// onto a down APNs. Fresh enqueue-time pushes are never gated.
+	// retryBreakerThreshold consecutive all-transient push calls — every
+	// response failed transiently (APNs 5xx storm, GOAWAYs), or the call
+	// itself failed — open the breaker for retryBreakerCooldown, pausing
+	// the retry loop so retries don't pile onto a down APNs. Any success or
+	// permanent rejection is a well-formed APNs answer and resets the
+	// streak. Fresh enqueue-time pushes are never gated.
 	retryBreakerThreshold = 5
 	retryBreakerCooldown  = 2 * time.Minute
 )
@@ -104,7 +106,7 @@ func (p *RetryingPusher) Push(ctx context.Context, ids []string) (map[string]*na
 	now := p.clock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.noteCallResultLocked(ctx, now, err)
+	p.noteCallOutcomeLocked(ctx, now, res, err)
 	for _, id := range ids {
 		r, ok := res[id]
 		switch {
@@ -171,7 +173,11 @@ func (p *RetryingPusher) flushDue(ctx context.Context) {
 	now = p.clock()
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.noteCallResultLocked(ctx, now, err)
+	p.noteCallOutcomeLocked(ctx, now, res, err)
+	// A foreground failure during the in-flight push can reset an entry's
+	// ladder, which the stale result below re-escalates by one rung.
+	// Tolerated: the window is milliseconds wide and the cost is one rung of
+	// delay in a flow the sweep already bounds.
 	for _, id := range due {
 		r := res[id]
 		if err != nil && r == nil {
@@ -202,19 +208,38 @@ func (p *RetryingPusher) flushDue(ctx context.Context) {
 	}
 }
 
-// noteCallResultLocked feeds the circuit breaker with a call-level Push
-// outcome. Requires p.mu held.
-func (p *RetryingPusher) noteCallResultLocked(ctx context.Context, now time.Time, err error) {
-	if err == nil {
-		p.consecutiveFailures = 0
-		return
+// noteCallOutcomeLocked feeds the circuit breaker with one inner.Push
+// outcome. A call strikes when it failed outright or when every response
+// failed transiently — the shapes an APNs outage produces, since the
+// provider surfaces 5xx and GOAWAY as per-device errors with a nil
+// call-level error. Any success or permanent rejection is a well-formed
+// APNs answer and resets the streak. Requires p.mu held.
+func (p *RetryingPusher) noteCallOutcomeLocked(ctx context.Context, now time.Time, res map[string]*nanomdm_push.Response, err error) {
+	var transientFailures, healthySignals int
+	for _, r := range res {
+		switch {
+		case r == nil || r.Err == nil:
+			healthySignals++
+		case retryablePushErr(r.Err):
+			transientFailures++
+		default:
+			healthySignals++
+		}
 	}
-	p.consecutiveFailures++
-	if p.consecutiveFailures >= retryBreakerThreshold && !now.Before(p.breakerOpenUntil) {
-		p.breakerOpenUntil = now.Add(retryBreakerCooldown)
+
+	switch {
+	case healthySignals > 0:
 		p.consecutiveFailures = 0
-		p.logger.WarnContext(ctx, "pausing APNs retries, pushes are failing at the provider level",
-			"cooldown", retryBreakerCooldown.String())
+	case err == nil && transientFailures == 0:
+		// no verdicts at all (e.g. the dev nop pusher): not an APNs signal
+	default:
+		p.consecutiveFailures++
+		if p.consecutiveFailures >= retryBreakerThreshold && !now.Before(p.breakerOpenUntil) {
+			p.breakerOpenUntil = now.Add(retryBreakerCooldown)
+			p.consecutiveFailures = 0
+			p.logger.WarnContext(ctx, "pausing APNs retries, pushes are failing at the provider level",
+				"cooldown", retryBreakerCooldown.String())
+		}
 	}
 }
 

--- a/server/mdm/apple/retrying_pusher.go
+++ b/server/mdm/apple/retrying_pusher.go
@@ -2,12 +2,14 @@ package apple_mdm
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	mathrand "math/rand/v2"
 	"sync"
 	"time"
 
 	nanomdm_push "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
+	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 )
 
 const (
@@ -117,7 +119,7 @@ func (p *RetryingPusher) Push(ctx context.Context, ids []string) (map[string]*na
 		case r.Err == nil:
 			// an observed success supersedes any pending retry
 			delete(p.pending, id)
-		case isPermanentAPNSRejection(r.Err):
+		case !retryablePushErr(r.Err):
 			// never retried; a pending entry is now known-hopeless too
 			delete(p.pending, id)
 		default:
@@ -185,9 +187,9 @@ func (p *RetryingPusher) flushDue(ctx context.Context) {
 		switch {
 		case r == nil || r.Err == nil:
 			delete(p.pending, id)
-		case isPermanentAPNSRejection(r.Err):
-			p.logger.InfoContext(ctx, "dropping APNs retry, rejection is permanent",
-				"enrollment_id", id, "reason", APNSReason(r.Err))
+		case !retryablePushErr(r.Err):
+			p.logger.InfoContext(ctx, "dropping APNs retry, failure is not retryable",
+				"enrollment_id", id, "reason", APNSReason(r.Err), "err", r.Err)
 			delete(p.pending, id)
 		case e.attempt >= len(retryBackoffs):
 			p.logger.InfoContext(ctx, "giving up on APNs retry, the sweep covers it",
@@ -217,10 +219,17 @@ func (p *RetryingPusher) noteCallResultLocked(ctx context.Context, now time.Time
 }
 
 // scheduleRetryLocked adds id to the pending set at the first backoff step.
-// Duplicates collapse: an already-pending entry keeps its backoff position.
+// Duplicates collapse onto one entry; a fresh enqueue-time failure restarts
+// an entry that had already backed off past the first step, so a device
+// failing right now isn't stuck waiting out an inherited 30m backoff.
 // Requires p.mu held.
 func (p *RetryingPusher) scheduleRetryLocked(ctx context.Context, id string, now time.Time) {
-	if _, ok := p.pending[id]; ok {
+	if e, ok := p.pending[id]; ok {
+		if e.attempt > 1 {
+			e.attempt = 1
+			e.nextAttempt = now.Add(jitteredBackoff(retryBackoffs[0]))
+			e.queuedAt = now
+		}
 		return
 	}
 	if len(p.pending) >= retryPendingCap {
@@ -240,6 +249,14 @@ func (p *RetryingPusher) scheduleRetryLocked(ctx context.Context, id string, now
 		nextAttempt: now.Add(jitteredBackoff(retryBackoffs[0])),
 		queuedAt:    now,
 	}
+}
+
+// retryablePushErr reports whether a per-device push error is worth
+// retrying: transient APNs and transport failures are; permanent APNs
+// rejections and enrollments the push service has no push info for
+// (deleted or unknown) are not.
+func retryablePushErr(err error) bool {
+	return !isPermanentAPNSRejection(err) && !errors.Is(err, nanomdm_pushsvc.ErrIdNotFound)
 }
 
 // jitteredBackoff spreads d by ±20% so a burst of failures doesn't retry in

--- a/server/mdm/apple/retrying_pusher.go
+++ b/server/mdm/apple/retrying_pusher.go
@@ -35,6 +35,23 @@ const (
 // it.
 var retryBackoffs = [...]time.Duration{30 * time.Second, 2 * time.Minute, 8 * time.Minute, 30 * time.Minute}
 
+// retry5xxFloor is the minimum wait before retrying a failure APNs answered
+// with a 5xx reason: "After 15 minutes, you can retry JSON payloads that
+// receive response status codes that begin with 5XX."
+const retry5xxFloor = 15 * time.Minute
+
+// retryWait returns the jittered wait before retry number attempt (1-based)
+// for the given failure, flooring 5xx-reason failures at Apple's documented
+// 15 minutes.
+func retryWait(err error, attempt int) time.Duration {
+	wait := jitteredBackoff(retryBackoffs[attempt-1])
+	if wait < retry5xxFloor && isAPNS5xxRejection(err) {
+		// upward-only jitter keeps the wait compliant while still spreading
+		wait = retry5xxFloor + time.Duration(mathrand.Float64()*0.2*float64(retry5xxFloor)) //nolint:gosec // non-security randomness
+	}
+	return wait
+}
+
 type retryEntry struct {
 	// attempt counts retries scheduled so far; the wait behind nextAttempt
 	// is retryBackoffs[attempt-1], and the entry is dropped once all of
@@ -116,7 +133,7 @@ func (p *RetryingPusher) Push(ctx context.Context, ids []string) (map[string]*na
 			// entirely, and that's a transient failure for each of them. No
 			// call-level error (e.g. the dev nop pusher) means nothing to do.
 			if err != nil {
-				p.scheduleRetryLocked(ctx, id, now)
+				p.scheduleRetryLocked(ctx, id, now, err)
 			}
 		case r.Err == nil:
 			// an observed success supersedes any pending retry
@@ -125,7 +142,7 @@ func (p *RetryingPusher) Push(ctx context.Context, ids []string) (map[string]*na
 			// never retried; a pending entry is now known-hopeless too
 			delete(p.pending, id)
 		default:
-			p.scheduleRetryLocked(ctx, id, now)
+			p.scheduleRetryLocked(ctx, id, now, r.Err)
 		}
 	}
 	return res, err
@@ -202,8 +219,8 @@ func (p *RetryingPusher) flushDue(ctx context.Context) {
 				"enrollment_id", id, "attempts", e.attempt)
 			delete(p.pending, id)
 		default:
-			e.nextAttempt = now.Add(jitteredBackoff(retryBackoffs[e.attempt]))
 			e.attempt++
+			e.nextAttempt = now.Add(retryWait(r.Err, e.attempt))
 		}
 	}
 }
@@ -248,11 +265,11 @@ func (p *RetryingPusher) noteCallOutcomeLocked(ctx context.Context, now time.Tim
 // an entry that had already backed off past the first step, so a device
 // failing right now isn't stuck waiting out an inherited 30m backoff.
 // Requires p.mu held.
-func (p *RetryingPusher) scheduleRetryLocked(ctx context.Context, id string, now time.Time) {
+func (p *RetryingPusher) scheduleRetryLocked(ctx context.Context, id string, now time.Time, cause error) {
 	if e, ok := p.pending[id]; ok {
 		if e.attempt > 1 {
 			e.attempt = 1
-			e.nextAttempt = now.Add(jitteredBackoff(retryBackoffs[0]))
+			e.nextAttempt = now.Add(retryWait(cause, 1))
 			e.queuedAt = now
 		}
 		return
@@ -271,7 +288,7 @@ func (p *RetryingPusher) scheduleRetryLocked(ctx context.Context, id string, now
 	}
 	p.pending[id] = &retryEntry{
 		attempt:     1,
-		nextAttempt: now.Add(jitteredBackoff(retryBackoffs[0])),
+		nextAttempt: now.Add(retryWait(cause, 1)),
 		queuedAt:    now,
 	}
 }

--- a/server/mdm/apple/retrying_pusher_test.go
+++ b/server/mdm/apple/retrying_pusher_test.go
@@ -1,0 +1,290 @@
+package apple_mdm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	nanomdm_push "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeInnerPusher returns canned per-id responses (default success) and a
+// canned call-level error, recording every call.
+type fakeInnerPusher struct {
+	mu    sync.Mutex
+	calls [][]string
+	res   map[string]*nanomdm_push.Response
+	err   error
+	raw   bool // return res exactly as configured (possibly nil), no per-id fill
+}
+
+func (f *fakeInnerPusher) Push(_ context.Context, ids []string) (map[string]*nanomdm_push.Response, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, append([]string(nil), ids...))
+	if f.raw {
+		return f.res, f.err
+	}
+	out := make(map[string]*nanomdm_push.Response, len(ids))
+	for _, id := range ids {
+		if r, ok := f.res[id]; ok {
+			out[id] = r
+		} else {
+			out[id] = &nanomdm_push.Response{Id: "apns-" + id}
+		}
+	}
+	return out, f.err
+}
+
+func (f *fakeInnerPusher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func transientErr() error {
+	return fmt.Errorf("push HTTP status: 503: %w", &nanopush.JSONPushError{Reason: "InternalServerError"})
+}
+
+// newTestRetryingPusher returns a wrapper with no background loop and a
+// controllable clock.
+func newTestRetryingPusher(inner *fakeInnerPusher) (*RetryingPusher, *time.Time) {
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC)
+	p := newRetryingPusher(inner, slog.New(slog.DiscardHandler))
+	p.clock = func() time.Time { return now }
+	return p, &now
+}
+
+func requireWithinJitter(t *testing.T, base time.Time, d time.Duration, got time.Time) {
+	t.Helper()
+	require.False(t, got.Before(base.Add(time.Duration(float64(d)*0.8))), "before jitter window: %s", got)
+	require.False(t, got.After(base.Add(time.Duration(float64(d)*1.2))), "after jitter window: %s", got)
+}
+
+func TestRetryingPusherPassthrough(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("results and error returned unchanged, even together", func(t *testing.T) {
+		wantRes := map[string]*nanomdm_push.Response{
+			"e1": {Id: "id1"},
+			"e2": {Err: transientErr()},
+		}
+		wantErr := errors.New("partial failure")
+		inner := &fakeInnerPusher{err: wantErr}
+		p, _ := newTestRetryingPusher(inner)
+		// bypass the canned-response builder to pin exact identity
+		inner.res = wantRes
+		res, err := p.Push(ctx, []string{"e1", "e2"})
+		require.Equal(t, wantErr, err)
+		require.Same(t, wantRes["e1"], res["e1"])
+		require.Same(t, wantRes["e2"], res["e2"])
+	})
+
+	t.Run("nil map and nil error pass through with nothing scheduled", func(t *testing.T) {
+		inner := &fakeInnerPusher{raw: true}
+		p, _ := newTestRetryingPusher(inner)
+		res, err := p.Push(ctx, []string{"e1"})
+		require.NoError(t, err)
+		require.Nil(t, res)
+		require.Empty(t, p.pending)
+	})
+}
+
+func TestRetryingPusherScheduling(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("transient failure schedules the first backoff", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, err := p.Push(ctx, []string{"e1"})
+		require.NoError(t, err)
+		require.Len(t, p.pending, 1)
+		require.Equal(t, 1, p.pending["e1"].attempt)
+		requireWithinJitter(t, *now, 30*time.Second, p.pending["e1"].nextAttempt)
+	})
+
+	t.Run("call-level failure with no per-device verdict schedules every id", func(t *testing.T) {
+		// a push-cert or push-info retrieval failure leaves the affected ids
+		// out of the response map entirely; they must still be retried —
+		// this is the common single-host lock/wipe shape.
+		inner := &fakeInnerPusher{raw: true, res: map[string]*nanomdm_push.Response{}, err: errors.New("retrieving push cert for topic: timeout")}
+		p, now := newTestRetryingPusher(inner)
+		_, err := p.Push(ctx, []string{"e1", "e2"})
+		require.Error(t, err)
+		require.Len(t, p.pending, 2)
+		requireWithinJitter(t, *now, 30*time.Second, p.pending["e1"].nextAttempt)
+	})
+
+	t.Run("per-device transport error is transient too", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: errors.New("dial tcp: connection refused")}}}
+		p, _ := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Len(t, p.pending, 1)
+	})
+
+	t.Run("permanent rejections are never scheduled", func(t *testing.T) {
+		for _, reason := range []string{
+			APNSReasonUnregistered, APNSReasonExpiredToken, APNSReasonBadDeviceToken,
+			APNSReasonDeviceTokenNotForTopic, APNSReasonExpiredProviderToken, APNSReasonForbidden,
+		} {
+			t.Run(reason, func(t *testing.T) {
+				inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{
+					"e1": {Err: fmt.Errorf("push HTTP status: 410: %w", &nanopush.JSONPushError{Reason: reason})},
+				}}
+				p, _ := newTestRetryingPusher(inner)
+				_, _ = p.Push(ctx, []string{"e1"})
+				require.Empty(t, p.pending)
+			})
+		}
+	})
+
+	t.Run("duplicate failures collapse onto the existing entry", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		// simulate one failed background retry: the entry is now at attempt 2
+		*now = now.Add(time.Minute)
+		p.flushDue(ctx)
+		require.Equal(t, 2, p.pending["e1"].attempt)
+		// a fresh enqueue-time failure must not reset the backoff position
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Equal(t, 2, p.pending["e1"].attempt)
+	})
+
+	t.Run("an observed success clears a pending retry", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, _ := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Len(t, p.pending, 1)
+		inner.res = nil // next push succeeds
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Empty(t, p.pending)
+	})
+
+	t.Run("overflow drops the oldest entry", func(t *testing.T) {
+		inner := &fakeInnerPusher{}
+		p, now := newTestRetryingPusher(inner)
+		var buf strings.Builder
+		p.logger = slog.New(slog.NewTextHandler(&buf, nil))
+		for i := range retryPendingCap {
+			p.scheduleRetryLocked(ctx, fmt.Sprintf("e%05d", i), *now)
+			*now = now.Add(time.Millisecond)
+		}
+		require.Len(t, p.pending, retryPendingCap)
+		p.scheduleRetryLocked(ctx, "one-more", *now)
+		require.Len(t, p.pending, retryPendingCap)
+		require.NotContains(t, p.pending, "e00000", "oldest entry dropped")
+		require.Contains(t, p.pending, "one-more")
+		require.Contains(t, buf.String(), "level=WARN")
+	})
+}
+
+func TestRetryingPusherFlush(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("escalates through the backoffs then gives up", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Equal(t, 1, inner.callCount())
+
+		// advance past each backoff (max + jitter margin) and flush; the
+		// entry escalates 2m -> 8m -> 30m and is dropped after the last.
+		for i, wantNext := range []time.Duration{2 * time.Minute, 8 * time.Minute, 30 * time.Minute} {
+			*now = p.pending["e1"].nextAttempt.Add(time.Second)
+			p.flushDue(ctx)
+			require.Equal(t, i+2, p.pending["e1"].attempt)
+			requireWithinJitter(t, *now, wantNext, p.pending["e1"].nextAttempt)
+		}
+		*now = p.pending["e1"].nextAttempt.Add(time.Second)
+		p.flushDue(ctx)
+		require.Empty(t, p.pending, "dropped after the last backoff")
+		require.Equal(t, 5, inner.callCount(), "initial push + four retries")
+
+		// nothing left to do
+		p.flushDue(ctx)
+		require.Equal(t, 5, inner.callCount())
+	})
+
+	t.Run("success on retry removes the entry", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		inner.res = nil // retry succeeds
+		*now = now.Add(time.Minute)
+		p.flushDue(ctx)
+		require.Empty(t, p.pending)
+	})
+
+	t.Run("entries not yet due are left alone", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, _ := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		p.flushDue(ctx) // now == schedule time, backoff not elapsed
+		require.Equal(t, 1, inner.callCount())
+	})
+
+	t.Run("call-level failure keeps entries due without escalating", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		inner.raw = true
+		inner.res = nil
+		inner.err = errors.New("cert store down")
+		*now = now.Add(time.Minute)
+		p.flushDue(ctx)
+		require.Len(t, p.pending, 1)
+		require.Equal(t, 1, p.pending["e1"].attempt, "not the device's fault")
+	})
+}
+
+func TestRetryingPusherBreaker(t *testing.T) {
+	ctx := t.Context()
+
+	inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+	p, now := newTestRetryingPusher(inner)
+	_, _ = p.Push(ctx, []string{"e1"})
+
+	// consecutive call-level failures open the breaker
+	inner.raw = true
+	inner.err = errors.New("apns is down")
+	for range retryBreakerThreshold {
+		_, err := p.Push(ctx, []string{"eX"})
+		require.Error(t, err)
+	}
+	require.True(t, p.breakerOpenUntil.After(*now), "breaker open")
+
+	// the retry loop is paused while open
+	*now = now.Add(time.Minute)
+	before := inner.callCount()
+	p.flushDue(ctx)
+	require.Equal(t, before, inner.callCount(), "no retry flush while the breaker is open")
+
+	// fresh enqueue-time pushes still pass through
+	_, _ = p.Push(ctx, []string{"eY"})
+	require.Equal(t, before+1, inner.callCount())
+
+	// after the cooldown the loop resumes, and a success closes the streak
+	inner.raw = false
+	inner.err = nil
+	inner.res = nil
+	*now = p.breakerOpenUntil.Add(time.Second)
+	p.flushDue(ctx)
+	require.Empty(t, p.pending, "retry delivered after cooldown")
+	require.Zero(t, p.consecutiveFailures)
+}
+
+func TestRetryingPusherStop(t *testing.T) {
+	inner := &fakeInnerPusher{}
+	p := NewRetryingPusher(inner, slog.New(slog.DiscardHandler))
+	_, err := p.Push(t.Context(), []string{"e1"})
+	require.NoError(t, err)
+	p.Stop() // must return promptly and not leak the loop goroutine (-race)
+}

--- a/server/mdm/apple/retrying_pusher_test.go
+++ b/server/mdm/apple/retrying_pusher_test.go
@@ -307,6 +307,49 @@ func TestRetryingPusherBreaker(t *testing.T) {
 	require.Zero(t, p.consecutiveFailures)
 }
 
+func TestRetryingPusherBreakerResponseSignals(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("all-transient response sets open the breaker", func(t *testing.T) {
+		// APNs 5xx storms and GOAWAYs surface as per-device errors with a
+		// nil call-level error; they must still count as outage strikes.
+		inner := &fakeInnerPusher{raw: true, res: map[string]*nanomdm_push.Response{
+			"e1": {Err: transientErr()},
+			"e2": {Err: errors.New("http2: server sent GOAWAY")},
+		}}
+		p, now := newTestRetryingPusher(inner)
+		for range retryBreakerThreshold {
+			_, err := p.Push(ctx, []string{"e1", "e2"})
+			require.NoError(t, err, "call-level error stays nil in this shape")
+		}
+		require.True(t, p.breakerOpenUntil.After(*now), "breaker must open on response-level outage signals")
+	})
+
+	t.Run("a success in the set resets the streak", func(t *testing.T) {
+		inner := &fakeInnerPusher{raw: true, res: map[string]*nanomdm_push.Response{
+			"e1": {Err: transientErr()},
+			"e2": {Id: "ok"},
+		}}
+		p, now := newTestRetryingPusher(inner)
+		for range retryBreakerThreshold + 2 {
+			_, _ = p.Push(ctx, []string{"e1", "e2"})
+		}
+		require.False(t, p.breakerOpenUntil.After(*now))
+		require.Zero(t, p.consecutiveFailures)
+	})
+
+	t.Run("all-permanent rejections are a healthy APNs, not an outage", func(t *testing.T) {
+		inner := &fakeInnerPusher{raw: true, res: map[string]*nanomdm_push.Response{
+			"e1": {Err: fmt.Errorf("push HTTP status: 410: %w", &nanopush.JSONPushError{Reason: APNSReasonUnregistered})},
+		}}
+		p, now := newTestRetryingPusher(inner)
+		for range retryBreakerThreshold + 2 {
+			_, _ = p.Push(ctx, []string{"e1"})
+		}
+		require.False(t, p.breakerOpenUntil.After(*now))
+	})
+}
+
 func TestRetryingPusherStop(t *testing.T) {
 	inner := &fakeInnerPusher{}
 	p := NewRetryingPusher(inner, slog.New(slog.DiscardHandler))

--- a/server/mdm/apple/retrying_pusher_test.go
+++ b/server/mdm/apple/retrying_pusher_test.go
@@ -12,6 +12,7 @@ import (
 
 	nanomdm_push "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/nanopush"
+	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,17 +146,32 @@ func TestRetryingPusherScheduling(t *testing.T) {
 		}
 	})
 
-	t.Run("duplicate failures collapse onto the existing entry", func(t *testing.T) {
+	t.Run("a fresh failure restarts a backed-off entry's ladder", func(t *testing.T) {
 		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
 		p, now := newTestRetryingPusher(inner)
 		_, _ = p.Push(ctx, []string{"e1"})
-		// simulate one failed background retry: the entry is now at attempt 2
+		firstAttemptAt := p.pending["e1"].nextAttempt
+
+		// at the first step, a duplicate failure collapses without rescheduling
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Equal(t, 1, p.pending["e1"].attempt)
+		require.Equal(t, firstAttemptAt, p.pending["e1"].nextAttempt)
+
+		// after a failed background retry escalates the entry, a fresh
+		// enqueue-time failure restarts the ladder
 		*now = now.Add(time.Minute)
 		p.flushDue(ctx)
 		require.Equal(t, 2, p.pending["e1"].attempt)
-		// a fresh enqueue-time failure must not reset the backoff position
 		_, _ = p.Push(ctx, []string{"e1"})
-		require.Equal(t, 2, p.pending["e1"].attempt)
+		require.Equal(t, 1, p.pending["e1"].attempt)
+		requireWithinJitter(t, *now, 30*time.Second, p.pending["e1"].nextAttempt)
+	})
+
+	t.Run("enrollments without push info are never scheduled", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: nanomdm_pushsvc.ErrIdNotFound}}}
+		p, _ := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		require.Empty(t, p.pending)
 	})
 
 	t.Run("an observed success clears a pending retry", func(t *testing.T) {
@@ -229,6 +245,16 @@ func TestRetryingPusherFlush(t *testing.T) {
 		_, _ = p.Push(ctx, []string{"e1"})
 		p.flushDue(ctx) // now == schedule time, backoff not elapsed
 		require.Equal(t, 1, inner.callCount())
+	})
+
+	t.Run("a retry that finds the enrollment gone drops the entry", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: transientErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		inner.res = map[string]*nanomdm_push.Response{"e1": {Err: nanomdm_pushsvc.ErrIdNotFound}}
+		*now = now.Add(time.Minute)
+		p.flushDue(ctx)
+		require.Empty(t, p.pending)
 	})
 
 	t.Run("call-level failure keeps entries due without escalating", func(t *testing.T) {

--- a/server/mdm/apple/retrying_pusher_test.go
+++ b/server/mdm/apple/retrying_pusher_test.go
@@ -50,8 +50,16 @@ func (f *fakeInnerPusher) callCount() int {
 	return len(f.calls)
 }
 
+// transientErr is a fast-ladder transient failure (429 — not 5xx, which gets
+// the 15-minute floor).
 func transientErr() error {
-	return fmt.Errorf("push HTTP status: 503: %w", &nanopush.JSONPushError{Reason: "InternalServerError"})
+	return fmt.Errorf("push HTTP status: 429: %w", &nanopush.JSONPushError{Reason: APNSReasonTooManyRequests})
+}
+
+// fiveXXErr is a transient failure with a 5xx reason, subject to Apple's
+// 15-minute retry floor.
+func fiveXXErr() error {
+	return fmt.Errorf("push HTTP status: 503: %w", &nanopush.JSONPushError{Reason: APNSReasonServiceUnavailable})
 }
 
 // newTestRetryingPusher returns a wrapper with no background loop and a
@@ -167,6 +175,29 @@ func TestRetryingPusherScheduling(t *testing.T) {
 		requireWithinJitter(t, *now, 30*time.Second, p.pending["e1"].nextAttempt)
 	})
 
+	t.Run("5xx failures wait at least Apple's 15-minute floor", func(t *testing.T) {
+		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: fiveXXErr()}}}
+		p, now := newTestRetryingPusher(inner)
+		_, _ = p.Push(ctx, []string{"e1"})
+		e := p.pending["e1"]
+		require.Equal(t, 1, e.attempt)
+		require.False(t, e.nextAttempt.Before(now.Add(retry5xxFloor)), "must not retry a 5xx sooner than 15m")
+		require.False(t, e.nextAttempt.After(now.Add(time.Duration(float64(retry5xxFloor)*1.2))))
+
+		// escalation on a repeated 5xx keeps the floor at rungs below 15m
+		*now = e.nextAttempt.Add(time.Second)
+		p.flushDue(ctx)
+		require.Equal(t, 2, e.attempt)
+		require.False(t, e.nextAttempt.Before(now.Add(retry5xxFloor)))
+
+		// the 30m rung already exceeds the floor and keeps its normal window
+		e.attempt = 3
+		*now = e.nextAttempt.Add(20 * time.Minute)
+		p.flushDue(ctx)
+		require.Equal(t, 4, e.attempt)
+		requireWithinJitter(t, *now, 30*time.Minute, e.nextAttempt)
+	})
+
 	t.Run("enrollments without push info are never scheduled", func(t *testing.T) {
 		inner := &fakeInnerPusher{res: map[string]*nanomdm_push.Response{"e1": {Err: nanomdm_pushsvc.ErrIdNotFound}}}
 		p, _ := newTestRetryingPusher(inner)
@@ -190,11 +221,11 @@ func TestRetryingPusherScheduling(t *testing.T) {
 		var buf strings.Builder
 		p.logger = slog.New(slog.NewTextHandler(&buf, nil))
 		for i := range retryPendingCap {
-			p.scheduleRetryLocked(ctx, fmt.Sprintf("e%05d", i), *now)
+			p.scheduleRetryLocked(ctx, fmt.Sprintf("e%05d", i), *now, transientErr())
 			*now = now.Add(time.Millisecond)
 		}
 		require.Len(t, p.pending, retryPendingCap)
-		p.scheduleRetryLocked(ctx, "one-more", *now)
+		p.scheduleRetryLocked(ctx, "one-more", *now, transientErr())
 		require.Len(t, p.pending, retryPendingCap)
 		require.NotContains(t, p.pending, "e00000", "oldest entry dropped")
 		require.Contains(t, p.pending, "one-more")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51649

Wraps the APNs push service in a `RetryingPusher` that retries transient per-device push failures in-process with jittered backoff (30s/2m/8m/30m, then the daily sweep covers it), replacing the legacy per-minute cron's de facto retry role. Permanent rejections (dead tokens, cert/topic errors) are never retried; a circuit breaker pauses the retry loop when pushes fail at the provider level; callers see the inner results and errors unchanged. In-memory and lossy by design (no DB/Redis) per the issue. One deviation: the wrapper owns its lifecycle via `Stop()` wired into server shutdown instead of a constructor `ctx` — no serve-lifetime context exists at the construction point (`cmd.Context()` is never cancelled in production). No changes file (the story entry rode #52265, whose branch this PR is based on until it merges).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually (dev server + mock APNs raced to simulate a transient outage: push failures surfaced unchanged to the UI, sweep- and click-armed failures recovered autonomously through the backoff ladder once the endpoint came up, coalescing and the 30-day expiration visible on the wire, prompt shutdown via Stop)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Apple MDM push delivery now automatically retries temporary failures with backoff and jitter.
  * Provider outages are handled with a circuit breaker to reduce repeated failed attempts.
  * Permanent delivery failures, invalid enrollments, and exhausted retries are excluded from further attempts.

* **Operations**
  * Push retry processing now shuts down cleanly when the server stops.

* **Testing**
  * Added coverage for retry scheduling, APNs error classification, circuit-breaker behavior, capacity limits, and clean shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
