### PR TITLE
Patch cached host team on transfer instead of invalidating

### DIFF
--- a/changes/46894-host-transfer-cache-stampede
+++ b/changes/46894-host-transfer-cache-stampede
@@ -1,0 +1,1 @@
+* Fixed a spike in database read traffic when transferring large numbers of hosts between fleets.

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -770,7 +770,6 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 
 	writes := make([]hostCacheKV, 0, len(targets))
 	var fallback []uint
-	patched := 0
 	for i, t := range targets {
 		raw := payloads[i]
 		if raw == "" {
@@ -793,15 +792,20 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 			fallback = append(fallback, t.id)
 			continue
 		}
-		writes = append(writes, hostCacheKV{key: t.fam.primaryKey(t.nodeKey), val: next})
-		patched++
+		writes = append(writes, hostCacheKV{key: t.fam.primaryKey(t.nodeKey), val: next, id: t.id})
 	}
 
-	d.pipelinedSETKeepTTL(ctx, writes)
+	applied := d.pipelinedSETKeepTTL(ctx, writes)
 	if len(fallback) > 0 {
 		d.invalidateHostIDs(ctx, fallback, "team")
 	}
-	d.recordHostCacheInvalidations(ctx, "team_rewrite", patched)
+	// Per host, to match the semantics of the invalidation counter: a host has
+	// one entry per family, and either can be absent or skipped.
+	patchedHosts := make(map[uint]struct{}, len(applied))
+	for _, kv := range applied {
+		patchedHosts[kv.id] = struct{}{}
+	}
+	d.recordHostCacheInvalidations(ctx, "team_rewrite", len(patchedHosts))
 }
 
 // escrowKeptOnTransfer mirrors cleanupDiskEncryptionKeysOnTeamChangeDB's
@@ -822,58 +826,73 @@ func escrowKeptOnTransfer(platform string, cfg fleet.DiskEncryptionConfig) bool 
 type hostCacheKV struct {
 	key string
 	val []byte
+	id  uint
 }
 
 // KEEPTTL keeps each entry's existing expiry; a plain SET would reset it and
