### PR TITLE
Don't display refetch error for pending hosts (#52384)

### DIFF
--- a/changes/52217-pending-host-refetch-error
+++ b/changes/52217-pending-host-refetch-error
@@ -1,0 +1,1 @@
+- Fixed pending hosts (Apple Business Manager, Windows Autopilot) showing a "Fetching fresh vitals" spinner and a "This host is offline. Please try refetching host vitals later." error on the host details page, even though nobody asked for a refetch.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tests.tsx
@@ -12,6 +12,7 @@ import hostAPI from "services/entities/hosts";
 import activitiesAPI from "services/entities/activities";
 import teamAPI from "services/entities/teams";
 import commandAPI from "services/entities/command";
+import { notify } from "components/ToastNotification";
 
 import HostDetailsPage from "./HostDetailsPage";
 
@@ -36,6 +37,17 @@ const mockLocation = {
 
 const ADMIN = createMockUser();
 const OBSERVER = createMockUser({ role: "observer", global_role: "observer" });
+
+const mockPendingWindowsHost = (status: "online" | "offline"): IHost => {
+  const host = createMockHost({
+    platform: "windows",
+    status,
+    refetch_requested: true,
+    last_enrolled_at: "2000-01-01T00:00:00Z",
+  });
+  host.mdm.enrollment_status = "Pending";
+  return host;
+};
 
 /** An Apple host that is MDM-enrolled and online -- the only combination that
  * pings APNS alongside the refetch. */
@@ -126,4 +138,50 @@ describe("HostDetailsPage - APNS ping on refetch", () => {
     });
     expect(hostAPI.apnsPing).toHaveBeenCalledWith(1);
   });
