### PR TITLE
Fixed JSON error regression due to Go 1.27

### DIFF
--- a/changes/51620-json-type-error-messages
+++ b/changes/51620-json-type-error-messages
@@ -1,1 +1,1 @@
-- Updated the wording of JSON type validation errors returned by the API (for example, when applying GitOps or spec files with a value of the wrong type). Array elements are now identified by index, and the field path is omitted for the fields where Go 1.27 no longer reports it.
+- Updated the wording of JSON type validation errors returned by the API (for example, when applying GitOps or spec files with a value of the wrong type). Array elements are now identified by index.

--- a/cmd/fleetctl/fleetctl/apply_deprecated_test.go
+++ b/cmd/fleetctl/fleetctl/apply_deprecated_test.go
@@ -2076,7 +2076,7 @@ spec:
         deadline_days: abc
         grace_period_days: 1
 `,
-			wantErr: `400 Bad Request: invalid value type: expected int but got string`,
+			wantErr: `400 Bad Request: invalid value type at 'specs.0.mdm.windows_updates.deadline_days': expected int but got string`,
 		},
 		{
 			desc: "windows_updates.grace_period_days not a number",
@@ -2091,7 +2091,7 @@ spec:
         deadline_days: 1
         grace_period_days: true
 `,
-			wantErr: `400 Bad Request: invalid value type: expected int but got bool`,
+			wantErr: `400 Bad Request: invalid value type at 'specs.0.mdm.windows_updates.grace_period_days': expected int but got bool`,
 		},
 		{
 			desc: "windows_updates valid",

--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -3772,7 +3772,7 @@ spec:
         deadline_days: abc
         grace_period_days: 1
 `,
-			wantErr: `400 Bad Request: invalid value type: expected int but got string`,
+			wantErr: `400 Bad Request: invalid value type at 'specs.0.mdm.windows_updates.deadline_days': expected int but got string`,
 		},
 		{
 			desc: "windows_updates.grace_period_days not a number",
@@ -3787,7 +3787,7 @@ spec:
         deadline_days: 1
         grace_period_days: true
 `,
-			wantErr: `400 Bad Request: invalid value type: expected int but got bool`,
+			wantErr: `400 Bad Request: invalid value type at 'specs.0.mdm.windows_updates.grace_period_days': expected int but got bool`,
 		},
 		{
 			desc: "windows_updates valid",

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -95,7 +95,7 @@ func (m *MDMAndroidConfigProfile) ValidateUserProvided(isPremium bool) error {
 		}
 	}
 
-	// The decoded policy is thrown away: this only checks that every value has the right type.
+	// This only checks that every value has the right type.
 	if err := jsondecode.Unmarshal(m.RawJSON, &androidmanagement.Policy{}); err != nil {
 		return parseAndroidProfileValidationError(err)
 	}

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/mdm"
+	"github.com/fleetdm/fleet/v4/server/platform/jsondecode"
 	"github.com/fleetdm/fleet/v4/server/variables"
 	"google.golang.org/api/androidmanagement/v1"
 )
@@ -94,8 +95,9 @@ func (m *MDMAndroidConfigProfile) ValidateUserProvided(isPremium bool) error {
 		}
 	}
 
