### PR TITLE
Add article: What the JFrog Artifactory token exploit means for tracking self-hosted artifact servers

### DIFF
--- a/articles/jfrog-artifactory-token-exploit-tracking-artifact-servers.md
+++ b/articles/jfrog-artifactory-token-exploit-tracking-artifact-servers.md
@@ -13,7 +13,7 @@
 
 <a purpose="cta-button" href="https://fleetdm.com/security-and-control">See vulnerability management in Fleet</a>
 
-JFrog disclosed a critical authentication bypass in Artifactory on August 28, 2026, and patched it the same day in version 7.161.20. By September 1, security researchers were reporting active exploitation: attackers using the flaw, tracked as CVE-2026-82329, to generate themselves valid administrator tokens against instances still running the vulnerable build. A four-day window between disclosure and real-world attacks is short even by the standards of a bad patch season.
+JFrog disclosed a critical authentication bypass in Artifactory on August 28, 2026, and patched it the same day in version 7.161.20. By September 1, security researchers were reporting active exploitation: attackers using the flaw, tracked as [CVE-2026-82329](https://docs.jfrog.com/releases/docs/jfrog-security-advisories#cve-2026-82329---potential-authentication-bypass-leading-to-administrative-access-in-artifactory) to generate themselves valid administrator tokens against instances still running the vulnerable build. A four-day window between disclosure and real-world attacks is short even by the standards of a bad patch season.
 
 That speed is the reason this is worth more than a routine "update your artifact server" reminder. If you can't say, right now, which of your Artifactory instances are still on a build older than 7.161.20, you're relying on the same assumption the attackers are counting on: that the patch takes a while to catch up with the disclosure.
 

--- a/articles/jfrog-artifactory-token-exploit-tracking-artifact-servers.md
+++ b/articles/jfrog-artifactory-token-exploit-tracking-artifact-servers.md
@@ -1,6 +1,6 @@
 # What the JFrog Artifactory token exploit means for tracking self-hosted artifact servers
 
-*A critical JFrog Artifactory authentication bypass went from patch to active exploitation in about four days, with attackers minting themselves admin tokens. Here's how to find every instance still running the vulnerable build.*
+*A critical JFrog Artifactory authentication bypass went from patch to active exploitation in about four days, with attackers minting themselves admin tokens. This is why it matters and how Fleet can help you find every device still running a vulnerable build.*
 
 ## Key takeaways
 
@@ -19,13 +19,15 @@ That speed is the reason this is worth more than a routine "update your artifact
 
 ## Why this bug is worse than a typical auth bypass
 
-CVE-2026-82329 carries a CVSS score of 9.8, and the number earns it. The flaw lets an unauthenticated attacker with plain network access to the instance mint a valid administrator token under Artifactory's default configuration, no credentials, no social engineering, no user interaction required. Once an attacker holds that token, they have the same reach a legitimate admin does: repository configuration, user accounts and access permissions, stored build artifacts, and the packages flowing through the platform.
+Most authentication bypasses let an unauthorized user view data they shouldn't see. CVE-2026-82329 goes a step further: it lets an unauthenticated attacker directly mint a valid administrator token under Artifactory's default configuration. There are no credentials to guess, no social engineering required, and zero user interaction to wait for.
+Once an attacker holds that administrative token, they possess the exact same operational reach as a legitimate admin. They can reconfigure repositories, manipulate user accounts and access permissions, and modify the build artifacts stored on the platform.
+
 
 That reach matters more for Artifactory than for most internal tools, because of where it sits. Self-hosted artifact servers are typically wired directly into CI/CD, holding the packages, containers, and build outputs your pipelines pull down as trusted inputs. An attacker with admin control doesn't just read data, they can potentially alter what a downstream build considers safe to pull. That's a software supply chain risk, not a single-server incident, which is exactly the shape of exposure that turns a missed patch into a much longer incident response.
 
 ## Finding every Artifactory instance you run
 
-The organizations that handled this well in the first four days weren't guessing which servers to check. They already had an inventory to query.
+You shouldn't have to scramble or ask around to see who remembers where Artifactory is installed. Device management platforms like Fleet allow you to search all of your devices directly. Because Fleet's software inventory covers whatever is installed on a host, you can find your exposure instantly.
 
 If Artifactory is installed through JFrog's native RPM or Debian package installers, which is a common deployment path for self-hosted instances, Fleet's software inventory picks it up the same way it picks up any other installed package:
 
@@ -37,7 +39,7 @@ SELECT name, version FROM deb_packages WHERE name LIKE '%artifactory%';
 SELECT name, version FROM rpm_packages WHERE name LIKE '%artifactory%';
 ```
 
-Compare whatever version comes back against 7.161.20. Anything older is still exposed.
+Compare the returned versions against the patched releases like 7.161.20. Anything older is vulnerable.
 
 If your instance runs containerized instead, which is JFrog's other common distribution path, the version lives in the image tag rather than a package entry, so pair the query above with your container inventory (Fleet's software tables cover the host's installed packages; a containerized Artifactory needs its image tag checked directly against JFrog's release notes) to make sure a container-based deployment doesn't slip past a packages-only check.
 
@@ -47,7 +49,12 @@ A single query answers "are we exposed today." A saved Fleet policy answers it e
 
 ## After the patch: assume the window was live
 
-Patching closes the hole. It doesn't tell you whether an attacker used it first. If any instance you run was reachable and unpatched between August 28 and whenever you applied 7.161.20, treat that as a real exposure window rather than a resolved incident. Review the admin token list for tokens minted during that window that you can't account for, and check repository and permission changes against your own change history. A four-day gap between patch and exploitation means the organizations still running an old build today are the ones most likely to have already been touched.
+Patching closes the vulnerability, but it does not remove attackers who already exploited it. If your instance was exposed between August 28 and the time you patched:
+
+1. Review the Artifactory admin token list for any unauthorized tokens minted during that window.
+
+2. Audit repository and permission changes against your internal change history.
+
 
 ## See it live
 

--- a/articles/jfrog-artifactory-token-exploit-tracking-artifact-servers.md
+++ b/articles/jfrog-artifactory-token-exploit-tracking-artifact-servers.md
@@ -1,0 +1,71 @@
+# What the JFrog Artifactory token exploit means for tracking self-hosted artifact servers
+
+*A critical JFrog Artifactory authentication bypass went from patch to active exploitation in about four days, with attackers minting themselves admin tokens. Here's how to find every instance still running the vulnerable build.*
+
+## Key takeaways
+
+- **You can find every self-hosted Artifactory instance you run, by version, right now.** Fleet's software inventory covers whatever's installed on a host, so instead of asking around for who remembers which box runs Artifactory, you query for it.
+- **The gap between patch and exploitation was about four days, not weeks.** JFrog shipped a fix on August 28, 2026, and attackers were already minting admin tokens against unpatched instances by September 1.
+- **The bug needs no credentials and no user interaction.** CVE-2026-82329 lets an unauthenticated attacker with network access generate a valid administrator token against a default configuration, so exposure is a network-reachability question, not a phishing one.
+- **An Artifactory instance sits inside your CI/CD pipeline, so a compromise isn't contained to one server.** Admin access there reaches repositories, build artifacts, stored secrets, and the packages your pipelines pull down and trust.
+- **A version check is a one-time answer to a problem that recurs.** Save it as a policy and the next Artifactory CVE gets the same fast answer instead of another manual sweep.
+- **Patching isn't the last step if the instance was exposed before you patched.** Confirming the version only tells you the hole is closed, not whether someone already walked through it.
+
+<a purpose="cta-button" href="https://fleetdm.com/security-and-control">See vulnerability management in Fleet</a>
+
+JFrog disclosed a critical authentication bypass in Artifactory on August 28, 2026, and patched it the same day in version 7.161.20. By September 1, security researchers were reporting active exploitation: attackers using the flaw, tracked as CVE-2026-82329, to generate themselves valid administrator tokens against instances still running the vulnerable build. A four-day window between disclosure and real-world attacks is short even by the standards of a bad patch season.
+
+That speed is the reason this is worth more than a routine "update your artifact server" reminder. If you can't say, right now, which of your Artifactory instances are still on a build older than 7.161.20, you're relying on the same assumption the attackers are counting on: that the patch takes a while to catch up with the disclosure.
+
+## Why this bug is worse than a typical auth bypass
+
+CVE-2026-82329 carries a CVSS score of 9.8, and the number earns it. The flaw lets an unauthenticated attacker with plain network access to the instance mint a valid administrator token under Artifactory's default configuration, no credentials, no social engineering, no user interaction required. Once an attacker holds that token, they have the same reach a legitimate admin does: repository configuration, user accounts and access permissions, stored build artifacts, and the packages flowing through the platform.
+
+That reach matters more for Artifactory than for most internal tools, because of where it sits. Self-hosted artifact servers are typically wired directly into CI/CD, holding the packages, containers, and build outputs your pipelines pull down as trusted inputs. An attacker with admin control doesn't just read data, they can potentially alter what a downstream build considers safe to pull. That's a software supply chain risk, not a single-server incident, which is exactly the shape of exposure that turns a missed patch into a much longer incident response.
+
+## Finding every Artifactory instance you run
+
+The organizations that handled this well in the first four days weren't guessing which servers to check. They already had an inventory to query.
+
+If Artifactory is installed through JFrog's native RPM or Debian package installers, which is a common deployment path for self-hosted instances, Fleet's software inventory picks it up the same way it picks up any other installed package:
+
+```sql
+-- Debian/Ubuntu hosts
+SELECT name, version FROM deb_packages WHERE name LIKE '%artifactory%';
+
+-- RHEL/Fedora-family hosts
+SELECT name, version FROM rpm_packages WHERE name LIKE '%artifactory%';
+```
+
+Compare whatever version comes back against 7.161.20. Anything older is still exposed.
+
+If your instance runs containerized instead, which is JFrog's other common distribution path, the version lives in the image tag rather than a package entry, so pair the query above with your container inventory (Fleet's software tables cover the host's installed packages; a containerized Artifactory needs its image tag checked directly against JFrog's release notes) to make sure a container-based deployment doesn't slip past a packages-only check.
+
+## Turning the check into a policy instead of a one-time sweep
+
+A single query answers "are we exposed today." A saved Fleet policy answers it every day, for every host that enrolls or changes, without anyone re-running the hunt when the next Artifactory advisory lands. Because Fleet policies live in Git as YAML and deploy through the same GitOps workflow as everything else, updating the version threshold when JFrog ships its next patch is a reviewable pull request, not an undocumented edit to a console rule somewhere.
+
+## After the patch: assume the window was live
+
+Patching closes the hole. It doesn't tell you whether an attacker used it first. If any instance you run was reachable and unpatched between August 28 and whenever you applied 7.161.20, treat that as a real exposure window rather than a resolved incident. Review the admin token list for tokens minted during that window that you can't account for, and check repository and permission changes against your own change history. A four-day gap between patch and exploitation means the organizations still running an old build today are the ones most likely to have already been touched.
+
+## See it live
+
+- **Get a demo** to see software inventory and vulnerability matching against your own fleet: [fleetdm.com/contact](https://fleetdm.com/contact)
+- **Explore the software catalog** Fleet already tracks across your hosts: [fleetdm.com/software-catalog](https://fleetdm.com/software-catalog)
+
+## Sources
+
+- The Hacker News, [Attackers Exploit Critical JFrog Artifactory Flaw to Mint Admin Tokens Days After Disclosure](https://thehackernews.com/2026/09/attackers-exploit-critical-jfrog.html).
+- SecurityWeek, [Critical JFrog Artifactory Vulnerability Reportedly Exploited in the Wild](https://www.securityweek.com/critical-jfrog-artifactory-vulnerability-reportedly-exploited-in-the-wild/).
+- Cyber Security News, [JFrog Artifactory Auth Bypass Exploited in Attacks to Gain Admin Access](https://cybersecuritynews.com/jfrog-artifactory-auth-bypass-exploited/).
+
+---
+*See which of your servers are still exposed. [Talk to Fleet](https://fleetdm.com/contact), or explore the [software catalog](https://fleetdm.com/software-catalog) Fleet already builds from your fleet.*
+
+<meta name="articleTitle" value="What the JFrog Artifactory token exploit means for tracking self-hosted artifact servers">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="category" value="industry news">
+<meta name="publishedOn" value="2026-09-02">
+<meta name="description" value="A critical JFrog Artifactory bypass went from patch to active exploitation in days. See how to find every vulnerable instance with Fleet.">


### PR DESCRIPTION
**Related issue:** NA

New article drafted from an approved content pitch in #_content-news-digest, covering the JFrog Artifactory authentication bypass (CVE-2026-82329) and how to inventory self-hosted Artifactory instances with Fleet.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually (reviewed against `fleet-article-formatting` and `content-style` skills; verified links and category value)

https://claude.ai/code/session_01Bte2pPvAg3dtBSeF76Eiej

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bte2pPvAg3dtBSeF76Eiej)_