### PR TITLE
Enable FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS on dogfood

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -90,6 +90,8 @@ locals {
     FLEET_SERVER_GZIP_RESPONSES     = "true"
     # https://github.com/fleetdm/fleet/issues/38366
     FLEET_MDM_ALLOW_ALL_DECLARATIONS = "true"
+    # https://github.com/fleetdm/fleet/issues/50764
+    FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS = "true"
 
     # Load TLS Certificate for RDS Authentication
     FLEET_MYSQL_TLS_CA                  = local.cert_path

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -90,7 +90,6 @@ locals {
     FLEET_SERVER_GZIP_RESPONSES     = "true"
     # https://github.com/fleetdm/fleet/issues/38366
     FLEET_MDM_ALLOW_ALL_DECLARATIONS = "true"
-    # https://github.com/fleetdm/fleet/issues/50764
     FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS = "true"
 
     # Load TLS Certificate for RDS Authentication


### PR DESCRIPTION
# Changes

Enable `FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS` on dogfood so we can add custom [activations](https://developer.apple.com/documentation/devicemanagement/activationsimple) to Apple declaration (DDM) profiles there.

- Added `FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS = "true"` to the extra environment variables in the dogfood AWS Terraform module, alongside the existing `FLEET_MDM_ALLOW_ALL_DECLARATIONS`.

The setting ([`mdm.allow_custom_activations`](https://fleetdm.com/docs/configuration/fleet-server-configuration#mdm-allow-custom-activations)) is off by default because Apple owns predicate syntax and Fleet can't validate a predicate before it reaches a host. On macOS 26.5 an invalid predicate can leave a host's MDM subsystem unrecoverable remotely (Apple FB24193230, #50764). Turning it on for dogfood lets us exercise the GitOps and API paths on real hosts.

Custom activations are Fleet Premium; dogfood already runs with a license key.

Once this deploys, an activation can be attached to a declaration in GitOps:

```yaml
controls:
  apple_settings:
    configuration_profiles:
      - path: ../lib/macos/profiles/ddm.json
        activation: ../lib/macos/activations/activation.json
```

# Checklist for submitter

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled custom MDM activations in the dogfood deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->