### PR TITLE
Keep the BYOD IdP authentication result in a server-side session

### DIFF
--- a/changes/enroll-byod-session
+++ b/changes/enroll-byod-session
@@ -1,0 +1,1 @@
+- Improved input validation for the BYOD (/enroll) end user authentication flow.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -488,6 +488,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			return svc.NewActivity(ctx, user, activity)
 		},
 		config.MDM.AndroidAgent,
+		redis_key_value.New(redisPool),
 	)
 	if err != nil {
 		initFatal(err, "initializing android service")
@@ -887,6 +888,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			svc,
 			config.Server.URLPrefix,
 			ds,
+			redis_key_value.New(redisPool),
 			logger,
 			serveCSP,
 		)

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -889,6 +889,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			config.Server.URLPrefix,
 			ds,
 			redis_key_value.New(redisPool),
+			clock.C,
 			logger,
 			serveCSP,
 		)

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/file"
+	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
@@ -1074,8 +1075,16 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 		for k, v := range u.Query() {
 			q.Add(k, v[0])
 		}
+		// The page resolves the IdP account from the session; the reference has
+		// no reader on this branch and would only land in browser history.
+		q.Del("enrollment_reference")
 		u.RawQuery = q.Encode()
-		return u.String(), enrollmentRef, "", 0
+		byodSessionID, err := shared_mdm.CreateBYODIdPSession(ctx, svc.keyValueStore, svc.clock, enrollmentRef)
+		if err != nil {
+			logging.WithErr(ctx, err)
+			return "/enroll?error=" + url.QueryEscape("An error occurred. : Failed to start enrollment session."), "", "", 0
+		}
+		return u.String(), byodSessionID, "", 0
 
 	case ssoRequestData.Initiator == fleet.SSOInitiatorFleetDesktop:
 		// Re-check the feature is still on: an admin may have disabled it between

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -580,7 +580,6 @@
       const MAC_MDM_ENABLED = "{{.MacMDMEnabled}}" == "true";
       const IS_APPLE_MANUAL_ENROLLMENT_BLOCKED = "{{.AppleManualEnrollmentBlocked}}" == "true";
       const ERROR_MESSAGE = "{{.ErrorMessage}}";
-      const IDP_UUID = "{{.IdpUUID}}";
       const isFullyManaged = new URLSearchParams(window.location.search).has(
         "fully_managed",
         true
@@ -837,12 +836,6 @@
 
         if (fullyManaged) {
           url = url.concat("&fully_managed=true");
-        }
-
-        if (IDP_UUID) {
-          url = url.concat(
-            `&idp_uuid=${encodeURIComponent(IDP_UUID)}`
-          );
         }
 
         const response = await fetch(url, {

--- a/pkg/mdm/byod_session.go
+++ b/pkg/mdm/byod_session.go
@@ -28,6 +28,9 @@ type BYODIdPSession struct {
 
 // CreateBYODIdPSession returns the opaque id to hand back in the cookie.
 func CreateBYODIdPSession(ctx context.Context, kv fleet.KeyValueStore, clk clock.Clock, idpAccountUUID string) (string, error) {
+	if kv == nil {
+		return "", ctxerr.New(ctx, "byod idp session store not configured")
+	}
 	sessionID, err := server.GenerateRandomURLSafeText(byodIdPSessionIDLength)
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "generate byod idp session id")

--- a/pkg/mdm/byod_session.go
+++ b/pkg/mdm/byod_session.go
@@ -48,6 +48,23 @@ func CreateBYODIdPSession(ctx context.Context, kv fleet.KeyValueStore, clk clock
 	return sessionID, nil
 }
 
+// ConsumeBYODIdPSession ends a session once the flow it authenticated has
+// completed. The key is overwritten rather than deleted so this works on any
+// store; ValidateBYODIdPSession rejects the expired record until it is dropped.
+func ConsumeBYODIdPSession(ctx context.Context, kv fleet.KeyValueStore, clk clock.Clock, sessionID string) error {
+	if kv == nil {
+		return ctxerr.New(ctx, "byod idp session store not configured")
+	}
+	b, err := json.Marshal(BYODIdPSession{ExpiresAt: clk.Now()})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "marshal consumed byod idp session")
+	}
+	if err := kv.Set(ctx, byodIdPSessionKeyPrefix+sessionID, string(b), time.Second); err != nil {
+		return ctxerr.Wrap(ctx, err, "consume byod idp session")
+	}
+	return nil
+}
+
 // ValidateBYODIdPSession returns an AuthRequiredError for an unknown or expired
 // session; any other error is the store failing.
 func ValidateBYODIdPSession(ctx context.Context, kv fleet.KeyValueStore, clk clock.Clock, sessionID string) (string, error) {

--- a/pkg/mdm/byod_session.go
+++ b/pkg/mdm/byod_session.go
@@ -1,0 +1,72 @@
+package mdm
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+const (
+	byodIdPSessionKeyPrefix = "byod_idp_session:"
+	byodIdPSessionIDLength  = 24
+	// BYODIdPSessionTTL bounds how long an end user has between finishing IdP
+	// authentication and downloading the enrollment profile.
+	BYODIdPSessionTTL = 30 * time.Minute
+)
+
+// BYODIdPSession is minted after a successful IdP callback for the BYOD /enroll
+// flow. The cookie carries only the session id; the IdP account lives here.
+type BYODIdPSession struct {
+	IdPAccountUUID string    `json:"idp_account_uuid"`
+	ExpiresAt      time.Time `json:"expires_at"`
+}
+
+// CreateBYODIdPSession returns the opaque id to hand back in the cookie.
+func CreateBYODIdPSession(ctx context.Context, kv fleet.KeyValueStore, clk clock.Clock, idpAccountUUID string) (string, error) {
+	sessionID, err := server.GenerateRandomURLSafeText(byodIdPSessionIDLength)
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "generate byod idp session id")
+	}
+	b, err := json.Marshal(BYODIdPSession{
+		IdPAccountUUID: idpAccountUUID,
+		ExpiresAt:      clk.Now().Add(BYODIdPSessionTTL),
+	})
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "marshal byod idp session")
+	}
+	if err := kv.Set(ctx, byodIdPSessionKeyPrefix+sessionID, string(b), BYODIdPSessionTTL); err != nil {
+		return "", ctxerr.Wrap(ctx, err, "store byod idp session")
+	}
+	return sessionID, nil
+}
+
+// ValidateBYODIdPSession returns an AuthRequiredError for an unknown or expired
+// session; any other error is the store failing.
+func ValidateBYODIdPSession(ctx context.Context, kv fleet.KeyValueStore, clk clock.Clock, sessionID string) (string, error) {
+	if kv == nil {
+		return "", ctxerr.New(ctx, "byod idp session store not configured")
+	}
+	if sessionID == "" {
+		return "", ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("byod idp session not found"))
+	}
+	val, err := kv.Get(ctx, byodIdPSessionKeyPrefix+sessionID)
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "get byod idp session")
+	}
+	if val == nil {
+		return "", ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("byod idp session not found"))
+	}
+	var session BYODIdPSession
+	if err := json.Unmarshal([]byte(*val), &session); err != nil {
+		return "", ctxerr.Wrap(ctx, err, "unmarshal byod idp session")
+	}
+	if !clk.Now().Before(session.ExpiresAt) {
+		return "", ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("byod idp session expired"))
+	}
+	return session.IdPAccountUUID, nil
+}

--- a/pkg/mdm/byod_session_test.go
+++ b/pkg/mdm/byod_session_test.go
@@ -1,0 +1,75 @@
+package mdm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	mockredis "github.com/fleetdm/fleet/v4/server/mock/redis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBYODIdPSession(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	vals := map[string]string{}
+	kv := &mockredis.KeyValueStore{
+		SetFunc: func(_ context.Context, key, value string, _ time.Duration) error {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[key] = value
+			return nil
+		},
+		GetFunc: func(_ context.Context, key string) (*string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			v, ok := vals[key]
+			if !ok {
+				return nil, nil
+			}
+			return &v, nil
+		},
+	}
+	clk := clock.NewMockClock()
+	ctx := t.Context()
+
+	sessionID, err := CreateBYODIdPSession(ctx, kv, clk, "idp-account-uuid")
+	require.NoError(t, err)
+	require.NotEmpty(t, sessionID)
+	require.NotEqual(t, "idp-account-uuid", sessionID)
+
+	got, err := ValidateBYODIdPSession(ctx, kv, clk, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, "idp-account-uuid", got)
+
+	// The reference the client would have sent is not a session id.
+	_, err = ValidateBYODIdPSession(ctx, kv, clk, "idp-account-uuid")
+	require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
+
+	_, err = ValidateBYODIdPSession(ctx, kv, clk, "")
+	require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
+
+	clk.AddTime(BYODIdPSessionTTL - time.Second)
+	got, err = ValidateBYODIdPSession(ctx, kv, clk, sessionID)
+	require.NoError(t, err)
+	require.Equal(t, "idp-account-uuid", got)
+
+	// The expiry instant itself is out; the window is closed, not half-open.
+	clk.AddTime(time.Second)
+	_, err = ValidateBYODIdPSession(ctx, kv, clk, sessionID)
+	require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
+
+	// A missing or failing store is not the user being signed out.
+	_, err = ValidateBYODIdPSession(ctx, nil, clk, sessionID)
+	require.Error(t, err)
+	require.NotErrorAs(t, err, new(*fleet.AuthRequiredError))
+	broken := &mockredis.KeyValueStore{GetFunc: func(context.Context, string) (*string, error) { return nil, errors.New("redis down") }}
+	_, err = ValidateBYODIdPSession(ctx, broken, clk, sessionID)
+	require.ErrorContains(t, err, "redis down")
+	require.NotErrorAs(t, err, new(*fleet.AuthRequiredError))
+}

