### PR TITLE
Fix delete label modal missing software targets warning

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteLabelModal/DeleteLabelModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteLabelModal/DeleteLabelModal.tsx
@@ -34,6 +34,10 @@ const DeleteLabelModal = ({
             deleted. You will need to delete the configuration profile first.
           </li>
           <li>
+            Labels that are used in custom software targets will not be deleted.
+            You will need to remove the label from the software targets first.
+          </li>
+          <li>
             Reports and policies that target this label will continue to run,
             but may target different hosts.
           </li>


### PR DESCRIPTION
Closed in favor of #50943 which addresses the same issue.