### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "157.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.9.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.9.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.mozilla.nightly' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-01-21-50-37-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-02-08-43-07-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "5ef0f7c58dca23e29d356ad5d9cb45f0966af2c600cbb229eb6f9ac8600ee507",
+      "sha256": "bac89b113aebfd6d2c648e429cfd833ddbec37c6742e99a19bb0cb069d1da7e8",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.187.0",
+      "version": "1.189.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.187.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.189.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.grammarly.ProjectLlama' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.187.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.189.2.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "b2f6d9f833b2b18d1d3a5f1834feaaa2d8432474a62b98a37aa62a7a75e0c983",
+      "sha256": "cc79b6e852ec3004e3274a5759e0760c363767c362734a689bdbd4cf3c5d9359",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.2.2",
+      "version": "3.2.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.2.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.2.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.brettterpstra.marked' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.2.2-1216.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.2.3-1217.zip",
       "install_script_ref": "23ea6da3",
       "uninstall_script_ref": "57b4bcf2",
-      "sha256": "b68e2469d787a754173a9c73086d47d7f8667da3ee1f4596da34f0481bcf6905",
+      "sha256": "3136c8722430b3eec0cd3ecd430b6bb02cd949e94857ae058be0e4002a998cf4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -1,13 +1,13 @@
 {
   "versions": [
     {
-      "version": "1.135.0",
+      "version": "1.136.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.135.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.136.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.microsoft.VSCode' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.135.0/darwin-universal/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.136.0/darwin-universal/stable",
       "install_script_ref": "58ade691",
       "uninstall_script_ref": "38d65803",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/wrike/darwin.json
+++ b/ee/maintained-apps/outputs/wrike/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.6.1",
+      "version": "4.6.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.wrike.Wrike';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.wrike.Wrike' AND version_compare(bundle_short_version, '4.6.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.wrike.Wrike' AND version_compare(bundle_short_version, '4.6.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.wrike.Wrike' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://dl.wrike.com/download/WrikeDesktopApp_ARM.v4.6.1.dmg",
+      "installer_url": "https://dl.wrike.com/download/WrikeDesktopApp_ARM.v4.6.2.dmg",
       "install_script_ref": "db0938a2",
       "uninstall_script_ref": "89651e32",
-      "sha256": "4bfe955f8421b5e44770a24481970402856c9f7b3408a89cbfc11495472577a2",
+      "sha256": "b8796829ac6d884df0bd65e9f5b399375c827852dbb51cfdd4420a091194c9bd",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS app definitions for Firefox Nightly, Grammarly Desktop, Marked, Visual Studio Code, and Wrike to newer releases.
  * Refreshed installer links, version checks, and verification checksums for the updated applications.
  * Improved Marked installation reliability by restoring the previous app if installation fails and relaunching it when it was previously running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->