### PR TITLE
Frontend tweaks for Microsoft Graph

### DIFF
--- a/frontend/components/MainContent/MainContent.tests.tsx
+++ b/frontend/components/MainContent/MainContent.tests.tsx
@@ -6,7 +6,10 @@ import { createMockConfig, createMockMdmConfig } from "__mocks__/configMock";
 
 import MainContent from "./MainContent";
 
-const GRAPH_BANNER_TEXT = /Your Microsoft Graph client secret is expired/i;
+const GRAPH_BANNER_TEXT =
+  "Your Microsoft Graph client secret is expired, deleted, or has missing " +
+  "permissions. Windows Autopilot devices won't sync to Fleet as pending " +
+  "hosts. Users with the admin role in Fleet can update the credential.";
 
 const renderMainContent = ({
   credentialInvalid = false,

--- a/frontend/components/MainContent/MainContent.tests.tsx
+++ b/frontend/components/MainContent/MainContent.tests.tsx
@@ -6,7 +6,7 @@ import { createMockConfig, createMockMdmConfig } from "__mocks__/configMock";
 
 import MainContent from "./MainContent";
 
-const GRAPH_BANNER_TEXT = /Your Microsoft Graph credential is invalid/i;
+const GRAPH_BANNER_TEXT = /Your Microsoft Graph client secret is expired/i;
 
 const renderMainContent = ({
   credentialInvalid = false,

--- a/frontend/components/MainContent/banners/MicrosoftGraphCredentialInvalidMessage/MicrosoftGraphCredentialInvalidMessage.tsx
+++ b/frontend/components/MainContent/banners/MicrosoftGraphCredentialInvalidMessage/MicrosoftGraphCredentialInvalidMessage.tsx
@@ -23,9 +23,9 @@ const MicrosoftGraphCredentialInvalidMessage = () => {
         />
       }
     >
-      Your Microsoft Graph credential is invalid. Windows Autopilot devices
-      won&apos;t sync to Fleet as pending hosts. Users with the admin role in
-      Fleet can update the credential.
+      Your Microsoft Graph client secret is expired, deleted, or has missing
+      permissions. Windows Autopilot devices won&apos;t sync to Fleet as pending
+      hosts. Users with the admin role in Fleet can update the credential.
     </InfoBanner>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tests.tsx
@@ -114,11 +114,31 @@ describe("MicrosoftGraphPage", () => {
     expect(await screen.findByText("Last synced:")).toBeInTheDocument();
     await user.hover(screen.getByTestId("error-icon"));
 
+    // Scoped to the tooltip.
     await waitFor(() => {
       expect(
-        screen.getByText("Microsoft Graph is temporarily unavailable (503).")
+        within(screen.getByRole("tooltip")).getByText(
+          "Microsoft Graph is temporarily unavailable (503)."
+        )
       ).toBeInTheDocument();
     });
+  });
+
+  it("exposes the sync error to screen readers without a hover", async () => {
+    renderPage([
+      createMockCredential({
+        last_synced_at: "2026-08-14T12:00:00Z",
+        last_sync_error: "Microsoft Graph is temporarily unavailable (503).",
+      }),
+    ]);
+
+    // The message is visible only on hover, which a screen reader cannot perform, so it is also rendered as
+    // visually-hidden text that stays in the accessibility tree.
+    expect(
+      await screen.findByText(
+        "Microsoft Graph is temporarily unavailable (503)."
+      )
+    ).toBeInTheDocument();
   });
 
   it("hides the error indicator when the credential was rejected", async () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tests.tsx
@@ -103,18 +103,37 @@ describe("MicrosoftGraphPage", () => {
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
   });
 
-  it("renders sync status, including the last error", async () => {
-    renderPage([
+  it("renders the last sync error in a tooltip on the error indicator", async () => {
+    const { user } = renderPage([
       createMockCredential({
         last_synced_at: "2026-08-14T12:00:00Z",
-        last_sync_error: "AADSTS7000215: Invalid client secret provided.",
+        last_sync_error: "Microsoft Graph is temporarily unavailable (503).",
       }),
     ]);
 
     expect(await screen.findByText("Last synced:")).toBeInTheDocument();
-    expect(
-      screen.getByText("AADSTS7000215: Invalid client secret provided.")
-    ).toBeInTheDocument();
+    await user.hover(screen.getByTestId("error-icon"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Microsoft Graph is temporarily unavailable (503).")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("hides the error indicator when the credential was rejected", async () => {
+    renderPage([
+      createMockCredential({
+        credential_invalid: true,
+        last_synced_at: "2026-08-14T12:00:00Z",
+        last_sync_error:
+          "Microsoft Graph rejected the credential. Check the tenant ID, client ID, and client secret.",
+      }),
+    ]);
+
+    // A rejected credential already raises the app-wide banner, so repeating it here would be the same news twice.
+    expect(await screen.findByText("Last synced:")).toBeInTheDocument();
+    expect(screen.queryByTestId("error-icon")).not.toBeInTheDocument();
   });
 
   it("reports never synced when the credential has not synced yet", async () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
@@ -311,8 +311,7 @@ const MicrosoftGraphPage = () => {
       credential_invalid,
     } = storedCredential;
 
-    // A rejected credential already raises the app-wide banner, which says the same thing with the action attached, so
-    // the indicator is left to the failures the banner says nothing about: throttling, Graph outages, and the rest.
+    // A rejected credential already raises the app-wide banner, so don't duplicate it here.
     const showSyncError = !!last_sync_error && !credential_invalid;
 
     return (

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
@@ -330,14 +330,17 @@ const MicrosoftGraphPage = () => {
           }
         />
         {showSyncError && (
-          <TooltipWrapper
-            showArrow
-            underline={false}
-            position="top"
-            tipContent={last_sync_error}
-          >
-            <Icon name="error" />
-          </TooltipWrapper>
+          <>
+            <TooltipWrapper
+              showArrow
+              underline={false}
+              position="top"
+              tipContent={last_sync_error}
+            >
+              <Icon name="error" />
+            </TooltipWrapper>
+            <span className="sr-only">{last_sync_error}</span>
+          </>
         )}
       </div>
     );

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/MicrosoftGraphPage.tsx
@@ -21,7 +21,7 @@ import CustomLink from "components/CustomLink";
 import DataError from "components/DataError";
 import DataSet from "components/DataSet";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import IconStatusMessage from "components/IconStatusMessage";
+import Icon from "components/Icon";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import InputField from "components/forms/fields/InputField";
 import isUUID from "components/forms/validators/valid_uuid";
@@ -29,6 +29,7 @@ import MainContent from "components/MainContent";
 import PageDescription from "components/PageDescription";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import Spinner from "components/Spinner";
+import TooltipWrapper from "components/TooltipWrapper";
 import { notify } from "components/ToastNotification";
 
 import DeleteMicrosoftGraphCredentialModal from "./DeleteMicrosoftGraphCredentialModal";
@@ -304,7 +305,15 @@ const MicrosoftGraphPage = () => {
       return null;
     }
 
-    const { last_synced_at, last_sync_error } = storedCredential;
+    const {
+      last_synced_at,
+      last_sync_error,
+      credential_invalid,
+    } = storedCredential;
+
+    // A rejected credential already raises the app-wide banner, which says the same thing with the action attached, so
+    // the indicator is left to the failures the banner says nothing about: throttling, Graph outages, and the rest.
+    const showSyncError = !!last_sync_error && !credential_invalid;
 
     return (
       <div className={`${baseClass}__sync-status`}>
@@ -320,12 +329,15 @@ const MicrosoftGraphPage = () => {
             )
           }
         />
-        {!!last_sync_error && (
-          <IconStatusMessage
-            className={`${baseClass}__sync-error`}
-            iconName="error"
-            message={last_sync_error}
-          />
+        {showSyncError && (
+          <TooltipWrapper
+            showArrow
+            underline={false}
+            position="top"
+            tipContent={last_sync_error}
+          >
+            <Icon name="error" />
+          </TooltipWrapper>
         )}
       </div>
     );
@@ -429,10 +441,7 @@ const MicrosoftGraphPage = () => {
               <>
                 Fleet uses a Microsoft Entra app registration to read your
                 tenant&apos;s Windows Autopilot devices and show them as pending
-                hosts. The app registration needs the{" "}
-                <b>DeviceManagementServiceConfig.Read.All</b> application
-                permission, with admin consent granted. To create it, follow the
-                instructions in the{" "}
+                hosts. To create it, follow the instructions in the{" "}
                 <CustomLink
                   newTab
                   text="guide"

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MicrosoftGraphPage/_styles.scss
@@ -7,11 +7,9 @@
   }
 
   &__sync-status {
-    @include flex-column-8px-gap;
-  }
-
-  &__sync-error {
-    color: $ui-error;
+    display: flex;
+    align-items: center;
+    gap: $gap-icon-text;
   }
 
   // button-wrap supplies the flex row and gap. Reversed the same way modal-cta-wrap is, so the primary action stays


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52225

Unreleased bug (product UI tweaks)

<img width="882" height="649" alt="image" src="https://github.com/user-attachments/assets/5da5de6f-f258-4463-b178-45c7d57583eb" />

and

<img width="1000" height="798" alt="image" src="https://github.com/user-attachments/assets/285ab816-363a-4113-9823-0d5b6982def9" />


# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Microsoft Graph credential warning to clarify that the client secret may be expired, deleted, or missing permissions.
  - Sync errors now appear in a tooltip and remain available to screen readers.
  - Credential-related sync errors are no longer displayed as general sync failures; other issues, such as throttling or service outages, remain visible.

- **Style**
  - Improved the sync status layout by aligning its indicators and text horizontally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->