### PR TITLE
Bump sails-hook-grunt to 5.0.2 in website and fleet-agent-downloader

### DIFF
--- a/ee/fleet-agent-downloader/package-lock.json
+++ b/ee/fleet-agent-downloader/package-lock.json
@@ -7177,9 +7177,9 @@
       }
     },
     "node_modules/sails-hook-grunt": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sails-hook-grunt/-/sails-hook-grunt-5.0.1.tgz",
-      "integrity": "sha512-KDarZVqCQCjWERVZUIoE5bJ6mQaGinfrE9tv4G80NzaHA6vXxGHquQCXKFCby66XDidbvlX7TC+Db+bkDTs1gg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sails-hook-grunt/-/sails-hook-grunt-5.0.2.tgz",
+      "integrity": "sha512-mfhKkE0oeZgCmk1o1qF8gJAaSU4ghTSCOX7BcYoHf5GIE1QCdU1xjwytpMfn0ZHjJs6LNa9IXRpzU0TKr09dVw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
@@ -7190,7 +7190,7 @@
         "babel-polyfill": "6.26.0",
         "babel-preset-env": "1.7.0",
         "chalk": "1.1.3",
-        "grunt": "1.5.3",
+        "grunt": "1.0.4",
         "grunt-babel": "7.0.0",
         "grunt-cli": "1.2.0",
         "grunt-contrib-clean": "1.0.0",
@@ -7997,9 +7997,9 @@
       }
     },
     "node_modules/sails-hook-grunt/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8992,9 +8992,9 @@
       "dev": true
     },
     "node_modules/sails-hook-grunt/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8135,9 +8135,9 @@
       }
     },
     "node_modules/sails-hook-grunt": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sails-hook-grunt/-/sails-hook-grunt-5.0.1.tgz",
-      "integrity": "sha512-KDarZVqCQCjWERVZUIoE5bJ6mQaGinfrE9tv4G80NzaHA6vXxGHquQCXKFCby66XDidbvlX7TC+Db+bkDTs1gg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sails-hook-grunt/-/sails-hook-grunt-5.0.2.tgz",
+      "integrity": "sha512-mfhKkE0oeZgCmk1o1qF8gJAaSU4ghTSCOX7BcYoHf5GIE1QCdU1xjwytpMfn0ZHjJs6LNa9IXRpzU0TKr09dVw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
@@ -8148,7 +8148,7 @@
         "babel-polyfill": "6.26.0",
         "babel-preset-env": "1.7.0",
         "chalk": "1.1.3",
-        "grunt": "1.5.3",
+        "grunt": "1.0.4",
         "grunt-babel": "7.0.0",
         "grunt-cli": "1.2.0",
         "grunt-contrib-clean": "1.0.0",
@@ -8955,9 +8955,9 @@
       }
     },
     "node_modules/sails-hook-grunt/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9950,9 +9950,9 @@
       "dev": true
     },
     "node_modules/sails-hook-grunt/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
**Related issue:** NA — routine dependency maintenance

Bumps `sails-hook-grunt` 5.0.1 → 5.0.2 in `website/package-lock.json` and `ee/fleet-agent-downloader/package-lock.json`, picking up the refreshed shrinkwrapped dependencies (js-yaml 3.15.1, brace-expansion 1.1.18) from sailshq/sails-hook-grunt#13. Dev-scoped build tooling only; no runtime changes.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Verified `npm update sails-hook-grunt` produced a minimal lockfile diff (regenerated under Node 20 / npm 10) and that the nested js-yaml and brace-expansion versions resolved as expected.
