### PR TITLE
Rescale t-shirt sizes for 3-week release cycles

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -538,10 +538,10 @@ T-shirt sizes represent a rough estimate on the effort required to complete a ta
 | T-shirt size | Time |
 |:---|:-----------------------------|
 | XXS | ≤1 day for 1 contributor |
-| XS | ≤1 week for 1 contributor |
-| S  | ≤1 release cycle for 1 contributor |
-| M  | 1 release cycle for 2 contributors |
-| L  | 1 release cycle for 3 contributors |
+| XS | ≤½ week for 1 contributor |
+| S  | ≤1 week for 1 contributor |
+| M  | ≤1 release cycle for 1 contributor |
+| L  | 1 release cycle for 2 contributors |
 | XL | >1 release cycle for 3 contributors |
 
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -538,7 +538,7 @@ T-shirt sizes represent a rough estimate on the effort required to complete a ta
 | T-shirt size | Time |
 |:---|:-----------------------------|
 | XXS | ≤1 day for 1 contributor |
-| XS | ≤½ week for 1 contributor |
+| XS | <3 days for 1 contributor |
 | S  | ≤1 week for 1 contributor |
 | M  | ≤1 release cycle for 1 contributor |
 | L  | 1 release cycle for 2 contributors |

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -538,11 +538,11 @@ T-shirt sizes represent a rough estimate on the effort required to complete a ta
 | T-shirt size | Time |
 |:---|:-----------------------------|
 | XXS | ≤1 day for 1 contributor |
-| XS | <3 days for 1 contributor |
+| XS | ≤3 days for 1 contributor |
 | S  | ≤1 week for 1 contributor |
-| M  | ≤1 release cycle for 1 contributor |
-| L  | 1 release cycle for 2 contributors |
-| XL | >1 release cycle for 3 contributors |
+| M  | ≤2 weeks for 1 contributor |
+| L  | ≤3 weeks for 1 contributor |
+| XL | >3 weeks for 1 contributor |
 
 
 ### Implementing


### PR DESCRIPTION
Rescales the [t-shirt sizing table](https://fleetdm.com/handbook/company/product-groups#t-shirt-sizing-capacity-planning) for 3-week release cycles. Every size is now scoped to 1 contributor with a simple duration progression:

| T-shirt size | Time |
|:---|:---|
| XXS | ≤1 day for 1 contributor |
| XS | ≤3 days for 1 contributor |
| S | ≤1 week for 1 contributor |
| M | ≤2 weeks for 1 contributor |
| L | ≤3 weeks for 1 contributor |
| XL | >3 weeks for 1 contributor |

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Handbook-only change, no code or user-visible product changes.