-// leave the whole batch expiring together.
-func (d *Datastore) pipelinedSETKeepTTL(ctx context.Context, kvs []hostCacheKV) {
+// leave the whole batch expiring together. XX drops a key that expired between
+// being read and being written back: without it that SET recreates the entry
+// with no expiry at all, and since the reverse index expired with it, no
+// invalidation could ever find it again. Returns the writes Redis applied.
+func (d *Datastore) pipelinedSETKeepTTL(ctx context.Context, kvs []hostCacheKV) []hostCacheKV {
 	if len(kvs) == 0 {
-		return
+		return nil
 	}
-	byKey := make(map[string][]byte, len(kvs))
+	byKey := make(map[string]hostCacheKV, len(kvs))
 	keys := make([]string, 0, len(kvs))
 	for _, kv := range kvs {
-		byKey[kv.key] = kv.val
+		byKey[kv.key] = kv
 		keys = append(keys, kv.key)
 	}
+	var applied []hostCacheKV
 	for _, group := range redis.SplitKeysBySlot(d.pool, keys...) {
 		for len(group) > 0 {
 			n := min(len(group), hostCacheInvalidateBatchSize)
 			chunk := group[:n]
 			group = group[n:]
-			d.setKeepTTLChunk(ctx, chunk, byKey)
+			applied = append(applied, d.setKeepTTLChunk(ctx, chunk, byKey)...)
 		}
 	}
+	return applied
 }
 
 // SET has no variadic form, so the chunk is pipelined to avoid a round-trip per key.
-func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey map[string][]byte) {
+func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey map[string]hostCacheKV) []hostCacheKV {
 	conn := d.pool.Get()
 	defer conn.Close()
+	// BindConn before ConfigureDoer, see mgetChunk for the rationale.
 	if err := redis.BindConn(d.pool, conn, chunk...); err != nil {
 		d.recordHostCacheErr(ctx, "set", err)
-		return
+		return nil
 	}
 	doer := redis.ConfigureDoer(d.pool, conn)
-	sent := 0
+	sent := make([]hostCacheKV, 0, len(chunk))
 	for _, k := range chunk {
-		if err := doer.Send("SET", k, byKey[k], "KEEPTTL"); err != nil {
+		if err := doer.Send("SET", k, byKey[k].val, "XX", "KEEPTTL"); err != nil {
 			d.recordHostCacheErr(ctx, "set", err)
 			break
 		}
-		sent++
+		sent = append(sent, byKey[k])
 	}
-	if sent == 0 {
-		return
+	if len(sent) == 0 {
+		return nil
 	}
 	if err := doer.Flush(); err != nil {
 		d.recordHostCacheErr(ctx, "set", err)
-		return
+		return nil
 	}
-	for i := 0; i < sent; i++ {
-		if _, err := doer.Receive(); err != nil {
+	applied := make([]hostCacheKV, 0, len(sent))
+	for _, kv := range sent {
+		reply, err := doer.Receive()
+		if err != nil {
 			d.recordHostCacheErr(ctx, "set", err)
-			return
+			return applied
 		}
+		if reply == nil {
+			// XX rejected the write: the entry expired since it was read.
+			continue
+		}
+		applied = append(applied, kv)
 	}
+	return applied
 }

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -418,7 +418,11 @@ func (d *Datastore) hostCacheClearDirectEntries(ctx context.Context, nodeKey, or
 // to redisSetMembersBatchSize=10000 in hosts.go (whose elements are ~10-byte host IDs). Common practice for
 // pipelined batches is 100-1000; 500 is a defensible middle. Lower if metrics show invalidation causing Redis CPU
 // spikes during bulk team moves; raise if round-trip latency dominates.
-const hostCacheInvalidateBatchSize = 500
+var hostCacheInvalidateBatchSize = 500
+
+// hostCacheRewriteHostBatchSize bounds how many hosts' snapshots the team patch holds in memory at once.
+// A var so tests can cross the chunk boundary without priming hundreds of hosts.
+var hostCacheRewriteHostBatchSize = 500
 
 // invalidateHostIDs efficiently invalidates both cache families for a batch
 // of host IDs. Equivalent to calling hostCacheDeleteByID in a loop but uses
@@ -445,7 +449,7 @@ func (d *Datastore) invalidateHostIDs(ctx context.Context, ids []uint, reason st
 			idxKeys = append(idxKeys, fam.indexKey(id))
 		}
 	}
-	resolved := d.pipelinedMGET(ctx, idxKeys)
+	resolved, _ := d.pipelinedMGET(ctx, idxKeys)
 
 	// Phase 2: build the full DEL key list (payload + negative + reverse index for whichever family was
 	// populated) and issue pipelined DELs.
@@ -472,10 +476,13 @@ func (d *Datastore) invalidateHostIDs(ctx context.Context, ids []uint, reason st
 // Works in both modes via redis.SplitKeysBySlot: in cluster mode keys are grouped by slot (CROSSSLOT-safe)
 // and one MGET per slot group is issued; in standalone mode SplitKeysBySlot returns a single group containing
 // all keys and BindConn is a no-op. Either way the group is further chunked at hostCacheInvalidateBatchSize.
-func (d *Datastore) pipelinedMGET(ctx context.Context, keys []string) []string {
+// The bool reports whether every chunk was read. A failed read leaves empty
+// strings, which a caller cannot tell apart from "not cached" — and the two need
+// opposite handling, since a key we failed to read may still hold a stale value.
+func (d *Datastore) pipelinedMGET(ctx context.Context, keys []string) ([]string, bool) {
 	result := make([]string, len(keys))
 	if len(keys) == 0 {
-		return result
+		return result, true
 	}
 
 	// Slot grouping rearranges keys; this map restores input order.
@@ -484,18 +491,21 @@ func (d *Datastore) pipelinedMGET(ctx context.Context, keys []string) []string {
 		indexOf[k] = i
 	}
 
+	ok := true
 	for _, group := range redis.SplitKeysBySlot(d.pool, keys...) {
 		for len(group) > 0 {
 			n := min(len(group), hostCacheInvalidateBatchSize)
 			chunk := group[:n]
 			group = group[n:]
-			d.mgetChunk(ctx, chunk, indexOf, result)
+			if !d.mgetChunk(ctx, chunk, indexOf, result) {
+				ok = false
+			}
 		}
 	}
-	return result
+	return result, ok
 }
 
-func (d *Datastore) mgetChunk(ctx context.Context, chunk []string, indexOf map[string]int, out []string) {
+func (d *Datastore) mgetChunk(ctx context.Context, chunk []string, indexOf map[string]int, out []string) bool {
 	conn := d.pool.Get()
 	defer conn.Close()
 	// BindConn MUST come before ConfigureDoer. redisc's BindConn expects the raw cluster conn from the pool,
@@ -503,7 +513,7 @@ func (d *Datastore) mgetChunk(ctx context.Context, chunk []string, indexOf map[s
 	// In standalone mode BindConn is a no-op.
 	if err := redis.BindConn(d.pool, conn, chunk...); err != nil {
 		d.recordHostCacheErr(ctx, "get", err)
-		return
+		return false
 	}
 	// ConfigureDoer returns a RetryConn wrapper around conn. We use the wrapper for the Do() call but keep the
 	// `defer conn.Close()` against the raw conn so the lifecycle is explicit and tools don't flag the assignment
@@ -513,7 +523,7 @@ func (d *Datastore) mgetChunk(ctx context.Context, chunk []string, indexOf map[s
 	values, err := redigo.Values(doer.Do("MGET", args...))
 	if err != nil {
 		d.recordHostCacheErr(ctx, "get", err)
-		return
+		return false
 	}
 	for i, v := range values {
 		if i >= len(chunk) {
@@ -526,6 +536,7 @@ func (d *Datastore) mgetChunk(ctx context.Context, chunk []string, indexOf map[s
 			out[indexOf[chunk[i]]] = string(b)
 		}
 	}
+	return true
 }
 
 // pipelinedDEL issues variadic DEL across all keys. Slot-grouped and chunked the same way as pipelinedMGET
@@ -733,6 +744,32 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 		return
 	}
 
+	var patched, fallback []uint
+	for len(ids) > 0 {
+		n := min(len(ids), hostCacheRewriteHostBatchSize)
+		chunkPatched, chunkFallback := d.rewriteTeamChunk(ctx, ids[:n], teamID, destDiskEncryption)
+		ids = ids[n:]
+		patched = append(patched, chunkPatched...)
+		fallback = append(fallback, chunkFallback...)
+	}
+
+	if len(fallback) > 0 {
+		d.invalidateHostIDs(ctx, fallback, "team")
+	}
+	// Per host, to match the semantics of the invalidation counter: a host has
+	// one entry per family, and either can be absent or skipped.
+	patchedHosts := make(map[uint]struct{}, len(patched))
+	for _, id := range patched {
+		patchedHosts[id] = struct{}{}
+	}
+	d.recordHostCacheInvalidations(ctx, "team_rewrite", len(patchedHosts))
+}
+
+// rewriteTeamChunk patches one chunk of host IDs, returning the hosts it patched
+// and the ones that must fall back to invalidation.
+func (d *Datastore) rewriteTeamChunk(
+	ctx context.Context, ids []uint, teamID *uint, destDiskEncryption fleet.DiskEncryptionConfig,
+) (patched, fallback []uint) {
 	families := []cacheFamily{osqueryCacheFamily, orbitCacheFamily}
 	nFam := len(families)
 
@@ -742,7 +779,12 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 			idxKeys = append(idxKeys, fam.indexKey(id))
 		}
 	}
-	resolved := d.pipelinedMGET(ctx, idxKeys)
+	resolved, ok := d.pipelinedMGET(ctx, idxKeys)
+	if !ok {
+		// Unresolved keys are indistinguishable from uncached ones, so patching
+		// only what came back would leave the rest holding the old team.
+		return nil, ids
+	}
 
 	// Reverse index -> payload key, so the payloads can be fetched in one pass.
 	type target struct {
@@ -763,15 +805,17 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 		}
 	}
 	if len(targets) == 0 {
-		// Nothing cached for this batch: clear the reverse index and any negative entries.
-		d.invalidateHostIDs(ctx, ids, "team")
-		return
+		// Nothing cached for these hosts: clear the reverse index and any negative entries.
+		return nil, ids
 	}
 
-	payloads := d.pipelinedMGET(ctx, payloadKeys)
+	payloads, ok := d.pipelinedMGET(ctx, payloadKeys)
+	if !ok {
+		// Same reasoning: an unread payload still holds the old snapshot.
+		return nil, ids
+	}
 
 	writes := make([]hostCacheKV, 0, len(targets))
-	var fallback []uint
 	for i, t := range targets {
 		raw := payloads[i]
 		if raw == "" {
@@ -801,16 +845,10 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 	for _, kv := range failed {
 		fallback = append(fallback, kv.id)
 	}
-	if len(fallback) > 0 {
-		d.invalidateHostIDs(ctx, fallback, "team")
-	}
-	// Per host, to match the semantics of the invalidation counter: a host has
-	// one entry per family, and either can be absent or skipped.
-	patchedHosts := make(map[uint]struct{}, len(applied))
 	for _, kv := range applied {
-		patchedHosts[kv.id] = struct{}{}
+		patched = append(patched, kv.id)
 	}
-	d.recordHostCacheInvalidations(ctx, "team_rewrite", len(patchedHosts))
+	return patched, fallback
 }
 
 // escrowKeptOnTransfer mirrors cleanupDiskEncryptionKeysOnTeamChangeDB's

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -712,9 +712,11 @@ func (d *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, orbitNodeKey str
 // their TTLs collapse into one wave that re-fires each TTL period.
 // Patching in place removes the reload entirely and preserves the natural TTL spread.
 //
-// Anything that cannot be patched confidently — an unreadable envelope, or a
-// failure to resolve the destination's disk encryption settings — falls back to
-// the DEL path, so correctness never depends on the patch succeeding.
+// Anything that cannot be patched confidently falls back to the DEL path: an
+// unreadable envelope, a failure to resolve the destination's disk encryption
+// settings, or a write that errored and so may have left the old snapshot in
+// place. A write that XX rejected needs no fallback — that entry had already
+// expired, so there is nothing stale to clear.
 func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID *uint) {
 	if !d.hostCacheEnabled || len(ids) == 0 {
 		return
@@ -795,7 +797,10 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 		writes = append(writes, hostCacheKV{key: t.fam.primaryKey(t.nodeKey), val: next, id: t.id})
 	}
 
-	applied := d.pipelinedSETKeepTTL(ctx, writes)
+	applied, failed := d.pipelinedSETKeepTTL(ctx, writes)
+	for _, kv := range failed {
+		fallback = append(fallback, kv.id)
+	}
 	if len(fallback) > 0 {
 		d.invalidateHostIDs(ctx, fallback, "team")
 	}
@@ -833,10 +838,11 @@ type hostCacheKV struct {
 // leave the whole batch expiring together. XX drops a key that expired between
 // being read and being written back: without it that SET recreates the entry
 // with no expiry at all, and since the reverse index expired with it, no
-// invalidation could ever find it again. Returns the writes Redis applied.
-func (d *Datastore) pipelinedSETKeepTTL(ctx context.Context, kvs []hostCacheKV) []hostCacheKV {
+// invalidation could ever find it again. Returns the writes Redis applied, and
+// the ones whose outcome is unknown because the write errored.
+func (d *Datastore) pipelinedSETKeepTTL(ctx context.Context, kvs []hostCacheKV) (applied, failed []hostCacheKV) {
 	if len(kvs) == 0 {
-		return nil
+		return nil, nil
 	}
 	byKey := make(map[string]hostCacheKV, len(kvs))
 	keys := make([]string, 0, len(kvs))
@@ -844,55 +850,70 @@ func (d *Datastore) pipelinedSETKeepTTL(ctx context.Context, kvs []hostCacheKV) 
 		byKey[kv.key] = kv
 		keys = append(keys, kv.key)
 	}
-	var applied []hostCacheKV
 	for _, group := range redis.SplitKeysBySlot(d.pool, keys...) {
 		for len(group) > 0 {
 			n := min(len(group), hostCacheInvalidateBatchSize)
 			chunk := group[:n]
 			group = group[n:]
-			applied = append(applied, d.setKeepTTLChunk(ctx, chunk, byKey)...)
+			chunkApplied, chunkFailed := d.setKeepTTLChunk(ctx, chunk, byKey)
+			applied = append(applied, chunkApplied...)
+			failed = append(failed, chunkFailed...)
 		}
 	}
-	return applied
+	return applied, failed
 }
 
 // SET has no variadic form, so the chunk is pipelined to avoid a round-trip per key.
-func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey map[string]hostCacheKV) []hostCacheKV {
+func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey map[string]hostCacheKV) (applied, failed []hostCacheKV) {
+	all := func() []hostCacheKV {
+		out := make([]hostCacheKV, 0, len(chunk))
+		for _, k := range chunk {
+			out = append(out, byKey[k])
+		}
+		return out
+	}
+
 	conn := d.pool.Get()
 	defer conn.Close()
 	// BindConn before ConfigureDoer, see mgetChunk for the rationale.
 	if err := redis.BindConn(d.pool, conn, chunk...); err != nil {
 		d.recordHostCacheErr(ctx, "set", err)
-		return nil
+		return nil, all()
 	}
 	doer := redis.ConfigureDoer(d.pool, conn)
+
 	sent := make([]hostCacheKV, 0, len(chunk))
-	for _, k := range chunk {
+	for i, k := range chunk {
 		if err := doer.Send("SET", k, byKey[k].val, "XX", "KEEPTTL"); err != nil {
 			d.recordHostCacheErr(ctx, "set", err)
+			for _, rest := range chunk[i:] {
+				failed = append(failed, byKey[rest])
+			}
 			break
 		}
 		sent = append(sent, byKey[k])
 	}
 	if len(sent) == 0 {
-		return nil
+		return nil, failed
 	}
 	if err := doer.Flush(); err != nil {
 		d.recordHostCacheErr(ctx, "set", err)
-		return nil
+		return nil, append(failed, sent...)
 	}
-	applied := make([]hostCacheKV, 0, len(sent))
-	for _, kv := range sent {
+
+	applied = make([]hostCacheKV, 0, len(sent))
+	for i, kv := range sent {
 		reply, err := doer.Receive()
 		if err != nil {
 			d.recordHostCacheErr(ctx, "set", err)
-			return applied
+			return applied, append(failed, sent[i:]...)
 		}
 		if reply == nil {
-			// XX rejected the write: the entry expired since it was read.
+			// XX rejected the write: the entry expired since it was read, so
+			// there is no stale snapshot to clear and nothing to fall back to.
 			continue
 		}
 		applied = append(applied, kv)
 	}
-	return applied
+	return applied, failed
 }

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -753,16 +753,30 @@ func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID
 		fallback = append(fallback, chunkFallback...)
 	}
 
-	if len(fallback) > 0 {
-		d.invalidateHostIDs(ctx, fallback, "team")
+	// Both counts are per host, matching the invalidation counter's semantics: a
+	// host has an entry per family, and each can independently be patched,
+	// skipped, or fall back — so either list can name the same host twice.
+	if fallbackHosts := uniqueHostIDs(fallback); len(fallbackHosts) > 0 {
+		d.invalidateHostIDs(ctx, fallbackHosts, "team")
 	}
-	// Per host, to match the semantics of the invalidation counter: a host has
-	// one entry per family, and either can be absent or skipped.
-	patchedHosts := make(map[uint]struct{}, len(patched))
-	for _, id := range patched {
-		patchedHosts[id] = struct{}{}
+	d.recordHostCacheInvalidations(ctx, "team_rewrite", len(uniqueHostIDs(patched)))
+}
+
+// uniqueHostIDs removes repeats while preserving order.
+func uniqueHostIDs(ids []uint) []uint {
+	if len(ids) < 2 {
+		return ids
 	}
-	d.recordHostCacheInvalidations(ctx, "team_rewrite", len(patchedHosts))
+	seen := make(map[uint]struct{}, len(ids))
+	out := make([]uint, 0, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
 }
 
 // rewriteTeamChunk patches one chunk of host IDs, returning the hosts it patched

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -701,3 +701,179 @@ func (d *Datastore) LoadHostByNodeKey(ctx context.Context, nodeKey string) (*fle
 func (d *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, orbitNodeKey string) (*fleet.Host, error) {
 	return d.loadHostFamily(ctx, orbitCacheFamily, orbitNodeKey, d.Datastore.LoadHostByOrbitNodeKey)
 }
+
+// rewriteTeamOnHostIDs patches team_id on the cached snapshots of a transferred
+// batch instead of deleting them, keeping each entry's existing expiry.
+//
+// Why not just invalidate: a team transfer changes exactly one cached field, but
+// DELing the batch makes every transferred host miss on its next check-in. The
+// whole population then reloads inside one poll interval, so the reader sees the
+// full uncached host-load rate in a burst, and because the reloads all repopulate together
+// their TTLs collapse into one wave that re-fires each TTL period.
+// Patching in place removes the reload entirely and preserves the natural TTL spread.
+//
+// Anything that cannot be patched confidently — an unreadable envelope, or a
+// failure to resolve the destination's disk encryption settings — falls back to
+// the DEL path, so correctness never depends on the patch succeeding.
+func (d *Datastore) rewriteTeamOnHostIDs(ctx context.Context, ids []uint, teamID *uint) {
+	if !d.hostCacheEnabled || len(ids) == 0 {
+		return
+	}
+
+	// The transfer drops escrowed disk encryption keys for platforms the
+	// destination doesn't escrow for, which is the one other cached field a
+	// transfer can change (orbit family only). Without these settings we can't
+	// tell, so invalidate rather than serve a stale key-available flag.
+	destDiskEncryption, err := d.Datastore.GetConfigEnableDiskEncryption(ctx, teamID)
+	if err != nil {
+		d.recordHostCacheErr(ctx, "get", err)
+		d.invalidateHostIDs(ctx, ids, "team")
+		return
+	}
+
+	families := []cacheFamily{osqueryCacheFamily, orbitCacheFamily}
+	nFam := len(families)
+
+	idxKeys := make([]string, 0, nFam*len(ids))
+	for _, id := range ids {
+		for _, fam := range families {
+			idxKeys = append(idxKeys, fam.indexKey(id))
+		}
+	}
+	resolved := d.pipelinedMGET(ctx, idxKeys)
+
+	// Reverse index -> payload key, so the payloads can be fetched in one pass.
+	type target struct {
+		fam     cacheFamily
+		nodeKey string
+		id      uint
+	}
+	targets := make([]target, 0, len(idxKeys))
+	payloadKeys := make([]string, 0, len(idxKeys))
+	for i, id := range ids {
+		for f, fam := range families {
+			key := resolved[i*nFam+f]
+			if key == "" {
+				continue
+			}
+			targets = append(targets, target{fam: fam, nodeKey: key, id: id})
+			payloadKeys = append(payloadKeys, fam.primaryKey(key))
+		}
+	}
+	if len(targets) == 0 {
+		// Nothing cached for this batch: clear the reverse index and any negative entries.
+		d.invalidateHostIDs(ctx, ids, "team")
+		return
+	}
+
+	payloads := d.pipelinedMGET(ctx, payloadKeys)
+
+	writes := make([]hostCacheKV, 0, len(targets))
+	var fallback []uint
+	patched := 0
+	for i, t := range targets {
+		raw := payloads[i]
+		if raw == "" {
+			// Expired between the two MGETs; nothing to patch and nothing stale.
+			continue
+		}
+		var env hostCacheEnvelope
+		if err := json.Unmarshal([]byte(raw), &env); err != nil {
+			d.recordHostCacheErr(ctx, "get", err)
+			fallback = append(fallback, t.id)
+			continue
+		}
+		env.TeamID = teamID
+		if t.fam.sfPrefix == orbitCacheFamily.sfPrefix && !escrowKeptOnTransfer(env.Platform, destDiskEncryption) {
+			env.MDM.EncryptionKeyAvailable = false
+		}
+		next, err := json.Marshal(&env)
+		if err != nil {
+			d.recordHostCacheErr(ctx, "set", err)
+			fallback = append(fallback, t.id)
+			continue
+		}
+		writes = append(writes, hostCacheKV{key: t.fam.primaryKey(t.nodeKey), val: next})
+		patched++
+	}
+
+	d.pipelinedSETKeepTTL(ctx, writes)
+	if len(fallback) > 0 {
+		d.invalidateHostIDs(ctx, fallback, "team")
+	}
+	d.recordHostCacheInvalidations(ctx, "team_rewrite", patched)
+}
+
+// escrowKeptOnTransfer mirrors cleanupDiskEncryptionKeysOnTeamChangeDB's
+// per-platform decision so the cached MDM.EncryptionKeyAvailable flag stays in
+// step with the rows the transfer just deleted.
+func escrowKeptOnTransfer(platform string, cfg fleet.DiskEncryptionConfig) bool {
+	switch (&fleet.Host{Platform: platform}).FleetPlatform() {
+	case "darwin":
+		return cfg.MacOSEscrowEnabled
+	case "windows":
+		return cfg.WindowsEnabled
+	case "linux":
+		return cfg.LinuxEscrowEnabled
+	}
+	return false
+}
+
+type hostCacheKV struct {
+	key string
+	val []byte
+}
+
+// KEEPTTL keeps each entry's existing expiry; a plain SET would reset it and
+// leave the whole batch expiring together.
+func (d *Datastore) pipelinedSETKeepTTL(ctx context.Context, kvs []hostCacheKV) {
+	if len(kvs) == 0 {
+		return
+	}
+	byKey := make(map[string][]byte, len(kvs))
+	keys := make([]string, 0, len(kvs))
+	for _, kv := range kvs {
+		byKey[kv.key] = kv.val
+		keys = append(keys, kv.key)
+	}
+	for _, group := range redis.SplitKeysBySlot(d.pool, keys...) {
+		for len(group) > 0 {
+			n := min(len(group), hostCacheInvalidateBatchSize)
+			chunk := group[:n]
+			group = group[n:]
+			d.setKeepTTLChunk(ctx, chunk, byKey)
+		}
+	}
+}
+
+// SET has no variadic form, so the chunk is pipelined to avoid a round-trip per key.
+func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey map[string][]byte) {
+	conn := d.pool.Get()
+	defer conn.Close()
+	if err := redis.BindConn(d.pool, conn, chunk...); err != nil {
+		d.recordHostCacheErr(ctx, "set", err)
+		return
+	}
+	doer := redis.ConfigureDoer(d.pool, conn)
+	sent := 0
+	for _, k := range chunk {
+		if err := doer.Send("SET", k, byKey[k], "KEEPTTL"); err != nil {
+			d.recordHostCacheErr(ctx, "set", err)
+			break
+		}
+		sent++
+	}
+	if sent == 0 {
+		return
+	}
+	if err := doer.Flush(); err != nil {
+		d.recordHostCacheErr(ctx, "set", err)
+		return
+	}
+	for i := 0; i < sent; i++ {
+		if _, err := doer.Receive(); err != nil {
+			d.recordHostCacheErr(ctx, "set", err)
+			return
+		}
+	}
+}

--- a/server/datastore/mysqlredis/host_cache.go
+++ b/server/datastore/mysqlredis/host_cache.go
@@ -927,16 +927,14 @@ func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey m
 
 	conn := d.pool.Get()
 	defer conn.Close()
-	// BindConn before ConfigureDoer, see mgetChunk for the rationale.
 	if err := redis.BindConn(d.pool, conn, chunk...); err != nil {
 		d.recordHostCacheErr(ctx, "set", err)
 		return nil, all()
 	}
-	doer := redis.ConfigureDoer(d.pool, conn)
 
 	sent := make([]hostCacheKV, 0, len(chunk))
 	for i, k := range chunk {
-		if err := doer.Send("SET", k, byKey[k].val, "XX", "KEEPTTL"); err != nil {
+		if err := conn.Send("SET", k, byKey[k].val, "XX", "KEEPTTL"); err != nil {
 			d.recordHostCacheErr(ctx, "set", err)
 			for _, rest := range chunk[i:] {
 				failed = append(failed, byKey[rest])
@@ -948,14 +946,14 @@ func (d *Datastore) setKeepTTLChunk(ctx context.Context, chunk []string, byKey m
 	if len(sent) == 0 {
 		return nil, failed
 	}
-	if err := doer.Flush(); err != nil {
+	if err := conn.Flush(); err != nil {
 		d.recordHostCacheErr(ctx, "set", err)
 		return nil, append(failed, sent...)
 	}
 
 	applied = make([]hostCacheKV, 0, len(sent))
 	for i, kv := range sent {
-		reply, err := doer.Receive()
+		reply, err := conn.Receive()
 		if err != nil {
 			d.recordHostCacheErr(ctx, "set", err)
 			return applied, append(failed, sent[i:]...)

--- a/server/datastore/mysqlredis/host_cache_transfer_test.go
+++ b/server/datastore/mysqlredis/host_cache_transfer_test.go
@@ -2,13 +2,12 @@ package mysqlredis
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
-	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -19,32 +18,13 @@ import (
 // uncached load returns. A transfer deletes escrowed disk encryption keys for
 // platforms the destination doesn't escrow for, per host, so a batch that mixes
 // platforms must come out of the patch with per-host answers.
-// isolatedRedis gives this test its own Redis logical database. It cannot use
-// redistest: mysqltest.CreateMySQLDS marks the test parallel, and redistest's
-// cleanup deletes every key under the host-cache prefix — which is the same
-// prefix the rest of this package's tests are actively using.
-func isolatedRedis(t *testing.T, database int) fleet.RedisPool {
-	if _, ok := os.LookupEnv("REDIS_TEST"); !ok {
-		t.Skip("set REDIS_TEST environment variable to run redis-based tests")
-	}
-	pool, err := redis.NewPool(redis.PoolConfig{
-		Server:      "127.0.0.1:6379",
-		Database:    database,
-		ConnTimeout: 5 * time.Second,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		conn := pool.Get()
-		_, _ = conn.Do("FLUSHDB")
-		conn.Close()
-		pool.Close()
-	})
-	return pool
-}
-
 func TestHostCacheTransferEscrowFlag(t *testing.T) {
 	ds := mysqltest.CreateMySQLDS(t)
-	pool := isolatedRedis(t, 3)
+	// CreateMySQLDS marks this test parallel, so it runs alongside the rest of the
+	// package while sharing this pool — and redistest's cleanup deletes every key
+	// under the host-cache prefix. Keep the cached working set here small and
+	// scoped to keys nothing else uses.
+	pool := redistest.SetupRedis(t, hostCacheKeyPrefix, false, false, false)
 	d := New(ds, pool, WithHostCache(3*time.Minute))
 	ctx := t.Context()
 

--- a/server/datastore/mysqlredis/host_cache_transfer_test.go
+++ b/server/datastore/mysqlredis/host_cache_transfer_test.go
@@ -2,12 +2,13 @@ package mysqlredis
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
-	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -18,9 +19,32 @@ import (
 // uncached load returns. A transfer deletes escrowed disk encryption keys for
 // platforms the destination doesn't escrow for, per host, so a batch that mixes
 // platforms must come out of the patch with per-host answers.
+// isolatedRedis gives this test its own Redis logical database. It cannot use
+// redistest: mysqltest.CreateMySQLDS marks the test parallel, and redistest's
+// cleanup deletes every key under the host-cache prefix — which is the same
+// prefix the rest of this package's tests are actively using.
+func isolatedRedis(t *testing.T, database int) fleet.RedisPool {
+	if _, ok := os.LookupEnv("REDIS_TEST"); !ok {
+		t.Skip("set REDIS_TEST environment variable to run redis-based tests")
+	}
+	pool, err := redis.NewPool(redis.PoolConfig{
+		Server:      "127.0.0.1:6379",
+		Database:    database,
+		ConnTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn := pool.Get()
+		_, _ = conn.Do("FLUSHDB")
+		conn.Close()
+		pool.Close()
+	})
+	return pool
+}
+
 func TestHostCacheTransferEscrowFlag(t *testing.T) {
 	ds := mysqltest.CreateMySQLDS(t)
-	pool := redistest.SetupRedis(t, hostCacheKeyPrefix, false, false, false)
+	pool := isolatedRedis(t, 3)
 	d := New(ds, pool, WithHostCache(3*time.Minute))
 	ctx := t.Context()
 

--- a/server/datastore/mysqlredis/host_cache_transfer_test.go
+++ b/server/datastore/mysqlredis/host_cache_transfer_test.go
@@ -1,0 +1,164 @@
+package mysqlredis
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHostCacheTransferEscrowFlag exercises the in-place team patch against a real
+// MySQL so the cached MDM.EncryptionKeyAvailable flag can be compared with what an
+// uncached load returns. A transfer deletes escrowed disk encryption keys for
+// platforms the destination doesn't escrow for, per host, so a batch that mixes
+// platforms must come out of the patch with per-host answers.
+func TestHostCacheTransferEscrowFlag(t *testing.T) {
+	ds := mysqltest.CreateMySQLDS(t)
+	pool := redistest.SetupRedis(t, hostCacheKeyPrefix, false, false, false)
+	d := New(ds, pool, WithHostCache(3*time.Minute))
+	ctx := t.Context()
+
+	newTeam := func(name string, mac, win, linux bool) *fleet.Team {
+		tm, err := ds.NewTeam(ctx, &fleet.Team{Name: name, Config: fleet.TeamConfig{
+			MDM: fleet.TeamMDM{
+				MacOSSettings:   fleet.MacOSSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(mac)},
+				WindowsSettings: fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(win)},
+				LinuxSettings:   fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(linux)},
+			},
+		}})
+		require.NoError(t, err)
+		return tm
+	}
+
+	// Escrows for macOS only, so one transfer covers "destination escrows for this
+	// host's platform" and "it doesn't" at the same time.
+	macOnly := newTeam("escrow-macos-only", true, false, false)
+	noEscrow := newTeam("escrow-none", false, false, false)
+
+	type testHost struct {
+		name     string
+		platform string
+		withKey  bool
+		host     *fleet.Host
+		orbitKey string
+	}
+	hosts := []*testHost{
+		{name: "darwin with escrowed key", platform: "darwin", withKey: true},
+		{name: "darwin without key", platform: "darwin", withKey: false},
+		{name: "windows with escrowed key", platform: "windows", withKey: true},
+		{name: "ubuntu with escrowed key", platform: "ubuntu", withKey: true},
+	}
+
+	hostIDs := make([]uint, 0, len(hosts))
+	for i, th := range hosts {
+		uid := uuid.NewString()
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			OsqueryHostID:   new(uid),
+			NodeKey:         new(fmt.Sprintf("nk-%d-%s", i, uid)),
+			UUID:            uid,
+			Hostname:        fmt.Sprintf("host-%d", i),
+			HardwareSerial:  fmt.Sprintf("serial-%d", i),
+			Platform:        th.platform,
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+		})
+		require.NoError(t, err)
+
+		th.orbitKey = fmt.Sprintf("onk-%d-%s", i, uid)
+		_, err = ds.EnrollOrbit(ctx,
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{HardwareUUID: uid, HardwareSerial: h.HardwareSerial}),
+			fleet.WithEnrollOrbitNodeKey(th.orbitKey),
+		)
+		require.NoError(t, err)
+
+		if th.withKey {
+			_, err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, h, "encrypted-key-blob", "", new(true))
+			require.NoError(t, err)
+		}
+		th.host = h
+		hostIDs = append(hostIDs, h.ID)
+	}
+
+	// requireConsistent asserts the cached snapshot agrees with an uncached load on
+	// both fields a transfer can change, and that the entry survived (was patched,
+	// not dropped by the fallback).
+	requireConsistent := func(t *testing.T, th *testHost, wantTeam *uint, wantKeyAvailable bool) {
+		t.Helper()
+
+		cached, lookup := d.hostCacheGetByOrbitNodeKey(ctx, th.orbitKey)
+		require.Equal(t, hostCacheLookupHit, lookup, "%s: entry must survive the transfer", th.name)
+		require.Equal(t, wantKeyAvailable, cached.MDM.EncryptionKeyAvailable, "%s: cached encryption_key_available", th.name)
+		require.Equal(t, wantTeam, cached.TeamID, "%s: cached team_id", th.name)
+
+		fresh, err := ds.LoadHostByOrbitNodeKey(ctx, th.orbitKey)
+		require.NoError(t, err)
+		require.Equal(t, fresh.MDM.EncryptionKeyAvailable, cached.MDM.EncryptionKeyAvailable,
+			"%s: cached flag must match an uncached load", th.name)
+		require.Equal(t, fresh.TeamID, cached.TeamID, "%s: cached team_id must match an uncached load", th.name)
+
+		key, err := ds.GetHostDiskEncryptionKey(ctx, th.host.ID)
+		if wantKeyAvailable {
+			require.NoError(t, err, "%s: escrowed key must still exist", th.name)
+			require.NotNil(t, key)
+		} else {
+			require.Error(t, err, "%s: escrowed key must be gone", th.name)
+			require.True(t, fleet.IsNotFound(err), "%s: expected NotFound, got %v", th.name, err)
+		}
+	}
+
+	primeCache := func(t *testing.T) {
+		t.Helper()
+		for _, th := range hosts {
+			_, err := d.LoadHostByOrbitNodeKey(ctx, th.orbitKey)
+			require.NoError(t, err)
+			_, lookup := d.hostCacheGetByOrbitNodeKey(ctx, th.orbitKey)
+			require.Equal(t, hostCacheLookupHit, lookup, "%s: failed to prime", th.name)
+		}
+	}
+
+	t.Run("destination escrows for some platforms but not others", func(t *testing.T) {
+		primeCache(t)
+		require.NoError(t, d.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&macOnly.ID, hostIDs)))
+
+		// macOS is escrowed by the destination, so the key survives and the flag
+		// stays true; Windows and Linux are not, so their keys were deleted and the
+		// patched flag must follow. The host that never had a key stays false.
+		requireConsistent(t, hosts[0], &macOnly.ID, true)
+		requireConsistent(t, hosts[1], &macOnly.ID, false)
+		requireConsistent(t, hosts[2], &macOnly.ID, false)
+		requireConsistent(t, hosts[3], &macOnly.ID, false)
+	})
+
+	t.Run("destination escrows for no platform", func(t *testing.T) {
+		// Re-escrow the macOS key so this transfer has something to drop.
+		_, err := ds.SetOrUpdateHostDiskEncryptionKey(ctx, hosts[0].host, "encrypted-key-blob", "", new(true))
+		require.NoError(t, err)
+		primeCache(t)
+		reprimed, lookup := d.hostCacheGetByOrbitNodeKey(ctx, hosts[0].orbitKey)
+		require.Equal(t, hostCacheLookupHit, lookup)
+		require.True(t, reprimed.MDM.EncryptionKeyAvailable, "precondition: macOS key must be escrowed again")
+
+		require.NoError(t, d.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&noEscrow.ID, hostIDs)))
+
+		for _, th := range hosts {
+			requireConsistent(t, th, &noEscrow.ID, false)
+		}
+	})
+
+	t.Run("transfer to No team", func(t *testing.T) {
+		primeCache(t)
+		require.NoError(t, d.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(nil, hostIDs)))
+
+		for _, th := range hosts {
+			requireConsistent(t, th, nil, false)
+		}
+	})
+}

--- a/server/datastore/mysqlredis/host_cache_writes.go
+++ b/server/datastore/mysqlredis/host_cache_writes.go
@@ -102,18 +102,15 @@ func (d *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnro
 	return host, nil
 }
 
-// AddHostsToTeam invalidates every host in the batch after a successful team
-// reassignment. Uses the pipelined batch invalidator (one MGET + one DEL per
-// Redis slot, chunked) rather than calling hostCacheDeleteByID in a loop —
-// that naive approach takes ~8 sequential Redis round-trips per host and at
-// 10k hosts × ~1 ms RTT adds ~80 s to the API call. The batched version is
-// O(slots × chunks) and stays synchronous on return.
+// AddHostsToTeam patches team_id on every cached host in the batch after a
+// successful team reassignment, keeping each entry's existing expiry (see
+// rewriteTeamOnHostIDs for why patching beats invalidating here).
 func (d *Datastore) AddHostsToTeam(ctx context.Context, params *fleet.AddHostsToTeamParams) error {
 	if err := d.Datastore.AddHostsToTeam(ctx, params); err != nil {
 		return err
 	}
 	if params != nil {
-		d.invalidateHostIDs(ctx, params.HostIDs, "team")
+		d.rewriteTeamOnHostIDs(ctx, params.HostIDs, params.TeamID)
 	}
 	return nil
 }

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -616,7 +616,7 @@ func TestWritePathInvalidation(t *testing.T) {
 // pool with a fault-injecting double, and the shared pool is in use by the rest
 // of the package's tests.
 func TestHostCacheReadFailureFallback(t *testing.T) {
-	pool := isolatedRedis(t, 4)
+	pool := redistest.SetupRedis(t, hostCacheKeyPrefix, false, false, false)
 	ctx := t.Context()
 
 	t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -3,6 +3,8 @@ package mysqlredis
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,6 +44,40 @@ func requireCacheMiss(t *testing.T, d *Datastore, nk string) {
 	_, result := d.hostCacheGetByNodeKey(t.Context(), nk)
 	require.Equal(t, hostCacheLookupMiss, result, "expected miss for %q, got %v", nk, result)
 }
+
+// failAfterPool delegates to a real pool but breaks specific connections: every
+// Get past healthyGets fails, or — when failOnlyNth is set — just that one Get
+// fails and the rest succeed. The team patch reads the reverse index and the
+// payloads in separate passes, each of which can span several round trips, so
+// tests need to choose exactly which read breaks.
+type failAfterPool struct {
+	fleet.RedisPool
+	healthyGets *int32
+	failOnlyNth int32 // 1-based Get to fail; 0 means "use healthyGets instead"
+	gets        *int32
+}
+
+func (p failAfterPool) Get() redigo.Conn {
+	if p.failOnlyNth > 0 {
+		if atomic.AddInt32(p.gets, 1) == p.failOnlyNth {
+			return failingConn{}
+		}
+		return p.RedisPool.Get()
+	}
+	if atomic.AddInt32(p.healthyGets, -1) < 0 {
+		return failingConn{}
+	}
+	return p.RedisPool.Get()
+}
+
+type failingConn struct{}
+
+func (failingConn) Close() error                   { return nil }
+func (failingConn) Err() error                     { return errors.New("redis is down") }
+func (failingConn) Do(string, ...any) (any, error) { return nil, errors.New("redis is down") }
+func (failingConn) Send(string, ...any) error      { return errors.New("redis is down") }
+func (failingConn) Flush() error                   { return errors.New("redis is down") }
+func (failingConn) Receive() (any, error)          { return nil, errors.New("redis is down") }
 
 func TestWritePathInvalidation(t *testing.T) {
 	runTest := func(t *testing.T, pool fleet.RedisPool) {
@@ -311,6 +347,42 @@ func TestWritePathInvalidation(t *testing.T) {
 			require.Equal(t, uint(7), *h.TeamID)
 		})
 
+		t.Run("AddHostsToTeam patches a batch larger than one chunk", func(t *testing.T) {
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			ds := new(mock.Store)
+			ds.AddHostsToTeamFunc = func(_ context.Context, _ *fleet.AddHostsToTeamParams) error { return nil }
+			ds.GetConfigEnableDiskEncryptionFunc = func(_ context.Context, _ *uint) (fleet.DiskEncryptionConfig, error) {
+				return fleet.DiskEncryptionConfig{MacOSEscrowEnabled: true}, nil
+			}
+			d := New(ds, pool, WithHostCache(30*time.Second))
+
+			// Shrink the chunk instead of priming hundreds of hosts: the point is
+			// crossing the boundary, and a large prime storms the pool with short-
+			// lived connections that later tests then trip over.
+			defer func(orig int) { hostCacheRewriteHostBatchSize = orig }(hostCacheRewriteHostBatchSize)
+			hostCacheRewriteHostBatchSize = 4
+
+			const total = 10
+			ids := make([]uint, 0, total)
+			nks := make([]string, 0, total)
+			for i := range total {
+				id := uint(5000 + i)
+				nk := fmt.Sprintf("nk-chunked-%d", id)
+				primeCachedHost(t, d, id, nk)
+				ids = append(ids, id)
+				nks = append(nks, nk)
+			}
+
+			require.NoError(t, d.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(new(uint(7)), ids)))
+
+			for i, nk := range nks {
+				h, result := d.hostCacheGetByNodeKey(ctx, nk)
+				require.Equal(t, hostCacheLookupHit, result, "host %d (index %d) must stay cached", ids[i], i)
+				require.NotNil(t, h.TeamID)
+				require.Equal(t, uint(7), *h.TeamID, "host %d (index %d) must be patched", ids[i], i)
+			}
+		})
+
 		t.Run("AddHostsToTeam falls back to invalidation when the destination config is unavailable", func(t *testing.T) {
 			// A transfer can drop escrowed disk encryption keys, which is cached
 			// in the orbit family. If we can't tell whether it did, dropping the
@@ -538,4 +610,65 @@ func TestWritePathInvalidation(t *testing.T) {
 		pool := redistest.SetupRedis(t, hostCacheTestCleanupPrefix, true, true, false)
 		runTest(t, pool)
 	})
+}
+
+// TestHostCacheReadFailureFallback runs on its own Redis database: it wraps the
+// pool with a fault-injecting double, and the shared pool is in use by the rest
+// of the package's tests.
+func TestHostCacheReadFailureFallback(t *testing.T) {
+	pool := isolatedRedis(t, 4)
+	ctx := t.Context()
+
+	t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+	// Every Get fails, standing in for Redis being unreachable. Wrapping the
+	// shared pool rather than building a second one: a pool of our own would
+	// have to be closed, and closing it disturbs the pool the rest of this
+	// package's tests are using.
+	noHealthyGets := int32(0)
+	d := New(new(mock.Store), failAfterPool{RedisPool: pool, healthyGets: &noHealthyGets}, WithHostCache(30*time.Second))
+
+	values, ok := d.pipelinedMGET(ctx, []string{"any-key"})
+	require.False(t, ok, "an unreachable Redis must report the read as failed")
+	require.Equal(t, []string{""}, values, "which is otherwise indistinguishable from a miss")
+
+	patched, fallback := d.rewriteTeamChunk(ctx, []uint{60}, new(uint(7)), fleet.DiskEncryptionConfig{})
+	require.Empty(t, patched)
+	require.Equal(t, []uint{60}, fallback, "the host must be routed to invalidation")
+
+	// The index read succeeds and the payload read fails: the entries are
+	// still there holding the old team, so skipping them would strand them.
+	live := New(new(mock.Store), pool, WithHostCache(30*time.Second))
+	nk := "nk-payload-read-fails"
+	primeCachedHost(t, live, 61, nk)
+
+	budget := int32(1) // one healthy Get: the index MGET, not the payload MGET
+	flaky := New(new(mock.Store), failAfterPool{RedisPool: pool, healthyGets: &budget}, WithHostCache(30*time.Second))
+	patched, fallback = flaky.rewriteTeamChunk(ctx, []uint{61}, new(uint(7)), fleet.DiskEncryptionConfig{})
+	require.Empty(t, patched, "an unread payload must not count as patched")
+	require.Equal(t, []uint{61}, fallback, "it must fall back to invalidation instead of being skipped")
+
+	// Partial index read: enough hosts that the index MGET spans two Redis
+	// round trips, with only the first succeeding. The hosts behind the
+	// failed half resolve to nothing, which is indistinguishable from being
+	// uncached, so without the check they would be silently skipped while
+	// the rest got patched.
+	// Shrink the Redis chunk so the index MGET spans two round trips.
+	defer func(orig int) { hostCacheInvalidateBatchSize = orig }(hostCacheInvalidateBatchSize)
+	hostCacheInvalidateBatchSize = 4
+
+	const spansTwoChunks = 6
+	ids := make([]uint, 0, spansTwoChunks)
+	for i := range spansTwoChunks {
+		id := uint(7000 + i)
+		primeCachedHost(t, live, id, fmt.Sprintf("nk-partial-%d", id))
+		ids = append(ids, id)
+	}
+
+	// Fail only the second Get — the index MGET's second round trip — so the
+	// payload reads still succeed and cannot mask the gap.
+	gets := int32(0)
+	flaky = New(new(mock.Store), failAfterPool{RedisPool: pool, failOnlyNth: 2, gets: &gets}, WithHostCache(30*time.Second))
+	patched, fallback = flaky.rewriteTeamChunk(ctx, ids, new(uint(7)), fleet.DiskEncryptionConfig{})
+	require.Empty(t, patched, "a partially-read index must not patch the half that resolved")
+	require.Equal(t, ids, fallback, "every host in the chunk must fall back")
 }

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -242,6 +242,43 @@ func TestWritePathInvalidation(t *testing.T) {
 			require.Greater(t, ttlAfter, ttlBefore-5, "expiry must be preserved, not reset")
 		})
 
+		t.Run("the team patch never resurrects an entry that expired since it was read", func(t *testing.T) {
+			// The payload is read and written back as two separate Redis round
+			// trips. If the entry expires in between, writing it back without XX
+			// recreates it with no expiry at all — and its reverse index expired
+			// with it, so no later invalidation could reach it: the host would
+			// authenticate from a frozen snapshot forever.
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			d := New(new(mock.Store), pool, WithHostCache(30*time.Second))
+
+			gone := hostCacheKeyByNodeKey("nk-expired-mid-rewrite")
+			applied := d.pipelinedSETKeepTTL(ctx, []hostCacheKV{{key: gone, val: []byte(`{"id":42}`), id: 42}})
+
+			require.Empty(t, applied, "a key that no longer exists must not count as patched")
+			conn := pool.Get()
+			defer conn.Close()
+			exists, err := redigo.Int(conn.Do("EXISTS", gone))
+			require.NoError(t, err)
+			require.Equal(t, 0, exists, "the write must not recreate the expired key")
+		})
+
+		t.Run("the team patch keeps the expiry of entries that are still alive", func(t *testing.T) {
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			d := New(new(mock.Store), pool, WithHostCache(30*time.Second))
+
+			nk := "nk-still-alive"
+			primeCachedHost(t, d, 43, nk)
+			key := hostCacheKeyByNodeKey(nk)
+			ttlBefore := hostCacheTTLOf(t, pool, key)
+
+			applied := d.pipelinedSETKeepTTL(ctx, []hostCacheKV{{key: key, val: []byte(`{"id":43}`), id: 43}})
+
+			require.Len(t, applied, 1)
+			ttlAfter := hostCacheTTLOf(t, pool, key)
+			require.NotEqual(t, -1, ttlAfter, "entry must keep an expiry")
+			require.LessOrEqual(t, ttlAfter, ttlBefore)
+		})
+
 		t.Run("AddHostsToTeam falls back to invalidation when the destination config is unavailable", func(t *testing.T) {
 			// A transfer can drop escrowed disk encryption keys, which is cached
 			// in the orbit family. If we can't tell whether it did, dropping the

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -252,9 +252,10 @@ func TestWritePathInvalidation(t *testing.T) {
 			d := New(new(mock.Store), pool, WithHostCache(30*time.Second))
 
 			gone := hostCacheKeyByNodeKey("nk-expired-mid-rewrite")
-			applied := d.pipelinedSETKeepTTL(ctx, []hostCacheKV{{key: gone, val: []byte(`{"id":42}`), id: 42}})
+			applied, failed := d.pipelinedSETKeepTTL(ctx, []hostCacheKV{{key: gone, val: []byte(`{"id":42}`), id: 42}})
 
 			require.Empty(t, applied, "a key that no longer exists must not count as patched")
+			require.Empty(t, failed, "an expired entry is not a failure: there is nothing stale to invalidate")
 			conn := pool.Get()
 			defer conn.Close()
 			exists, err := redigo.Int(conn.Do("EXISTS", gone))
@@ -271,12 +272,43 @@ func TestWritePathInvalidation(t *testing.T) {
 			key := hostCacheKeyByNodeKey(nk)
 			ttlBefore := hostCacheTTLOf(t, pool, key)
 
-			applied := d.pipelinedSETKeepTTL(ctx, []hostCacheKV{{key: key, val: []byte(`{"id":43}`), id: 43}})
+			applied, failed := d.pipelinedSETKeepTTL(ctx, []hostCacheKV{{key: key, val: []byte(`{"id":43}`), id: 43}})
 
 			require.Len(t, applied, 1)
+			require.Empty(t, failed)
 			ttlAfter := hostCacheTTLOf(t, pool, key)
 			require.NotEqual(t, -1, ttlAfter, "entry must keep an expiry")
 			require.LessOrEqual(t, ttlAfter, ttlBefore)
+		})
+
+		t.Run("one expired family does not invalidate the host's other family", func(t *testing.T) {
+			// An expired entry needs no fallback, so the sibling entry that was
+			// patched successfully must survive: treating expiry as a failure
+			// would drop it and put the host back on the reload path.
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			ds := new(mock.Store)
+			ds.AddHostsToTeamFunc = func(_ context.Context, _ *fleet.AddHostsToTeamParams) error { return nil }
+			ds.GetConfigEnableDiskEncryptionFunc = func(_ context.Context, _ *uint) (fleet.DiskEncryptionConfig, error) {
+				return fleet.DiskEncryptionConfig{MacOSEscrowEnabled: true}, nil
+			}
+			d := New(ds, pool, WithHostCache(30*time.Second))
+
+			nk, onk := "nk-two-families", "onk-two-families"
+			d.hostCachePutByNodeKey(ctx, &fleet.Host{ID: 44, NodeKey: &nk, Hostname: "primed"})
+			d.hostCachePutByOrbitNodeKey(ctx, &fleet.Host{ID: 44, OrbitNodeKey: &onk, Hostname: "primed"})
+
+			// Stand in for the orbit payload expiring between the read and the write.
+			conn := pool.Get()
+			_, err := conn.Do("DEL", hostCacheKeyByOrbitNodeKey(onk))
+			require.NoError(t, err)
+			conn.Close()
+
+			require.NoError(t, d.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(new(uint(7)), []uint{44})))
+
+			h, result := d.hostCacheGetByNodeKey(ctx, nk)
+			require.Equal(t, hostCacheLookupHit, result, "the surviving family must stay cached")
+			require.NotNil(t, h.TeamID)
+			require.Equal(t, uint(7), *h.TeamID)
 		})
 
 		t.Run("AddHostsToTeam falls back to invalidation when the destination config is unavailable", func(t *testing.T) {

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
+	redigo "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +23,18 @@ func primeCachedHost(t *testing.T, d *Datastore, id uint, nk string) {
 	d.hostCachePutByNodeKey(ctx, &fleet.Host{ID: id, NodeKey: &nk, Hostname: "primed-" + nk})
 	_, result := d.hostCacheGetByNodeKey(ctx, nk)
 	require.Equal(t, hostCacheLookupHit, result, "primeCachedHost failed to prime %q", nk)
+}
+
+// hostCacheTTLOf returns the remaining TTL in seconds for key (-1 = no expiry,
+// -2 = missing), used to assert that the in-place team patch keeps the entry's
+// original expiry rather than resetting it.
+func hostCacheTTLOf(t *testing.T, pool fleet.RedisPool, key string) int {
+	t.Helper()
+	conn := pool.Get()
+	defer conn.Close()
+	ttl, err := redigo.Int(conn.Do("TTL", key))
+	require.NoError(t, err)
+	return ttl
 }
 
 func requireCacheMiss(t *testing.T, d *Datastore, nk string) {
@@ -191,10 +204,17 @@ func TestWritePathInvalidation(t *testing.T) {
 			require.Equal(t, hostCacheLookupMiss, after, "EnrollOrbit must clear the pre-enrollment negative cache")
 		})
 
-		t.Run("AddHostsToTeam invalidates every host in the batch", func(t *testing.T) {
+		t.Run("AddHostsToTeam patches team_id in place and keeps the entry's expiry", func(t *testing.T) {
+			// The whole point of patching rather than DELing: no transferred host
+			// misses on its next check-in, so a bulk transfer can't stampede the
+			// reader, and each entry keeps its staggered expiry instead of
+			// collapsing the batch into one synchronized TTL wave.
 			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
 			ds := new(mock.Store)
 			ds.AddHostsToTeamFunc = func(_ context.Context, _ *fleet.AddHostsToTeamParams) error { return nil }
+			ds.GetConfigEnableDiskEncryptionFunc = func(_ context.Context, _ *uint) (fleet.DiskEncryptionConfig, error) {
+				return fleet.DiskEncryptionConfig{MacOSEscrowEnabled: true, WindowsEnabled: true, LinuxEscrowEnabled: true}, nil
+			}
 			d := New(ds, pool, WithHostCache(30*time.Second))
 
 			nks := []string{"nk-team-a", "nk-team-b", "nk-team-c"}
@@ -202,13 +222,42 @@ func TestWritePathInvalidation(t *testing.T) {
 			for i, nk := range nks {
 				primeCachedHost(t, d, ids[i], nk)
 			}
+			ttlBefore := hostCacheTTLOf(t, pool, hostCacheKeyByNodeKey(nks[0]))
 
 			params := fleet.NewAddHostsToTeamParams(new(uint(7)), ids)
 			require.NoError(t, d.AddHostsToTeam(ctx, params))
 			require.True(t, ds.AddHostsToTeamFuncInvoked)
+
 			for _, nk := range nks {
-				requireCacheMiss(t, d, nk)
+				h, result := d.hostCacheGetByNodeKey(ctx, nk)
+				require.Equal(t, hostCacheLookupHit, result, "entry for %q must survive the transfer", nk)
+				require.NotNil(t, h.TeamID)
+				require.Equal(t, uint(7), *h.TeamID, "cached team_id must reflect the transfer")
+				require.Equal(t, "primed-"+nk, h.Hostname, "the rest of the snapshot must be preserved")
 			}
+
+			ttlAfter := hostCacheTTLOf(t, pool, hostCacheKeyByNodeKey(nks[0]))
+			require.NotEqual(t, -1, ttlAfter, "entry must keep an expiry, not become persistent")
+			require.LessOrEqual(t, ttlAfter, ttlBefore, "KEEPTTL must not extend the entry's life")
+			require.Greater(t, ttlAfter, ttlBefore-5, "expiry must be preserved, not reset")
+		})
+
+		t.Run("AddHostsToTeam falls back to invalidation when the destination config is unavailable", func(t *testing.T) {
+			// A transfer can drop escrowed disk encryption keys, which is cached
+			// in the orbit family. If we can't tell whether it did, dropping the
+			// entry is the only safe move.
+			t.Cleanup(func() { cleanupHostCacheKeys(t, pool) })
+			ds := new(mock.Store)
+			ds.AddHostsToTeamFunc = func(_ context.Context, _ *fleet.AddHostsToTeamParams) error { return nil }
+			ds.GetConfigEnableDiskEncryptionFunc = func(_ context.Context, _ *uint) (fleet.DiskEncryptionConfig, error) {
+				return fleet.DiskEncryptionConfig{}, errors.New("boom")
+			}
+			d := New(ds, pool, WithHostCache(30*time.Second))
+
+			nk := "nk-team-fallback"
+			primeCachedHost(t, d, 13, nk)
+			require.NoError(t, d.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(new(uint(7)), []uint{13})))
+			requireCacheMiss(t, d, nk)
 		})
 
 		t.Run("DeleteTeam invalidates every host in the batch", func(t *testing.T) {

--- a/server/datastore/mysqlredis/host_cache_writes_test.go
+++ b/server/datastore/mysqlredis/host_cache_writes_test.go
@@ -672,3 +672,23 @@ func TestHostCacheReadFailureFallback(t *testing.T) {
 	require.Empty(t, patched, "a partially-read index must not patch the half that resolved")
 	require.Equal(t, ids, fallback, "every host in the chunk must fall back")
 }
+
+func TestUniqueHostIDs(t *testing.T) {
+	// A host has an entry per cache family, so a failure that hits both would
+	// otherwise name it twice: duplicate Redis deletes and a doubled count.
+	for _, tc := range []struct {
+		name string
+		in   []uint
+		want []uint
+	}{
+		{"empty", nil, nil},
+		{"single", []uint{7}, []uint{7}},
+		{"both families of one host", []uint{7, 7}, []uint{7}},
+		{"keeps first-seen order", []uint{9, 7, 9, 8, 7}, []uint{9, 7, 8}},
+		{"already unique", []uint{1, 2, 3}, []uint{1, 2, 3}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, uniqueHostIDs(tc.in))
+		})
+	}
+}

--- a/server/datastore/mysqlredis/metrics.go
+++ b/server/datastore/mysqlredis/metrics.go
@@ -25,7 +25,8 @@ var (
 
 	// hostCacheInvalidations counts cache invalidation operations, labeled by
 	// the write path that triggered the invalidation. Attribute `reason` is
-	// one of: update, enroll, team, delete, cert.
+	// one of: update, enroll, team, delete, cert, team_rewrite (the last being
+	// an in-place team patch that kept the entry rather than dropping it).
 	hostCacheInvalidations metric.Int64Counter
 )
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46894

Today, transferring hosts between fleets drops every transferred host's entry from the Redis host lookup cache, so the whole population reloads from the read replica inside one agent poll window. In a local 1k-host run this made the reader's host-load query spike from 5.2 q/s at steady state to 35.2 q/s (6.7x) immediately after the transfer, and since every entry repopulates at once their TTLs collapse into a single band that re-fires one TTL later.

Metrics: https://github.com/fleetdm/fleet/pull/52524

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually

### Loadtest

Ran with 24k hosts.
Transferred them via API from the Ducks to the Goose fleet at 16:07. Transfer finished in around 10s.

Observed that the problematic query in the [issue](https://github.com/fleetdm/fleet/issues/46894) sat at 0.07 (vs 3.28)

```
SELECT `h`.`id`, `h`.`osquery_host_id`, `h`.`created_at`, `h`.`updated_at`, `h`.`detail_updated_at`, `h`.`node_key`, `h`.`hostname`, `h`.`uuid`, `h`.`platform`, `h`.`osquery_version`, `h`.`os_version`, `h`.`build`, `h`.`platform_like`, `h`.`code_name`, `h`.`uptime`, `h`.MEMORY, `h`.`cpu_type`, `h`.`cpu_subtype`, `h`.`cpu_brand`, `h`.`cpu_physical_cores`, `h`.`cpu_logical_cores`, `h`.`hardware_vendor`, `h`.`hardware_model`, ...
```


##### Reader

Interval: 16:00 to 16:20

<img width="1440" height="462" alt="Screenshot 2026-09-03 at 4 22 25 PM" src="https://github.com/user-attachments/assets/175b5b3a-497b-4f7a-b3ff-5e1fa41e9521" />
<img width="1439" height="613" alt="Screenshot 2026-09-03 at 4 22 34 PM" src="https://github.com/user-attachments/assets/cd995beb-4395-41f5-a5ec-a2a993c18d2e" />

Interval: 16:06 to 16:12

<img width="1434" height="463" alt="Screenshot 2026-09-03 at 4 23 06 PM" src="https://github.com/user-attachments/assets/804bfaf5-40b6-443c-bb74-d0b626927fc6" />
<img width="1437" height="605" alt="Screenshot 2026-09-03 at 4 23 12 PM" src="https://github.com/user-attachments/assets/2601ab3f-e747-4910-b303-77334778bb0f" />

##### Writer

Interval: 16:00 to 16:20

<img width="1439" height="503" alt="Screenshot 2026-09-03 at 4 23 56 PM" src="https://github.com/user-attachments/assets/7cbd54e8-5ac2-4562-9188-919326128d15" />
<img width="1448" height="623" alt="Screenshot 2026-09-03 at 4 24 05 PM" src="https://github.com/user-attachments/assets/a115ac5c-e7e0-496e-b6eb-be9bf731b102" />

Interval: 16:06 to 16:12

<img width="1429" height="495" alt="Screenshot 2026-09-03 at 4 24 26 PM" src="https://github.com/user-attachments/assets/2de87405-8a0d-4577-b4c6-4a7874d280fd" />
<img width="1435" height="320" alt="Screenshot 2026-09-03 at 4 24 31 PM" src="https://github.com/user-attachments/assets/088d52a6-946d-41cd-aef1-4804a4e16d4b" />


---

<details>
<summary><b>How this was verified</b> (Redis command traces + measurements)</summary>

Six simulated hosts (`osquery-perf`) against a local server wired to a real MySQL
primary/replica pair, with the host cache on. Same transfer run twice — once on `main`,
once on this branch — watching what the server sends Redis.

```bash
# reader/writer split (writer 3308, replica 3309)
docker compose -f tools/mysql-replica-testing/docker-compose.yml up -d
make db-replica-setup && make db-replica-reset

# 6 orbit-enrolled hosts
go run ./cmd/osquery-perf --server_url http://127.0.0.1:8085 \
  --enroll_secret <secret> --host_count 6 --orbit_prob 1.0

# terminal 2: watch what the transfer actually does to the cache
docker exec fleet-redis-1 redis-cli -n 1 monitor | grep --line-buffered hostcache

# terminal 1: transfer all six
curl -sX POST http://127.0.0.1:8085/api/v1/fleet/hosts/transfer \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"team_id":1,"hosts":[2007,2008,2009,2010,2011,2012]}'
```

### Before — two commands, everything dropped

```
"MGET" "fleet:hostcache:v1:id2nk:2001" "fleet:hostcache:v1:id2onk:2001"  ...  [12 keys]
"DEL"  "fleet:hostcache:v1:nk:DoIDwZ+..." "fleet:hostcache:v1:nk_miss:DoIDwZ+..."
       "fleet:hostcache:v1:id2nk:2001"  ...  [36 keys]
```

`MGET` resolves `host_id -> node key` for both families; `DEL` removes payload + negative + index per host per family — 6 hosts x 2 families x 3 keys = 36. The cache is then empty for those hosts, and each one pays for it on its next check-in:

```
"GET" "fleet:hostcache:v1:nk:DoIDwZ+..."           <- payload gone
"GET" "fleet:hostcache:v1:nk_miss:DoIDwZ+..."      <- no negative entry either -> real miss
"SET" "fleet:hostcache:v1:nk:DoIDwZ+..."     "{...host json...}" "EXAT" "1788299895"
"SET" "fleet:hostcache:v1:id2nk:2001" "DoIDwZ+..." "EXAT" "1788299895"
```

The `LoadHostByNodeKey` / `LoadHostByOrbitNodeKey` query against the read replica sits
between those GETs and that SET. Multiply by the transferred population landing inside one
poll interval — that's the spike. Note `EXAT`: every entry gets a brand-new expiry stamped
at the same moment, which is why the TTLs bunch up and re-fire together one TTL later.

### After — three commands, nothing dropped

```
"MGET" "fleet:hostcache:v1:id2nk:2001" "fleet:hostcache:v1:id2onk:2001"          ...  [12 keys]
"MGET" "fleet:hostcache:v1:nk:DoIDwZ+..." "fleet:hostcache:v1:onk:LiTKbcV/..."   ...  [12 keys]
"SET"  "fleet:hostcache:v1:nk:DoIDwZ+..."  "{...host json...}" "XX" "KEEPTTL"
"SET"  "fleet:hostcache:v1:onk:LiTKbcV/..." "{...host json...}" "XX" "KEEPTTL"
...  [12 SETs total, every one with XX KEEPTTL]
```

Same first `MGET`. The second one fetches the payloads so they can be patched instead of
thrown away. Then one `SET ... XX KEEPTTL` per payload — 12, not 24, because the index keys
map `host_id -> node key` and a transfer changes neither. `KEEPTTL` preserves the staggered
expiry; `XX` skips a key that expired between the two commands, which a plain `SET` would
otherwise recreate with no expiry at all (and no reverse index left to invalidate it through).

No `DEL`, no `nk_miss` GETs, no `EXAT` repopulation — zero reader queries attributable to
the transfer.

### In pseudocode

```
before:                                  after:
  keys = MGET(index keys)                  cfg  = GetConfigEnableDiskEncryption(destTeam)
  DEL(payload, negative, index)            keys = MGET(index keys)
  # every host now misses ->               snaps = MGET(payload keys)
  #   N x SELECT ... FROM hosts            for each snapshot:
  #   N x SET ... EXAT (new TTL)             snapshot.team_id = destTeam
                                             if orbit and not escrowed(platform, cfg):
                                               snapshot.encryption_key_available = false
                                           SET each payload ... XX KEEPTTL  # pipelined
                                           # unparseable envelope, unavailable config,
                                           # or errored write -> DEL that host
                                           # XX-rejected (already expired) -> nothing to do
```

### Numbers

Same experiment at 1000 hosts, measuring executions on the **replica only** (via
`performance_schema.prepared_statements_instances` — these run as prepared statements and
so do not appear in the digest table), baselined on the 60s before each transfer:

| run | `LoadHostByOrbitNodeKey` steady | peak 0-60s after transfer |
|---|---|---|
| `main` | 5.2 q/s | **35.2 q/s (6.7x)** |
| cache disabled (control) | 32.9 q/s | 34.4 q/s (1.0x — no spike, isolates the cause to invalidation) |
| this branch | 15.3 q/s | **7.2 q/s (0.5x)** |

Those rates were measured at d0888a5e2a. The two follow-up commits (`XX` guard, invalidate on
errored write) only affect keys that expired mid-flight or writes that error, so they do not move
the steady-state or spike numbers; the 6-host traces above were re-captured on the current HEAD
and show the same `2 MGET / 12 SET / 0 DEL` shape with TTLs preserved.

Transfer latency was unaffected (0.20s -> 0.28s for 1k-2k hosts); the 12 SETs go out in
one pipelined flush, measured at 1.17 ms.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host transfers now update cached host records with their new fleet assignment instead of removing them.
  * Cache expiration times are preserved during transfers.
  * Disk-encryption key availability reflects destination fleet settings.
  * Safe fallback invalidation is used when cached data cannot be updated or validated.
  * Transfers to the No team are handled consistently.
  * Expired cache entries are not recreated during updates.
  * Large host transfers no longer cause database read spikes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
