### PR TITLE
Unfreeze Keeper Password Manager (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/keeper-password-manager.json
+++ b/ee/maintained-apps/inputs/homebrew/keeper-password-manager.json
@@ -6,6 +6,5 @@
   "slug": "keeper-password-manager/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/keeper-password-manager/darwin.json
+++ b/ee/maintained-apps/outputs/keeper-password-manager/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "18.5.0",
+      "version": "18.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.keepersecurity.passwordmanager';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.keepersecurity.passwordmanager' AND version_compare(bundle_short_version, '18.5.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.keepersecurity.passwordmanager' AND version_compare(bundle_short_version, '18.6.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.keepersecurity.passwordmanager' AND a.bundle_executable != '');"
       },
       "installer_url": "https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `keeper-password-manager/darwin` at its current upstream version.

Frozen since: 2026-03-26 or earlier (freeze predates available git history)
Version: 18.5.0 -> 18.6.0

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

https://claude.ai/code/session_013bAuAKLwaaHDGP5SJ7i1hw

---
_Generated by [Claude Code](https://claude.ai/code/session_013bAuAKLwaaHDGP5SJ7i1hw)_