### PR TITLE
Include the failing profile's name in fleetctl gitops custom settings errors

### DIFF
--- a/changes/51530-fleetctl-profile-batch-error-name
+++ b/changes/51530-fleetctl-profile-batch-error-name
@@ -1,0 +1,1 @@
+- Fixed `fleetctl gitops` reporting configuration profile validation errors without saying which profile failed. Errors from applying custom settings now include the offending profile's name.

--- a/server/service/client_appconfig.go
+++ b/server/service/client_appconfig.go
@@ -42,7 +42,8 @@ func (c *Client) ApplyNoTeamProfiles(profiles []fleet.MDMProfileBatchPayload, op
 		}
 		query += "assume_enabled=true"
 	}
-	return c.authenticatedRequestWithQuery(map[string]interface{}{"profiles": profiles}, verb, path, nil, query)
+	err := c.authenticatedRequestWithQuery(map[string]any{"profiles": profiles}, verb, path, nil, query)
+	return rewrapProfileBatchNameErr(err, profiles)
 }
 
 // GetAppConfig fetches the application config from the server API

--- a/server/service/client_profiles.go
+++ b/server/service/client_profiles.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -206,4 +207,30 @@ func (c *Client) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetup
 		return nil, err
 	}
 	return &responseBody.MDMAppleSetupAssistant, nil
+}
+
+// rewrapProfileBatchNameErr surfaces the offending profile's name when the
+// batch-set profiles endpoint rejects one of them. The server puts the name in
+// the error's name field, bare or as "profiles[<name>]", but not in the reason,
+// so fleetctl output could not say which profile failed. Names that don't match
+// a profile in the batch (e.g. "mdm", "labels") are left alone.
+func rewrapProfileBatchNameErr(err error, profiles []fleet.MDMProfileBatchPayload) error {
+	var scErr *StatusCodeErr
+	if !errors.As(err, &scErr) || scErr.Name == "" {
+		return err
+	}
+	name := scErr.Name
+	if inner, ok := strings.CutPrefix(name, "profiles["); ok {
+		inner, ok = strings.CutSuffix(inner, "]")
+		if !ok {
+			return err
+		}
+		name = inner
+	}
+	for _, p := range profiles {
+		if p.Name == name {
+			return fmt.Errorf("profile %q: %w", name, err)
+		}
+	}
+	return err
 }

--- a/server/service/client_profiles_test.go
+++ b/server/service/client_profiles_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyProfilesBatchErrorNamesProfile(t *testing.T) {
+	t.Parallel()
+
+	// 422 response as returned by POST /api/latest/fleet/mdm/profiles/batch when
+	// one profile in the batch fails validation.
+	newClient := func(t *testing.T, body map[string]any) *Client {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(body)
+		}))
+		t.Cleanup(srv.Close)
+		client, err := NewClient(srv.URL, true, "", "")
+		require.NoError(t, err)
+		client.SetToken("test-token")
+		return client
+	}
+
+	profiles := []fleet.MDMProfileBatchPayload{
+		{Name: "screen-lock", Contents: []byte("<Replace/>")},
+		{Name: "bitlocker", Contents: []byte("<Replace/>")},
+	}
+	invalidBody := map[string]any{
+		"message": "Validation Failed",
+		"errors":  []map[string]string{{"name": "profiles[bitlocker]", "reason": "Couldn't add. The configuration profile can't include BitLocker settings."}},
+	}
+
+	t.Run("team profiles name the failing profile", func(t *testing.T) {
+		client := newClient(t, invalidBody)
+		err := client.ApplyTeamProfiles("Workstations", profiles, fleet.ApplyTeamSpecOptions{})
+		require.ErrorContains(t, err, `profile "bitlocker"`)
+		require.ErrorContains(t, err, "can't include BitLocker settings")
+		// the original error stays in the chain for status-code checks
+		var scErr *StatusCodeErr
+		require.ErrorAs(t, err, &scErr)
+		require.Equal(t, http.StatusUnprocessableEntity, scErr.Code)
+	})
+
+	t.Run("no-team profiles name the failing profile", func(t *testing.T) {
+		client := newClient(t, invalidBody)
+		err := client.ApplyNoTeamProfiles(profiles, fleet.ApplySpecOptions{}, false)
+		require.ErrorContains(t, err, `profile "bitlocker"`)
+	})
+
+	t.Run("errors not tied to a profile pass through unchanged", func(t *testing.T) {
+		client := newClient(t, map[string]any{
+			"message": "Validation Failed",
+			"errors":  []map[string]string{{"name": "mdm", "reason": "cannot set custom settings: Windows MDM is not configured"}},
+		})
+		err := client.ApplyNoTeamProfiles(profiles, fleet.ApplySpecOptions{}, false)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), `profile "`)
+		require.ErrorContains(t, err, "Windows MDM is not configured")
+	})
+}
+
+func TestRewrapProfileBatchNameErr(t *testing.T) {
+	t.Parallel()
+
+	profiles := []fleet.MDMProfileBatchPayload{{Name: "screen-lock"}, {Name: "Passcode policy"}}
+
+	statusErr := func(name string) error {
+		return &StatusCodeErr{Code: http.StatusUnprocessableEntity, Body: "Validation Failed: boom", Name: name}
+	}
+
+	require.NoError(t, rewrapProfileBatchNameErr(nil, profiles))
+
+	plain := errors.New("boom")
+	require.Equal(t, plain, rewrapProfileBatchNameErr(plain, profiles))
+
+	cases := []struct {
+		desc     string
+		name     string
+		wantWrap string // empty means unchanged
+	}{
+		{"windows/android style", "profiles[screen-lock]", `profile "screen-lock"`},
+		{"apple style bare name", "Passcode policy", `profile "Passcode policy"`},
+		{"bare name with spaces in brackets", "profiles[Passcode policy]", `profile "Passcode policy"`},
+		{"no name", "", ""},
+		{"endpoint field", "mdm", ""},
+		{"whole-list field", "profiles", ""},
+		{"unknown profile", "profiles[other]", ""},
+		{"missing closing bracket", "profiles[screen-lock", ""},
+		{"platform sub-list index", "windowsProfiles[0]", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			in := statusErr(c.name)
+			out := rewrapProfileBatchNameErr(in, profiles)
+			if c.wantWrap == "" {
+				require.Equal(t, in, out)
+			} else {
+				require.ErrorContains(t, out, c.wantWrap)
+				require.ErrorIs(t, out, in)
+			}
+		})
+	}
+}

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -96,7 +96,8 @@ func (c *Client) ApplyTeamProfiles(tmName string, profiles []fleet.MDMProfileBat
 	if opts.DryRunAssumptions != nil && opts.DryRunAssumptions.WindowsEnabledAndConfigured.Valid {
 		query.Add("assume_enabled", strconv.FormatBool(opts.DryRunAssumptions.WindowsEnabledAndConfigured.Value))
 	}
-	return c.authenticatedRequestWithQuery(map[string]interface{}{"profiles": profiles}, verb, path, nil, query.Encode())
+	err = c.authenticatedRequestWithQuery(map[string]any{"profiles": profiles}, verb, path, nil, query.Encode())
+	return rewrapProfileBatchNameErr(err, profiles)
 }
 
 // applyDDMAssets sets the complete desired set of Apple DDM assets for the


