### PR TITLE
CP: remove in house app and VPP backdating and only fire APNS ping after committed transaction (#52281)

### DIFF
--- a/changes/50682-backdating-racy-ping
+++ b/changes/50682-backdating-racy-ping
@@ -1,0 +1,1 @@
+- Fixed an issue where VPP and In House Apps would backdate and sometimes fall outside of the MDM command queue.

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -1755,7 +1755,10 @@ INSERT INTO
 SELECT
 	?,
 	execution_id,
-	created_at -- force same timestamp to keep ordering
+	-- distinct, forward-dated timestamps: nanomdm orders the queue by
+	-- created_at alone, and one statement's rows would otherwise tie on the
+	-- column default and be served in arbitrary order
+	NOW(6) + INTERVAL ROW_NUMBER() OVER (ORDER BY priority DESC, created_at ASC, id ASC) MICROSECOND
 FROM
 	upcoming_activities
 WHERE
@@ -1900,11 +1903,17 @@ WHERE
 
 	// best-effort APNs push notification to the host, not critical because we
 	// have a cron job that will retry for hosts with pending MDM commands.
-	if ds.pusher != nil {
+	wrapped, ok := tx.(common_mysql.WrappedExtContext)
+	if ds.pusher == nil || !ok {
+		return nil
+	}
+	// we wrap the APNs Push here, as activate next upcoming is called from many sites
+	// and it's racy to ping before we have committed the transaction.
+	wrapped.AddOnCommitHook(func() {
 		if _, err := ds.pusher.Push(ctx, []string{hostData.UUID}); err != nil {
 			ds.logger.ErrorContext(ctx, "failed to send push notification", "err", err, "hostID", hostID, "hostUUID", hostData.UUID)
 		}
-	}
+	})
 	return nil
 }
 

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
@@ -3288,7 +3289,10 @@ INSERT INTO
 SELECT
 	?,
 	execution_id,
-	created_at -- force same timestamp to keep ordering
+	-- distinct, forward-dated timestamps: nanomdm orders the queue by
+	-- created_at alone, and one statement's rows would otherwise tie on the
+	-- column default and be served in arbitrary order
+	NOW(6) + INTERVAL ROW_NUMBER() OVER (ORDER BY priority DESC, created_at ASC, id ASC) MICROSECOND
 FROM
 	upcoming_activities
 WHERE
@@ -3309,11 +3313,17 @@ ORDER BY
 
 	// best-effort APNs push notification to the host, not critical because we
 	// have a cron job that will retry for hosts with pending MDM commands.
-	if ds.pusher != nil {
+	wrapped, ok := tx.(platform_mysql.WrappedExtContext)
+	if ds.pusher == nil || !ok {
+		return nil
+	}
+	// we wrap the APNs Push here, as activate next upcoming is called from many sites
+	// and it's racy to ping before we have committed the transaction.
+	wrapped.AddOnCommitHook(func() {
 		if _, err := ds.pusher.Push(ctx, []string{hostData.UUID}); err != nil {
 			ds.logger.ErrorContext(ctx, "failed to send push notification", "err", err, "hostID", hostID, "hostUUID", hostData.UUID)
 		}
-	}
+	})
 	return nil
 }
 

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	nanomdm_mysql "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/storage/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
@@ -51,6 +52,8 @@ func TestVPP(t *testing.T) {
 		{"VPPInstallEnqueuesConfigurationDict", testVPPInstallEnqueuesConfigurationDict},
 		{"VPPInstallOmitsConfigurationOnMacOS", testVPPInstallOmitsConfigurationOnMacOS},
 		{"VPPInstallEnrollmentChannelRouting", testVPPInstallEnrollmentChannelRouting},
+		{"VPPInstallPushesAfterCommit", testVPPInstallPushesAfterCommit},
+		{"VPPInstallQueueRowNotBackdated", testVPPInstallQueueRowNotBackdated},
 		{"MapAdamIDsPendingInstallVerification", testMapAdamIDsPendingInstallVerification},
 		{"MapAdamIDsRecentInstalls", testMapAdamIDsRecentInstalls},
 		{"MapAdamIDsRecentlyVerifiedInstalls", testMapAdamIDsRecentlyVerifiedInstalls},
@@ -3452,6 +3455,113 @@ func testRetryVPPAppInstallForHost(t *testing.T, ds *Datastore) {
 		require.Equal(t, 1, queueCommandCount)
 		return nil
 	})