+});
+
+describe("HostDetailsPage - pending hosts", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("doesn't spin on vitals or report the host offline", async () => {
+    stubQueries(mockPendingWindowsHost("online"));
+    // The host row ages out of the 60-second online window while the page is open.
+    (hostAPI.loadHostDetails as jest.Mock)
+      .mockResolvedValueOnce({ host: mockPendingWindowsHost("online") })
+      .mockResolvedValue({ host: mockPendingWindowsHost("offline") });
+
+    renderPageAs(ADMIN, true);
+    await screen.findByText("Vitals");
+    // Give the poll timer (2s) room to fire if it was scheduled.
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    expect(
+      screen.queryByText(/fetching fresh vitals/i)
+    ).not.toBeInTheDocument();
+    expect(notify.error).not.toHaveBeenCalled();
+  }, 15000);
+
+  it("still reports back when the user asks for the refetch", async () => {
+    stubQueries(mockPendingWindowsHost("online"));
+    (hostAPI.loadHostDetails as jest.Mock)
+      .mockResolvedValueOnce({ host: mockPendingWindowsHost("online") })
+      .mockResolvedValue({ host: mockPendingWindowsHost("offline") });
+
+    const { user } = renderPageAs(ADMIN, true);
+    await user.click(await screen.findByRole("button", { name: /refetch/i }));
+    await waitFor(() => {
+      expect(hostAPI.refetch).toHaveBeenCalled();
+    });
+
+    await waitFor(
+      () => {
+        expect(notify.error).toHaveBeenCalledWith(
+          "This host is offline. Please try refetching host vitals later."
+        );
+      },
+      { timeout: 10000 }
+    );
+  }, 20000);
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -160,7 +160,11 @@ import {
 } from "../helpers";
 import WipeModal from "./modals/WipeModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
-import { canShowMyDeviceButton, getErrorMessage } from "./helpers";
+import {
+  canShowMyDeviceButton,
+  getErrorMessage,
+  hasEverEnrolled,
+} from "./helpers";
 import CancelActivityModal from "./modals/CancelActivityModal";
 import CancelCommandModal from "./modals/CancelCommandModal";
 import CertificateDetailsModal from "../modals/CertificateDetailsModal";
@@ -331,7 +335,13 @@ const HostDetailsPage = ({
     setEnrollmentProfileFailedDetails,
   ] = useState<Omit<IFailedEnrollmentProfileModalProps, "onDone"> | null>(null);
 
-  const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
+  // React Router reuses this component when only host_id changes.
+  const [refetchStart, setRefetchStart] = useState<{
+    hostId: number;
+    at: number;
+  } | null>(null);
+  const refetchStartTime =
+    refetchStart?.hostId === hostIdFromURL ? refetchStart.at : null;
   const [showRefetchSpinner, setShowRefetchSpinner] = useState(false);
   const [usersState, setUsersState] = useState<{ username: string }[]>([]);
   const [usersSearchString, setUsersSearchString] = useState("");
@@ -436,7 +446,7 @@ const HostDetailsPage = ({
    */
   const resetHostRefetchStates = () => {
     setShowRefetchSpinner(false);
-    setRefetchStartTime(null);
+    setRefetchStart(null);
   };
 
   const {
@@ -453,9 +463,15 @@ const HostDetailsPage = ({
       onSuccess: (returnedHost) => {
         // If API returns refetch_requested: true,
         // only set timer if *not* already set!
-        if (returnedHost.refetch_requested) {
+        // Pending hosts carry the flag from the moment they're created, so ignore it unless the host has enrolled and
+        // can actually return vitals. On a never-enrolled host only a click (within first 60s) sets refetchStartTime,
+        // so an explicit request still gets its spinner and its feedback.
+        if (
+          returnedHost.refetch_requested &&
+          (hasEverEnrolled(returnedHost) || refetchStartTime !== null)
+        ) {
           if (!refetchStartTime) {
-            setRefetchStartTime(Date.now());
+            setRefetchStart({ hostId: hostIdFromURL, at: Date.now() });
           }
           setShowRefetchSpinner(true);
 
@@ -791,7 +807,7 @@ const HostDetailsPage = ({
 
       try {
         await hostAPI.refetch(host).then(() => {
-          setRefetchStartTime(Date.now());
+          setRefetchStart({ hostId: hostIdFromURL, at: Date.now() });
           setTimeout(() => {
             refetchHostDetails();
             refetchExtensions();

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
@@ -1,6 +1,6 @@
 import createMockHost from "__mocks__/hostMock";
 
-import { canShowMyDeviceButton } from "./helpers";
+import { canShowMyDeviceButton, hasEverEnrolled } from "./helpers";
 
 describe("canShowMyDeviceButton", () => {
   it("returns true when Fleet Desktop is installed and the host is not wiped", () => {
@@ -56,5 +56,29 @@ describe("canShowMyDeviceButton", () => {
       },
     });
     expect(canShowMyDeviceButton(host)).toBe(true);
+  });
+});
+
+describe("hasEverEnrolled", () => {
+  it("returns true for a host that has checked in", () => {
+    expect(
+      hasEverEnrolled(
+        createMockHost({ last_enrolled_at: "2026-08-21T10:30:00Z" })
+      )
+    ).toBe(true);
+  });
+
+  it("returns false for a pending host holding the never sentinel", () => {
+    expect(
+      hasEverEnrolled(
+        createMockHost({ last_enrolled_at: "2000-01-01T00:00:00Z" })
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when the date is missing", () => {
+    expect(hasEverEnrolled(createMockHost({ last_enrolled_at: "" }))).toBe(
+      false
+    );
   });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
@@ -1,5 +1,6 @@
 import { getErrorReason } from "interfaces/errors";
 import { IHost } from "interfaces/host";
+import { INITIAL_FLEET_DATE } from "utilities/constants";
 
 import { getHostDeviceStatusUIState } from "../helpers";
 
@@ -32,3 +33,10 @@ export const canShowMyDeviceButton = (
   );
   return uiState !== "wiped" && uiState !== "wiping";
 };
+
+// Hosts created in a pending state (Apple Business Manager, Windows Autopilot) are inserted with
+// refetch_requested already set, but there is nothing on the device yet to answer it, so the flag
+// stays on until the host actually enrolls. Their last_enrolled_at holds the "never" sentinel until
+// then, which is what separates them from hosts that can return vitals.
+export const hasEverEnrolled = (host: Pick<IHost, "last_enrolled_at">) =>
+  !!host.last_enrolled_at && host.last_enrolled_at >= INITIAL_FLEET_DATE;

--- a/frontend/test/test-setup.ts
+++ b/frontend/test/test-setup.ts
@@ -20,11 +20,14 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: jest.fn(),
   })),
 });
-global.ResizeObserver = jest.fn().mockImplementation(() => ({
-  observe: jest.fn(),
-  unobserve: jest.fn(),
-  disconnect: jest.fn(),
-}));
+// jsdom has no ResizeObserver, so this is a polyfill, not a test double, and it deliberately avoids jest.fn(). A suite
+// that needs a spy can swap in its own and restore it (see HostsEnrolledCard.tests.tsx).
+const noop = () => undefined;
+global.ResizeObserver = class {
+  observe = noop;
+  unobserve = noop;
+  disconnect = noop;
+};
 
 // Mock server setup
 beforeAll(() => mockServer.listen());


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52217

Screenshot: N/A, error no longer visible

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Pending hosts no longer incorrectly show a “Fetching fresh vitals” spinner or offline error on the host details page.
- Background refetch requests are limited to hosts that have previously enrolled.
- Users can still manually refetch pending hosts and receive appropriate feedback.
- Refetch activity is correctly scoped when switching between host details pages.

## Tests
- Expanded coverage for pending-host behavior and enrollment-date handling.
- Improved test stability for components that observe layout changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit 8e8b375239491273c6d47d0ac6f07ee4fbbef3d2)

