### PR TITLE
Policy automation: Show pre-install query failure copy in Details modal and Details column

### DIFF
--- a/changes/52287-policy-automation-preinstall-failure-details
+++ b/changes/52287-policy-automation-preinstall-failure-details
@@ -1,0 +1,1 @@
+Fixed the policy automation Details modal and Automation runs table's Details column showing no explanation when a software install failed because its pre-install query returned no rows.

--- a/server/service/policies.go
+++ b/server/service/policies.go
@@ -169,5 +169,19 @@ func (svc Service) ListPolicyAutomationActivities(ctx context.Context, policyID 
 	if err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "list policy automation activities")
 	}
+
+	// A pre-install-query failure is stored as an empty (non-null)
+	// pre_install_query_output, which the modal and table drop as no-output.
+	// Substitute the same copy /software_install_results uses via
+	// HostSoftwareInstallerResult.EnhanceOutputDetails.
+	for _, a := range activities {
+		if a.Type == "installed_software" && a.Status == "error" &&
+			a.PreInstallOutput != nil && *a.PreInstallOutput == "" {
+			// Rebind rather than mutating through the pointer: the caller may
+			// share the underlying string across rows.
+			out := fleet.SoftwareInstallerQueryFailCopy
+			a.PreInstallOutput = &out
+		}
+	}
 	return activities, meta, nil
 }

--- a/server/service/policies_test.go
+++ b/server/service/policies_test.go
@@ -204,6 +204,59 @@ func TestListPolicyAutomationActivities(t *testing.T) {
 		require.True(t, capturedFilter.IncludeObserver)
 	})
 
+	t.Run("empty pre_install_output on a failed install is enhanced to the query-fail copy", func(t *testing.T) {
+		// A pre-install-query failure is stored as an empty (non-null)
+		// pre_install_query_output, which the FE otherwise drops as no-output.
+		// The service must substitute the same copy /software_install_results
+		// does so the Policy Details modal / Automation runs table's Details
+		// column show why the install failed.
+		emptyOutput := ""
+		nonEmptyOutput := "pre-install ok"
+		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, _ fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
+			// Rows that MUST be rewritten.
+			rewriteFailedInstall := &fleet.PolicyAutomationActivity{
+				Activity: fleet.Activity{Type: "installed_software"},
+				Status:   "error", PreInstallOutput: &emptyOutput,
+			}
+			// Rows that MUST NOT be rewritten.
+			nonEmptyPreInstall := &fleet.PolicyAutomationActivity{
+				Activity: fleet.Activity{Type: "installed_software"},
+				Status:   "error", PreInstallOutput: &nonEmptyOutput,
+			}
+			successfulInstall := &fleet.PolicyAutomationActivity{
+				Activity: fleet.Activity{Type: "installed_software"},
+				Status:   "success", PreInstallOutput: &emptyOutput,
+			}
+			noPreInstallConfigured := &fleet.PolicyAutomationActivity{
+				Activity: fleet.Activity{Type: "installed_software"},
+				Status:   "error", PreInstallOutput: nil,
+			}
+			nonInstallActivity := &fleet.PolicyAutomationActivity{
+				Activity: fleet.Activity{Type: "ran_script"},
+				Status:   "error", PreInstallOutput: &emptyOutput,
+			}
+			return []*fleet.PolicyAutomationActivity{
+				rewriteFailedInstall, nonEmptyPreInstall, successfulInstall,
+				noPreInstallConfigured, nonInstallActivity,
+			}, &fleet.PaginationMetadata{}, nil
+		}
+		userCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new("admin")}})
+		activities, _, err := svc.ListPolicyAutomationActivities(userCtx, 1, fleet.ListOptions{}, "")
+		require.NoError(t, err)
+		require.Len(t, activities, 5)
+
+		require.Equal(t, fleet.SoftwareInstallerQueryFailCopy, *activities[0].PreInstallOutput,
+			"failed install with empty pre-install output should be rewritten")
+		require.Equal(t, "pre-install ok", *activities[1].PreInstallOutput,
+			"non-empty pre-install output must not be overwritten")
+		require.Empty(t, *activities[2].PreInstallOutput,
+			"successful install must not be rewritten even if pre-install is empty")
+		require.Nil(t, activities[3].PreInstallOutput,
+			"nil pre-install output (no pre-install query configured) must stay nil")
+		require.Empty(t, *activities[4].PreInstallOutput,
+			"non-installed_software activity must not be rewritten")
+	})
+
 	t.Run("endpoint surfaces total count from meta", func(t *testing.T) {
 		ds.ListPolicyAutomationActivitiesFunc = func(_ context.Context, _ uint, _ fleet.TeamFilter, _ fleet.ListOptions, _ string) ([]*fleet.PolicyAutomationActivity, *fleet.PaginationMetadata, error) {
 			return returnedActivities, &fleet.PaginationMetadata{TotalResults: 123, HasNextResults: true}, nil


### PR DESCRIPTION
## Issue
Closes #52287

## Description
- Bug fix (root cause): the SQL projection at `server/datastore/mysql/activities.go` reads `hsi.pre_install_query_output` raw, so a pre-install-query failure (stored as an empty non-null string by orbit at `orbit/pkg/installer/installer.go:299-311` when the query returns no rows or errors) flowed through to the frontend as `""`. The Policy Details modal's `renderOutputSection` and the Automation runs table's `getDetailOutputText` both dropped the empty string as no-output, so the surface showed only "Software failed (<title>)" / `---` with no reason.
- Fix (`server/service/policies.go`): in `ListPolicyAutomationActivities`, post-process installed_software rows with `status == "error"` and empty non-nil `PreInstallOutput` and rebind the pointer to `fleet.SoftwareInstallerQueryFailCopy` ("Query didn't return result or failed / Install stopped"). This is the same copy `/software_install_results` already surfaces via `HostSoftwareInstallerResult.EnhanceOutputDetails`, so the general `SoftwareInstallDetailsModal` and the policy automation feed now say the same thing for the same underlying state.
- Guarded so the rewrite only fires on installed_software + error + non-nil-empty pointer: nil pointer (no pre-install query configured), non-empty string, success status, and other activity types are all left untouched. Rebinds a fresh string rather than mutating through the pointer so shared underlying strings across rows can't be aliased.
- No wire type, migration, orbit, or frontend change required — the empty-string signal already exists end-to-end; only the enrichment was missing on this one path.

## Screenrecording
- Policy Details modal + Automation runs table Details column after a pre-install-query failure on a custom package and on an FMA

### On FMA - Surfaces that pre-install query failure copy
<img width="1104" height="976" alt="Screenshot 2026-09-02 at 10 03 20 AM" src="https://github.com/user-attachments/assets/61f58a8d-2f7c-49d3-bab3-cb5ba622a6b7" />


### On Custom package - Surfaces that pre-install query failure copy

<img width="1132" height="949" alt="Screenshot 2026-09-02 at 10 10 58 AM" src="https://github.com/user-attachments/assets/964d2fbb-34df-439e-8e54-919ca7180072" />


### Confirm the preinstall query failure of an app skipped because opened remains unchanged

<img width="1132" height="981" alt="Screenshot 2026-09-02 at 10 07 08 AM" src="https://github.com/user-attachments/assets/73e5ff68-0868-4c0d-b63b-24234eb33d9e" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an explanatory message to Policy Automation activity details when a software installation fails because its pre-install query returns no results.
  * Updated both the Automation runs table and Details modal to display this failure information consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->