-	if err := json.Unmarshal(m.RawJSON, &androidmanagement.Policy{}); err != nil {
-		return parseAndroidProfileValidationError(err)
+	policy := &androidmanagement.Policy{}
+	if err := json.Unmarshal(m.RawJSON, policy); err != nil {
+		return parseAndroidProfileValidationError(jsondecode.Enrich(err, m.RawJSON, policy))
 	}
 
 	if err := validateAndroidProfileFleetVariables(m.RawJSON, profileKeyMap); err != nil {

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -95,9 +95,9 @@ func (m *MDMAndroidConfigProfile) ValidateUserProvided(isPremium bool) error {
 		}
 	}
 
-	policy := &androidmanagement.Policy{}
-	if err := json.Unmarshal(m.RawJSON, policy); err != nil {
-		return parseAndroidProfileValidationError(jsondecode.Enrich(err, m.RawJSON, policy))
+	// The decoded policy is thrown away: this only checks that every value has the right type.
+	if err := jsondecode.Unmarshal(m.RawJSON, &androidmanagement.Policy{}); err != nil {
+		return parseAndroidProfileValidationError(err)
 	}
 
 	if err := validateAndroidProfileFleetVariables(m.RawJSON, profileKeyMap); err != nil {
@@ -108,11 +108,9 @@ func (m *MDMAndroidConfigProfile) ValidateUserProvided(isPremium bool) error {
 }
 
 func parseAndroidProfileValidationError(err error) error {
-	var typeErr *json.UnmarshalTypeError
-
 	// Check for type mismatches (e.g., array where object expected)
-	if errors.As(err, &typeErr) {
-		fieldPath := typeErr.Field
+	if jsondecode.IsTypeError(err) {
+		fieldPath := jsondecode.FieldPath(err)
 		if fieldPath == "" {
 			fieldPath = "<root>"
 		}

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -1,8 +1,8 @@
 package fleet
 
 import (
-	"bytes"
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"errors"
 	"io"
 	"regexp"
@@ -49,16 +49,19 @@ func WriteAppleBMTermsExpiredBanner(w io.Writer) {
 // any unknown key is specified in the JSON value, and if there is any trailing
 // byte after the JSON value.
 func JSONStrictDecode(r io.Reader, v interface{}) error {
-	// The body is buffered so that a decode failure can be located a second time; see jsondecode.Enrich.
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
+	return jsonDecode(r, v, jsondecode.RejectUnknownMembers())
+}
 
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
+// JSONDecode is JSONStrictDecode without the unknown-key rejection: unrecognized keys are ignored, as
+// with a plain json.Unmarshal. Trailing bytes are still an error.
+func JSONDecode(r io.Reader, v interface{}) error {
+	return jsonDecode(r, v)
+}
+
+func jsonDecode(r io.Reader, v interface{}, opts ...jsonv2.Options) error {
+	dec := jsondecode.NewDecoder(r, opts...)
 	if err := dec.Decode(v); err != nil {
-		return jsondecode.Enrich(err, data, v)
+		return err
 	}
 
 	var extra json.RawMessage

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
+	"github.com/fleetdm/fleet/v4/server/platform/jsondecode"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -47,10 +49,16 @@ func WriteAppleBMTermsExpiredBanner(w io.Writer) {
 // any unknown key is specified in the JSON value, and if there is any trailing
 // byte after the JSON value.
 func JSONStrictDecode(r io.Reader, v interface{}) error {
-	dec := json.NewDecoder(r)
+	// The body is buffered so that a decode failure can be located a second time; see jsondecode.Enrich.
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(v); err != nil {
-		return err
+		return jsondecode.Enrich(err, data, v)
 	}
 
 	var extra json.RawMessage

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -54,11 +54,11 @@ func JSONStrictDecode(r io.Reader, v interface{}) error {
 
 // JSONDecode is JSONStrictDecode without the unknown-key rejection: unrecognized keys are ignored, as
 // with a plain json.Unmarshal. Trailing bytes are still an error.
-func JSONDecode(r io.Reader, v interface{}) error {
+func JSONDecode(r io.Reader, v any) error {
 	return jsonDecode(r, v)
 }
 
-func jsonDecode(r io.Reader, v interface{}, opts ...jsonv2.Options) error {
+func jsonDecode(r io.Reader, v any, opts ...jsonv2.Options) error {
 	dec := jsondecode.NewDecoder(r, opts...)
 	if err := dec.Decode(v); err != nil {
 		return err

--- a/server/platform/arch_test.go
+++ b/server/platform/arch_test.go
@@ -66,6 +66,15 @@ func TestHTTPPackageDependencies(t *testing.T) {
 		Check()
 }
 
+func TestJSONDecodePackageDependencies(t *testing.T) {
+	t.Parallel()
+	archtest.NewPackageTest(t, m+"/server/platform/jsondecode").
+		OnlyInclude(regexp.MustCompile(`^github\.com/fleetdm/`)).
+		WithTests().
+		ShouldNotDependOn(m + "/...").
+		Check()
+}
+
 func TestAuthzCheckPackageDependencies(t *testing.T) {
 	t.Parallel()
 	archtest.NewPackageTest(t, m+"/server/platform/middleware/authzcheck").

--- a/server/platform/jsondecode/jsondecode.go
+++ b/server/platform/jsondecode/jsondecode.go
@@ -1,5 +1,4 @@
-// Package jsondecode decodes the JSON that Fleet validates strictly: spec and GitOps files via
-// fleet.JSONStrictDecode, and Android configuration profiles.
+// Package jsondecode decodes the JSON that Fleet validates strictly.
 //
 // It decodes exactly like encoding/json but reports errors through encoding/json/v2, because as of Go
 // 1.27 that is the only way to learn *where* a decode failed. Under v1 error semantics an error returned

--- a/server/platform/jsondecode/jsondecode.go
+++ b/server/platform/jsondecode/jsondecode.go
@@ -60,11 +60,12 @@ func Unmarshal(data []byte, v any) error {
 // being decoded into; it supplies the type name UnmarshalTypeError.Struct reports, matching what Go
 // 1.27's own v1 shim does.
 //
-// Anything that is not a v2 semantic error is returned unchanged, so io.EOF still ends a stream. That
-// also means malformed JSON keeps jsontext's wording ("unexpected EOF after offset 1") rather than
-// encoding/json's ("unexpected end of JSON input"): nothing matches on it, and the offset is the more
-// useful of the two. See TestMalformedJSONUsesV2Wording.
+// Anything else is returned unchanged, so io.EOF still ends a stream.
 func translate(err error, root any) error {
+	if _, ok := errors.AsType[*jsontext.SyntacticError](err); ok {
+		return syntaxError(err)
+	}
+
 	serr, ok := errors.AsType[*jsonv2.SemanticError](err)
 	if err == nil || !ok {
 		return err
@@ -102,6 +103,18 @@ func translate(err error, root any) error {
 		Struct: rootTypeName(root),
 		Field:  FieldPath(err),
 	}
+}
+
+// syntaxError restates a jsontext syntax error in encoding/json's wording.
+func syntaxError(err error) error {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return errors.New("unexpected end of JSON input")
+	}
+	msg := err.Error()
+	if i := strings.LastIndex(msg, "jsontext: "); i >= 0 {
+		msg = msg[i+len("jsontext: "):]
+	}
+	return errors.New(msg)
 }
 
 // isNumberOverflow reports whether serr is v2 failing to fit a JSON number into a Go numeric type.

--- a/server/platform/jsondecode/jsondecode.go
+++ b/server/platform/jsondecode/jsondecode.go
@@ -1,0 +1,90 @@
+// Package jsondecode recovers the field path from JSON decode errors.
+//
+// As of Go 1.27 encoding/json is implemented on top of encoding/json/v2. Under v1 error semantics an
+// error returned from a custom UnmarshalJSON method is reported verbatim, so it reaches the caller with
+// no position information: UnmarshalTypeError.Field is empty. Every pkg/optjson type has such a method,
+// which is why "deadline_days must be a number" degraded into an error that could not say which field
+// it meant.
+//
+// The position is only available under v2 error semantics, and that setting is not separable from v2
+// decoding behavior -- the same option also makes a decode abort at the first error instead of
+// continuing, which callers such as the GitOps "force" path depend on. So rather than change how Fleet
+// decodes, Enrich decodes a second time purely to locate the failure, and only when the first decode
+// already failed without a position. Decoding behavior is therefore completely unchanged.
+package jsondecode
+
+import (
+	jsonv1 "encoding/json"
+	jsonv2 "encoding/json/v2"
+	"errors"
+	"reflect"
+	"strings"
+)
+
+// v2Errors decodes exactly like encoding/json but reports errors with v2's structure, which is the only
+// form that carries the position of the failure.
+var v2Errors = []jsonv2.Options{
+	jsonv1.DefaultOptionsV1(),
+	jsonv1.ReportErrorsWithLegacySemantics(false),
+}
+
+// Enrich annotates a decode error with the path of the value that failed, for the cases where Go can no
+// longer report it: err must be an *encoding/json.UnmarshalTypeError with an empty Field. data is the
+// input that produced err and v is the value it was decoded into; both are needed to locate the failure
+// again. Any other error, and any error that already names a field, is returned unchanged.
+//
+// The returned error is the same *UnmarshalTypeError, annotated in place, which is what the pre-Go 1.27
+// decoder did. Callers that resolve an error to its root cause therefore keep working.
+func Enrich(err error, data []byte, v any) error {
+	terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
+	if err == nil || !ok || terr.Field != "" {
+		return err
+	}
+
+	// Decode again into a throwaway value of the same type. Both decoders report the first error in the
+	// input, so this locates the same failure the caller already saw.
+	scratch := reflect.New(indirectType(reflect.TypeOf(v)))
+	path := FieldPath(jsonv2.Unmarshal(data, scratch.Interface(), v2Errors...))
+	if path == "" {
+		return err
+	}
+
+	terr.Struct = rootTypeName(v)
+	terr.Field = path
+	return err
+}
+
+// FieldPath returns the dot-separated path to the value that failed to decode, or "" when the position
+// is unknown. Array elements appear as their index, so "specs.0.name" is the first element's name.
+func FieldPath(err error) string {
+	if serr, ok := errors.AsType[*jsonv2.SemanticError](err); ok && serr.JSONPointer != "" {
+		var b strings.Builder
+		for token := range serr.JSONPointer.Tokens() {
+			if b.Len() > 0 {
+				b.WriteByte('.')
+			}
+			b.WriteString(token)
+		}
+		return b.String()
+	}
+
+	if terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err); ok {
+		return terr.Field
+	}
+	return ""
+}
+
+func indirectType(t reflect.Type) reflect.Type {
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
+}
+
+func rootTypeName(v any) string {
+	t := indirectType(reflect.TypeOf(v))
+	if t == nil {
+		return ""
+	}
+	return t.Name()
+}

--- a/server/platform/jsondecode/jsondecode.go
+++ b/server/platform/jsondecode/jsondecode.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -93,18 +94,29 @@ func translate(err error, root any) error {
 		return fmt.Errorf("json: unknown field %q", serr.JSONPointer.LastToken())
 	}
 
-	// A custom UnmarshalJSON that delegates to encoding/json (every pkg/optjson type) has already
-	// produced an UnmarshalTypeError naming the concrete Go type that failed -- int, say, rather than the
-	// optjson.Int wrapping it. Annotate that error with the position rather than wrapping it, which is
-	// what the pre-Go 1.27 decoder did and keeps callers that walk to the root cause working.
-	if inner, ok := errors.AsType[*jsonv1.UnmarshalTypeError](serr.Err); ok {
+	// A custom UnmarshalJSON that passes an encoding/json error straight back (every pkg/optjson type
+	// does) has already named the concrete Go type that failed -- int, say, rather than the optjson.Int
+	// wrapping it. Annotate that error with the position rather than replacing it, which is what the
+	// pre-Go 1.27 decoder did and keeps callers that walk to the root cause working.
+	//
+	// The type assertion is deliberately direct rather than errors.As: a method that *wraps* an
+	// UnmarshalTypeError has added a message of its own, and that message is the useful part.
+	if inner, ok := serr.Err.(*jsonv1.UnmarshalTypeError); ok { //nolint:errorlint // see above
 		inner.Struct = rootTypeName(root)
 		inner.Field = FieldPath(err)
 		return inner
 	}
 
-	// Err is deliberately left unset: callers resolve errors to their root cause, so wrapping the v2
-	// error here would hide this one and defeat the point of reporting a position at all.
+	// Anything else a custom UnmarshalJSON returned is a validation failure in its own right -- "contents
+	// must be base64", say. encoding/json reports those verbatim, and replacing one with a synthesized
+	// type error would throw away the only description of what is actually wrong.
+	if serr.Err != nil && !isNumberFormatError(serr.Err) {
+		return serr.Err
+	}
+
+	// A genuine type mismatch: either v2 reported no underlying cause, or it is the numeric parse failure
+	// that encoding/json renders as "number 1.23". Err is deliberately left unset on the result, because
+	// callers resolve errors to their root cause and wrapping would hide this one.
 	return &jsonv1.UnmarshalTypeError{
 		Value:  describeValue(serr),
 		Type:   serr.GoType,
@@ -112,6 +124,13 @@ func translate(err error, root any) error {
 		Struct: rootTypeName(root),
 		Field:  FieldPath(err),
 	}
+}
+
+// isNumberFormatError reports whether err is the failure to parse a JSON number into a Go numeric type,
+// which encoding/json describes as a type error ("cannot unmarshal number 1.23 into ... of type int")
+// rather than surfacing the strconv error.
+func isNumberFormatError(err error) bool {
+	return errors.Is(err, strconv.ErrSyntax) || errors.Is(err, strconv.ErrRange)
 }
 
 // IsTypeError reports whether err describes a value of the wrong type, as opposed to malformed JSON or

--- a/server/platform/jsondecode/jsondecode.go
+++ b/server/platform/jsondecode/jsondecode.go
@@ -1,20 +1,10 @@
-// Package jsondecode is how Fleet decodes JSON request bodies and spec files.
+// Package jsondecode decodes the JSON that Fleet validates strictly: spec and GitOps files via
+// fleet.JSONStrictDecode, and Android configuration profiles.
 //
 // It decodes exactly like encoding/json but reports errors through encoding/json/v2, because as of Go
 // 1.27 that is the only way to learn *where* a decode failed. Under v1 error semantics an error returned
 // from a custom UnmarshalJSON method is reported verbatim, so it reaches the caller with no position at
-// all: UnmarshalTypeError.Field is empty. Every pkg/optjson type has such a method, which is why
-// "deadline_days must be a number" degraded into an error that could not say which field it meant.
-//
-// Callers never see a v2 error. Everything is translated back into the encoding/json error values Fleet
-// already matches on, with the field path filled in, so consumers such as platform/http.UserMessageError,
-// pkg/spec.ParseTypeError and the "unknown field" checks in server/service and server/fleet keep working
-// unchanged.
-//
-// The one behavior difference is that v2 stops decoding at the first error where v1 kept going and
-// reported the first error at the end. That only matters to a caller that reads a partially decoded
-// value after a failure. server/service.applyTeamSpecsRequest.DecodeBody is the only such caller, and it
-// re-decodes leniently when it wants to accept a spec despite an unknown field.
+// all: UnmarshalTypeError.Field is empty.
 package jsondecode
 
 import (
@@ -29,8 +19,8 @@ import (
 	"strings"
 )
 
-// decodeOptions keeps decoding byte-for-byte compatible with encoding/json -- case-insensitive member
-// matching, duplicate names allowed, and so on -- while turning off legacy error reporting, which is
+// decodeOptions keeps decoding byte-for-byte compatible with encoding/json (case-insensitive member
+// matching, duplicate names allowed, and so on) while turning off legacy error reporting, which is
 // what makes the position of a failure available.
 var decodeOptions = []jsonv2.Options{
 	jsonv1.DefaultOptionsV1(),
@@ -40,8 +30,7 @@ var decodeOptions = []jsonv2.Options{
 // RejectUnknownMembers is the equivalent of (*json.Decoder).DisallowUnknownFields.
 func RejectUnknownMembers() jsonv2.Options { return jsonv2.RejectUnknownMembers(true) }
 
-// Decoder reads JSON values from a stream, mirroring (*json.Decoder). Callers reading more than one
-// value from the same reader need this rather than repeated Decode calls, which would each start over.
+// Decoder reads JSON values from a stream, mirroring (*json.Decoder).
 type Decoder struct {
 	dec  *jsontext.Decoder
 	opts []jsonv2.Options
@@ -49,7 +38,10 @@ type Decoder struct {
 
 // NewDecoder returns a Decoder reading from r.
 func NewDecoder(r io.Reader, opts ...jsonv2.Options) *Decoder {
-	all := combine(opts)
+	// Built up rather than appended onto decodeOptions, which would risk writing into the shared slice.
+	all := make([]jsonv2.Options, 0, len(decodeOptions)+len(opts))
+	all = append(all, decodeOptions...)
+	all = append(all, opts...)
 	return &Decoder{dec: jsontext.NewDecoder(r, all...), opts: all}
 }
 
@@ -59,29 +51,20 @@ func (d *Decoder) Decode(v any) error {
 	return translate(jsonv2.UnmarshalDecode(d.dec, v, d.opts...), v)
 }
 
-// Decode reads a single JSON value from r into v. Like (*json.Decoder).Decode, and unlike
-// json.Unmarshal, bytes after the value are left in r rather than rejected.
-func Decode(r io.Reader, v any, opts ...jsonv2.Options) error {
-	return NewDecoder(r, opts...).Decode(v)
-}
-
 // Unmarshal decodes the JSON value in data into v, rejecting trailing bytes like json.Unmarshal.
-func Unmarshal(data []byte, v any, opts ...jsonv2.Options) error {
-	all := combine(opts)
-	return translate(jsonv2.Unmarshal(data, v, all...), v)
-}
-
-func combine(extra []jsonv2.Options) []jsonv2.Options {
-	all := make([]jsonv2.Options, 0, len(decodeOptions)+len(extra))
-	all = append(all, decodeOptions...)
-	return append(all, extra...)
+func Unmarshal(data []byte, v any) error {
+	return translate(jsonv2.Unmarshal(data, v, decodeOptions...), v)
 }
 
 // translate rewrites a v2 error into the encoding/json error the v1 API would have produced, except that
 // the field path is populated even when the failure came from a custom UnmarshalJSON. root is the value
 // being decoded into; it supplies the type name UnmarshalTypeError.Struct reports, matching what Go
-// 1.27's own v1 shim does. Anything that is not a v2 semantic error is returned unchanged, so io.EOF and
-// syntax errors reach callers as they always did.
+// 1.27's own v1 shim does.
+//
+// Anything that is not a v2 semantic error is returned unchanged, so io.EOF still ends a stream. That
+// also means malformed JSON keeps jsontext's wording ("unexpected EOF after offset 1") rather than
+// encoding/json's ("unexpected end of JSON input"): nothing matches on it, and the offset is the more
+// useful of the two. See TestMalformedJSONUsesV2Wording.
 func translate(err error, root any) error {
 	serr, ok := errors.AsType[*jsonv2.SemanticError](err)
 	if err == nil || !ok {
@@ -95,28 +78,24 @@ func translate(err error, root any) error {
 	}
 
 	// A custom UnmarshalJSON that passes an encoding/json error straight back (every pkg/optjson type
-	// does) has already named the concrete Go type that failed -- int, say, rather than the optjson.Int
-	// wrapping it. Annotate that error with the position rather than replacing it, which is what the
-	// pre-Go 1.27 decoder did and keeps callers that walk to the root cause working.
+	// does) has already named the concrete Go type that failed.
 	//
 	// The type assertion is deliberately direct rather than errors.As: a method that *wraps* an
-	// UnmarshalTypeError has added a message of its own, and that message is the useful part.
+	// UnmarshalTypeError has added a message of its own, and we want to keep that message.
 	if inner, ok := serr.Err.(*jsonv1.UnmarshalTypeError); ok { //nolint:errorlint // see above
 		inner.Struct = rootTypeName(root)
 		inner.Field = FieldPath(err)
 		return inner
 	}
 
-	// Anything else a custom UnmarshalJSON returned is a validation failure in its own right -- "contents
-	// must be base64", say. encoding/json reports those verbatim, and replacing one with a synthesized
-	// type error would throw away the only description of what is actually wrong.
-	if serr.Err != nil && !isNumberFormatError(serr.Err) {
+	// Anything else a custom UnmarshalJSON returned is a validation failure in its own right.
+	if serr.Err != nil && !isNumberOverflow(serr) {
 		return serr.Err
 	}
 
-	// A genuine type mismatch: either v2 reported no underlying cause, or it is the numeric parse failure
-	// that encoding/json renders as "number 1.23". Err is deliberately left unset on the result, because
-	// callers resolve errors to their root cause and wrapping would hide this one.
+	// A genuine type mismatch, which is the ordinary case and reaches here in one of two shapes. Usually
+	// serr.Err is nil, because v2 spotted the mismatch itself -- a JSON string against a bool field, say
+	// -- and nothing failed underneath it to report.
 	return &jsonv1.UnmarshalTypeError{
 		Value:  describeValue(serr),
 		Type:   serr.GoType,
@@ -126,11 +105,22 @@ func translate(err error, root any) error {
 	}
 }
 
-// isNumberFormatError reports whether err is the failure to parse a JSON number into a Go numeric type,
-// which encoding/json describes as a type error ("cannot unmarshal number 1.23 into ... of type int")
-// rather than surfacing the strconv error.
-func isNumberFormatError(err error) bool {
-	return errors.Is(err, strconv.ErrSyntax) || errors.Is(err, strconv.ErrRange)
+// isNumberOverflow reports whether serr is v2 failing to fit a JSON number into a Go numeric type.
+func isNumberOverflow(serr *jsonv2.SemanticError) bool {
+	if !errors.Is(serr.Err, strconv.ErrSyntax) && !errors.Is(serr.Err, strconv.ErrRange) {
+		return false
+	}
+	if serr.GoType == nil {
+		return false
+	}
+	switch serr.GoType.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
 }
 
 // IsTypeError reports whether err describes a value of the wrong type, as opposed to malformed JSON or

--- a/server/platform/jsondecode/jsondecode.go
+++ b/server/platform/jsondecode/jsondecode.go
@@ -1,57 +1,124 @@
-// Package jsondecode recovers the field path from JSON decode errors.
+// Package jsondecode is how Fleet decodes JSON request bodies and spec files.
 //
-// As of Go 1.27 encoding/json is implemented on top of encoding/json/v2. Under v1 error semantics an
-// error returned from a custom UnmarshalJSON method is reported verbatim, so it reaches the caller with
-// no position information: UnmarshalTypeError.Field is empty. Every pkg/optjson type has such a method,
-// which is why "deadline_days must be a number" degraded into an error that could not say which field
-// it meant.
+// It decodes exactly like encoding/json but reports errors through encoding/json/v2, because as of Go
+// 1.27 that is the only way to learn *where* a decode failed. Under v1 error semantics an error returned
+// from a custom UnmarshalJSON method is reported verbatim, so it reaches the caller with no position at
+// all: UnmarshalTypeError.Field is empty. Every pkg/optjson type has such a method, which is why
+// "deadline_days must be a number" degraded into an error that could not say which field it meant.
 //
-// The position is only available under v2 error semantics, and that setting is not separable from v2
-// decoding behavior -- the same option also makes a decode abort at the first error instead of
-// continuing, which callers such as the GitOps "force" path depend on. So rather than change how Fleet
-// decodes, Enrich decodes a second time purely to locate the failure, and only when the first decode
-// already failed without a position. Decoding behavior is therefore completely unchanged.
+// Callers never see a v2 error. Everything is translated back into the encoding/json error values Fleet
+// already matches on, with the field path filled in, so consumers such as platform/http.UserMessageError,
+// pkg/spec.ParseTypeError and the "unknown field" checks in server/service and server/fleet keep working
+// unchanged.
+//
+// The one behavior difference is that v2 stops decoding at the first error where v1 kept going and
+// reported the first error at the end. That only matters to a caller that reads a partially decoded
+// value after a failure. server/service.applyTeamSpecsRequest.DecodeBody is the only such caller, and it
+// re-decodes leniently when it wants to accept a spec despite an unknown field.
 package jsondecode
 
 import (
 	jsonv1 "encoding/json"
+	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
 	"errors"
+	"fmt"
+	"io"
 	"reflect"
 	"strings"
 )
 
-// v2Errors decodes exactly like encoding/json but reports errors with v2's structure, which is the only
-// form that carries the position of the failure.
-var v2Errors = []jsonv2.Options{
+// decodeOptions keeps decoding byte-for-byte compatible with encoding/json -- case-insensitive member
+// matching, duplicate names allowed, and so on -- while turning off legacy error reporting, which is
+// what makes the position of a failure available.
+var decodeOptions = []jsonv2.Options{
 	jsonv1.DefaultOptionsV1(),
 	jsonv1.ReportErrorsWithLegacySemantics(false),
 }
 
-// Enrich annotates a decode error with the path of the value that failed, for the cases where Go can no
-// longer report it: err must be an *encoding/json.UnmarshalTypeError with an empty Field. data is the
-// input that produced err and v is the value it was decoded into; both are needed to locate the failure
-// again. Any other error, and any error that already names a field, is returned unchanged.
-//
-// The returned error is the same *UnmarshalTypeError, annotated in place, which is what the pre-Go 1.27
-// decoder did. Callers that resolve an error to its root cause therefore keep working.
-func Enrich(err error, data []byte, v any) error {
-	terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
-	if err == nil || !ok || terr.Field != "" {
+// RejectUnknownMembers is the equivalent of (*json.Decoder).DisallowUnknownFields.
+func RejectUnknownMembers() jsonv2.Options { return jsonv2.RejectUnknownMembers(true) }
+
+// Decoder reads JSON values from a stream, mirroring (*json.Decoder). Callers reading more than one
+// value from the same reader need this rather than repeated Decode calls, which would each start over.
+type Decoder struct {
+	dec  *jsontext.Decoder
+	opts []jsonv2.Options
+}
+
+// NewDecoder returns a Decoder reading from r.
+func NewDecoder(r io.Reader, opts ...jsonv2.Options) *Decoder {
+	all := combine(opts)
+	return &Decoder{dec: jsontext.NewDecoder(r, all...), opts: all}
+}
+
+// Decode reads the next JSON value from the stream into v. It returns io.EOF once the stream is
+// exhausted, which callers use to detect trailing content.
+func (d *Decoder) Decode(v any) error {
+	return translate(jsonv2.UnmarshalDecode(d.dec, v, d.opts...), v)
+}
+
+// Decode reads a single JSON value from r into v. Like (*json.Decoder).Decode, and unlike
+// json.Unmarshal, bytes after the value are left in r rather than rejected.
+func Decode(r io.Reader, v any, opts ...jsonv2.Options) error {
+	return NewDecoder(r, opts...).Decode(v)
+}
+
+// Unmarshal decodes the JSON value in data into v, rejecting trailing bytes like json.Unmarshal.
+func Unmarshal(data []byte, v any, opts ...jsonv2.Options) error {
+	all := combine(opts)
+	return translate(jsonv2.Unmarshal(data, v, all...), v)
+}
+
+func combine(extra []jsonv2.Options) []jsonv2.Options {
+	all := make([]jsonv2.Options, 0, len(decodeOptions)+len(extra))
+	all = append(all, decodeOptions...)
+	return append(all, extra...)
+}
+
+// translate rewrites a v2 error into the encoding/json error the v1 API would have produced, except that
+// the field path is populated even when the failure came from a custom UnmarshalJSON. root is the value
+// being decoded into; it supplies the type name UnmarshalTypeError.Struct reports, matching what Go
+// 1.27's own v1 shim does. Anything that is not a v2 semantic error is returned unchanged, so io.EOF and
+// syntax errors reach callers as they always did.
+func translate(err error, root any) error {
+	serr, ok := errors.AsType[*jsonv2.SemanticError](err)
+	if err == nil || !ok {
 		return err
 	}
 
-	// Decode again into a throwaway value of the same type. Both decoders report the first error in the
-	// input, so this locates the same failure the caller already saw.
-	scratch := reflect.New(indirectType(reflect.TypeOf(v)))
-	path := FieldPath(jsonv2.Unmarshal(data, scratch.Interface(), v2Errors...))
-	if path == "" {
-		return err
+	// encoding/json reports an unrecognized member as `json: unknown field "x"`, and server/service,
+	// server/fleet and pkg/spec all detect that case by matching the wording, so keep producing it.
+	if errors.Is(serr.Err, jsonv2.ErrUnknownName) {
+		return fmt.Errorf("json: unknown field %q", serr.JSONPointer.LastToken())
 	}
 
-	terr.Struct = rootTypeName(v)
-	terr.Field = path
-	return err
+	// A custom UnmarshalJSON that delegates to encoding/json (every pkg/optjson type) has already
+	// produced an UnmarshalTypeError naming the concrete Go type that failed -- int, say, rather than the
+	// optjson.Int wrapping it. Annotate that error with the position rather than wrapping it, which is
+	// what the pre-Go 1.27 decoder did and keeps callers that walk to the root cause working.
+	if inner, ok := errors.AsType[*jsonv1.UnmarshalTypeError](serr.Err); ok {
+		inner.Struct = rootTypeName(root)
+		inner.Field = FieldPath(err)
+		return inner
+	}
+
+	// Err is deliberately left unset: callers resolve errors to their root cause, so wrapping the v2
+	// error here would hide this one and defeat the point of reporting a position at all.
+	return &jsonv1.UnmarshalTypeError{
+		Value:  describeValue(serr),
+		Type:   serr.GoType,
+		Offset: serr.ByteOffset,
+		Struct: rootTypeName(root),
+		Field:  FieldPath(err),
+	}
+}
+
+// IsTypeError reports whether err describes a value of the wrong type, as opposed to malformed JSON or
+// an unrelated failure.
+func IsTypeError(err error) bool {
+	_, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
+	return ok
 }
 
 // FieldPath returns the dot-separated path to the value that failed to decode, or "" when the position
@@ -74,15 +141,31 @@ func FieldPath(err error) string {
 	return ""
 }
 
-func indirectType(t reflect.Type) reflect.Type {
-	for t != nil && t.Kind() == reflect.Pointer {
-		t = t.Elem()
+// describeValue renders the offending JSON value the way UnmarshalTypeError.Value does: a bare kind
+// ("bool", "string", "object"), except for numbers, which encoding/json spells out as "number 1.23".
+func describeValue(serr *jsonv2.SemanticError) string {
+	var value string
+	switch serr.JSONKind {
+	case 'n', '"', '0':
+		value = serr.JSONKind.String()
+	case 'f', 't':
+		value = "bool"
+	case '[', ']':
+		value = "array"
+	case '{', '}':
+		value = "object"
 	}
-	return t
+	if serr.JSONKind == '0' && len(serr.JSONValue) > 0 {
+		value += " " + string(serr.JSONValue)
+	}
+	return value
 }
 
 func rootTypeName(v any) string {
-	t := indirectType(reflect.TypeOf(v))
+	t := reflect.TypeOf(v)
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
 	if t == nil {
 		return ""
 	}

--- a/server/platform/jsondecode/jsondecode_test.go
+++ b/server/platform/jsondecode/jsondecode_test.go
@@ -96,6 +96,53 @@ func TestEnrichLeavesAlreadyLocatedErrorsAlone(t *testing.T) {
 	}
 }
 
+// optSlice mirrors optjson.Slice[T]: a custom unmarshaler over a *composite*, which delegates the whole
+// element list to encoding/json.
+type optSlice[T any] struct {
+	Set   bool
+	Value []T
+}
+
+func (s *optSlice[T]) UnmarshalJSON(b []byte) error {
+	s.Set = true
+	return jsonv1.Unmarshal(b, &s.Value)
+}
+
+// TestEnrichStopsAtCompositeUnmarshalerBoundary documents a known limit. Locating a failure relies on
+// v2 error semantics, and v2 cannot see inside a custom UnmarshalJSON: it reports the position of the
+// value handed to the method, not of the field within it. For a scalar wrapper such as optjson.Int that
+// is the whole path, but for a composite such as optjson.Slice the path stops at the slice.
+//
+// Go 1.26 reported the full "specs.software.packages.self_service" here, because the v1 decoder
+// accumulated its field stack across the custom unmarshaler. Recovering that last segment again would
+// mean giving the optjson composites a v2 UnmarshalJSONFrom method, which changes how they decode
+// everywhere v2 is used, so it is deliberately out of scope here. A truncated-but-correct prefix is
+// still a large improvement on the empty path this package exists to fix.
+func TestEnrichStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
+	type pkg struct {
+		SelfService optInt `json:"self_service"`
+	}
+	type software struct {
+		Packages optSlice[pkg] `json:"packages"`
+	}
+	type spec struct {
+		Software software `json:"software"`
+	}
+	type request struct {
+		Specs []spec `json:"specs"`
+	}
+
+	in := []byte(`{"specs":[{"software":{"packages":[{"self_service":"yes"}]}}]}`)
+	var v request
+	err := Enrich(jsonv1.Unmarshal(in, &v), in, &v)
+
+	terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
+	require.True(t, ok)
+	require.Equal(t, "specs.0.software.packages", terr.Field)
+	// The prefix is correct as far as it goes, which is what callers render.
+	require.NotEmpty(t, terr.Field, "an empty path is the regression this package fixes")
+}
+
 func TestEnrichIgnoresUnrelatedErrors(t *testing.T) {
 	data := []byte(`{}`)
 	v := &root{}

--- a/server/platform/jsondecode/jsondecode_test.go
+++ b/server/platform/jsondecode/jsondecode_test.go
@@ -1,0 +1,129 @@
+package jsondecode
+
+import (
+	jsonv1 "encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// optInt stands in for the pkg/optjson types: a custom UnmarshalJSON that delegates to encoding/json.
+// These are the types whose errors lost all position information in Go 1.27.
+type optInt struct {
+	Set, Valid bool
+	Value      int
+}
+
+func (o *optInt) UnmarshalJSON(b []byte) error {
+	o.Set = true
+	if err := jsonv1.Unmarshal(b, &o.Value); err != nil {
+		return err
+	}
+	o.Valid = true
+	return nil
+}
+
+type inner struct {
+	Plain  string `json:"plain"`
+	Custom optInt `json:"custom"`
+	Nums   []int  `json:"nums"`
+}
+
+type root struct {
+	Inner inner   `json:"inner"`
+	Specs []inner `json:"specs"`
+}
+
+// decode reproduces what a caller does today: decode with encoding/json, then enrich on failure.
+func decode(t *testing.T, in string) (*jsonv1.UnmarshalTypeError, error) {
+	t.Helper()
+	var v root
+	err := Enrich(jsonv1.Unmarshal([]byte(in), &v), []byte(in), &v)
+	terr, _ := errors.AsType[*jsonv1.UnmarshalTypeError](err)
+	return terr, err
+}
+
+func TestEnrichRecoversPathLostByCustomUnmarshaler(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		in       string
+		wantPath string
+	}{
+		{"custom unmarshaler", `{"inner":{"custom":"nope"}}`, "inner.custom"},
+		{"through a slice of structs", `{"specs":[{"custom":"nope"}]}`, "specs.0.custom"},
+		{"second element", `{"specs":[{"custom":1},{"custom":"nope"}]}`, "specs.1.custom"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			terr, err := decode(t, c.in)
+			require.Error(t, err)
+			require.NotNil(t, terr, "callers type-switch on *json.UnmarshalTypeError")
+
+			require.Equal(t, c.wantPath, terr.Field)
+			require.Equal(t, "root", terr.Struct)
+			// The concrete type that failed, not the optjson wrapper around it.
+			require.Equal(t, "int", terr.Type.String())
+			require.Equal(t, "string", terr.Value)
+		})
+	}
+}
+
+func TestEnrichLeavesAlreadyLocatedErrorsAlone(t *testing.T) {
+	// Plain fields never lost their path, so Enrich must not touch them: re-deriving it would risk
+	// disagreeing with what encoding/json already reported.
+	for _, c := range []struct {
+		name     string
+		in       string
+		wantPath string
+	}{
+		{"plain field", `{"inner":{"plain":123}}`, "inner.plain"},
+		{"slice element", `{"inner":{"nums":[1,"two"]}}`, "inner.nums"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var v root
+			before := jsonv1.Unmarshal([]byte(c.in), &v)
+			var beforeType *jsonv1.UnmarshalTypeError
+			require.ErrorAs(t, before, &beforeType)
+			original := *beforeType
+
+			after, _ := decode(t, c.in)
+			require.NotNil(t, after)
+			require.Equal(t, original.Field, after.Field)
+			require.Equal(t, original.Type, after.Type)
+			require.Equal(t, original.Value, after.Value)
+			require.Contains(t, after.Field, c.wantPath)
+		})
+	}
+}
+
+func TestEnrichIgnoresUnrelatedErrors(t *testing.T) {
+	data := []byte(`{}`)
+	v := &root{}
+
+	require.NoError(t, Enrich(nil, data, v))
+
+	sentinel := errors.New("boom")
+	require.Equal(t, sentinel, Enrich(sentinel, data, v))
+
+	// Syntax errors carry an offset rather than a path, and are not UnmarshalTypeErrors.
+	syntax := jsonv1.Unmarshal([]byte(`{`), v)
+	require.Equal(t, syntax, Enrich(syntax, []byte(`{`), v))
+}
+
+func TestEnrichIsANoOpWhenPositionCannotBeRecovered(t *testing.T) {
+	// If the second decode disagrees (here: nothing wrong with the input), the original error survives
+	// untouched rather than being annotated with a misleading path.
+	original := &jsonv1.UnmarshalTypeError{Value: "string", Type: nil}
+	err := Enrich(original, []byte(`{"inner":{"plain":"fine"}}`), &root{})
+	require.Same(t, original, err)
+	require.Empty(t, original.Field)
+}
+
+func TestFieldPath(t *testing.T) {
+	terr, _ := decode(t, `{"specs":[{"custom":"nope"}]}`)
+	require.Equal(t, "specs.0.custom", FieldPath(terr))
+
+	require.Equal(t, "a.b", FieldPath(&jsonv1.UnmarshalTypeError{Field: "a.b"}))
+	require.Empty(t, FieldPath(errors.New("boom")))
+	require.Empty(t, FieldPath(nil))
+}

--- a/server/platform/jsondecode/jsondecode_test.go
+++ b/server/platform/jsondecode/jsondecode_test.go
@@ -3,6 +3,7 @@ package jsondecode
 import (
 	jsonv1 "encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -141,6 +142,71 @@ func TestStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
 	require.Equal(t, "specs.0.software.packages", terr.Field)
 	// The prefix is correct as far as it goes, which is what callers render.
 	require.NotEmpty(t, terr.Field, "an empty path is the regression this package fixes")
+}
+
+// errNotBase64 stands in for a domain validation failure raised by a custom UnmarshalJSON, as
+// server/service's backwardsCompatProfilesParam does when profile contents will not decode.
+var errNotBase64 = errors.New("contents must be base64")
+
+type validated struct{ V string }
+
+func (s *validated) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := jsonv1.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw != "ok" {
+		return fmt.Errorf("field %q: %w", raw, errNotBase64)
+	}
+	return nil
+}
+
+// wrapped stands in for a custom UnmarshalJSON that adds context to an encoding/json failure rather
+// than returning it untouched.
+type wrapped struct{ V map[string][]byte }
+
+func (w *wrapped) UnmarshalJSON(data []byte) error {
+	if err := jsonv1.Unmarshal(data, &w.V); err != nil {
+		return fmt.Errorf("unmarshal profile spec. Error using old format: %w", err)
+	}
+	return nil
+}
+
+type customs struct {
+	Validated validated `json:"validated"`
+	Wrapped   wrapped   `json:"wrapped"`
+}
+
+// TestPreservesErrorsFromCustomUnmarshalers guards the distinction that makes this package safe to put
+// in front of every decode: a value of the wrong type is reported as a type error with the path filled
+// in, but anything else a custom UnmarshalJSON reports is its own description of what is wrong and must
+// survive untouched. Synthesizing a type error over the top of one would throw that description away.
+func TestPreservesErrorsFromCustomUnmarshalers(t *testing.T) {
+	t.Run("validation error survives and is not a type error", func(t *testing.T) {
+		err := Unmarshal([]byte(`{"validated":"nope"}`), &customs{})
+		require.ErrorIs(t, err, errNotBase64, "the sentinel must still be reachable")
+		require.EqualError(t, err, `field "nope": contents must be base64`)
+		require.False(t, IsTypeError(err), "a validation failure is not a type mismatch")
+	})
+
+	t.Run("added context survives", func(t *testing.T) {
+		err := Unmarshal([]byte(`{"wrapped":{"a":123}}`), &customs{})
+		require.ErrorContains(t, err, "unmarshal profile spec. Error using old format:")
+	})
+
+	t.Run("matches encoding/json exactly", func(t *testing.T) {
+		for _, in := range []string{
+			`{"validated":"nope"}`,
+			`{"wrapped":{"a":123}}`,
+			`{"wrapped":123}`,
+		} {
+			var want, got customs
+			wantErr := jsonv1.Unmarshal([]byte(in), &want)
+			gotErr := Unmarshal([]byte(in), &got)
+			require.Error(t, wantErr)
+			require.EqualError(t, gotErr, wantErr.Error(), "input %s", in)
+		}
+	})
 }
 
 func TestPassesThroughNonSemanticErrors(t *testing.T) {

--- a/server/platform/jsondecode/jsondecode_test.go
+++ b/server/platform/jsondecode/jsondecode_test.go
@@ -5,154 +5,33 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// optInt stands in for the pkg/optjson types: a custom UnmarshalJSON that delegates to encoding/json.
-// These are the types whose errors lost all position information in Go 1.27.
-type optInt struct {
-	Set, Valid bool
-	Value      int
-}
+// passthrough mirrors the pkg/optjson scalars: it hands an encoding/json error straight back, which is
+// the case that lost its position in Go 1.27 and the reason this package exists.
+type passthrough struct{ V int }
 
-func (o *optInt) UnmarshalJSON(b []byte) error {
-	o.Set = true
-	if err := jsonv1.Unmarshal(b, &o.Value); err != nil {
-		return err
-	}
-	o.Valid = true
-	return nil
-}
+func (p *passthrough) UnmarshalJSON(b []byte) error { return jsonv1.Unmarshal(b, &p.V) }
 
-type inner struct {
-	Plain  string `json:"plain"`
-	Custom optInt `json:"custom"`
-	Nums   []int  `json:"nums"`
-}
+// composite mirrors optjson.Slice[T]: a custom unmarshaler over a list rather than a scalar.
+type composite struct{ V []passthrough }
 
-type root struct {
-	Inner inner   `json:"inner"`
-	Specs []inner `json:"specs"`
-}
+func (c *composite) UnmarshalJSON(b []byte) error { return jsonv1.Unmarshal(b, &c.V) }
 
-func decode(t *testing.T, in string) (*jsonv1.UnmarshalTypeError, error) {
-	t.Helper()
-	var v root
-	err := Unmarshal([]byte(in), &v)
-	terr, _ := errors.AsType[*jsonv1.UnmarshalTypeError](err)
-	return terr, err
-}
-
-func TestReportsPathLostByCustomUnmarshaler(t *testing.T) {
-	for _, c := range []struct {
-		name     string
-		in       string
-		wantPath string
-	}{
-		{"custom unmarshaler", `{"inner":{"custom":"nope"}}`, "inner.custom"},
-		{"through a slice of structs", `{"specs":[{"custom":"nope"}]}`, "specs.0.custom"},
-		{"second element", `{"specs":[{"custom":1},{"custom":"nope"}]}`, "specs.1.custom"},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			terr, err := decode(t, c.in)
-			require.Error(t, err)
-			require.NotNil(t, terr, "callers type-switch on *json.UnmarshalTypeError")
-
-			require.Equal(t, c.wantPath, terr.Field)
-			require.Equal(t, "root", terr.Struct)
-			// The concrete type that failed, not the optjson wrapper around it.
-			require.Equal(t, "int", terr.Type.String())
-			require.Equal(t, "string", terr.Value)
-		})
-	}
-}
-
-func TestMatchesEncodingJSONForPlainFields(t *testing.T) {
-	// Plain fields never lost their path under Go 1.27, so the translation must reproduce exactly what
-	// encoding/json reports for them: same Value and Type, same field path.
-	for _, c := range []struct {
-		name     string
-		in       string
-		wantPath string
-	}{
-		{"plain field", `{"inner":{"plain":123}}`, "inner.plain"},
-		{"slice element", `{"inner":{"nums":[1,"two"]}}`, "inner.nums"},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			var v root
-			before := jsonv1.Unmarshal([]byte(c.in), &v)
-			var beforeType *jsonv1.UnmarshalTypeError
-			require.ErrorAs(t, before, &beforeType)
-			original := *beforeType
-
-			after, _ := decode(t, c.in)
-			require.NotNil(t, after)
-			require.Equal(t, original.Field, after.Field)
-			require.Equal(t, original.Type, after.Type)
-			require.Equal(t, original.Value, after.Value)
-			require.Contains(t, after.Field, c.wantPath)
-		})
-	}
-}
-
-// optSlice mirrors optjson.Slice[T]: a custom unmarshaler over a *composite*, which delegates the whole
-// element list to encoding/json.
-type optSlice[T any] struct {
-	Set   bool
-	Value []T
-}
-
-func (s *optSlice[T]) UnmarshalJSON(b []byte) error {
-	s.Set = true
-	return jsonv1.Unmarshal(b, &s.Value)
-}
-
-// TestStopsAtCompositeUnmarshalerBoundary documents a known limit. Locating a failure relies on v2
-// error semantics, and v2 cannot see inside a custom UnmarshalJSON: it reports the position of the
-// value handed to the method, not of the field within it. For a scalar wrapper such as optjson.Int that
-// is the whole path, but for a composite such as optjson.Slice the path stops at the slice.
-//
-// Go 1.26 reported the full "specs.software.packages.self_service" here, because the v1 decoder
-// accumulated its field stack across the custom unmarshaler. Recovering that last segment again would
-// mean giving the optjson composites a v2 UnmarshalJSONFrom method, which changes how they decode
-// everywhere v2 is used, so it is deliberately out of scope here. A truncated-but-correct prefix is
-// still a large improvement on the empty path this package exists to fix.
-func TestStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
-	type pkg struct {
-		SelfService optInt `json:"self_service"`
-	}
-	type software struct {
-		Packages optSlice[pkg] `json:"packages"`
-	}
-	type spec struct {
-		Software software `json:"software"`
-	}
-	type request struct {
-		Specs []spec `json:"specs"`
-	}
-
-	var v request
-	err := Unmarshal([]byte(`{"specs":[{"software":{"packages":[{"self_service":"yes"}]}}]}`), &v)
-
-	terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
-	require.True(t, ok)
-	require.Equal(t, "specs.0.software.packages", terr.Field)
-	// The prefix is correct as far as it goes, which is what callers render.
-	require.NotEmpty(t, terr.Field, "an empty path is the regression this package fixes")
-}
-
-// errNotBase64 stands in for a domain validation failure raised by a custom UnmarshalJSON, as
-// server/service's backwardsCompatProfilesParam does when profile contents will not decode.
+// errNotBase64 stands in for a domain validation failure, as server/service's
+// backwardsCompatProfilesParam raises when profile contents will not decode.
 var errNotBase64 = errors.New("contents must be base64")
 
 type validated struct{ V string }
 
-func (s *validated) UnmarshalJSON(data []byte) error {
+func (s *validated) UnmarshalJSON(b []byte) error {
 	var raw string
-	if err := jsonv1.Unmarshal(data, &raw); err != nil {
+	if err := jsonv1.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if raw != "ok" {
@@ -161,143 +40,179 @@ func (s *validated) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// wrapped stands in for a custom UnmarshalJSON that adds context to an encoding/json failure rather
-// than returning it untouched.
-type wrapped struct{ V map[string][]byte }
+// wrapping adds context to an encoding/json failure instead of returning it untouched.
+type wrapping struct{ V map[string][]byte }
 
-func (w *wrapped) UnmarshalJSON(data []byte) error {
-	if err := jsonv1.Unmarshal(data, &w.V); err != nil {
+func (w *wrapping) UnmarshalJSON(b []byte) error {
+	if err := jsonv1.Unmarshal(b, &w.V); err != nil {
 		return fmt.Errorf("unmarshal profile spec. Error using old format: %w", err)
 	}
 	return nil
 }
 
-type customs struct {
-	Validated validated `json:"validated"`
-	Wrapped   wrapped   `json:"wrapped"`
+// port uses strconv, so the error it returns looks exactly like the one v2 raises for a number that
+// will not fit a Go numeric type.
+type port struct{ V int }
+
+func (p *port) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := jsonv1.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return fmt.Errorf("port must be numeric: %w", err)
+	}
+	p.V = v
+	return nil
 }
 
-// TestPreservesErrorsFromCustomUnmarshalers guards the distinction that makes this package safe to put
-// in front of every decode: a value of the wrong type is reported as a type error with the path filled
-// in, but anything else a custom UnmarshalJSON reports is its own description of what is wrong and must
-// survive untouched. Synthesizing a type error over the top of one would throw that description away.
-func TestPreservesErrorsFromCustomUnmarshalers(t *testing.T) {
-	t.Run("validation error survives and is not a type error", func(t *testing.T) {
-		err := Unmarshal([]byte(`{"validated":"nope"}`), &customs{})
-		require.ErrorIs(t, err, errNotBase64, "the sentinel must still be reachable")
-		require.EqualError(t, err, `field "nope": contents must be base64`)
-		require.False(t, IsTypeError(err), "a validation failure is not a type mismatch")
-	})
+type payload struct {
+	Plain     string      `json:"plain"`
+	Num       int         `json:"num"`
+	Nums      []int       `json:"nums"`
+	Custom    passthrough `json:"custom"`
+	List      composite   `json:"list"`
+	Validated validated   `json:"validated"`
+	Wrapping  wrapping    `json:"wrapping"`
+	Port      port        `json:"port"`
+	Items     []payload   `json:"items"`
+}
 
-	t.Run("added context survives", func(t *testing.T) {
-		err := Unmarshal([]byte(`{"wrapped":{"a":123}}`), &customs{})
-		require.ErrorContains(t, err, "unmarshal profile spec. Error using old format:")
-	})
-
-	t.Run("matches encoding/json exactly", func(t *testing.T) {
-		for _, in := range []string{
-			`{"validated":"nope"}`,
-			`{"wrapped":{"a":123}}`,
-			`{"wrapped":123}`,
-		} {
-			var want, got customs
+// TestMatchesEncodingJSON is the main guarantee: for everything except the errors that lost their
+// position (see TestAddsFieldPathWhereEncodingJSONCannot), a caller must see exactly the error
+// encoding/json would have produced. Comparing against the real decoder rather than a hard-coded string
+// keeps this honest across Go releases.
+func TestMatchesEncodingJSON(t *testing.T) {
+	for _, in := range []string{
+		// Plain type mismatches, where v2 reports no underlying cause.
+		`{"plain":123}`,
+		`{"num":"x"}`,
+		`{"nums":true}`,
+		`{"nums":[1,"two"]}`,
+		// Numbers that will not fit, where strconv is the cause but the result is still a type error.
+		`{"num":1.23}`,
+		`{"num":1e400}`,
+		// Errors raised by a custom UnmarshalJSON, which must survive verbatim.
+		`{"validated":"nope"}`,
+		`{"wrapping":{"a":123}}`,
+		`{"wrapping":123}`,
+		`{"port":"http"}`,
+	} {
+		t.Run(in, func(t *testing.T) {
+			var want, got payload
 			wantErr := jsonv1.Unmarshal([]byte(in), &want)
 			gotErr := Unmarshal([]byte(in), &got)
-			require.Error(t, wantErr)
-			require.EqualError(t, gotErr, wantErr.Error(), "input %s", in)
-		}
-	})
+
+			require.Error(t, wantErr, "fixture should fail to decode")
+			require.EqualError(t, gotErr, wantErr.Error())
+			require.Equal(t, IsTypeError(wantErr), IsTypeError(gotErr))
+		})
+	}
 }
 
-func TestPassesThroughNonSemanticErrors(t *testing.T) {
-	// Syntax errors and io.EOF have to reach callers unchanged: JSONStrictDecode relies on io.EOF to
-	// detect trailing content, and nothing treats malformed JSON as a type error.
-	syntax := Unmarshal([]byte(`{`), &root{})
-	require.Error(t, syntax)
-	require.False(t, IsTypeError(syntax))
-	require.Empty(t, FieldPath(syntax))
+// TestAddsFieldPathWhereEncodingJSONCannot covers the regression this package fixes. A custom
+// UnmarshalJSON that returns an encoding/json error reaches the caller stripped of its position under
+// Go 1.27, so here alone the error is deliberately *not* identical to encoding/json's.
+func TestAddsFieldPathWhereEncodingJSONCannot(t *testing.T) {
+	for _, c := range []struct {
+		in       string
+		wantPath string
+	}{
+		{`{"custom":"nope"}`, "custom"},
+		{`{"items":[{"custom":"nope"}]}`, "items.0.custom"},
+		{`{"items":[{"custom":1},{"custom":"nope"}]}`, "items.1.custom"},
+	} {
+		t.Run(c.in, func(t *testing.T) {
+			var bare payload
+			bareErr := jsonv1.Unmarshal([]byte(c.in), &bare)
+			bareType, ok := errors.AsType[*jsonv1.UnmarshalTypeError](bareErr)
+			require.True(t, ok)
+			require.Empty(t, bareType.Field, "encoding/json cannot locate this on its own")
 
-	require.NoError(t, Unmarshal([]byte(`{}`), &root{}))
+			err := Unmarshal([]byte(c.in), &payload{})
+			terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
+			require.True(t, ok, "callers type-switch on *json.UnmarshalTypeError")
+			require.Equal(t, c.wantPath, terr.Field)
+			require.Equal(t, "payload", terr.Struct)
+			// The concrete type that failed, not the wrapper around it.
+			require.Equal(t, "int", terr.Type.String())
+			require.Equal(t, "string", terr.Value)
+		})
+	}
+}
+
+// TestStopsAtCompositeUnmarshalerBoundary documents a known limit. Locating a failure relies on v2 error
+// semantics, and v2 cannot see inside a custom UnmarshalJSON: it reports the position of the value
+// handed to the method, not of the field within it. For a scalar wrapper that is the whole path, but for
+// a composite the path stops at the list.
+func TestStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
+	err := Unmarshal([]byte(`{"list":[{"v":"nope"}]}`), &payload{})
+	require.Equal(t, "list", FieldPath(err))
+}
+
+// TestValidationErrorsAreNotTypeErrors guards the distinction that makes this package safe to put in
+// front of a decode: a wrong type is reported as a type error with the path filled in, but a validation
+// failure is the caller's own description of what is wrong and must not be rewritten into one.
+func TestValidationErrorsAreNotTypeErrors(t *testing.T) {
+	t.Run("plain validation error", func(t *testing.T) {
+		err := Unmarshal([]byte(`{"validated":"nope"}`), &payload{})
+		require.ErrorIs(t, err, errNotBase64, "the sentinel must stay reachable")
+		require.False(t, IsTypeError(err))
+	})
+
+	t.Run("strconv error from a custom unmarshaler", func(t *testing.T) {
+		// The number-overflow branch keys off a strconv error, so it also checks the target type;
+		// otherwise this would be rewritten into "cannot unmarshal string into ...".
+		err := Unmarshal([]byte(`{"port":"http"}`), &payload{})
+		require.ErrorIs(t, err, strconv.ErrSyntax)
+		require.False(t, IsTypeError(err))
+	})
 }
 
 func TestUnknownFieldKeepsV1Wording(t *testing.T) {
-	// server/service/teams.go, server/fleet/agent_options.go and pkg/spec all detect this case by
-	// matching encoding/json's exact message, so it has to survive verbatim.
-	err := Unmarshal([]byte(`{"nope":1}`), &root{}, RejectUnknownMembers())
+	// Some code detects this case by matching encoding/json's exact message, so it has to survive
+	// verbatim, and only when the caller asked for strictness.
+	err := NewDecoder(strings.NewReader(`{"nope":1}`), RejectUnknownMembers()).Decode(&payload{})
 	require.EqualError(t, err, `json: unknown field "nope"`)
 
-	// ...and only when asked for: unknown members are ignored by default, as json.Unmarshal does.
-	require.NoError(t, Unmarshal([]byte(`{"nope":1}`), &root{}))
+	require.NoError(t, Unmarshal([]byte(`{"nope":1}`), &payload{}))
 }
 
 func TestPreservesEncodingJSONDecodingBehavior(t *testing.T) {
 	t.Run("member matching stays case-insensitive", func(t *testing.T) {
-		var v root
-		require.NoError(t, Unmarshal([]byte(`{"INNER":{"PLAIN":"x"}}`), &v))
-		require.Equal(t, "x", v.Inner.Plain)
+		var v payload
+		require.NoError(t, Unmarshal([]byte(`{"PLAIN":"x"}`), &v))
+		require.Equal(t, "x", v.Plain)
 	})
 
 	t.Run("duplicate names allowed", func(t *testing.T) {
-		var v root
-		require.NoError(t, Unmarshal([]byte(`{"inner":{"plain":"a"},"inner":{"plain":"b"}}`), &v))
+		require.NoError(t, Unmarshal([]byte(`{"plain":"a","plain":"b"}`), &payload{}))
 	})
 
 	t.Run("Decode leaves trailing bytes, Unmarshal rejects them", func(t *testing.T) {
-		r := strings.NewReader(`{"inner":{"plain":"a"}}{"inner":{"plain":"b"}}`)
-		dec := NewDecoder(r)
+		// JSONStrictDecode reads a second value to detect trailing content, and relies on io.EOF here.
+		dec := NewDecoder(strings.NewReader(`{"plain":"a"}{"plain":"b"}`))
 
-		var first root
+		var first, second payload
 		require.NoError(t, dec.Decode(&first))
-		require.Equal(t, "a", first.Inner.Plain)
-
-		// A second Decode reaches the next value, and a third reports io.EOF.
-		var second root
+		require.Equal(t, "a", first.Plain)
 		require.NoError(t, dec.Decode(&second))
-		require.Equal(t, "b", second.Inner.Plain)
+		require.Equal(t, "b", second.Plain)
 		require.ErrorIs(t, dec.Decode(&second), io.EOF)
 
-		require.Error(t, Unmarshal([]byte(`{"inner":{}}{"inner":{}}`), &root{}))
+		require.Error(t, Unmarshal([]byte(`{"plain":"a"}{"plain":"b"}`), &payload{}))
 	})
 }
 
-func TestReportsPathForPlainFields(t *testing.T) {
-	for _, c := range []struct {
-		name     string
-		in       string
-		wantPath string
-	}{
-		{"plain field", `{"inner":{"plain":123}}`, "inner.plain"},
-		{"custom unmarshaler", `{"inner":{"custom":"nope"}}`, "inner.custom"},
-		{"slice element", `{"specs":[{"custom":"nope"}]}`, "specs.0.custom"},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			err := Unmarshal([]byte(c.in), &root{})
-			require.Error(t, err)
-			require.True(t, IsTypeError(err))
-			require.Equal(t, c.wantPath, FieldPath(err))
-		})
-	}
-
-	require.NoError(t, Unmarshal([]byte(`{"inner":{"plain":"fine"}}`), &root{}))
-}
-
-func TestIsTypeError(t *testing.T) {
-	require.True(t, IsTypeError(Unmarshal([]byte(`{"inner":{"plain":123}}`), &root{})))
-	// Also recognizes an error from a plain encoding/json decode, for callers that mix the two.
-	var v root
-	require.True(t, IsTypeError(jsonv1.Unmarshal([]byte(`{"inner":{"plain":123}}`), &v)))
-
-	// Malformed JSON is a syntax problem, not a type problem.
-	require.False(t, IsTypeError(Unmarshal([]byte(`{`), &root{})))
-	require.False(t, IsTypeError(errors.New("boom")))
-	require.False(t, IsTypeError(nil))
-}
-
-func TestFieldPath(t *testing.T) {
-	terr, _ := decode(t, `{"specs":[{"custom":"nope"}]}`)
-	require.Equal(t, "specs.0.custom", FieldPath(terr))
-
+func TestIsTypeErrorAndFieldPathOnForeignErrors(t *testing.T) {
+	// Both are used on errors this package did not produce, so they have to cope with anything.
+	var v payload
+	require.True(t, IsTypeError(jsonv1.Unmarshal([]byte(`{"plain":123}`), &v)))
 	require.Equal(t, "a.b", FieldPath(&jsonv1.UnmarshalTypeError{Field: "a.b"}))
-	require.Empty(t, FieldPath(errors.New("boom")))
-	require.Empty(t, FieldPath(nil))
+
+	for _, err := range []error{errors.New("boom"), nil} {
+		require.False(t, IsTypeError(err))
+		require.Empty(t, FieldPath(err))
+	}
 }

--- a/server/platform/jsondecode/jsondecode_test.go
+++ b/server/platform/jsondecode/jsondecode_test.go
@@ -170,6 +170,19 @@ func TestValidationErrorsAreNotTypeErrors(t *testing.T) {
 	})
 }
 
+func TestMalformedJSONKeepsV1Wording(t *testing.T) {
+	for _, in := range []string{`{`, ``, `{"plain":`} {
+		var want, got payload
+		require.EqualError(t, Unmarshal([]byte(in), &got), jsonv1.Unmarshal([]byte(in), &want).Error(), in)
+	}
+
+	// Other syntax errors keep encoding/json's leading wording, without jsontext's prefix.
+	err := Unmarshal([]byte(`{"plain":}`), &payload{})
+	require.ErrorContains(t, err, "invalid character '}'")
+	require.NotContains(t, err.Error(), "jsontext")
+	require.False(t, IsTypeError(err))
+}
+
 func TestUnknownFieldKeepsV1Wording(t *testing.T) {
 	// Some code detects this case by matching encoding/json's exact message, so it has to survive
 	// verbatim, and only when the caller asked for strictness.

--- a/server/platform/jsondecode/jsondecode_test.go
+++ b/server/platform/jsondecode/jsondecode_test.go
@@ -3,6 +3,8 @@ package jsondecode
 import (
 	jsonv1 "encoding/json"
 	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,16 +37,15 @@ type root struct {
 	Specs []inner `json:"specs"`
 }
 
-// decode reproduces what a caller does today: decode with encoding/json, then enrich on failure.
 func decode(t *testing.T, in string) (*jsonv1.UnmarshalTypeError, error) {
 	t.Helper()
 	var v root
-	err := Enrich(jsonv1.Unmarshal([]byte(in), &v), []byte(in), &v)
+	err := Unmarshal([]byte(in), &v)
 	terr, _ := errors.AsType[*jsonv1.UnmarshalTypeError](err)
 	return terr, err
 }
 
-func TestEnrichRecoversPathLostByCustomUnmarshaler(t *testing.T) {
+func TestReportsPathLostByCustomUnmarshaler(t *testing.T) {
 	for _, c := range []struct {
 		name     string
 		in       string
@@ -68,9 +69,9 @@ func TestEnrichRecoversPathLostByCustomUnmarshaler(t *testing.T) {
 	}
 }
 
-func TestEnrichLeavesAlreadyLocatedErrorsAlone(t *testing.T) {
-	// Plain fields never lost their path, so Enrich must not touch them: re-deriving it would risk
-	// disagreeing with what encoding/json already reported.
+func TestMatchesEncodingJSONForPlainFields(t *testing.T) {
+	// Plain fields never lost their path under Go 1.27, so the translation must reproduce exactly what
+	// encoding/json reports for them: same Value and Type, same field path.
 	for _, c := range []struct {
 		name     string
 		in       string
@@ -108,8 +109,8 @@ func (s *optSlice[T]) UnmarshalJSON(b []byte) error {
 	return jsonv1.Unmarshal(b, &s.Value)
 }
 
-// TestEnrichStopsAtCompositeUnmarshalerBoundary documents a known limit. Locating a failure relies on
-// v2 error semantics, and v2 cannot see inside a custom UnmarshalJSON: it reports the position of the
+// TestStopsAtCompositeUnmarshalerBoundary documents a known limit. Locating a failure relies on v2
+// error semantics, and v2 cannot see inside a custom UnmarshalJSON: it reports the position of the
 // value handed to the method, not of the field within it. For a scalar wrapper such as optjson.Int that
 // is the whole path, but for a composite such as optjson.Slice the path stops at the slice.
 //
@@ -118,7 +119,7 @@ func (s *optSlice[T]) UnmarshalJSON(b []byte) error {
 // mean giving the optjson composites a v2 UnmarshalJSONFrom method, which changes how they decode
 // everywhere v2 is used, so it is deliberately out of scope here. A truncated-but-correct prefix is
 // still a large improvement on the empty path this package exists to fix.
-func TestEnrichStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
+func TestStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
 	type pkg struct {
 		SelfService optInt `json:"self_service"`
 	}
@@ -132,9 +133,8 @@ func TestEnrichStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
 		Specs []spec `json:"specs"`
 	}
 
-	in := []byte(`{"specs":[{"software":{"packages":[{"self_service":"yes"}]}}]}`)
 	var v request
-	err := Enrich(jsonv1.Unmarshal(in, &v), in, &v)
+	err := Unmarshal([]byte(`{"specs":[{"software":{"packages":[{"self_service":"yes"}]}}]}`), &v)
 
 	terr, ok := errors.AsType[*jsonv1.UnmarshalTypeError](err)
 	require.True(t, ok)
@@ -143,27 +143,88 @@ func TestEnrichStopsAtCompositeUnmarshalerBoundary(t *testing.T) {
 	require.NotEmpty(t, terr.Field, "an empty path is the regression this package fixes")
 }
 
-func TestEnrichIgnoresUnrelatedErrors(t *testing.T) {
-	data := []byte(`{}`)
-	v := &root{}
+func TestPassesThroughNonSemanticErrors(t *testing.T) {
+	// Syntax errors and io.EOF have to reach callers unchanged: JSONStrictDecode relies on io.EOF to
+	// detect trailing content, and nothing treats malformed JSON as a type error.
+	syntax := Unmarshal([]byte(`{`), &root{})
+	require.Error(t, syntax)
+	require.False(t, IsTypeError(syntax))
+	require.Empty(t, FieldPath(syntax))
 
-	require.NoError(t, Enrich(nil, data, v))
-
-	sentinel := errors.New("boom")
-	require.Equal(t, sentinel, Enrich(sentinel, data, v))
-
-	// Syntax errors carry an offset rather than a path, and are not UnmarshalTypeErrors.
-	syntax := jsonv1.Unmarshal([]byte(`{`), v)
-	require.Equal(t, syntax, Enrich(syntax, []byte(`{`), v))
+	require.NoError(t, Unmarshal([]byte(`{}`), &root{}))
 }
 
-func TestEnrichIsANoOpWhenPositionCannotBeRecovered(t *testing.T) {
-	// If the second decode disagrees (here: nothing wrong with the input), the original error survives
-	// untouched rather than being annotated with a misleading path.
-	original := &jsonv1.UnmarshalTypeError{Value: "string", Type: nil}
-	err := Enrich(original, []byte(`{"inner":{"plain":"fine"}}`), &root{})
-	require.Same(t, original, err)
-	require.Empty(t, original.Field)
+func TestUnknownFieldKeepsV1Wording(t *testing.T) {
+	// server/service/teams.go, server/fleet/agent_options.go and pkg/spec all detect this case by
+	// matching encoding/json's exact message, so it has to survive verbatim.
+	err := Unmarshal([]byte(`{"nope":1}`), &root{}, RejectUnknownMembers())
+	require.EqualError(t, err, `json: unknown field "nope"`)
+
+	// ...and only when asked for: unknown members are ignored by default, as json.Unmarshal does.
+	require.NoError(t, Unmarshal([]byte(`{"nope":1}`), &root{}))
+}
+
+func TestPreservesEncodingJSONDecodingBehavior(t *testing.T) {
+	t.Run("member matching stays case-insensitive", func(t *testing.T) {
+		var v root
+		require.NoError(t, Unmarshal([]byte(`{"INNER":{"PLAIN":"x"}}`), &v))
+		require.Equal(t, "x", v.Inner.Plain)
+	})
+
+	t.Run("duplicate names allowed", func(t *testing.T) {
+		var v root
+		require.NoError(t, Unmarshal([]byte(`{"inner":{"plain":"a"},"inner":{"plain":"b"}}`), &v))
+	})
+
+	t.Run("Decode leaves trailing bytes, Unmarshal rejects them", func(t *testing.T) {
+		r := strings.NewReader(`{"inner":{"plain":"a"}}{"inner":{"plain":"b"}}`)
+		dec := NewDecoder(r)
+
+		var first root
+		require.NoError(t, dec.Decode(&first))
+		require.Equal(t, "a", first.Inner.Plain)
+
+		// A second Decode reaches the next value, and a third reports io.EOF.
+		var second root
+		require.NoError(t, dec.Decode(&second))
+		require.Equal(t, "b", second.Inner.Plain)
+		require.ErrorIs(t, dec.Decode(&second), io.EOF)
+
+		require.Error(t, Unmarshal([]byte(`{"inner":{}}{"inner":{}}`), &root{}))
+	})
+}
+
+func TestReportsPathForPlainFields(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		in       string
+		wantPath string
+	}{
+		{"plain field", `{"inner":{"plain":123}}`, "inner.plain"},
+		{"custom unmarshaler", `{"inner":{"custom":"nope"}}`, "inner.custom"},
+		{"slice element", `{"specs":[{"custom":"nope"}]}`, "specs.0.custom"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := Unmarshal([]byte(c.in), &root{})
+			require.Error(t, err)
+			require.True(t, IsTypeError(err))
+			require.Equal(t, c.wantPath, FieldPath(err))
+		})
+	}
+
+	require.NoError(t, Unmarshal([]byte(`{"inner":{"plain":"fine"}}`), &root{}))
+}
+
+func TestIsTypeError(t *testing.T) {
+	require.True(t, IsTypeError(Unmarshal([]byte(`{"inner":{"plain":123}}`), &root{})))
+	// Also recognizes an error from a plain encoding/json decode, for callers that mix the two.
+	var v root
+	require.True(t, IsTypeError(jsonv1.Unmarshal([]byte(`{"inner":{"plain":123}}`), &v)))
+
+	// Malformed JSON is a syntax problem, not a type problem.
+	require.False(t, IsTypeError(Unmarshal([]byte(`{`), &root{})))
+	require.False(t, IsTypeError(errors.New("boom")))
+	require.False(t, IsTypeError(nil))
 }
 
 func TestFieldPath(t *testing.T) {

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +15,7 @@ import (
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/fleetdm/fleet/v4/server/platform/http/multipartform"
+	"github.com/fleetdm/fleet/v4/server/platform/jsondecode"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/auth"
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -114,7 +114,7 @@ func parseCustomTags(urlTagValue string, r *http.Request, field reflect.Value) (
 }
 
 func jsonDecode(body io.Reader, req any) error {
-	return json.NewDecoder(body).Decode(req)
+	return jsondecode.Decode(body, req)
 }
 
 func isBodyDecoder(v reflect.Value) bool {

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -15,7 +16,6 @@ import (
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/fleetdm/fleet/v4/server/platform/http/multipartform"
-	"github.com/fleetdm/fleet/v4/server/platform/jsondecode"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/auth"
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -114,7 +114,7 @@ func parseCustomTags(urlTagValue string, r *http.Request, field reflect.Value) (
 }
 
 func jsonDecode(body io.Reader, req any) error {
-	return jsondecode.Decode(body, req)
+	return json.NewDecoder(body).Decode(req)
 }
 
 func isBodyDecoder(v reflect.Value) bool {

--- a/server/service/teams.go
+++ b/server/service/teams.go
@@ -247,13 +247,15 @@ type applyTeamSpecsRequest struct {
 }
 
 func (req *applyTeamSpecsRequest) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {
-	if err := fleet.JSONStrictDecode(r, req); err != nil {
-		err = fleet.NewUserMessageError(err, http.StatusBadRequest)
-		if !req.Force || !fleet.IsJSONUnknownFieldError(err) {
-			// only unknown field errors can be forced at this point (other errors
-			// can be forced later, after agent options' validations)
-			return ctxerr.Wrap(ctx, err, "strict decode team specs")
-		}
+	// force accepts specs containing unknown fields, so decode without rejecting them rather than
+	// decoding strictly and ignoring the resulting error. Every other error still has to surface, and
+	// other kinds of error can be forced later, after agent options' validations.
+	decode := fleet.JSONStrictDecode
+	if req.Force {
+		decode = fleet.JSONDecode
+	}
+	if err := decode(r, req); err != nil {
+		return ctxerr.Wrap(ctx, fleet.NewUserMessageError(err, http.StatusBadRequest), "strict decode team specs")
 	}
 
 	// the MacOSSettings field must be validated separately, since it


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51620 

This PR only covers regressions caught by unit tests. We also have a separate regression which was not caught by unit tests: #52493, which will be handled by a separate PR.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - JSON validation errors now identify the specific configuration field containing an invalid value.
  - Array element errors now include the relevant index.
  - Windows update settings report clearer paths for invalid `deadline_days` and `grace_period_days` values.
  - Android profile validation provides more precise field-level type errors.
  - Forced team-spec updates accept unknown fields, while standard updates continue strict validation.

- **Documentation**
  - Updated JSON validation error-message guidance to reflect field paths and array indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->