--- a/pkg/mdm/byod_session_test.go
+++ b/pkg/mdm/byod_session_test.go
@@ -64,6 +64,13 @@ func TestBYODIdPSession(t *testing.T) {
 	_, err = ValidateBYODIdPSession(ctx, kv, clk, sessionID)
 	require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
 
+	// Consuming ends the session immediately, before the store drops the key.
+	sessionID, err = CreateBYODIdPSession(ctx, kv, clk, "idp-account-uuid")
+	require.NoError(t, err)
+	require.NoError(t, ConsumeBYODIdPSession(ctx, kv, clk, sessionID))
+	_, err = ValidateBYODIdPSession(ctx, kv, clk, sessionID)
+	require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
+
 	// A missing or failing store is not the user being signed out.
 	_, err = ValidateBYODIdPSession(ctx, nil, clk, sessionID)
 	require.Error(t, err)

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -100,8 +100,9 @@ type TestAppleMDMClient struct {
 	fetchEnrollmentProfileFromOTA bool
 	// otaEnrollSecret is the team enroll secret to be used during the OTA flow.
 	otaEnrollSecret string
-	// otaIdpUUID is the optional uuid of the idp account that should be associated with the host enrolling
-	otaIdpUUID string
+	// otaIdpSession is the optional BYOD IdP session cookie value, as minted by
+	// the SSO callback, that associates the enrolling host with an idp account.
+	otaIdpSession string
 
 	// fetchEnrollmentProfileFromMDMBYOD indicates whether this simulated device will fetch
 	// the enrollment profile from Fleet as if it were a device running the Account Driven User
@@ -164,9 +165,9 @@ func WithEnrollmentProfileFromDEPUsingPost() TestMDMAppleClientOption {
 }
 
 // Will set a cookie for OTA requests which mimics SSO being enabled before OTA enrollment.
-func WithOTAIdpUUID(idpUUID string) TestMDMAppleClientOption {
+func WithOTAIdpSession(sessionID string) TestMDMAppleClientOption {
 	return func(c *TestAppleMDMClient) {
-		c.otaIdpUUID = idpUUID
+		c.otaIdpSession = sessionID
 	}
 }
 
@@ -586,10 +587,10 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 		InsecureSkipVerify: true,
 	}))
 