+}
+
+// testVPPInstallPushesAfterCommit pins the ordering between the best-effort
+// APNs ping and the transaction that enqueues the command. The ping is
+// registered as an on-commit hook (see nanoEnqueueVPPInstall), so by the time
+// it fires the nano_commands and nano_enrollment_queue rows must be visible on
+// every other connection: a device that checks in on the strength of the ping
+// always finds the command waiting for it.
+func testVPPInstallPushesAfterCommit(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	test.CreateInsertGlobalVPPToken(t, ds)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "push-after-commit-host",
+		UUID:           uuid.NewString(),
+		Platform:       string(fleet.IOSPlatform),
+		HardwareSerial: uuid.NewString(),
+	})
+	require.NoError(t, err)
+	nanoEnroll(t, ds, host, false)
+
+	const adamID = "push_after_commit"
+	setupTestVPPApp(t, ds, adamID, fleet.IOSPlatform)
+	appID := fleet.VPPAppID{AdamID: adamID, Platform: fleet.IOSPlatform}
+
+	const cmdUUID = "push-after-commit-cmd"
+	var (
+		pushedIDs          []string
+		cmdRows, queueRows int
+	)
+	ds.WithPusher(pusherFunc(func(ctx context.Context, ids []string) (map[string]*push.Response, error) {
+		pushedIDs = append(pushedIDs, ids...)
+		// ExecAdhocSQL runs on a connection of its own, outside the enqueue
+		// transaction, so it only sees the command once that transaction has
+		// committed.
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			if err := sqlx.GetContext(ctx, q, &cmdRows,
+				"SELECT COUNT(*) FROM nano_commands WHERE command_uuid = ?", cmdUUID); err != nil {
+				return err
+			}
+			return sqlx.GetContext(ctx, q, &queueRows,
+				"SELECT COUNT(*) FROM nano_enrollment_queue WHERE command_uuid = ?", cmdUUID)
+		})
+		return okPusherFunc(ctx, ids)
+	}))
+	t.Cleanup(func() { ds.WithPusher(nil) })
+
+	require.NoError(t, ds.InsertHostVPPSoftwareInstall(ctx, host.ID, appID, cmdUUID, "evt-push-after-commit", fleet.HostSoftwareInstallOptions{}))
+
+	require.Equal(t, []string{host.UUID}, pushedIDs, "no APNs push for the activated VPP install")
+	require.Equal(t, 1, cmdRows, "push fired before the nano_commands row was committed")
+	require.Equal(t, 1, queueRows, "push fired before the nano_enrollment_queue row was committed")
+}
+
+// testVPPInstallQueueRowNotBackdated ensures we don't backdate VPP installs into the nano commands table.
+func testVPPInstallQueueRowNotBackdated(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	test.CreateInsertGlobalVPPToken(t, ds)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "backdate-host",
+		UUID:           uuid.NewString(),
+		Platform:       string(fleet.IOSPlatform),
+		HardwareSerial: uuid.NewString(),
+	})
+	require.NoError(t, err)
+	nanoEnroll(t, ds, host, false)
+
+	const adamID = "not_backdated"
+	setupTestVPPApp(t, ds, adamID, fleet.IOSPlatform)
+	appID := fleet.VPPAppID{AdamID: adamID, Platform: fleet.IOSPlatform}
+
+	const cmdUUID = "not-backdated-cmd"
+	require.NoError(t, ds.InsertHostVPPSoftwareInstall(ctx, host.ID, appID, cmdUUID, "evt-not-backdated", fleet.HostSoftwareInstallOptions{}))
+
+	install, err := ds.GetHostVPPInstallByCommandUUID(ctx, cmdUUID)
+	require.NoError(t, err)
+	require.NotNil(t, install)
+
+	// Age the upcoming activity the way a long wait behind another install
+	// does. The first attempt's queue row is aged along with it so the
+	// pending-command assertion below can only be satisfied by the re-enqueued
+	// command.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		if _, err := q.ExecContext(ctx,
+			"UPDATE upcoming_activities SET created_at = NOW(6) - INTERVAL 10 DAY WHERE execution_id = ?", cmdUUID); err != nil {
+			return err
+		}
+		_, err := q.ExecContext(ctx,
+			"UPDATE nano_enrollment_queue SET created_at = NOW(6) - INTERVAL 10 DAY WHERE command_uuid = ?", cmdUUID)
+		return err
+	})
+
+	require.NoError(t, ds.RetryVPPInstall(ctx, install))
+
+	var newCmdUUID string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &newCmdUUID,
+			"SELECT command_uuid FROM host_vpp_software_installs WHERE host_id = ?", host.ID)
+	})
+	require.NotEqual(t, cmdUUID, newCmdUUID)
+
+	// The consequence that matters: the cron that re-pings hosts with pending
+	// commands still sees this host.
+	pendingIDs, err := ds.GetEnrollmentIDsWithPendingMDMAppleCommands(ctx)
+	require.NoError(t, err)
+	require.Contains(t, pendingIDs, host.UUID)
 }
 
 // setupTestVPPApp creates a VPP app for use in datastore tests. Caller is

