### PR TITLE
Regenerate yarn.lock for v4.91.0 release build

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9154,7 +9154,7 @@ nano-time@1.0.0:
   dependencies:
     big-integer "^1.6.16"
 
-nanoid@^3.3.11, nanoid@^3.3.16:
+nanoid@^3.3.16:
   version "3.3.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==


### PR DESCRIPTION
**Related issue:** N/A — unblocks the v4.91.0 goreleaser build ([failed run](https://github.com/fleetdm/fleet/actions/runs/33683912106/job/100426683098))

Regenerates `yarn.lock` so it is consistent with `package.json`. The goreleaser workflow runs `yarn` during the release build, which rewrote the lockfile (a `nanoid` version-spec dedupe) and left git in a dirty state, failing the build. No dependency versions change.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually (ran `yarn` locally on Node 24.10.0; verified the working tree is clean after install)

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