-	if c.otaIdpUUID != "" {
+	if c.otaIdpSession != "" {
 		request.AddCookie(&http.Cookie{
 			Name:  shared_mdm.BYODIdpCookieName,
-			Value: c.otaIdpUUID,
+			Value: c.otaIdpSession,
 		})
 	}
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1243,7 +1243,7 @@ type Service interface {
 	// GetOTAProfile gets the OTA (over-the-air) profile for a given team based on the enroll secret provided.
 	// personal indicates whether the end user selected "Personal (BYOD)" on the /enroll page; it is
 	// baked into the POST-back URL so the OTA enrollment handler can set the correct access rights.
-	GetOTAProfile(ctx context.Context, enrollSecret, idpUUID string, personal bool) ([]byte, error)
+	GetOTAProfile(ctx context.Context, enrollSecret, idpSessionID string, personal bool) ([]byte, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// CronSchedulesService

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -15,7 +15,7 @@ type Service interface {
 	EnterpriseSignupSSE(ctx context.Context) (chan string, error)
 
 	// CreateEnrollmentToken creates an enrollment token for a new Android device.
-	CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID, idpSessionID string, fullyManaged bool) (*EnrollmentToken, error)
+	CreateEnrollmentToken(ctx context.Context, enrollSecret, idpSessionID string, fullyManaged bool) (*EnrollmentToken, error)
 	ProcessPubSubPush(ctx context.Context, token string, message *PubSubMessage) error
 
 	// UnenrollAndroidHost triggers unenrollment (work profile removal) for the given Android host ID.

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -15,7 +15,7 @@ type Service interface {
 	EnterpriseSignupSSE(ctx context.Context) (chan string, error)
 
 	// CreateEnrollmentToken creates an enrollment token for a new Android device.
-	CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID string, fullyManaged bool) (*EnrollmentToken, error)
+	CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID, idpSessionID string, fullyManaged bool) (*EnrollmentToken, error)
 	ProcessPubSubPush(ctx context.Context, token string, message *PubSubMessage) error
 
 	// UnenrollAndroidHost triggers unenrollment (work profile removal) for the given Android host ID.

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/pkg/mdm"
 	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/server"
@@ -55,6 +56,7 @@ type Service struct {
 	SignupSSEInterval time.Duration
 	// AllowLocalhostServerURL is set during tests.
 	AllowLocalhostServerURL bool
+	keyValueStore           fleet.KeyValueStore
 }
 
 func NewService(
@@ -66,9 +68,18 @@ func NewService(
 	fleetDS fleet.Datastore,
 	newActivity fleet.NewActivityFunc,
 	androidAgentConfig config.AndroidAgentConfig,
+	keyValueStore fleet.KeyValueStore,
 ) (android.Service, error) {
 	client := newAMAPIClient(ctx, logger, licenseKey)
-	return NewServiceWithClient(logger, ds, client, serverPrivateKey, fleetDS, newActivity, androidAgentConfig)
+	return NewServiceWithClient(logger, ds, client, serverPrivateKey, fleetDS, newActivity, androidAgentConfig, WithKeyValueStore(keyValueStore))
+}
+
+// ServiceOption configures optional dependencies of the android service.
+type ServiceOption func(*Service)
+
+// WithKeyValueStore provides the store backing BYOD IdP sessions.
+func WithKeyValueStore(kv fleet.KeyValueStore) ServiceOption {
+	return func(s *Service) { s.keyValueStore = kv }
 }
 
 func NewServiceWithClient(
@@ -79,6 +90,7 @@ func NewServiceWithClient(
 	fleetDS fleet.Datastore,
 	newActivity fleet.NewActivityFunc,
 	androidAgentConfig config.AndroidAgentConfig,
+	opts ...ServiceOption,
 ) (android.Service, error) {
 	authorizer, err := authz.NewAuthorizer()
 	if err != nil {
@@ -95,6 +107,9 @@ func NewServiceWithClient(
 		fleetDS:            fleetDS,
 		newActivity:        newActivity,
 		androidAgentConfig: androidAgentConfig,
+	}
+	for _, opt := range opts {
+		opt(svc)
 	}
 
 	// OK to use background context here because this function is only called during server bootstrap
@@ -481,7 +496,8 @@ func (svc *Service) DeleteEnterprise(ctx context.Context) error {
 type enrollmentTokenRequest struct {
 	EnrollSecret string `query:"enroll_secret"`
 	FullyManaged bool   `query:"fully_managed"`
-	IdpUUID      string // The UUID of the mdm_idp_account that was used if any, can be empty, will be taken from cookies
+	IdpUUID      string // from the idp_uuid query parameter, if any
+	IdpSessionID string // from the BYOD IdP cookie, if any
 }
 
 func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
@@ -533,27 +549,39 @@ func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request
 
 	return &enrollmentTokenRequest{
 		EnrollSecret: enrollSecret,
-		IdpUUID:      byodIdpCookie.Value,
+		IdpSessionID: byodIdpCookie.Value,
 		FullyManaged: fullyManaged,
 	}, nil
 }
 
 func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {
 	req := request.(*enrollmentTokenRequest)
-	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret, req.IdpUUID, req.FullyManaged)
+	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret, req.IdpUUID, req.IdpSessionID, req.FullyManaged)
 	if err != nil {
 		return android.DefaultResponse{Err: err}
 	}
 	return android.EnrollmentTokenResponse{EnrollmentToken: token}
 }
 
-func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID string, fullyManaged bool) (*android.EnrollmentToken, error) {
+func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID, idpSessionID string, fullyManaged bool) (*android.EnrollmentToken, error) {
 	// Authorization is done by VerifyEnrollSecret below.
 	// We call SkipAuthorization here to avoid explicitly calling it when errors occur.
 	svc.authz.SkipAuthorization(ctx)
 	_, err := svc.checkIfAndroidNotConfigured(ctx, http.StatusConflict)
 	if err != nil {
 		return nil, err
+	}
+
+	if idpSessionID != "" {
+		uuid, err := shared_mdm.ValidateBYODIdPSession(ctx, svc.keyValueStore, clock.C, idpSessionID)
+		var noSession *fleet.AuthRequiredError
+		switch {
+		case errors.As(err, &noSession):
+		case err != nil:
+			return nil, ctxerr.Wrap(ctx, err, "resolving byod idp session")
+		default:
+			idpUUID = uuid
+		}
 	}
 
 	_, err = svc.ds.VerifyEnrollSecret(ctx, enrollSecret)

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -675,6 +676,13 @@ func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idp
 	token, err = svc.androidAPIClient.EnterprisesEnrollmentTokensCreate(ctx, enterprise.Name(), token)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "creating Android enrollment token")
+	}
+
+	// the token carries the account now; the session has done its job
+	if idpUUID != "" {
+		if err := shared_mdm.ConsumeBYODIdPSession(ctx, svc.keyValueStore, svc.clock, idpSessionID); err != nil {
+			logging.WithErr(ctx, err)
+		}
 	}
 
 	return &android.EnrollmentToken{

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -57,6 +57,7 @@ type Service struct {
 	// AllowLocalhostServerURL is set during tests.
 	AllowLocalhostServerURL bool
 	keyValueStore           fleet.KeyValueStore
+	clock                   clock.Clock
 }
 
 func NewService(
@@ -82,6 +83,11 @@ func WithKeyValueStore(kv fleet.KeyValueStore) ServiceOption {
 	return func(s *Service) { s.keyValueStore = kv }
 }
 
+// WithClock replaces the clock, for tests.
+func WithClock(clk clock.Clock) ServiceOption {
+	return func(s *Service) { s.clock = clk }
+}
+
 func NewServiceWithClient(
 	logger *slog.Logger,
 	ds fleet.AndroidDatastore,
@@ -98,6 +104,7 @@ func NewServiceWithClient(
 	}
 
 	svc := &Service{
+		clock:              clock.C,
 		logger:             logger,
 		authz:              authorizer,
 		ds:                 ds,
@@ -590,7 +597,7 @@ func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idp
 
 	var idpUUID string
 	if idpSessionID != "" {
-		uuid, err := shared_mdm.ValidateBYODIdPSession(ctx, svc.keyValueStore, clock.C, idpSessionID)
+		uuid, err := shared_mdm.ValidateBYODIdPSession(ctx, svc.keyValueStore, svc.clock, idpSessionID)
 		var noSession *fleet.AuthRequiredError
 		switch {
 		case errors.As(err, &noSession):

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -580,10 +580,9 @@ func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc andro
 	if err != nil {
 		return android.DefaultResponse{Err: err}
 	}
-	return enrollmentTokenResponse{
-		EnrollmentTokenResponse: android.EnrollmentTokenResponse{EnrollmentToken: token},
-		clearIdPCookie:          req.FullyManaged && req.IdpSessionID != "",
-	}
+	resp := enrollmentTokenResponse{clearIdPCookie: req.FullyManaged && req.IdpSessionID != ""}
+	resp.EnrollmentToken = token
+	return resp
 }
 
 func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpSessionID string, fullyManaged bool) (*android.EnrollmentToken, error) {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -496,7 +496,7 @@ func (svc *Service) DeleteEnterprise(ctx context.Context) error {
 type enrollmentTokenRequest struct {
 	EnrollSecret string `query:"enroll_secret"`
 	FullyManaged bool   `query:"fully_managed"`
-	IdpUUID      string // from the idp_uuid query parameter, if any
+	IdpUUID      string // resolved from the session; carried in the token, never read from the request
 	IdpSessionID string // from the BYOD IdP cookie, if any
 }
 
@@ -514,21 +514,12 @@ func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request
 		fullyManaged = true
 	}
 
-	if idpUUID := r.URL.Query().Get("idp_uuid"); idpUUID != "" {
-		return &enrollmentTokenRequest{
-			EnrollSecret: enrollSecret,
-			IdpUUID:      idpUUID,
-			FullyManaged: fullyManaged,
-		}, nil
-	}
-
 	byodIdpCookie, err := r.Cookie(mdm.BYODIdpCookieName)
 
 	if err == http.ErrNoCookie {
 		// We do not fail here if no cookie is found, we validate later down the line if it's required
 		return &enrollmentTokenRequest{
 			EnrollSecret: enrollSecret,
-			IdpUUID:      "",
 			FullyManaged: fullyManaged,
 		}, nil
 	}
@@ -554,16 +545,40 @@ func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request
 	}, nil
 }
 
+type enrollmentTokenResponse struct {
+	android.EnrollmentTokenResponse
+	// clearIdPCookie ends the IdP session for a fully managed enrollment so the
+	// next device enrolled from the same browser authenticates again.
+	clearIdPCookie bool
+}
+
+func (r enrollmentTokenResponse) SetCookies(_ context.Context, w http.ResponseWriter) {
+	if !r.clearIdPCookie {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     mdm.BYODIdpCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
 func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {
 	req := request.(*enrollmentTokenRequest)
-	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret, req.IdpUUID, req.IdpSessionID, req.FullyManaged)
+	token, err := svc.CreateEnrollmentToken(ctx, req.EnrollSecret, req.IdpSessionID, req.FullyManaged)
 	if err != nil {
 		return android.DefaultResponse{Err: err}
 	}
-	return android.EnrollmentTokenResponse{EnrollmentToken: token}
+	return enrollmentTokenResponse{
+		EnrollmentTokenResponse: android.EnrollmentTokenResponse{EnrollmentToken: token},
+		clearIdPCookie:          req.FullyManaged && req.IdpSessionID != "",
+	}
 }
 
-func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID, idpSessionID string, fullyManaged bool) (*android.EnrollmentToken, error) {
+func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpSessionID string, fullyManaged bool) (*android.EnrollmentToken, error) {
 	// Authorization is done by VerifyEnrollSecret below.
 	// We call SkipAuthorization here to avoid explicitly calling it when errors occur.
 	svc.authz.SkipAuthorization(ctx)
@@ -572,6 +587,7 @@ func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idp
 		return nil, err
 	}
 
+	var idpUUID string
 	if idpSessionID != "" {
 		uuid, err := shared_mdm.ValidateBYODIdPSession(ctx, svc.keyValueStore, clock.C, idpSessionID)
 		var noSession *fleet.AuthRequiredError

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -553,7 +553,8 @@ func (enrollmentTokenRequest) DecodeRequest(ctx context.Context, r *http.Request
 }
 
 type enrollmentTokenResponse struct {
-	android.EnrollmentTokenResponse
+	*android.EnrollmentToken
+	android.DefaultResponse
 	// clearIdPCookie ends the IdP session for a fully managed enrollment so the
 	// next device enrolled from the same browser authenticates again.
 	clearIdPCookie bool
@@ -580,9 +581,10 @@ func enrollmentTokenEndpoint(ctx context.Context, request interface{}, svc andro
 	if err != nil {
 		return android.DefaultResponse{Err: err}
 	}
-	resp := enrollmentTokenResponse{clearIdPCookie: req.FullyManaged && req.IdpSessionID != ""}
-	resp.EnrollmentToken = token
-	return resp
+	return enrollmentTokenResponse{
+		EnrollmentToken: token,
+		clearIdPCookie:  req.FullyManaged && req.IdpSessionID != "",
+	}
 }
 
 func (svc *Service) CreateEnrollmentToken(ctx context.Context, enrollSecret, idpSessionID string, fullyManaged bool) (*android.EnrollmentToken, error) {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -561,6 +561,7 @@ func (r enrollmentTokenResponse) SetCookies(_ context.Context, w http.ResponseWr
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,
+		Secure:   true,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})

--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -2,12 +2,14 @@ package tests
 
 import (
 	"context"
+	mockredis "github.com/fleetdm/fleet/v4/server/mock/redis"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
@@ -124,7 +126,7 @@ func (ts *WithServer) SetupSuite(t *testing.T, dbName string) {
 	ts.createCommonProxyMocks(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	svc, err := service.NewServiceWithClient(logger, &ts.DS, &ts.AndroidAPIClient, "test-private-key", ts.DS.Datastore, noopNewActivity, config.AndroidAgentConfig{})
+	svc, err := service.NewServiceWithClient(logger, &ts.DS, &ts.AndroidAPIClient, "test-private-key", ts.DS.Datastore, noopNewActivity, config.AndroidAgentConfig{}, service.WithKeyValueStore(newMemKeyValueStore()))
 	require.NoError(t, err)
 	ts.Svc = svc
 
@@ -260,4 +262,26 @@ func CreateNamedMySQLDS(t *testing.T, name string) *mysql.Datastore {
 	}
 	// Use a named Fleet datastore for Android integration tests to ensure the expected database exists
 	return mysqltest.CreateNamedMySQLDS(t, name)
+}
+
+func newMemKeyValueStore() fleet.KeyValueStore {
+	var mu sync.Mutex
+	vals := map[string]string{}
+	return &mockredis.KeyValueStore{
+		SetFunc: func(_ context.Context, key, value string, _ time.Duration) error {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[key] = value
+			return nil
+		},
+		GetFunc: func(_ context.Context, key string) (*string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			v, ok := vals[key]
+			if !ok {
+				return nil, nil
+			}
+			return &v, nil
+		},
+	}
 }

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1879,7 +1879,7 @@ func turnOffMDMIfAPNSFailed(ctx context.Context, ds fleet.Datastore, err error, 
 	return true, nil
 }
 
-func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, idpUUID string, personal bool) ([]byte, error) {
+func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, idpSessionID string, personal bool) ([]byte, error) {
 	path, err := url.JoinPath(fleetURL, "/api/v1/fleet/ota_enrollment")
 	if err != nil {
 		return nil, fmt.Errorf("creating path for ota enrollment url: %w", err)
@@ -1892,8 +1892,8 @@ func GenerateOTAEnrollmentProfileMobileconfig(orgName, fleetURL, enrollSecret, i
 
 	q := enrollURL.Query()
 	q.Set("enroll_secret", enrollSecret)
-	if idpUUID != "" {
-		q.Set("idp_uuid", idpUUID)
+	if idpSessionID != "" {
+		q.Set("idp_session", idpSessionID)
 	}
 	if personal {
 		q.Set("byod", "true")

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -733,7 +733,7 @@ type TriggerLinuxDiskEncryptionEscrowFunc func(ctx context.Context, host *fleet.
 
 type CheckMDMAppleEnrollmentWithMinimumOSVersionFunc func(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error)
 
-type GetOTAProfileFunc func(ctx context.Context, enrollSecret string, idpUUID string, personal bool) ([]byte, error)
+type GetOTAProfileFunc func(ctx context.Context, enrollSecret string, idpSessionID string, personal bool) ([]byte, error)
 
 type TriggerCronScheduleFunc func(ctx context.Context, name string) error
 
@@ -5007,11 +5007,11 @@ func (s *Service) CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Contex
 	return s.CheckMDMAppleEnrollmentWithMinimumOSVersionFunc(ctx, m)
 }
 
-func (s *Service) GetOTAProfile(ctx context.Context, enrollSecret string, idpUUID string, personal bool) ([]byte, error) {
+func (s *Service) GetOTAProfile(ctx context.Context, enrollSecret string, idpSessionID string, personal bool) ([]byte, error) {
 	s.mu.Lock()
 	s.GetOTAProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetOTAProfileFunc(ctx, enrollSecret, idpUUID, personal)
+	return s.GetOTAProfileFunc(ctx, enrollSecret, idpSessionID, personal)
 }
 
 func (s *Service) TriggerCronSchedule(ctx context.Context, name string) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -8658,7 +8658,12 @@ func (svc *Service) GetOTAProfile(ctx context.Context, enrollSecret, idpSessionI
 		)
 	}
 
-	profBytes, err := apple_mdm.GenerateOTAEnrollmentProfileMobileconfig(cfg.OrgInfo.OrgName, cfg.MDMUrl(), enrollSecret, idpUUID, personal)
+	// the device posts back to the URL in the profile, so the session travels
+	// with it rather than the account it resolved to
+	if idpUUID == "" {
+		idpSessionID = ""
+	}
+	profBytes, err := apple_mdm.GenerateOTAEnrollmentProfileMobileconfig(cfg.OrgInfo.OrgName, cfg.MDMUrl(), enrollSecret, idpSessionID, personal)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generating ota mobileconfig file")
 	}
@@ -8672,12 +8677,12 @@ func (svc *Service) GetOTAProfile(ctx context.Context, enrollSecret, idpSessionI
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// POST /ota_enrollment?enroll_secret=xyz
+// POST /ota_enrollment?enroll_secret=xyz&idp_session=abc
 ////////////////////////////////////////////////////////////////////////////////
 
 type mdmAppleOTARequest struct {
 	EnrollSecret string `query:"enroll_secret"`
-	IdpUUID      string `query:"idp_uuid"`
+	IdpSessionID string `query:"idp_session"`
 	// Personal is set when the end user chose "Personal (BYOD)" on the /enroll page.
 	// It is propagated through the OTA mobileconfig POST-back URL by GetOTAProfile.
 	Personal     bool
@@ -8694,7 +8699,7 @@ func (mdmAppleOTARequest) DecodeRequest(ctx context.Context, r *http.Request) (i
 		}
 	}
 
-	idpUUID := r.URL.Query().Get("idp_uuid") // Can be empty.
+	idpSessionID := r.URL.Query().Get("idp_session") // Can be empty.
 
 	rawData, err := io.ReadAll(io.LimitReader(r.Body, limit10KiB))
 	if err != nil {
@@ -8732,7 +8737,7 @@ func (mdmAppleOTARequest) DecodeRequest(ctx context.Context, r *http.Request) (i
 	}
 
 	request.EnrollSecret = enrollSecret
-	request.IdpUUID = idpUUID
+	request.IdpSessionID = idpSessionID
 	request.Personal = r.URL.Query().Get("byod") == "true" || r.URL.Query().Get("byod") == "1"
 	request.Certificates = p7.Certificates
 	request.RootSigner = p7.GetOnlySigner()
@@ -8781,7 +8786,7 @@ func (r mdmAppleOTAResponse) HijackRender(ctx context.Context, w http.ResponseWr
 
 func mdmAppleOTAEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*mdmAppleOTARequest)
-	xml, err := svc.MDMAppleProcessOTAEnrollment(ctx, req.Certificates, req.RootSigner, req.EnrollSecret, req.IdpUUID, req.Personal, req.DeviceInfo)
+	xml, err := svc.MDMAppleProcessOTAEnrollment(ctx, req.Certificates, req.RootSigner, req.EnrollSecret, req.IdpSessionID, req.Personal, req.DeviceInfo)
 	if err != nil {
 		return mdmAppleGetInstallerResponse{Err: err}, nil
 	}
@@ -8794,7 +8799,7 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 	certificates []*x509.Certificate,
 	rootSigner *x509.Certificate,
 	enrollSecret string,
-	idpUUID string,
+	idpSessionID string,
 	personal bool,
 	deviceInfo fleet.MDMAppleMachineInfo,
 ) ([]byte, error) {
@@ -8890,6 +8895,19 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, ctxerr.Wrap(ctx, err, "generating manual enrollment profile")
 	}
 
+	var idpUUID string
+	if idpSessionID != "" {
+		uuid, err := shared_mdm.ValidateBYODIdPSession(ctx, svc.keyValueStore, svc.clock, idpSessionID)
+		var noSession *fleet.AuthRequiredError
+		switch {
+		case errors.As(err, &noSession):
+		case err != nil:
+			return nil, ctxerr.Wrap(ctx, err, "resolving byod idp session")
+		default:
+			idpUUID = uuid
+		}
+	}
+
 	requiresIdPUUID, err := shared_mdm.RequiresEnrollOTAAuthentication(ctx, svc.ds, enrollSecret, appCfg.MDM.MacOSSetup.EnableEndUserAuthentication)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "checking requirement of ota enrollment authentication")
@@ -8922,6 +8940,13 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 	signed, err := mdmcrypto.Sign(ctx, enrollmentProf, svc.ds)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
+	}
+
+	// the host is bound to the account now; the session has done its job
+	if idpUUID != "" {
+		if err := shared_mdm.ConsumeBYODIdPSession(ctx, svc.keyValueStore, svc.clock, idpSessionID); err != nil {
+			logging.WithErr(ctx, err)
+		}
 	}
 
 	softwareUpdateDeviceID := deviceInfo.Product

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4428,7 +4428,7 @@ func (r callbackMDMSSOResponse) HijackRender(ctx context.Context, w http.Respons
 func (r callbackMDMSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter) {
 	deleteSSOCookie(w)
 	if r.byodEnrollCookieValue != "" {
-		setBYODCookie(w, r.byodEnrollCookieValue, 30*60) // valid for 30 minutes
+		setBYODCookie(w, r.byodEnrollCookieValue, int(shared_mdm.BYODIdPSessionTTL.Seconds()))
 	}
 	if r.deviceSSOSessionID != "" {
 		setDeviceSSOSessionCookie(w, r.deviceSSOSessionID, r.deviceSSOSessionDuration)
@@ -8568,8 +8568,8 @@ type getOTAProfileRequest struct {
 	EnrollSecret string `query:"enroll_secret"`
 	// Personal indicates the end user chose "Personal (BYOD)" on the /enroll page.
 	// Defaults to false (company-owned) when omitted.
-	Personal bool   `query:"byod"`
-	IdpUUID  string // The UUID of the mdm_idp_account that was used if any, can be empty, will be taken from cookies
+	Personal     bool `query:"byod"`
+	IdpSessionID string
 }
 
 func (getOTAProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
@@ -8590,7 +8590,7 @@ func (getOTAProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) 
 		return &getOTAProfileRequest{
 			EnrollSecret: enrollSecret,
 			Personal:     personal,
-			IdpUUID:      "",
+			IdpSessionID: "",
 		}, nil
 	}
 
@@ -8604,13 +8604,13 @@ func (getOTAProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) 
 	return &getOTAProfileRequest{
 		EnrollSecret: enrollSecret,
 		Personal:     personal,
-		IdpUUID:      boydIdpCookie.Value,
+		IdpSessionID: boydIdpCookie.Value,
 	}, nil
 }
 
 func getOTAProfileEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*getOTAProfileRequest)
-	profile, err := svc.GetOTAProfile(ctx, req.EnrollSecret, req.IdpUUID, req.Personal)
+	profile, err := svc.GetOTAProfile(ctx, req.EnrollSecret, req.IdpSessionID, req.Personal)
 	if err != nil {
 		return &getMDMAppleConfigProfileResponse{Err: err}, err
 	}
@@ -8619,10 +8619,23 @@ func getOTAProfileEndpoint(ctx context.Context, request interface{}, svc fleet.S
 	return &getMDMAppleConfigProfileResponse{fileReader: io.NopCloser(reader), fileLength: reader.Size(), fileName: "fleet-mdm-enrollment-profile"}, nil
 }
 
-func (svc *Service) GetOTAProfile(ctx context.Context, enrollSecret, idpUUID string, personal bool) ([]byte, error) {
+func (svc *Service) GetOTAProfile(ctx context.Context, enrollSecret, idpSessionID string, personal bool) ([]byte, error) {
 	// Skip authz as this endpoint is used by end users from their iPhones or iPads; authz is done
 	// by the enroll secret verification below
 	svc.authz.SkipAuthorization(ctx)
+
+	var idpUUID string
+	if idpSessionID != "" {
+		uuid, err := shared_mdm.ValidateBYODIdPSession(ctx, svc.keyValueStore, svc.clock, idpSessionID)
+		var noSession *fleet.AuthRequiredError
+		switch {
+		case errors.As(err, &noSession):
+		case err != nil:
+			return nil, ctxerr.Wrap(ctx, err, "resolving byod idp session")
+		default:
+			idpUUID = uuid
+		}
+	}
 
 	cfg, err := svc.ds.AppConfig(ctx)
 	if err != nil {

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"net/url"
 	"regexp"
 
+	"github.com/WatchBeam/clock"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
 	"github.com/fleetdm/fleet/v4/server/bindata"
@@ -89,6 +91,7 @@ func ServeEndUserEnrollOTA(
 	svc fleet.Service,
 	urlPrefix string,
 	ds fleet.Datastore,
+	kv fleet.KeyValueStore,
 	logger *slog.Logger,
 	serveCSP bool,
 ) http.Handler {
@@ -143,19 +146,20 @@ func ServeEndUserEnrollOTA(
 			return
 		}
 
+		var cookieIdPRef string
 		if authRequired {
 			// check if authentication cookie is present, in which case we go ahead with
 			// offering the enrollment profile to download.
-			var cookieIdPRef string
-			if byodCookie, _ := r.Cookie(shared_mdm.BYODIdpCookieName); byodCookie != nil {
-				cookieIdPRef = byodCookie.Value
-
-				// if the cookie is present, we should also receive a (matching) enroll reference
-				if cookieIdPRef != "" {
-					enrollRef := r.URL.Query().Get("enrollment_reference")
-					if cookieIdPRef != enrollRef {
-						cookieIdPRef = "" // cookie does not match the enroll reference, so we ignore it and require authentication
-					}
+			if byodCookie, _ := r.Cookie(shared_mdm.BYODIdpCookieName); byodCookie != nil && byodCookie.Value != "" {
+				uuid, err := shared_mdm.ValidateBYODIdPSession(r.Context(), kv, clock.C, byodCookie.Value)
+				var noSession *fleet.AuthRequiredError
+				switch {
+				case errors.As(err, &noSession):
+				case err != nil:
+					herr(ctx, w, "resolve IdP session err: "+err.Error())
+					return
+				default:
+					cookieIdPRef = uuid
 				}
 			}
 
@@ -174,11 +178,10 @@ func ServeEndUserEnrollOTA(
 		// been successfully completed (we have a cookie with the IdP account
 		// reference).
 
-		// Clear the BYOD IdP cookie now that we are about to render the enrollment page.
 		var idpUUID string
 		fullyManaged := r.URL.Query().Get("fully_managed")
 		if authRequired && (fullyManaged == "true" || fullyManaged == "1") {
-			idpUUID = r.URL.Query().Get("enrollment_reference")
+			idpUUID = cookieIdPRef
 			http.SetCookie(w, &http.Cookie{
 				Name:     shared_mdm.BYODIdpCookieName,
 				Value:    "",

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -125,7 +125,7 @@ func ServeEndUserEnrollOTA(
 
 		errorMsg := r.URL.Query().Get("error")
 		if errorMsg != "" {
-			if err := renderEnrollPage(w, appCfg, urlPrefix, "", errorMsg, nonce, "", appleManualEnrollmentBlocked); err != nil {
+			if err := renderEnrollPage(w, appCfg, urlPrefix, "", errorMsg, nonce, appleManualEnrollmentBlocked); err != nil {
 				herr(ctx, w, err.Error())
 			}
 			return
@@ -133,7 +133,7 @@ func ServeEndUserEnrollOTA(
 
 		enrollSecret := r.URL.Query().Get("enroll_secret")
 		if enrollSecret == "" {
-			if err := renderEnrollPage(w, appCfg, urlPrefix, "", "This URL is invalid. : Enroll secret is invalid. Please contact your IT admin.", nonce, "", appleManualEnrollmentBlocked); err != nil {
+			if err := renderEnrollPage(w, appCfg, urlPrefix, "", "This URL is invalid. : Enroll secret is invalid. Please contact your IT admin.", nonce, appleManualEnrollmentBlocked); err != nil {
 				herr(ctx, w, err.Error())
 			}
 			return
@@ -178,22 +178,7 @@ func ServeEndUserEnrollOTA(
 		// been successfully completed (we have a cookie with the IdP account
 		// reference).
 
-		var idpUUID string
-		fullyManaged := r.URL.Query().Get("fully_managed")
-		if authRequired && (fullyManaged == "true" || fullyManaged == "1") {
-			idpUUID = cookieIdPRef
-			http.SetCookie(w, &http.Cookie{
-				Name:     shared_mdm.BYODIdpCookieName,
-				Value:    "",
-				Path:     "/",
-				MaxAge:   -1,
-				Secure:   cookieSecure,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			})
-		}
-
-		if err := renderEnrollPage(w, appCfg, urlPrefix, enrollSecret, "", nonce, idpUUID, appleManualEnrollmentBlocked); err != nil {
+		if err := renderEnrollPage(w, appCfg, urlPrefix, enrollSecret, "", nonce, appleManualEnrollmentBlocked); err != nil {
 			herr(ctx, w, err.Error())
 			return
 		}
@@ -217,7 +202,7 @@ func generateEnrollOTAURL(fleetURL string, enrollSecret string) (string, error) 
 	return enrollURL.String(), nil
 }
 
-func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSecret, errorMessage, nonce, idpUUID string, appleManualEnrollmentBlocked bool) error {
+func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSecret, errorMessage, nonce string, appleManualEnrollmentBlocked bool) error {
 	fs := newBinaryFileSystem("/frontend")
 	file, err := fs.Open("templates/enroll-ota.html")
 	if err != nil {
@@ -246,7 +231,6 @@ func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSec
 		MacMDMEnabled                bool
 		AndroidFeatureEnabled        bool
 		CSPNonce                     string
-		IdpUUID                      string
 		AppleManualEnrollmentBlocked bool
 	}{
 		URLPrefix:                    urlPrefix,
@@ -256,7 +240,6 @@ func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSec
 		MacMDMEnabled:                appCfg.MDM.EnabledAndConfigured,
 		AndroidFeatureEnabled:        true,
 		CSPNonce:                     nonce,
-		IdpUUID:                      idpUUID,
 		AppleManualEnrollmentBlocked: appleManualEnrollmentBlocked,
 	}); err != nil {
 		return fmt.Errorf("execute react template: %w", err)

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -92,6 +92,7 @@ func ServeEndUserEnrollOTA(
 	urlPrefix string,
 	ds fleet.Datastore,
 	kv fleet.KeyValueStore,
+	clk clock.Clock,
 	logger *slog.Logger,
 	serveCSP bool,
 ) http.Handler {
@@ -151,7 +152,7 @@ func ServeEndUserEnrollOTA(
 			// check if authentication cookie is present, in which case we go ahead with
 			// offering the enrollment profile to download.
 			if byodCookie, _ := r.Cookie(shared_mdm.BYODIdpCookieName); byodCookie != nil && byodCookie.Value != "" {
-				uuid, err := shared_mdm.ValidateBYODIdPSession(r.Context(), kv, clock.C, byodCookie.Value)
+				uuid, err := shared_mdm.ValidateBYODIdPSession(r.Context(), kv, clk, byodCookie.Value)
 				var noSession *fleet.AuthRequiredError
 				switch {
 				case errors.As(err, &noSession):

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -224,7 +224,7 @@ func TestInitiateOTAEnrollSSOPersistsQueryParams(t *testing.T) {
 	}
 }
 
-func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
+func TestServeEndUserEnrollOTAKeepsSessionForFullyManaged(t *testing.T) {
 	if !hasBuildTag("full") {
 		t.Skip("This test requires running with -tags full")
 	}
@@ -272,70 +272,32 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	sessionID, err := shared_mdm.CreateBYODIdPSession(ctx, kv, clock.C, idpUUID)
 	require.NoError(t, err)
 
-	// A fully-managed Android enrollment with a valid BYOD session.
-	req, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&fully_managed=true", nil)
-	require.NoError(t, err)
-	req.AddCookie(&http.Cookie{
-		Name:  shared_mdm.BYODIdpCookieName,
-		Value: sessionID,
-	})
+	// The session must outlive the page: the token endpoint resolves it and
+	// only then ends it.
+	for _, query := range []string{"?enroll_secret=foo&fully_managed=true", "?enroll_secret=foo"} {
+		req, err := http.NewRequest("GET", ts.URL+query, nil)
+		require.NoError(t, err)
+		req.AddCookie(&http.Cookie{Name: shared_mdm.BYODIdpCookieName, Value: sessionID})
 
-	client := fleethttp.NewClient(fleethttp.WithFollowRedir(false))
-	response, err := client.Do(req)
-	require.NoError(t, err)
-	defer response.Body.Close()
+		response, err := fleethttp.NewClient(fleethttp.WithFollowRedir(false)).Do(req)
+		require.NoError(t, err)
+		defer response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode)
 
-	require.Equal(t, http.StatusOK, response.StatusCode)
-
-	// Assert that Set-Cookie header is present and clears the BYOD cookie.
-	setCookieHeaders := response.Header.Values("Set-Cookie")
-	var foundClear bool
-	for _, sc := range setCookieHeaders {
-		if bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
-			bytes.Contains([]byte(sc), []byte("Max-Age=0")) {
-			foundClear = true
-			break
+		for _, sc := range response.Header.Values("Set-Cookie") {
+			require.False(t,
+				bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
+					bytes.Contains([]byte(sc), []byte("Max-Age=0")),
+				"%s should not clear %s, got: %v", query, shared_mdm.BYODIdpCookieName, sc,
+			)
 		}
+		body, err := io.ReadAll(response.Body)
+		require.NoError(t, err)
+		require.NotContains(t, string(body), idpUUID)
+		require.NotContains(t, string(body), "IDP_UUID")
 	}
-	require.True(t, foundClear, "expected Set-Cookie header to clear %s, got: %v", shared_mdm.BYODIdpCookieName, setCookieHeaders)
-
-	// Assert that the rendered HTML contains the IdP UUID for JS to use.
-	bodyBytes, err := io.ReadAll(response.Body)
-	require.NoError(t, err)
-	bodyString := string(bodyBytes)
-	require.Contains(t, bodyString, fmt.Sprintf(`const IDP_UUID = "%s";`, idpUUID))
-
-	// BYOD (non-fully-managed) requests should NOT clear the cookie
-	req2, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo", nil)
-	require.NoError(t, err)
-	req2.AddCookie(&http.Cookie{
-		Name:  shared_mdm.BYODIdpCookieName,
-		Value: sessionID,
-	})
-
-	response2, err := client.Do(req2)
-	require.NoError(t, err)
-	defer response2.Body.Close()
-
-	require.Equal(t, http.StatusOK, response2.StatusCode)
-
-	setCookieHeaders2 := response2.Header.Values("Set-Cookie")
-	for _, sc := range setCookieHeaders2 {
-		require.False(t,
-			bytes.Contains([]byte(sc), []byte(shared_mdm.BYODIdpCookieName)) &&
-				bytes.Contains([]byte(sc), []byte("Max-Age=0")),
-			"BYOD request should not clear %s, got: %v", shared_mdm.BYODIdpCookieName, setCookieHeaders2,
-		)
-	}
-
-	// Assert that BYOD rendered HTML has an empty IdP UUID (not passed through template).
-	bodyBytes2, err := io.ReadAll(response2.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(bodyBytes2), `const IDP_UUID = "";`)
 }
 
-// A cookie that merely matches the enrollment_reference query string is not a
-// completed IdP authentication and must not render the page.
 func TestServeEndUserEnrollOTARejectsUnknownSession(t *testing.T) {
 	ds := new(mock.Store)
 	ds.HasUsersFunc = func(ctx context.Context) (bool, error) { return true, nil }

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -128,7 +128,7 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 			appCfg.MDM.AndroidEnabledAndConfigured = enabled
 
 			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-			h := ServeEndUserEnrollOTA(svc, "", ds, newMemKeyValueStore(), logger, false)
+			h := ServeEndUserEnrollOTA(svc, "", ds, newMemKeyValueStore(), clock.C, logger, false)
 			ts := httptest.NewServer(h)
 			t.Cleanup(func() {
 				ts.Close()
@@ -262,7 +262,7 @@ func TestServeEndUserEnrollOTAKeepsSessionForFullyManaged(t *testing.T) {
 	kv := newMemKeyValueStore()
 	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{KeyValueStore: kv})
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	h := ServeEndUserEnrollOTA(svc, "", ds, kv, logger, false)
+	h := ServeEndUserEnrollOTA(svc, "", ds, kv, clock.C, logger, false)
 	ts := httptest.NewServer(h)
 	t.Cleanup(func() {
 		ts.Close()
@@ -309,7 +309,7 @@ func TestServeEndUserEnrollOTARejectsUnknownSession(t *testing.T) {
 	}
 	kv := newMemKeyValueStore()
 	svc := &enrollPageService{}
-	h := ServeEndUserEnrollOTA(svc, "", ds, kv, slog.New(slog.NewTextHandler(os.Stdout, nil)), false)
+	h := ServeEndUserEnrollOTA(svc, "", ds, kv, clock.C, slog.New(slog.NewTextHandler(os.Stdout, nil)), false)
 	ts := httptest.NewServer(h)
 	t.Cleanup(ts.Close)
 

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -277,7 +277,7 @@ func TestServeEndUserEnrollOTAKeepsSessionForFullyManaged(t *testing.T) {
 	for _, query := range []string{"?enroll_secret=foo&fully_managed=true", "?enroll_secret=foo"} {
 		req, err := http.NewRequest("GET", ts.URL+query, nil)
 		require.NoError(t, err)
-		req.AddCookie(&http.Cookie{Name: shared_mdm.BYODIdpCookieName, Value: sessionID})
+		req.AddCookie(&http.Cookie{Name: shared_mdm.BYODIdpCookieName, Value: sessionID, Secure: true, HttpOnly: true, SameSite: http.SameSiteLaxMode})
 
 		response, err := fleethttp.NewClient(fleethttp.WithFollowRedir(false)).Do(req)
 		require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestServeEndUserEnrollOTARejectsUnknownSession(t *testing.T) {
 	unknown := "not-a-session"
 	req, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&fully_managed=true&enrollment_reference="+unknown, nil)
 	require.NoError(t, err)
-	req.AddCookie(&http.Cookie{Name: shared_mdm.BYODIdpCookieName, Value: unknown})
+	req.AddCookie(&http.Cookie{Name: shared_mdm.BYODIdpCookieName, Value: unknown, Secure: true, HttpOnly: true, SameSite: http.SameSiteLaxMode})
 
 	resp, err := fleethttp.NewClient(fleethttp.WithFollowRedir(false)).Do(req)
 	require.NoError(t, err)

--- a/server/service/frontend_test.go
+++ b/server/service/frontend_test.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/WatchBeam/clock"
+	mockredis "github.com/fleetdm/fleet/v4/server/mock/redis"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
@@ -124,7 +128,7 @@ func TestServeEndUserEnrollOTA(t *testing.T) {
 			appCfg.MDM.AndroidEnabledAndConfigured = enabled
 
 			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-			h := ServeEndUserEnrollOTA(svc, "", ds, logger, false)
+			h := ServeEndUserEnrollOTA(svc, "", ds, newMemKeyValueStore(), logger, false)
 			ts := httptest.NewServer(h)
 			t.Cleanup(func() {
 				ts.Close()
@@ -255,23 +259,25 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 		return appCfg, nil
 	}
 
-	svc, _ := newTestService(t, ds, nil, nil)
+	kv := newMemKeyValueStore()
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{KeyValueStore: kv})
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	h := ServeEndUserEnrollOTA(svc, "", ds, logger, false)
+	h := ServeEndUserEnrollOTA(svc, "", ds, kv, logger, false)
 	ts := httptest.NewServer(h)
 	t.Cleanup(func() {
 		ts.Close()
 	})
 
 	idpUUID := "test-idp-uuid-1234"
+	sessionID, err := shared_mdm.CreateBYODIdPSession(ctx, kv, clock.C, idpUUID)
+	require.NoError(t, err)
 
-	// Simulate a request with a valid BYOD cookie + matching enrollment_reference
-	// for a fully-managed Android enrollment.
-	req, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&fully_managed=true&enrollment_reference="+idpUUID, nil)
+	// A fully-managed Android enrollment with a valid BYOD session.
+	req, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&fully_managed=true", nil)
 	require.NoError(t, err)
 	req.AddCookie(&http.Cookie{
 		Name:  shared_mdm.BYODIdpCookieName,
-		Value: idpUUID,
+		Value: sessionID,
 	})
 
 	client := fleethttp.NewClient(fleethttp.WithFollowRedir(false))
@@ -300,11 +306,11 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	require.Contains(t, bodyString, fmt.Sprintf(`const IDP_UUID = "%s";`, idpUUID))
 
 	// BYOD (non-fully-managed) requests should NOT clear the cookie
-	req2, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&enrollment_reference="+idpUUID, nil)
+	req2, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo", nil)
 	require.NoError(t, err)
 	req2.AddCookie(&http.Cookie{
 		Name:  shared_mdm.BYODIdpCookieName,
-		Value: idpUUID,
+		Value: sessionID,
 	})
 
 	response2, err := client.Do(req2)
@@ -327,3 +333,66 @@ func TestServeEndUserEnrollOTAClearsCookieForFullyManaged(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(bodyBytes2), `const IDP_UUID = "";`)
 }
+
+// A cookie that merely matches the enrollment_reference query string is not a
+// completed IdP authentication and must not render the page.
+func TestServeEndUserEnrollOTARejectsUnknownSession(t *testing.T) {
+	ds := new(mock.Store)
+	ds.HasUsersFunc = func(ctx context.Context) (bool, error) { return true, nil }
+	ds.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+		return &fleet.EnrollSecret{Secret: secret}, nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{MacOSSetup: fleet.MacOSSetup{EnableEndUserAuthentication: true}}}, nil
+	}
+	kv := newMemKeyValueStore()
+	svc := &enrollPageService{}
+	h := ServeEndUserEnrollOTA(svc, "", ds, kv, slog.New(slog.NewTextHandler(os.Stdout, nil)), false)
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+
+	unknown := "not-a-session"
+	req, err := http.NewRequest("GET", ts.URL+"?enroll_secret=foo&fully_managed=true&enrollment_reference="+unknown, nil)
+	require.NoError(t, err)
+	req.AddCookie(&http.Cookie{Name: shared_mdm.BYODIdpCookieName, Value: unknown})
+
+	resp, err := fleethttp.NewClient(fleethttp.WithFollowRedir(false)).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	require.NotEmpty(t, resp.Header.Get("Location"))
+	require.NotContains(t, string(body), unknown)
+}
+
+func newMemKeyValueStore() *mockredis.KeyValueStore {
+	var mu sync.Mutex
+	vals := map[string]string{}
+	return &mockredis.KeyValueStore{
+		SetFunc: func(_ context.Context, key, value string, _ time.Duration) error {
+			mu.Lock()
+			defer mu.Unlock()
+			vals[key] = value
+			return nil
+		},
+		GetFunc: func(_ context.Context, key string) (*string, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			v, ok := vals[key]
+			if !ok {
+				return nil, nil
+			}
+			return &v, nil
+		},
+	}
+}
+
+// enrollPageService is the ssoURLCaptureService plus what /enroll asks of the
+// service before it decides to start SSO.
+type enrollPageService struct {
+	ssoURLCaptureService
+}
+
+func (s *enrollPageService) SetupRequired(context.Context) (bool, error) { return false, nil }

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -6894,8 +6894,9 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 		require.NoError(t, err)
 
 		idpUUID := uuid.New()
+		sessionID := s.mustBYODIdPSession(t, idpUUID.String())
 		resp := s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
-			"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, s.mustBYODIdPSession(t, idpUUID.String())),
+			"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, sessionID),
 		}, "enroll_secret", globalEnrollSec)
 
 		require.NotZero(t, resp.ContentLength)
@@ -6907,7 +6908,8 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 		require.NoError(t, err)
 		require.Equal(t, resp.ContentLength, int64(len(b)))
 		require.Contains(t, string(b), "com.fleetdm.fleet.mdm.apple.ota")
-		require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s&amp;idp_uuid=%s", cfg.ServerSettings.ServerURL, escSec, idpUUID.String()))
+		require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s&amp;idp_session=%s", cfg.ServerSettings.ServerURL, escSec, url.QueryEscape(sessionID)))
+		require.NotContains(t, string(b), idpUUID.String())
 
 		// the raw account reference is not a session, so the profile carries no account
 		resp = s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
@@ -6931,7 +6933,7 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 		require.Equal(t, resp.ContentLength, int64(len(b)))
 		require.Contains(t, string(b), "com.fleetdm.fleet.mdm.apple.ota")
 		require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s", cfg.ServerSettings.ServerURL, escSec))
-		require.NotContains(t, string(b), "idp_uuid=")
+		require.NotContains(t, string(b), "idp_session=")
 		require.Contains(t, string(b), cfg.OrgInfo.OrgName)
 	})
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -6895,8 +6895,9 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 
 		idpUUID := uuid.New()
 		resp := s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
-			"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, idpUUID.String()),
+			"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, s.mustBYODIdPSession(t, idpUUID.String())),
 		}, "enroll_secret", globalEnrollSec)
+
 		require.NotZero(t, resp.ContentLength)
 		require.Contains(t, resp.Header.Get("Content-Disposition"), `attachment;filename="fleet-mdm-enrollment-profile.mobileconfig"`)
 		require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
@@ -6907,6 +6908,15 @@ func (s *integrationMDMTestSuite) TestOTAProfile() {
 		require.Equal(t, resp.ContentLength, int64(len(b)))
 		require.Contains(t, string(b), "com.fleetdm.fleet.mdm.apple.ota")
 		require.Contains(t, string(b), fmt.Sprintf("%s/api/v1/fleet/ota_enrollment?enroll_secret=%s&amp;idp_uuid=%s", cfg.ServerSettings.ServerURL, escSec, idpUUID.String()))
+
+		// the raw account reference is not a session, so the profile carries no account
+		resp = s.DoRawWithHeaders("GET", "/api/latest/fleet/enrollment_profiles/ota", j, http.StatusOK, map[string]string{
+			"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, idpUUID.String()),
+		}, "enroll_secret", globalEnrollSec)
+		defer resp.Body.Close()
+		b, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NotContains(t, string(b), idpUUID.String())
 		require.Contains(t, string(b), cfg.OrgInfo.OrgName)
 	})
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -17128,7 +17128,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 			require.Equal(t, specResp.TeamIDsByName["newteam"], *hostByIdentifierResp.Host.TeamID)
 		})
 
-		t.Run("ota enrollment if idp_uuid is not set does not associate host with idp account", func(t *testing.T) {
+		t.Run("ota enrollment without an idp session does not associate host with idp account", func(t *testing.T) {
 			hwModel := "MacBookPro16,1"
 			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
 				s.server.URL,
@@ -17146,7 +17146,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 			require.Nil(t, account) // We do not fail but return nil for both if not found, and we do not expect an entry here.
 		})
 
-		t.Run("ota enrollment if idp_uuid is set associates host with idp account", func(t *testing.T) {
+		t.Run("ota enrollment with an idp session associates host with idp account", func(t *testing.T) {
 			idpEmail := "test@example.com"
 			err := s.ds.InsertMDMIdPAccount(context.Background(), &fleet.MDMIdPAccount{
 				Username: "test",
@@ -17155,13 +17155,14 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 			require.NoError(t, err)
 			idpAccount, err := s.ds.GetMDMIdPAccountByEmail(context.Background(), idpEmail)
 			require.NoError(t, err)
+			sessionID := s.mustBYODIdPSession(t, idpAccount.UUID)
 
 			hwModel := "MacBookPro16,1"
 			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
 				s.server.URL,
 				globalSecret,
 				hwModel,
-				mdmtest.WithOTAIdpSession(s.mustBYODIdPSession(t, idpAccount.UUID)),
+				mdmtest.WithOTAIdpSession(sessionID),
 			)
 			enrollTime := time.Now().UTC().Truncate(time.Second)
 			require.NoError(t, mdmDevice.Enroll())
@@ -17170,6 +17171,52 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 
 			resp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "darwin", enrollTime)
 			verifySuccessfulIdpAssociation(resp.Host.UUID, idpAccount.UUID)
+
+			// the session is single-use: enrolling burned it
+			_, err = shared_mdm.ValidateBYODIdPSession(t.Context(), redis_key_value.New(s.redisPool), clock.C, sessionID)
+			require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
+
+			// a second device presenting the same session enrolls without an account
+			secondDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				globalSecret,
+				hwModel,
+				mdmtest.WithOTAIdpSession(sessionID),
+			)
+			require.NoError(t, secondDevice.Enroll())
+			s.awaitRunAppleMDMWorkerSchedule()
+			resp = verifySuccessfulOTAEnrollment(secondDevice, hwModel, "darwin", enrollTime)
+			hostToIdpMap, err := s.ds.GetMDMIdPAccountsByHostUUIDs(context.Background(), []string{resp.Host.UUID})
+			require.NoError(t, err)
+			require.Nil(t, hostToIdpMap[resp.Host.UUID])
+		})
+
+		t.Run("ota enrollment with a used idp session is refused where authentication is required", func(t *testing.T) {
+			idpEmail := "used@example.com"
+			err := s.ds.InsertMDMIdPAccount(context.Background(), &fleet.MDMIdPAccount{
+				Username: "used",
+				Email:    idpEmail,
+			})
+			require.NoError(t, err)
+			idpAccount, err := s.ds.GetMDMIdPAccountByEmail(context.Background(), idpEmail)
+			require.NoError(t, err)
+			sessionID := s.mustBYODIdPSession(t, idpAccount.UUID)
+			require.NoError(t, shared_mdm.ConsumeBYODIdPSession(t.Context(), redis_key_value.New(s.redisPool), clock.C, sessionID))
+
+			var specResp applyTeamSpecsResponse
+			teamSecret := "team_secret_used_session"
+			teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: "team used session", Secrets: &[]fleet.EnrollSecret{{Secret: teamSecret}}, MDM: fleet.TeamSpecMDM{MacOSSetup: fleet.MacOSSetup{EnableEndUserAuthentication: true}}}}}
+			s.DoJSON("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK, &specResp)
+
+			mdmDevice := mdmtest.NewTestMDMClientAppleOTA(
+				s.server.URL,
+				teamSecret,
+				"MacBookPro16,1",
+				mdmtest.WithOTAIdpSession(sessionID),
+			)
+			err = mdmDevice.Enroll()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "403 Forbidden")
 		})
 	})
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/WatchBeam/clock"
 	"io"
 	"log/slog"
 	"math/big"
@@ -17033,7 +17034,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 				s.server.URL,
 				globalSecret,
 				hwModel,
-				mdmtest.WithOTAIdpUUID(uuid.New().String()),
+				mdmtest.WithOTAIdpSession(s.mustBYODIdPSession(t, uuid.New().String())),
 			)
 			err := mdmDevice.Enroll()
 			require.Error(t, err)
@@ -17160,7 +17161,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 				s.server.URL,
 				globalSecret,
 				hwModel,
-				mdmtest.WithOTAIdpUUID(idpAccount.UUID),
+				mdmtest.WithOTAIdpSession(s.mustBYODIdPSession(t, idpAccount.UUID)),
 			)
 			enrollTime := time.Now().UTC().Truncate(time.Second)
 			require.NoError(t, mdmDevice.Enroll())
@@ -22358,20 +22359,24 @@ func (s *integrationMDMTestSuite) TestBYODEnrollmentWithIdPEnabled() {
 	require.NotEmpty(t, location)
 	require.True(t, strings.HasPrefix(location, "/enroll")) // expect to be redirect from /enroll page for BYOD
 
-	// requesting the /enroll page again and simulating the BYOD IdP cookie being set
-	// still redirects to the SSO login if the cookie value does not match the
-	// enrollment reference query string.
+	var byodSession string
+	for _, c := range res.Cookies() {
+		if c.Name == shared_mdm.BYODIdpCookieName {
+			byodSession = c.Value
+		}
+	}
+	require.NotEmpty(t, byodSession)
+
+	// a cookie that merely matches the enrollment reference in the query string
+	// is not an authenticated session and still redirects to the SSO login.
 	res = s.DoRawWithHeaders("GET", "/enroll", nil, http.StatusSeeOther,
-		map[string]string{"Cookie": shared_mdm.BYODIdpCookieName + "=abc"}, "enroll_secret", "idp", "enrollment_reference", "not_matching!")
+		map[string]string{"Cookie": shared_mdm.BYODIdpCookieName + "=abc"}, "enroll_secret", "idp", "enrollment_reference", "abc")
 	location = res.Header.Get("Location")
 	require.NotEmpty(t, location)
 	require.True(t, strings.HasPrefix(location, testSAMLIDPBaseURL+"/simplesaml/"))
 
-	// requesting the /enroll page again and simulating the BYOD IdP cookie being
-	// set renders the download profile page when there is a matching enrollment
-	// reference.
 	res = s.DoRawWithHeaders("GET", "/enroll", nil, http.StatusOK,
-		map[string]string{"Cookie": shared_mdm.BYODIdpCookieName + "=abc"}, "enroll_secret", "idp", "enrollment_reference", "abc")
+		map[string]string{"Cookie": shared_mdm.BYODIdpCookieName + "=" + byodSession}, "enroll_secret", "idp")
 	page, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(page), "How to enroll your Android device to Fleet")
@@ -22425,8 +22430,17 @@ func (s *integrationMDMTestSuite) TestOTAEnrollSSOWithoutAppleDEPProfile() {
 	// The callback should redirect back to the /enroll page (not to ?error=true).
 	require.True(t, strings.HasPrefix(u.Path, "/enroll"), "expected redirect to /enroll, got: %s", location)
 	require.Empty(t, u.Query().Get("error"), "expected no error in redirect, got: %s", location)
-	require.NotEmpty(t, u.Query().Get("enrollment_reference"), "expected enrollment_reference in redirect")
+	require.Empty(t, u.Query().Get("enrollment_reference"), "expected no enrollment_reference in redirect, got: %s", location)
 	require.Equal(t, fleet.SSOInitiatorOTAEnroll, u.Query().Get("initiator"))
+	var byodCookie *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == shared_mdm.BYODIdpCookieName {
+			byodCookie = c
+		}
+	}
+	require.NotNil(t, byodCookie, "expected BYOD IdP session cookie")
+	require.NotEmpty(t, byodCookie.Value)
+	require.Equal(t, int(shared_mdm.BYODIdPSessionTTL.Seconds()), byodCookie.MaxAge)
 }
 
 func (s *integrationMDMTestSuite) TestIOSiPadOSRefetch() {
@@ -28626,4 +28640,12 @@ func (s *integrationMDMTestSuite) TestMDMAppleHostDiskEncryptionEnforceOnly() {
 	require.NoError(t, s.ds.SetHostsDiskEncryptionKeyStatus(ctx, []uint{host.ID}, false, time.Now()))
 	checkHost(fleet.DiskEncryptionVerified, nil)
 	s.checkMDMDiskEncryptionSummaries(t, nil, fleet.MDMDiskEncryptionSummary{Verified: fleet.MDMPlatformsCounts{MacOS: 1}}, true)
+}
+
+// mustBYODIdPSession mints the session the IdP callback would have, so a test can
+// present a valid BYOD cookie without driving the SAML flow.
+func (s *integrationMDMTestSuite) mustBYODIdPSession(t *testing.T, idpAccountUUID string) string {
+	sessionID, err := shared_mdm.CreateBYODIdPSession(t.Context(), redis_key_value.New(s.redisPool), clock.C, idpAccountUUID)
+	require.NoError(t, err)
+	return sessionID
 }

--- a/server/service/integrationtest/android/android_test.go
+++ b/server/service/integrationtest/android/android_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/WatchBeam/clock"
 	"io"
 	"net/http"
 	"testing"
@@ -153,7 +154,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			secret := "global-no-idp-account" // nolint: gosec
 			createTeamAndSecret(secret, secret, false)
 			resp := s.DoRawWithHeaders(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusUnprocessableEntity, map[string]string{
-				"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, "test-uuid"),
+				"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, mustBYODIdPSession(t, s, "test-uuid")),
 			}, "enroll_secret", secret)
 			je := decodeJsonError(t, resp)
 
@@ -218,7 +219,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			require.NoError(t, err)
 
 			resp := s.DoRawWithHeaders(t, "GET", "/api/v1/fleet/android_enterprise/enrollment_token", nil, http.StatusOK, map[string]string{
-				"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, idpAccount.UUID),
+				"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, mustBYODIdPSession(t, s, idpAccount.UUID)),
 			}, "enroll_secret", globalSecret)
 
 			bodyBytes, err := io.ReadAll(resp.Body)
@@ -320,7 +321,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			resp := s.DoRawWithHeaders(t, "GET",
 				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true&idp_uuid=%s", globalSecret, paramAccount.UUID),
 				nil, http.StatusOK, map[string]string{
-					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, cookieAccount.UUID),
+					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, mustBYODIdPSession(t, s, cookieAccount.UUID)),
 				},
 			)
 			defer resp.Body.Close()
@@ -430,4 +431,12 @@ func decodeJsonError(t *testing.T, response *http.Response) endpointer.JsonError
 	require.NoError(t, err)
 
 	return je
+}
+
+// mustBYODIdPSession mints the session the IdP callback would have, so a test can
+// present a valid BYOD cookie without driving the SAML flow.
+func mustBYODIdPSession(t *testing.T, s *Suite, idpAccountUUID string) string {
+	sessionID, err := shared_mdm.CreateBYODIdPSession(t.Context(), s.KeyValueStore, clock.C, idpAccountUUID)
+	require.NoError(t, err)
+	return sessionID
 }

--- a/server/service/integrationtest/android/android_test.go
+++ b/server/service/integrationtest/android/android_test.go
@@ -261,13 +261,22 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			idpAccount, err := s.DS.GetMDMIdPAccountByEmail(t.Context(), idpEmail)
 			require.NoError(t, err)
 
-			// Pass idp_uuid as query parameter (no cookie). This is the path
-			// used after the BYOD cookie is cleared for fully-managed Android.
 			resp := s.DoRawWithHeaders(t, "GET",
-				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true&idp_uuid=%s", globalSecret, idpAccount.UUID),
-				nil, http.StatusOK, nil,
+				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true", globalSecret),
+				nil, http.StatusOK, map[string]string{
+					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, mustBYODIdPSession(t, s, idpAccount.UUID)),
+				},
 			)
 			defer resp.Body.Close()
+
+			// a fully managed enrollment ends the browser session with the token
+			var cleared bool
+			for _, c := range resp.Cookies() {
+				if c.Name == shared_mdm.BYODIdpCookieName && c.MaxAge < 0 {
+					cleared = true
+				}
+			}
+			require.True(t, cleared, "expected %s to be cleared", shared_mdm.BYODIdpCookieName)
 
 			bodyBytes, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
@@ -295,7 +304,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			})
 		})
 
-		t.Run("when idp_uuid query param takes precedence over cookie", func(t *testing.T) {
+		t.Run("when idp_uuid query param is ignored in favor of the cookie", func(t *testing.T) {
 			enableAndroidMDM()
 			createTeamAndSecret(globalSecret, globalSecret, true)
 			setupAndroidEnterprise()
@@ -317,7 +326,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			paramAccount, err := s.DS.GetMDMIdPAccountByEmail(t.Context(), "param@local.com")
 			require.NoError(t, err)
 
-			// Send both cookie and query param with different UUIDs
+			// the query parameter is not an input; only the session counts
 			resp := s.DoRawWithHeaders(t, "GET",
 				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true&idp_uuid=%s", globalSecret, paramAccount.UUID),
 				nil, http.StatusOK, map[string]string{
@@ -343,7 +352,7 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			require.NoError(t, err)
 
 			// Query param UUID should win over cookie UUID
-			require.Equal(t, paramAccount.UUID, enrollmentRequest.IdpUUID)
+			require.Equal(t, cookieAccount.UUID, enrollmentRequest.IdpUUID)
 
 			t.Cleanup(func() {
 				mysqltest.TruncateTables(t, s.DS)

--- a/server/service/integrationtest/android/android_test.go
+++ b/server/service/integrationtest/android/android_test.go
@@ -248,7 +248,8 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			})
 		})
 
-		t.Run("when idp_uuid is passed as query param", func(t *testing.T) {
+		t.Run("when the session cookie is set", func(t *testing.T) {
+			var sessionID string
 			enableAndroidMDM()
 			createTeamAndSecret(globalSecret, globalSecret, true)
 			setupAndroidEnterprise()
@@ -261,10 +262,11 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 			idpAccount, err := s.DS.GetMDMIdPAccountByEmail(t.Context(), idpEmail)
 			require.NoError(t, err)
 
+			sessionID = mustBYODIdPSession(t, s, idpAccount.UUID)
 			resp := s.DoRawWithHeaders(t, "GET",
 				fmt.Sprintf("/api/v1/fleet/android_enterprise/enrollment_token?enroll_secret=%s&fully_managed=true", globalSecret),
 				nil, http.StatusOK, map[string]string{
-					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, mustBYODIdPSession(t, s, idpAccount.UUID)),
+					"Cookie": fmt.Sprintf("%s=%s", shared_mdm.BYODIdpCookieName, sessionID),
 				},
 			)
 			defer resp.Body.Close()
@@ -298,6 +300,10 @@ func testCreateEnrollmentToken(t *testing.T, s *Suite) {
 
 			require.Equal(t, globalSecret, enrollmentRequest.EnrollSecret)
 			require.Equal(t, idpAccount.UUID, enrollmentRequest.IdpUUID)
+
+			// the session is single-use: minting the token burned it
+			_, err = shared_mdm.ValidateBYODIdPSession(t.Context(), s.KeyValueStore, clock.C, sessionID)
+			require.ErrorAs(t, err, new(*fleet.AuthRequiredError))
 
 			t.Cleanup(func() {
 				mysqltest.TruncateTables(t, s.DS)

--- a/server/service/integrationtest/android/suite.go
+++ b/server/service/integrationtest/android/suite.go
@@ -1,6 +1,7 @@
 package android
 
 import (
+	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"log/slog"
 	"os"
 	"testing"
@@ -19,11 +20,13 @@ import (
 
 type Suite struct {
 	integrationtest.BaseSuite
-	AndroidProxy *android_mock.Client
+	AndroidProxy  *android_mock.Client
+	KeyValueStore fleet.KeyValueStore
 }
 
 func SetUpSuite(t *testing.T, uniqueTestName string) *Suite {
 	ds, redisPool, fleetCfg, fleetSvc, ctx := integrationtest.SetUpMySQLAndRedisAndService(t, uniqueTestName)
+	keyValueStore := redis_key_value.New(redisPool)
 	slogLogger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	proxy := android_mock.Client{}
 	proxy.InitCommonMocks()
@@ -38,6 +41,7 @@ func SetUpSuite(t *testing.T, uniqueTestName string) *Suite {
 			Package:       "com.fleetdm.agent",
 			SigningSHA256: "abc123def456",
 		},
+		android_service.WithKeyValueStore(keyValueStore),
 	)
 	require.NoError(t, err)
 	androidSvc.(*android_service.Service).AllowLocalhostServerURL = true
@@ -61,7 +65,8 @@ func SetUpSuite(t *testing.T, uniqueTestName string) *Suite {
 			Users:    users,
 			Server:   server,
 		},
-		AndroidProxy: &proxy,
+		AndroidProxy:  &proxy,
+		KeyValueStore: keyValueStore,
 	}
 
 	integrationtest.SetUpServerURL(t, ds, server)

--- a/server/service/svctest/server.go
+++ b/server/service/svctest/server.go
@@ -3,6 +3,7 @@ package svctest
 import (
 	"context"
 	"crypto/x509"
+	"github.com/WatchBeam/clock"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -264,7 +265,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	}
 	debugHandler := service.MakeDebugHandler(svc, cfg, logger, errHandler, ds, nil)
 	rootMux.Handle("/debug/", debugHandler)
-	rootMux.Handle("/enroll", service.ServeEndUserEnrollOTA(svc, "", ds, redis_key_value.New(redisPool), logger, false))
+	rootMux.Handle("/enroll", service.ServeEndUserEnrollOTA(svc, "", ds, redis_key_value.New(redisPool), clock.C, logger, false))
 
 	if len(opts) > 0 && opts[0].EnableSCIM {
 		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger, &cfg))

--- a/server/service/svctest/server.go
+++ b/server/service/svctest/server.go
@@ -264,7 +264,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	}
 	debugHandler := service.MakeDebugHandler(svc, cfg, logger, errHandler, ds, nil)
 	rootMux.Handle("/debug/", debugHandler)
-	rootMux.Handle("/enroll", service.ServeEndUserEnrollOTA(svc, "", ds, logger, false))
+	rootMux.Handle("/enroll", service.ServeEndUserEnrollOTA(svc, "", ds, redis_key_value.New(redisPool), logger, false))
 
 	if len(opts) > 0 && opts[0].EnableSCIM {
 		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger, &cfg))

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -690,11 +690,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	}
 	debugHandler := MakeDebugHandler(svc, cfg, logger, errHandler, ds, nil)
 	rootMux.Handle("/debug/", debugHandler)
-	var enrollKV fleet.KeyValueStore
-	if len(opts) > 0 && opts[0].Pool != nil {
-		enrollKV = redis_key_value.New(opts[0].Pool)
-	}
-	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, enrollKV, clock.C, logger, false))
+	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, redis_key_value.New(redisPool), clock.C, logger, false))
 
 	if len(opts) > 0 && opts[0].EnableSCIM {
 		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger, &cfg))

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -690,7 +690,11 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	}
 	debugHandler := MakeDebugHandler(svc, cfg, logger, errHandler, ds, nil)
 	rootMux.Handle("/debug/", debugHandler)
-	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, logger, false))
+	var enrollKV fleet.KeyValueStore
+	if len(opts) > 0 && opts[0].Pool != nil {
+		enrollKV = redis_key_value.New(opts[0].Pool)
+	}
+	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, enrollKV, logger, false))
 
 	if len(opts) > 0 && opts[0].EnableSCIM {
 		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger, &cfg))

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -694,7 +694,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	if len(opts) > 0 && opts[0].Pool != nil {
 		enrollKV = redis_key_value.New(opts[0].Pool)
 	}
-	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, enrollKV, logger, false))
+	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, enrollKV, clock.C, logger, false))
 
 	if len(opts) > 0 && opts[0].EnableSCIM {
 		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger, &cfg))


### PR DESCRIPTION
**Related issue:** N/A

The IdP callback for the BYOD `/enroll` flow now stores the authentication result in a short-lived server-side session and hands the browser only the session id. `/enroll`, the OTA profile endpoint and the Android enrollment token endpoint resolve the IdP account from that session. This is the same shape as the device SSO session in `ee/server/service/devices.go`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure BYOD enrollment sessions with expiring authentication cookies.
  * BYOD enrollment now validates session cookies before displaying enrollment details.
  * Enrollment redirects no longer expose enrollment references in the URL.

* **Bug Fixes**
  * Prevented raw identity references from being accepted as BYOD authentication credentials.
  * Improved handling of unknown, missing, and expired enrollment sessions.
  * Improved input validation during BYOD enrollment.
  * Preserved valid enrollment sessions across supported enrollment flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->