### PR TITLE
Fix github-manage bug reporting

### DIFF
--- a/tools/github-manage/cmd/gm/bugs.go
+++ b/tools/github-manage/cmd/gm/bugs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"slices"
 	"strings"
 	"time"
 
@@ -31,11 +30,9 @@ type BugIssue struct {
 	} `json:"labels"`
 }
 
-var productGroupLabels = []string{"#g-software", "#g-orchestration", "#g-mdm", "#g-supply-chain"}
-
 func (i BugIssue) ProductGroup() string {
 	for _, label := range i.Labels {
-		if slices.Contains(productGroupLabels, label.Name) {
+		if strings.HasPrefix(label.Name, "#g-") {
 			return label.Name
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Product group recognition now supports any label beginning with the `#g-` prefix, allowing newly introduced product group labels to be recognized automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->