### PR DESCRIPTION
**Related issue:** Follow-up to #51530 (scripts half landed in #52169)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Details

#52169 noted the same gap for configuration profiles. This is the fleetctl/client-only follow-up, no API changes.

**Where the name was lost:** the batch profiles endpoint (`POST /api/latest/fleet/mdm/profiles/batch`) already identifies the failing profile in the error's `name` field, either bare (Apple mobileconfig validation uses `NewInvalidArgumentError(prof.Name, ...)`) or as `profiles[<name>]` (Windows and Android `ValidateUserProvided`), but the reason text never includes it. Since `ParseResponse` used to discard the name, `fleetctl gitops` printed:

```
Error: applying custom settings: Validation Failed: Couldn't add. The configuration profile can't include BitLocker settings. To control disk encryption use config API endpoint or add "enable_disk_encryption" to your YAML file.
```

**The fix:** `ApplyNoTeamProfiles` and `ApplyTeamProfiles` re-wrap a `StatusCodeErr` whose `Name` (after stripping an optional `profiles[...]`) matches a profile in the batch payload. GitOps sets `MDMProfileBatchPayload.Name` to the filename stem for Windows/DDM profiles and to `PayloadDisplayName` for mobileconfigs, and rejects duplicate names client-side, so the match is unambiguous. `%w` keeps the original error in the chain and `CleanStatusCodeErr` still strips the HTTP prefix at print time. Result:

```
Error: applying custom settings: profile "bitlocker": Validation Failed: Couldn't add. The configuration profile can't include BitLocker settings. To control disk encryption use config API endpoint or add "enable_disk_encryption" to your YAML file.
```

Errors whose name isn't a profile in the batch (`mdm`, `labels`, `activation`, `profiles`, the `windowsProfiles[N]`-style duplicate checks whose reason already names the profile) pass through unchanged.

**Tests:** client tests against a mocked 422 batch response for the team and no-team paths, plus table-driven tests for the re-wrap helper (bracketed and bare names, endpoint field names, unknown profile, malformed input).

**Manual QA:** dev server built from this branch with a WSTEP cert so Windows MDM can be turned on, comparing `fleetctl` from `main` against this branch on the same GitOps files. A Windows profile with a BitLocker LocURI is rejected only server-side (gitops doesn't check LocURIs client-side), which makes it a good repro. Covered: no-team and team paths, both with and without `--dry-run`; a fully valid config still applies (`gitops succeeded`). Before/after recordings in the first comment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `fleetctl gitops` validation errors for custom settings by identifying the configuration profile that caused the failure.
  * Applied clearer profile names to both team and no-team profile errors while preserving the original error details.
  * Unrelated or unrecognized errors continue to be reported unchanged.

* **Documentation**
  * Added a changelog entry describing the improved error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