--- a/server/platform/mysql/common.go
+++ b/server/platform/mysql/common.go
@@ -190,6 +190,8 @@ func WithTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger *slog.Logger) err
 		return ctxerr.Wrap(ctx, err, "create transaction")
 	}
 
+	wrappedTx := wrappedTx{Tx: tx}
+
 	defer func() {
 		if p := recover(); p != nil {
 			if err := tx.Rollback(); err != nil {
@@ -199,7 +201,7 @@ func WithTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger *slog.Logger) err
 		}
 	}()
 
-	if err := fn(tx); err != nil {
+	if err := fn(&wrappedTx); err != nil {
 		rbErr := tx.Rollback()
 		if rbErr != nil && rbErr != sql.ErrTxDone {
 			return ctxerr.Wrapf(ctx, err, "got err '%s' rolling back after err", rbErr.Error())
@@ -216,6 +218,10 @@ func WithTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger *slog.Logger) err
 			TriggerFatalError(ctx, err)
 		}
 		return err
+	}
+
+	for _, hook := range wrappedTx.onCommitHooks {
+		hook()
 	}
 
 	return nil

--- a/server/platform/mysql/retry.go
+++ b/server/platform/mysql/retry.go
@@ -52,6 +52,20 @@ func TriggerFatalError(ctx context.Context, err error) {
 
 var DoRetryErr = errors.New("fleet datastore retry")
 
+type wrappedTx struct {
+	*sqlx.Tx
+	onCommitHooks []func()
+}
+
+func (tx *wrappedTx) AddOnCommitHook(hook func()) {
+	tx.onCommitHooks = append(tx.onCommitHooks, hook)
+}
+
+type WrappedExtContext interface {
+	sqlx.ExtContext
+	AddOnCommitHook(hook func())
+}
+
 type TxFn func(tx sqlx.ExtContext) error
 
 // ReadTxFn is the read-only variant of TxFn, with tx only exposing the read methods
@@ -64,6 +78,7 @@ func WithRetryTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger *slog.Logger
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "create transaction")
 		}
+		wrappedTx := wrappedTx{Tx: tx}
 
 		defer func() {
 			if p := recover(); p != nil {
@@ -74,7 +89,7 @@ func WithRetryTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger *slog.Logger
 			}
 		}()
 
