### PR TITLE
Fix ChromeOS system_info queries failing when hardware platform API is disabled

### DIFF
--- a/ee/fleetd-chrome/changes/46499-chromeos-system-info-policy
+++ b/ee/fleetd-chrome/changes/46499-chromeos-system-info-policy
@@ -1,0 +1,1 @@
+- Fixed ChromeOS `system_info` queries and policies failing with "Not allowed" errors when the Google admin `EnterpriseHardwarePlatformAPIEnabled` policy is disabled.

--- a/ee/fleetd-chrome/src/tables/system_info.ts
+++ b/ee/fleetd-chrome/src/tables/system_info.ts
@@ -77,12 +77,6 @@ export default class TableSystemInfo extends Table {
       hwModel = "";
     try {
       if (!devMode) {
-        // This throws "Not allowed" error if
-        // https://chromeenterprise.google/policies/?policy=EnterpriseHardwarePlatformAPIEnabled is
-        // not configured to enabled for the device. When the policy is disabled, we gracefully
-        // return empty strings instead of pushing warnings, because warnings cause the entire
-        // query to be marked as failed (status=1) even when valid data is returned for all
-        // other columns.
         // @ts-expect-error @types/chrome doesn't yet have the deviceAttributes Promise API.
         const platformInfo = await chrome.enterprise.hardwarePlatform.getHardwarePlatformInfo();
         hwVendor = platformInfo.manufacturer;
@@ -93,6 +87,20 @@ export default class TableSystemInfo extends Table {
       }
     } catch (err) {
       console.warn("get platform info:", err);
+      // "Not allowed" is the expected error when EnterpriseHardwarePlatformAPIEnabled is
+      // disabled for the device's OU. Suppress warnings for this case because warnings
+      // cause the entire query to be marked as failed (status=1). For any other error,
+      // preserve the warning so it surfaces in the UI.
+      if (err.message?.toString() !== "Not allowed") {
+        warningsArray.push({
+          column: "hardware_vendor",
+          error_message: err.message.toString(),
+        });
+        warningsArray.push({
+          column: "hardware_model",
+          error_message: err.message.toString(),
+        });
+      }
     }
 
     let cpuBrand = "",

--- a/ee/fleetd-chrome/src/tables/system_info.ts
+++ b/ee/fleetd-chrome/src/tables/system_info.ts
@@ -79,7 +79,10 @@ export default class TableSystemInfo extends Table {
       if (!devMode) {
         // This throws "Not allowed" error if
         // https://chromeenterprise.google/policies/?policy=EnterpriseHardwarePlatformAPIEnabled is
-        // not configured to enabled for the device.
+        // not configured to enabled for the device. When the policy is disabled, we gracefully
+        // return empty strings instead of pushing warnings, because warnings cause the entire
+        // query to be marked as failed (status=1) even when valid data is returned for all
+        // other columns.
         // @ts-expect-error @types/chrome doesn't yet have the deviceAttributes Promise API.
         const platformInfo = await chrome.enterprise.hardwarePlatform.getHardwarePlatformInfo();
         hwVendor = platformInfo.manufacturer;
@@ -90,14 +93,6 @@ export default class TableSystemInfo extends Table {
       }
     } catch (err) {
       console.warn("get platform info:", err);
-      warningsArray.push({
-        column: "hardware_vendor",
-        error_message: err.message.toString(),
-      });
-      warningsArray.push({
-        column: "hardware_model",
-        error_message: err.message.toString(),
-      });
     }
 
     let cpuBrand = "",


### PR DESCRIPTION
> Generated by Claude on behalf of Sharon FDM

**Related issue:** Resolves #46499

## Summary

When a ChromeOS device is in a Google OU that has `EnterpriseHardwarePlatformAPIEnabled` disabled, **all** queries and policies targeting the `system_info` table fail with:

```
Column: hardware_vendor - Not allowed
Column: hardware_model - Not allowed
```

This happens even when the query doesn't reference those columns at all (e.g., `SELECT 1 FROM system_info WHERE hardware_serial IS NOT NULL`).

## Root cause (code investigation)

The bug is in the fleetd Chrome extension's virtual table implementation. I traced the full request lifecycle:

1. **`ee/fleetd-chrome/src/tables/system_info.ts` `generate()`** - The virtual table's `generate()` method always fetches ALL columns from Chrome APIs, regardless of which columns the SQL query actually references. This is a fundamental behavior of SQLite virtual tables where `xFilter` doesn't receive column projection info.

2. **`getHardwarePlatformInfo()` throws "Not allowed"** (line 84) - When `EnterpriseHardwarePlatformAPIEnabled` is disabled on the Google OU, the Chrome Enterprise API throws. The code catches it, logs to `console.warn`, but also pushes two warnings to `warningsArray` for `hardware_vendor` and `hardware_model`.

3. **`ee/fleetd-chrome/src/tables/Table.ts` `xFilter()`** (lines 115-119) - Warnings from `generate()` are concatenated via `CONCAT_CHROME_WARNINGS()` and stored on `globalThis.DB.warnings`.

4. **`ee/fleetd-chrome/src/background.ts` `live_query()`** (lines 176-179) - When any warnings exist on the query result, `statuses[query_name]` is set to `1` (error), which causes Fleet to count the host as "failing" even though `results[query_name]` contains valid data.

The existing code comment at line 80-82 already documented that this API throws "Not allowed" when the policy is disabled, acknowledging this is an expected condition, not a true error.

## Fix

Removed the `warningsArray.push()` calls for `hardware_vendor` and `hardware_model` in the `getHardwarePlatformInfo()` catch block. The error is still logged to `console.warn` for debugging. The columns return empty strings, which is the correct graceful degradation.

This means queries against `system_info` will now succeed (status=0) when the hardware platform API is disabled, returning valid data for all other columns and empty strings for `hardware_vendor`/`hardware_model`.

## QA note

**This change was NOT tested locally or via automated tests.** It was identified and fixed through code-level investigation only. It **must be tested on a real ChromeOS device** before merging.

To test:
1. Move a ChromeOS device to a Google OU that has `EnterpriseHardwarePlatformAPIEnabled` **disabled**
2. Run a report/query against those ChromeOS devices using the `system_info` table, e.g.:
   `SELECT 1 FROM system_info WHERE hardware_serial IS NOT NULL AND hardware_serial != '';`
3. **Before this fix:** the query fails with `Column: hardware_vendor - Not allowed` / `Column: hardware_model - Not allowed`
4. **After this fix:** the query should succeed. `hardware_vendor` and `hardware_model` will return empty strings, but all other columns (including `hardware_serial`) should return valid data
5. Also verify that when `EnterpriseHardwarePlatformAPIEnabled` **is enabled**, `hardware_vendor` and `hardware_model` still return correct values (no regression)

# Checklist for submitter

- [x] Changes file added for user-visible changes in `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually - **Not yet: requires ChromeOS device testing (see QA note above)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ChromeOS `system_info` queries no longer fail with “Not allowed” errors when the Google admin `EnterpriseHardwarePlatformAPIEnabled` policy is disabled.
  * Hardware vendor and model information no longer generates warnings for this expected policy restriction; other platform API errors continue to produce warnings.

* **Documentation**
  * Added a changelog entry describing the ChromeOS system information policy fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->