### PR TITLE
Reject company-owned only Android commands on BYOD hosts (#52123)

### DIFF
--- a/changes/52123-android-company-owned-only-commands
+++ b/changes/52123-android-company-owned-only-commands
@@ -1,0 +1,1 @@
+- Rejected Android MDM commands that Google only supports on company-owned devices (`REBOOT`, `RELINQUISH_OWNERSHIP`, `START_LOST_MODE`, and `STOP_LOST_MODE`) when they target a personally-owned (BYOD) host, instead of reporting them as running when the device would never carry them out.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9283,7 +9283,7 @@ Edit managed local account enforcement settings for eligible hosts.
 
 > `POST /api/v1/fleet/mdm/apple/enqueue` API endpoint is deprecated as of Fleet 4.40. It is maintained for backward compatibility. Please use the new API endpoint below. [Archived documentation](https://github.com/fleetdm/fleet/blob/fleet-v4.39.0/docs/REST%20API/rest-api.md#run-custom-mdm-command) is available for the deprecated endpoint.
 
-This endpoint tells Fleet to run a custom MDM command on the targeted macOS, iOS, iPadOS, or Windows hosts the next time they come online.
+This endpoint tells Fleet to run a custom MDM command on the targeted macOS, iOS, iPadOS, Windows, or Android hosts the next time they come online.
 
 > This endpoint accepts a maximum request body size of 2MiB.
 
@@ -9297,6 +9297,8 @@ This endpoint tells Fleet to run a custom MDM command on the targeted macOS, iOS
 | host_uuids                | array  | json  | An array of host UUIDs enrolled in Fleet on which the command should run. |
 
 Note that the `EraseDevice` and `DeviceLock` commands are _available in Fleet Premium_ only.
+
+On Android hosts, the `REBOOT`, `RELINQUISH_OWNERSHIP`, `START_LOST_MODE`, and `STOP_LOST_MODE` commands are only supported on company-owned hosts. Sending one to a personally-owned (BYOD) host returns a 400.
 
 #### Example
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -28225,6 +28225,84 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateTransferTeamToNoTeam() {
 // TestAndroidCustomCommandsListAndResults exercises the full API flow for Android custom commands:
 // send a command via POST /commands/run, verify it appears in GET /commands (list), deliver a
 // Pub/Sub ack, and verify GET /commands/results returns the stored result.
+func (s *integrationMDMTestSuite) TestAndroidCompanyOwnedOnlyCommands() {
+	t := s.T()
+	ctx := t.Context()
+
+	enterpriseID, err := s.ds.CreateEnterprise(ctx, s.users["admin1"].ID)
+	require.NoError(t, err)
+	require.NoError(t, s.ds.UpdateEnterprise(ctx, &android.EnterpriseDetails{
+		ID:           enterpriseID,
+		EnterpriseID: "cobo-only-fake",
+		SignupName:   "fake",
+		SignupToken:  "value",
+		TopicID:      "yep",
+	}))
+	require.NoError(t, s.ds.InsertOrReplaceMDMConfigAsset(ctx, fleet.MDMConfigAsset{
+		Name:  fleet.MDMAssetAndroidPubSubToken,
+		Value: []byte("test-android-cobo-only-pubsub-token"),
+	}))
+
+	var (
+		issueCallsMu sync.Mutex
+		issueCounter int
+	)
+	s.androidAPIClient.EnterprisesDevicesIssueCommandFunc = func(_ context.Context, deviceName string, _ *androidmanagement.Command) (*androidmanagement.Operation, error) {
+		issueCallsMu.Lock()
+		defer issueCallsMu.Unlock()
+		issueCounter++
+		return &androidmanagement.Operation{Name: fmt.Sprintf("%s/operations/cobo-only-op-%d", deviceName, issueCounter)}, nil
+	}
+	issuedCount := func() int {
+		issueCallsMu.Lock()
+		defer issueCallsMu.Unlock()
+		return issueCounter
+	}
+
+	uuidForHost := func(hostID uint) string {
+		var hostResp getHostResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", hostID), nil, http.StatusOK, &hostResp)
+		return hostResp.Host.UUID
+	}
+	byodUUID := uuidForHost(createAndroidHostForTest(t, s.ds, nil, false))
+	coboUUID := uuidForHost(createAndroidHostForTest(t, s.ds, nil, true))
+
+	for _, rawCmd := range []string{
+		`{"type":"REBOOT"}`,
+		`{"type":"RELINQUISH_OWNERSHIP"}`,
+		`{"type":"START_LOST_MODE"}`,
+		`{"type":"STOP_LOST_MODE"}`,
+		// AMAPI infers the type from these params, so omitting it must not bypass the check
+		`{"startLostModeParams":{"lostMessage":{"defaultMessage":"lost"}}}`,
+		`{"stopLostModeParams":{}}`,
+	} {
+		before := issuedCount()
+		res := s.Do("POST", "/api/latest/fleet/commands/run", &runMDMCommandRequest{
+			Command:   base64.StdEncoding.EncodeToString([]byte(rawCmd)),
+			HostUUIDs: []string{byodUUID},
+		}, http.StatusBadRequest)
+		require.Contains(t, extractServerErrorText(res.Body),
+			"This Android command is only supported on company-owned hosts.", rawCmd)
+		require.Equal(t, before, issuedCount(), "%s must not reach AMAPI", rawCmd)
+	}
+
+	// The same command on a company-owned host still goes through.
+	var runResp runMDMCommandResponse
+	s.DoJSON("POST", "/api/latest/fleet/commands/run", &runMDMCommandRequest{
+		Command:   base64.StdEncoding.EncodeToString([]byte(`{"type":"REBOOT"}`)),
+		HostUUIDs: []string{coboUUID},
+	}, http.StatusOK, &runResp)
+	require.Equal(t, "REBOOT", runResp.RequestType)
+
+	// A command that works on a work profile is unaffected by the restriction.
+	runResp = runMDMCommandResponse{}
+	s.DoJSON("POST", "/api/latest/fleet/commands/run", &runMDMCommandRequest{
+		Command:   base64.StdEncoding.EncodeToString([]byte(`{"type":"CLEAR_APP_DATA"}`)),
+		HostUUIDs: []string{byodUUID},
+	}, http.StatusOK, &runResp)
+	require.Equal(t, "CLEAR_APP_DATA", runResp.RequestType)
+}
+
 func (s *integrationMDMTestSuite) TestAndroidCustomCommandsListAndResults() {
 	t := s.T()
 	ctx := t.Context()

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -630,6 +630,16 @@ var androidMDMPremiumCommands = map[string]struct{}{
 	"RESET_PASSWORD": {},
 }
 
+// androidMDMCompanyOwnedOnlyCommands are AMAPI commands Google only honors on fully
+// managed or company-owned devices. On a BYOD work profile AMAPI still accepts the
+// request and reports it as running, but the device never carries it out.
+var androidMDMCompanyOwnedOnlyCommands = map[string]struct{}{
+	"REBOOT":               {},
+	"RELINQUISH_OWNERSHIP": {},
+	"START_LOST_MODE":      {},
+	"STOP_LOST_MODE":       {},
+}
+
 // enqueueAndroidMDMCommand issues an AMAPI custom command for each targeted Android host.
 // rawJSON is the base64-decoded JSON bytes of the AMAPI Command object.
 // For now, only single-host targeting is supported.
@@ -639,21 +649,32 @@ func (svc *Service) enqueueAndroidMDMCommand(ctx context.Context, rawJSON []byte
 			"Android custom commands can only target a single host at a time.").WithStatus(http.StatusBadRequest)
 	}
 
-	// Parse the command type and sensitive fields for premium gating.
+	// Parse the command type, along with the fields AMAPI infers a type from, for
+	// premium and company-owned gating.
 	var cmdPayload struct {
-		Type        string `json:"type"`
-		NewPassword string `json:"newPassword"`
+		Type                string          `json:"type"`
+		NewPassword         string          `json:"newPassword"`
+		StartLostModeParams json.RawMessage `json:"startLostModeParams"`
+		StopLostModeParams  json.RawMessage `json:"stopLostModeParams"`
 	}
 	if err := json.Unmarshal(rawJSON, &cmdPayload); err != nil {
 		return nil, fleet.NewInvalidArgumentError("command", "invalid Android command JSON").WithStatus(http.StatusBadRequest)
 	}
 
-	// Normalize to uppercase to match AMAPI convention and our premium map keys.
+	// Normalize to uppercase to match AMAPI convention and our gating map keys.
 	cmdType := strings.ToUpper(strings.TrimSpace(cmdPayload.Type))
 
-	// If type is omitted but newPassword is set, AMAPI infers RESET_PASSWORD.
-	if cmdType == "" && cmdPayload.NewPassword != "" {
-		cmdType = "RESET_PASSWORD"
+	// AMAPI infers the type from these params when it is omitted, so gating on the
+	// literal type alone would let a caller skip the checks below by leaving it out.
+	if cmdType == "" {
+		switch {
+		case cmdPayload.NewPassword != "":
+			cmdType = "RESET_PASSWORD"
+		case cmdPayload.StartLostModeParams != nil:
+			cmdType = "START_LOST_MODE"
+		case cmdPayload.StopLostModeParams != nil:
+			cmdType = "STOP_LOST_MODE"
+		}
 	}
 
 	if _, ok := androidMDMPremiumCommands[cmdType]; ok {
@@ -667,6 +688,21 @@ func (svc *Service) enqueueAndroidMDMCommand(ctx context.Context, rawJSON []byte
 	}
 
 	host := hosts[0]
+
+	if _, ok := androidMDMCompanyOwnedOnlyCommands[cmdType]; ok {
+		// The hosts here come from ListHostsLiteByUUIDs, which does not join host_mdm,
+		// so host.MDM carries no enrollment status and the ownership has to be read.
+		hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
+		if err != nil && !fleet.IsNotFound(err) {
+			return nil, ctxerr.Wrap(ctx, err, "get host mdm for android command ownership check")
+		}
+		if hostMDM != nil && hostMDM.IsPersonalEnrollment {
+			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: "This Android command is only supported on company-owned hosts.",
+			}, "company-owned only android command targeting a personally-owned host")
+		}
+	}
+
 	cmd, err := svc.androidSvc.IssueCustomCommand(ctx, host.ID, rawJSON)
 	if err != nil {
 		return nil, err

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -5220,7 +5220,17 @@ func TestRunMDMCommandAndroid(t *testing.T) {
 				MDM: fleet.MDM{AndroidEnabledAndConfigured: true},
 			}, nil
 		}
+		ds.GetHostMDMFunc = func(_ context.Context, _ uint) (*fleet.HostMDM, error) {
+			return &fleet.HostMDM{Enrolled: true}, nil
+		}
 		return ds
+	}
+
+	// personallyOwned makes the host read back as a BYOD (work profile) enrollment.
+	personallyOwned := func(ds *mock.Store) {
+		ds.GetHostMDMFunc = func(_ context.Context, _ uint) (*fleet.HostMDM, error) {
+			return &fleet.HostMDM{Enrolled: true, IsPersonalEnrollment: true}, nil
+		}
 	}
 
 	t.Run("success creates activity", func(t *testing.T) {
@@ -5388,6 +5398,123 @@ func TestRunMDMCommandAndroid(t *testing.T) {
 		_, err := svc.RunMDMCommand(ctx, encoded, []string{androidHost.UUID})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Android MDM isn't turned on")
+	})
+
+	// AMAPI accepts these on a BYOD work profile and reports them as running, but the
+	// device never carries them out, so Fleet rejects them up front instead.
+	t.Run("rejects company-owned only commands on a personally-owned host", func(t *testing.T) {
+		for _, rawCmd := range []string{
+			`{"type":"REBOOT"}`,
+			`{"type":"RELINQUISH_OWNERSHIP"}`,
+			`{"type":"START_LOST_MODE"}`,
+			`{"type":"STOP_LOST_MODE"}`,
+			// lowercase must gate too, since the type is normalized before the check
+			`{"type":"reboot"}`,
+			// AMAPI infers the type from these params when it is omitted, so leaving
+			// the type out must not slip past the check
+			`{"startLostModeParams":{"lostMessage":{"defaultMessage":"lost"}}}`,
+			`{"stopLostModeParams":{}}`,
+		} {
+			t.Run(rawCmd, func(t *testing.T) {
+				ds := setupDS(t)
+				personallyOwned(ds)
+				// The command must be rejected before it reaches AMAPI, so record
+				// rather than panic on a call that should never happen.
+				var issued bool
+				androidMock := &mockAndroidService{
+					IssueCustomCommandFunc: func(_ context.Context, _ uint, _ []byte) (*android.MDMAndroidCommand, error) {
+						issued = true
+						return &android.MDMAndroidCommand{CommandUUID: "cmd-uuid", CommandType: "UNEXPECTED"}, nil
+					},
+				}
+				opts := &TestServerOpts{SkipCreateTestUsers: true, AndroidModule: androidMock}
+				svc, ctx := newTestService(t, ds, nil, nil, opts)
+				ctx = test.UserContext(ctx, test.UserAdmin)
+
+				opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+					return nil
+				}
+
+				encoded := base64.StdEncoding.EncodeToString([]byte(rawCmd))
+				_, err := svc.RunMDMCommand(ctx, encoded, []string{androidHost.UUID})
+				require.Error(t, err)
+				require.ErrorContains(t, err, "This Android command is only supported on company-owned hosts.")
+				var bre *fleet.BadRequestError
+				require.ErrorAs(t, err, &bre)
+				assert.False(t, issued, "the command must not be sent to AMAPI")
+			})
+		}
+	})
+
+	t.Run("allows a command that works on a work profile on a personally-owned host", func(t *testing.T) {
+		ds := setupDS(t)
+		personallyOwned(ds)
+		androidMock := &mockAndroidService{
+			IssueCustomCommandFunc: func(_ context.Context, _ uint, _ []byte) (*android.MDMAndroidCommand, error) {
+				return &android.MDMAndroidCommand{CommandUUID: "cmd-uuid-lock-byod", CommandType: "LOCK"}, nil
+			},
+		}
+		opts := &TestServerOpts{
+			SkipCreateTestUsers: true,
+			AndroidModule:       androidMock,
+			License:             &fleet.LicenseInfo{Tier: fleet.TierPremium},
+		}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		encoded := base64.StdEncoding.EncodeToString([]byte(`{"type":"LOCK"}`))
+		result, err := svc.RunMDMCommand(ctx, encoded, []string{androidHost.UUID})
+		require.NoError(t, err)
+		assert.Equal(t, "LOCK", result.RequestType)
+	})
+
+	t.Run("allows company-owned only commands when no host_mdm row exists", func(t *testing.T) {
+		ds := setupDS(t)
+		ds.GetHostMDMFunc = func(_ context.Context, _ uint) (*fleet.HostMDM, error) {
+			return nil, newNotFoundError()
+		}
+		androidMock := &mockAndroidService{
+			IssueCustomCommandFunc: func(_ context.Context, _ uint, _ []byte) (*android.MDMAndroidCommand, error) {
+				return &android.MDMAndroidCommand{CommandUUID: "cmd-uuid-reboot", CommandType: "REBOOT"}, nil
+			},
+		}
+		opts := &TestServerOpts{SkipCreateTestUsers: true, AndroidModule: androidMock}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		encoded := base64.StdEncoding.EncodeToString([]byte(`{"type":"REBOOT"}`))
+		result, err := svc.RunMDMCommand(ctx, encoded, []string{androidHost.UUID})
+		require.NoError(t, err)
+		assert.Equal(t, "REBOOT", result.RequestType)
+	})
+
+	t.Run("does not read host_mdm for commands that are not restricted", func(t *testing.T) {
+		ds := setupDS(t)
+		androidMock := &mockAndroidService{
+			IssueCustomCommandFunc: func(_ context.Context, _ uint, _ []byte) (*android.MDMAndroidCommand, error) {
+				return &android.MDMAndroidCommand{CommandUUID: "cmd-uuid-clear", CommandType: "CLEAR_APP_DATA"}, nil
+			},
+		}
+		opts := &TestServerOpts{SkipCreateTestUsers: true, AndroidModule: androidMock}
+		svc, ctx := newTestService(t, ds, nil, nil, opts)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		encoded := base64.StdEncoding.EncodeToString([]byte(`{"type":"CLEAR_APP_DATA"}`))
+		_, err := svc.RunMDMCommand(ctx, encoded, []string{androidHost.UUID})
+		require.NoError(t, err)
+		assert.False(t, ds.GetHostMDMFuncInvoked, "unrestricted commands must not pay for the ownership lookup")
 	})
 }
 


### PR DESCRIPTION
**Related issue:** Resolves #52123

## What

`REBOOT`, `RELINQUISH_OWNERSHIP`, `START_LOST_MODE` and `STOP_LOST_MODE` are only honored by AMAPI on fully managed or company-owned devices — [Google's own reference](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/issueCommand#CommandType) says so for each of the four:

| Command | Google's constraint |
| --- | --- |
| `REBOOT` | "Only supported on fully managed devices running Android 7.0 (API level 24) or higher." |
| `RELINQUISH_OWNERSHIP` | "Removes the work profile and all policies from a **company-owned** Android 8.0+ device…" |
| `START_LOST_MODE` | "Only supported on fully managed devices or organization-owned devices with a managed profile." |
| `STOP_LOST_MODE` | "Only supported on fully managed devices or organization-owned devices with a managed profile." |

Sent to a BYOD work profile, AMAPI still accepts the request and Fleet reports the command as running. The device never carries it out, so the command sits in the list looking successful forever.

This rejects those four up front with a 400 and the message from the issue, so the admin finds out immediately instead of waiting on a command that will never complete.

## Where the check goes

`enqueueAndroidMDMCommand` in `server/service/mdm.go`, right beside the existing `androidMDMPremiumCommands` gate, which already normalizes the command type in the same place.

Two details worth calling out for review:

**The ownership has to be read, not taken from the host.** `RunMDMCommand` loads hosts through `ListHostsLiteByUUIDs`, which does not join `host_mdm`. So `host.MDM.EnrollmentStatus` is nil on this path, and a check written against it — the way `ValidateAndroidWipeRequest` does, where the host is fully loaded — would compile, read correctly, and silently never fire. The gate calls `GetHostMDM` instead, and only for the four restricted commands, so unrestricted ones don't pay for the lookup. There's a test asserting exactly that.

**Omitting the type must not bypass it.** AMAPI infers the command type from `startLostModeParams` / `stopLostModeParams` when `type` is absent, the same way it already infers `RESET_PASSWORD` from `newPassword` (which this function handles today). Gating on the literal `type` alone would let `{"startLostModeParams":{…}}` through. The inference is now handled for all three.

A host with no `host_mdm` row is treated as not personally-owned, so a missing row can't turn into a 500 or a spurious rejection.

## Scope

Only the four commands above. `LOCK`, `RESET_PASSWORD` and `CLEAR_APP_DATA` work on a work profile and are untouched on BYOD hosts — there are tests pinning that, so this can't quietly grow into a general BYOD block.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes — no path or payload change; only a new rejection.

## Testing

- [x] Added/updated automated tests

**Unit** — `TestRunMDMCommandAndroid` in `server/service/mdm_test.go`:
- all four commands rejected on a personally-owned host, plus lowercase `reboot` and both params-inferred forms (7 cases)
- each asserts the 400, the message, `*fleet.BadRequestError`, and that the command never reached AMAPI
- `LOCK` still allowed on a personally-owned host
- `REBOOT` still allowed when there is no `host_mdm` row
- `GetHostMDM` not called for an unrestricted command

**Integration** — `TestAndroidCompanyOwnedOnlyCommands` in `server/service/integration_mdm_test.go`, end-to-end through `POST /api/latest/fleet/commands/run`: the six rejection cases return HTTP 400 with the message and issue no AMAPI call, while the same `REBOOT` on a company-owned host and `CLEAR_APP_DATA` on the BYOD host both return 200.

Both layers were checked against a reverted `mdm.go`: all seven unit cases and the integration test fail without the change, and every other assertion in `TestRunMDMCommandAndroid` passes either way. All 17 `TestIntegrationsMDM/TestAndroid*` tests pass, including the existing `Wipe BYO is rejected`.

- [ ] QA'd all new/changed functionality manually — not done; I don't have a real BYOD Android enrollment. The integration test covers the API path against the AMAPI test client.

## Docs

The REST API reference for this endpoint didn't list Android among the supported platforms even though the endpoint has handled it for a while, which made a note about an Android-only restriction read as a contradiction. Added Android to that list along with the restriction note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted Android commands such as reboot, ownership relinquishment, and lost-mode actions are now rejected on personally owned (BYOD) devices.
  * Rejected commands return a clear error and are not sent to the device management service.
  * These commands continue to work on company-owned devices.
  * Work-profile commands, including clearing app data, remain supported on BYOD devices.
  * Lost-mode command variants are now handled correctly when command types are inferred from their parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->