-		if err := fn(tx); err != nil {
+		if err := fn(&wrappedTx); err != nil {
 			rbErr := tx.Rollback()
 			if rbErr != nil && rbErr != sql.ErrTxDone {
 				// Consider rollback errors to be non-retryable
@@ -109,6 +124,11 @@ func WithRetryTxx(ctx context.Context, db *sqlx.DB, fn TxFn, logger *slog.Logger
 			}
 
 			return backoff.Permanent(err)
+		}
+
+		// run any onCommit hooks.
+		for _, hook := range wrappedTx.onCommitHooks {
+			hook()
 		}
 
 		return nil

--- a/server/platform/mysql/retry_test.go
+++ b/server/platform/mysql/retry_test.go
@@ -145,6 +145,124 @@ func TestTransactionReadOnlyTriggersFatalError(t *testing.T) {
 	}
 }
 
+// TestWithRetryTxxOnCommitHooks pins the contract the deferred APNs push in
+// nanoEnqueueVPPInstall depends on: a hook registered from inside the
+// transaction runs only once the commit has succeeded, so nothing outside the
+// transaction is ever notified about writes that never landed.
+func TestWithRetryTxxOnCommitHooks(t *testing.T) {
+	discard := slog.New(slog.DiscardHandler)
+
+	newDB := func(t *testing.T) (*sqlx.DB, sqlmock.Sqlmock) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+		return sqlx.NewDb(db, "sqlmock"), mock
+	}
+
+	t.Run("run after commit in registration order", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectBegin()
+		mock.ExpectExec("INSERT INTO t").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+
+		var order []string
+		err := WithRetryTxx(t.Context(), db, func(tx sqlx.ExtContext) error {
+			wrapped, ok := tx.(WrappedExtContext)
+			require.True(t, ok, "the tx handed to the fn must accept on-commit hooks")
+
+			if _, err := tx.ExecContext(t.Context(), "INSERT INTO t VALUES (1)"); err != nil {
+				return err
+			}
+			wrapped.AddOnCommitHook(func() {
+				// Every expectation, COMMIT included, is already satisfied, so
+				// the hook cannot be observing an in-flight transaction.
+				require.NoError(t, mock.ExpectationsWereMet())
+				order = append(order, "first")
+			})
+			wrapped.AddOnCommitHook(func() {
+				order = append(order, "second")
+			})
+			order = append(order, "fn")
+			return nil
+		}, discard)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fn", "first", "second"}, order)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("do not run when the fn fails", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+
+		fnErr := errors.New("boom")
+		var ran bool
+		err := WithRetryTxx(t.Context(), db, func(tx sqlx.ExtContext) error {
+			tx.(WrappedExtContext).AddOnCommitHook(func() { ran = true })
+			return fnErr
+		}, discard)
+
+		require.ErrorIs(t, err, fnErr)
+		assert.False(t, ran, "hook ran for a rolled back transaction")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("do not run when the commit fails", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectBegin()
+		mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+
+		var ran bool
+		err := WithRetryTxx(t.Context(), db, func(tx sqlx.ExtContext) error {
+			tx.(WrappedExtContext).AddOnCommitHook(func() { ran = true })
+			return nil
+		}, discard)
+
+		require.Error(t, err)
+		assert.False(t, ran, "hook ran for a transaction that failed to commit")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("do not carry over hooks from a retried attempt", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+		mock.ExpectBegin()
+		mock.ExpectCommit()
+
+		var attempts, hookRuns int
+		err := WithRetryTxx(t.Context(), db, func(tx sqlx.ExtContext) error {
+			attempts++
+			tx.(WrappedExtContext).AddOnCommitHook(func() { hookRuns++ })
+			if attempts == 1 {
+				return &gmysql.MySQLError{Number: mysqlerr.ER_LOCK_DEADLOCK, Message: "Deadlock found"}
+			}
+			return nil
+		}, discard)
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+		assert.Equal(t, 1, hookRuns, "a hook registered by the rolled back attempt ran anyway")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("withTxx should always have WrappedExtContext", func(t *testing.T) {
+		db, mock := newDB(t)
+		mock.ExpectBegin()
+		mock.ExpectCommit()
+
+		err := WithRetryTxx(t.Context(), db, func(tx sqlx.ExtContext) error {
+			_, ok := tx.(WrappedExtContext)
+			require.True(t, ok, "tx is not a WrappedExtContext")
+			return nil
+		}, discard)
+
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestRetryableError(t *testing.T) {
 	cases := []struct {
 		name      string


### PR DESCRIPTION
Cherry picks: #52281 -> 4.92