### PR TITLE
Bump Druva inSync FMA (custom-tap) to 8.1.4,110973

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/druva-insync.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/druva-insync.rb
@@ -1,6 +1,6 @@
 cask "druva-insync" do
-  version "8.1.3,110967"
-  sha256 "316d9e7dc7f23f8307008de9c67504c46f38e648458b75db1ef015879106f85f"
+  version "8.1.4,110973"
+  sha256 "c705eeea0ceb7b3022fed577da7dc4725751dd3c383efbb3850e049b5abc137a"
 
   url "https://downloads.druva.com/downloads/inSync/MAC/#{version.csv.first}/inSync-#{version.csv.first}-r#{version.csv.second}.dmg"
   name "Druva inSync"

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/api/druva-insync.json
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/api/druva-insync.json
@@ -6,9 +6,9 @@
   ],
   "desc": "Endpoint data backup and recovery client",
   "homepage": "https://www.druva.com/",
-  "url": "https://downloads.druva.com/downloads/inSync/MAC/8.1.3/inSync-8.1.3-r110967.dmg",
+  "url": "https://downloads.druva.com/downloads/inSync/MAC/8.1.4/inSync-8.1.4-r110973.dmg",
   "url_specs": {},
-  "version": "8.1.3,110967",
+  "version": "8.1.4,110973",
   "autobump": true,
   "no_autobump_message": null,
   "skip_livecheck": true,
@@ -16,7 +16,7 @@
   "bundle_short_version": null,
   "pinned": false,
   "pinned_version": null,
-  "sha256": "316d9e7dc7f23f8307008de9c67504c46f38e648458b75db1ef015879106f85f",
+  "sha256": "c705eeea0ceb7b3022fed577da7dc4725751dd3c383efbb3850e049b5abc137a",
   "artifacts": [
     {
       "uninstall": [
@@ -85,6 +85,6 @@
   "languages": [],
   "ruby_source_path": "Casks/druva-insync.rb",
   "ruby_source_checksum": {
-    "sha256": "906e8a21df9e56e3c94b8eefdbdb246ca8b94b34722fe405594c86edbd4662bb"
+    "sha256": "5b1a276f8335f6aa585e94f6b64fe1c95419c450770ce5cc6af1b7ef890e206b"
   }
 }

--- a/ee/maintained-apps/outputs/druva-insync/darwin.json
+++ b/ee/maintained-apps/outputs/druva-insync/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.1.3",
+      "version": "8.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.druva.inSyncClient';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.druva.inSyncClient' AND version_compare(bundle_short_version, '8.1.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.druva.inSyncClient' AND version_compare(bundle_short_version, '8.1.4') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.druva.inSyncClient' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.druva.com/downloads/inSync/MAC/8.1.3/inSync-8.1.3-r110967.dmg",
+      "installer_url": "https://downloads.druva.com/downloads/inSync/MAC/8.1.4/inSync-8.1.4-r110973.dmg",
       "install_script_ref": "2a267f97",
       "uninstall_script_ref": "b27fc088",
-      "sha256": "316d9e7dc7f23f8307008de9c67504c46f38e648458b75db1ef015879106f85f",
+      "sha256": "c705eeea0ceb7b3022fed577da7dc4725751dd3c383efbb3850e049b5abc137a",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
**Related issue:** NA — routine custom-tap FMA maintenance

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
  (Not applicable — mechanical FMA version bump, no user-facing product change; consistent with prior cask-bump PRs.)

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes (N/A)

## Testing

- [ ] Added/updated automated tests (N/A — data-only bump)
- [ ] Where appropriate, automated tests simulate multiple hosts and test for host isolation (N/A)

- [x] QA'd all new/changed functionality manually (installer downloaded and verified — see below; `go run cmd/maintained-apps/main.go --slug="druva-insync/darwin"` ran clean)

## Frontend

N/A — no frontend changes.

## Database migrations

N/A — no schema changes.

## New Fleet configuration settings

N/A — no new settings.

## fleetd/orbit/Fleet Desktop

N/A — not a fleetd/orbit/Fleet Desktop change.

---

## Bump details

| | Old | New |
|---|-----|-----|
| Version | 8.1.3,110967 | **8.1.4,110973** |

- **Upstream source used for discovery:** [https://downloads.druva.com/insync/js/data.json](https://downloads.druva.com/insync/js/data.json) (Druva's downloads-page data feed; macOS `supportedVersions` lists `8.1.4` as latest, with `installerVersion: inSync-8.1.4r110973`)
- **New download URL:** `https://downloads.druva.com/downloads/inSync/MAC/8.1.4/inSync-8.1.4-r110973.dmg`
- **sha256:** `c705eeea0ceb7b3022fed577da7dc4725751dd3c383efbb3850e049b5abc137a`
- Verified the download is a genuine disk image before computing the checksum: 306 MB, `file` reports zlib-compressed data, and the trailing 512 bytes carry the `koly` UDIF trailer.
- Regenerated `ee/maintained-apps/outputs/druva-insync/darwin.json` via `go run cmd/maintained-apps/main.go --slug="druva-insync/darwin"`; diff is limited to the version/URL/sha256 fields as expected.

**Reviewer note:** `api/druva-insync.json` was updated mechanically because `regenerate.sh` requires macOS. Before merging, run `ee/maintained-apps/inputs/homebrew/custom-tap/regenerate.sh` locally and confirm `git diff` is clean for `api/druva-insync.json`.

https://claude.ai/code/session_01DVWuAZZNnM2YrdxHTrfLNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVWuAZZNnM2YrdxHTrfLNE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Druva inSync macOS app to version 8.1.4 (build 110973).
  - Updated the download location and verification checksums for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->