### PR TITLE
additional attempts at apns-mock racy/ci stress flakes

### DIFF
--- a/cmd/apple-apns-mock/coordinator.go
+++ b/cmd/apple-apns-mock/coordinator.go
@@ -200,6 +200,11 @@ func (c *coordinator) Subscribe(ctx context.Context, token string) (*subscriber,
 	if err := c.publish(ctx, pushMsg{Token: token, Owner: c.cfg.NodeID, Seq: seq}); err != nil {
 		c.logger.ErrorContext(ctx, "announce token ownership", "token", token, "error", err)
 	}
+
+	// Counted only now that the claim is done: a push announced while this
+	// connect was still claiming can be taken by either path, so a stream
+	// that shows up in the gauge has to be one a later push reaches live.
+	c.reg.connected.Add(1)
 	return sub, p
 }
 
@@ -222,6 +227,8 @@ func (c *coordinator) nextSeq(ctx context.Context) int64 {
 // Unsubscribe releases the stream and puts back a wake-up the device dropped
 // before reading.
 func (c *coordinator) Unsubscribe(ctx context.Context, token string, sub *subscriber) {
+	// Always decrements: the handler calls this exactly once per Subscribe.
+	c.reg.connected.Add(-1)
 	evicted := c.reg.unsubscribe(token, sub)
 	if evicted == nil {
 		return

--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -332,7 +332,9 @@ func getStats(t *testing.T, baseURL string) statsResponse {
 // waitConnected polls /stats until the expected number of clients is
 // connected. Subscription happens after the SSE response headers are sent,
 // so a connect immediately followed by a push can race it; tests that need
-// the live-delivery path synchronize here.
+// the live-delivery path synchronize here. The gauge is bumped once the
+// connect has claimed, so a stream it counts is one a later push reaches
+// live rather than one whose claim could still take that push itself.
 func waitConnected(t *testing.T, baseURL string, want int64) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/cmd/apple-apns-mock/registry.go
+++ b/cmd/apple-apns-mock/registry.go
@@ -91,17 +91,13 @@ func (r *registry) subscribe(token string, seq int64) (*subscriber, *ping) {
 	}
 	e.sub = sub
 	e.seq = seq
-	r.connected.Add(1)
 	return sub, evicted
 }
 
 // unsubscribe releases the stream and returns any unwritten ping. It detaches
 // only if sub is still the token's current subscriber, so a replaced handler's
-// deferred cleanup cannot evict its replacement. connected always decrements:
-// the handler calls this exactly once per subscribe.
+// deferred cleanup cannot evict its replacement.
 func (r *registry) unsubscribe(token string, sub *subscriber) *ping {
-	r.connected.Add(-1)
-
 	token, sh := r.shardFor(token)
 	sh.Lock()
 	defer sh.Unlock()

--- a/cmd/apple-apns-mock/registry_test.go
+++ b/cmd/apple-apns-mock/registry_test.go
@@ -66,7 +66,6 @@ func TestRegistryDeliverToLiveSubscriber(t *testing.T) {
 
 	assert.Equal(t, delivered, r.deliver("aabb01", testPing("p1")))
 	assert.Equal(t, "p1", recv(t, sub))
-	assert.EqualValues(t, 1, r.connected.Load())
 }
 
 func TestRegistryDeliverToUnknownTokenIsNotHeld(t *testing.T) {
@@ -145,7 +144,6 @@ func TestRegistryUnsubscribeReturnsUndeliveredPing(t *testing.T) {
 
 	require.NotNil(t, evicted)
 	assert.Equal(t, "p1", string(evicted.payload))
-	assert.EqualValues(t, 0, r.connected.Load())
 	assert.Equal(t, 0, countEntries(r), "an unsubscribed token leaves nothing behind")
 }
 
@@ -153,13 +151,11 @@ func TestRegistryStaleUnsubscribeDoesNotEvictReplacement(t *testing.T) {
 	r := newRegistry()
 	subA, _ := r.subscribe("aabb01", 1)
 	subB, _ := r.subscribe("aabb01", 1)
-	require.EqualValues(t, 2, r.connected.Load())
 
 	// The replaced handler's deferred unsubscribe fires after the takeover.
 	evicted := r.unsubscribe("aabb01", subA)
 
 	assert.Nil(t, evicted, "subscribe already drained this subscriber when it evicted it")
-	assert.EqualValues(t, 1, r.connected.Load(), "the gauge counts connections, so a stale unsubscribe still decrements")
 	assert.True(t, r.isCurrent("aabb01", subB), "the replacement must survive")
 	require.Equal(t, delivered, r.deliver("aabb01", testPing("p1")))
 	assert.Equal(t, "p1", recv(t, subB))


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, but occasional flaky tests due to waiting on a wrong signal.

# Checklist for submitter

- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection tracking in the Apple push notification mock so each subscription is counted once throughout its lifecycle.
  * Ensured connection counts reflect streams that are ready to receive live pushes.
* **Documentation**
  * Clarified connection readiness behavior in end-to-end test documentation.
* **Tests**
  * Updated registry tests to focus on subscription and delivery behavior rather than internal connection gauge values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->