### PR TITLE
Fix: DigiCert CA common name, seat ID and UPN Modern IDP Variables support

### DIFF
--- a/changes/52368-fix-digicert-ca-modern-idp-vars-support.md
+++ b/changes/52368-fix-digicert-ca-modern-idp-vars-support.md
@@ -1,0 +1,1 @@
+Added DigiCert CA support for Built-In Fleet Modern IDP Variables

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -273,8 +273,7 @@ func validateDigicertCACN(cn string, errPrefix string) error {
 }
 
 func isSupportedDigicertFleetVar(fleetVar fleet.FleetVarName) bool {
-	return fleetVar == fleet.FleetVarHostEndUserEmailIDP || fleetVar == fleet.FleetVarHostHardwareSerial || fleetVar == fleet.FleetVarHostPlatform ||
-		slices.Contains(fleet.IDPFleetVariables, fleetVar)
+	return slices.Contains(fleet.FleetVarsSupportedInDigiCert, fleetVar)
 }
 
 var alphanumeric = regexp.MustCompile(`^\w+$`)

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/ee/server/service/scep"
@@ -259,19 +260,25 @@ func validateDigicertCACN(cn string, errPrefix string) error {
 	if len(strings.TrimSpace(cn)) == 0 {
 		return fleet.NewInvalidArgumentError("certificate_common_name", fmt.Sprintf("%sCA Common Name (CN) cannot be empty", errPrefix))
 	}
+	if unsupportedVar := unsupportedDigicertFleetVarRegexp.FindString(cn); unsupportedVar != "" {
+		return fleet.NewInvalidArgumentError("certificate_common_name", fmt.Sprintf("%s%s is not allowed in CA Common Name (CN)", errPrefix, unsupportedVar))
+	}
 	fleetVars := variables.Find(cn)
 	for _, fleetVar := range fleetVars {
-		switch fleetVar {
-		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial), string(fleet.FleetVarHostPlatform):
-			// ok
-		default:
+		if !isSupportedDigicertFleetVar(fleet.FleetVarName(fleetVar)) {
 			return fleet.NewInvalidArgumentError("certificate_common_name", fmt.Sprintf("%sFLEET_VAR_%s is not allowed in CA Common Name (CN)", errPrefix, fleetVar))
 		}
 	}
 	return nil
 }
 
+func isSupportedDigicertFleetVar(fleetVar fleet.FleetVarName) bool {
+	return fleetVar == fleet.FleetVarHostEndUserEmailIDP || fleetVar == fleet.FleetVarHostHardwareSerial || fleetVar == fleet.FleetVarHostPlatform ||
+		slices.Contains(fleet.IDPFleetVariables, fleetVar)
+}
+
 var alphanumeric = regexp.MustCompile(`^\w+$`)
+var unsupportedDigicertFleetVarRegexp = regexp.MustCompile(`\$\{?FLEET_(?:SECRET|HOST_VITAL)_[A-Z0-9_]+\}?`)
 
 func isAlphanumeric(s string) bool {
 	return alphanumeric.MatchString(s)
@@ -281,12 +288,12 @@ func validateDigicertSeatID(seatID string, errPrefix string) error {
 	if len(strings.TrimSpace(seatID)) == 0 {
 		return fleet.NewInvalidArgumentError("certificate_seat_id", fmt.Sprintf("%sCA Seat ID cannot be empty", errPrefix))
 	}
+	if unsupportedVar := unsupportedDigicertFleetVarRegexp.FindString(seatID); unsupportedVar != "" {
+		return fleet.NewInvalidArgumentError("certificate_seat_id", fmt.Sprintf("%s%s is not allowed in DigiCert Seat ID", errPrefix, unsupportedVar))
+	}
 	fleetVars := variables.Find(seatID)
 	for _, fleetVar := range fleetVars {
-		switch fleetVar {
-		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial), string(fleet.FleetVarHostPlatform):
-			// ok
-		default:
+		if !isSupportedDigicertFleetVar(fleet.FleetVarName(fleetVar)) {
 			return fleet.NewInvalidArgumentError("certificate_seat_id", fmt.Sprintf("%sFLEET_VAR_%s is not allowed in DigiCert Seat ID", errPrefix, fleetVar))
 		}
 	}
@@ -305,12 +312,13 @@ func validateDigicertUserPrincipalNames(userPrincipalNames []string, errPrefix s
 		return fleet.NewInvalidArgumentError("certificate_user_principal_names",
 			fmt.Sprintf("%sDigiCert certificate_user_principal_name cannot be empty if specified", errPrefix))
 	}
+	if unsupportedVar := unsupportedDigicertFleetVarRegexp.FindString(userPrincipalNames[0]); unsupportedVar != "" {
+		return fleet.NewInvalidArgumentError("certificate_user_principal_names",
+			fmt.Sprintf("%s%s is not allowed in CA User Principal Name", errPrefix, unsupportedVar))
+	}
 	fleetVars := variables.Find(userPrincipalNames[0])
 	for _, fleetVar := range fleetVars {
-		switch fleetVar {
-		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial), string(fleet.FleetVarHostPlatform):
-			// ok
-		default:
+		if !isSupportedDigicertFleetVar(fleet.FleetVarName(fleetVar)) {
 			return fleet.NewInvalidArgumentError("certificate_user_principal_names",
 				fmt.Sprintf("%sFLEET_VAR_%s is not allowed in CA User Principal Name", errPrefix, fleetVar))
 		}

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -292,17 +292,45 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 	})
 
 	t.Run("Create DigiCert CA - Happy path with variables", func(t *testing.T) {
-		svc, ctx := baseSetupForCATests()
+		fleetVars := append([]fleet.FleetVarName{fleet.FleetVarHostHardwareSerial}, fleet.IDPFleetVariables...)
+		for _, fleetVar := range fleetVars {
+			t.Run(string(fleetVar), func(t *testing.T) {
+				svc, ctx := baseSetupForCATests()
+				value := fleetVar.WithPrefix()
+				createDigicertRequest := fleet.CertificateAuthorityPayload{
+					DigiCert: &fleet.DigiCertCA{
+						Name:                          "DigicertWIFI",
+						URL:                           digicertURL,
+						APIToken:                      "digicert_api_token",
+						ProfileID:                     "digicert_profile_id",
+						CertificateCommonName:         value,
+						CertificateUserPrincipalNames: []string{value},
+						CertificateSeatID:             value,
+					},
+				}
 
+				_, err := svc.NewCertificateAuthority(ctx, createDigicertRequest)
+				require.EqualError(t, err, "mock error to avoid NewActivity panic")
+				require.Len(t, createdCAs, 1)
+				createdCA := createdCAs[0]
+				assert.Equal(t, value, *createdCA.CertificateCommonName)
+				assert.Equal(t, []string{value}, *createdCA.CertificateUserPrincipalNames)
+				assert.Equal(t, value, *createdCA.CertificateSeatID)
+			})
+		}
+	})
+
+	t.Run("Create DigiCert CA - Happy path with hardware serial and IDP username variables", func(t *testing.T) {
+		svc, ctx := baseSetupForCATests()
 		createDigicertRequest := fleet.CertificateAuthorityPayload{
 			DigiCert: &fleet.DigiCertCA{
 				Name:                          "DigicertWIFI",
 				URL:                           digicertURL,
 				APIToken:                      "digicert_api_token",
 				ProfileID:                     "digicert_profile_id",
-				CertificateCommonName:         "$FLEET_VAR_HOST_HARDWARE_SERIAL",
-				CertificateUserPrincipalNames: []string{"$FLEET_VAR_HOST_HARDWARE_SERIAL"},
-				CertificateSeatID:             "$FLEET_VAR_HOST_HARDWARE_SERIAL",
+				CertificateCommonName:         fleet.FleetVarHostHardwareSerial.WithPrefix(),
+				CertificateUserPrincipalNames: []string{fleet.FleetVarHostEndUserIDPUsername.WithPrefix()},
+				CertificateSeatID:             fleet.FleetVarHostEndUserIDPUsernameLocalPart.WithPrefix(),
 			},
 		}
 
@@ -310,20 +338,13 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		require.EqualError(t, err, "mock error to avoid NewActivity panic")
 		require.Len(t, createdCAs, 1)
 		createdCA := createdCAs[0]
-
-		assert.Equal(t, createDigicertRequest.DigiCert.Name, *createdCA.Name)
-		assert.Equal(t, createDigicertRequest.DigiCert.URL, *createdCA.URL)
-		assert.Equal(t, string(fleet.CATypeDigiCert), createdCA.Type)
-		require.NotNil(t, createdCA.APIToken)
-		assert.Equal(t, createDigicertRequest.DigiCert.APIToken, *createdCA.APIToken)
-		require.NotNil(t, createdCA.ProfileID)
-		assert.Equal(t, createDigicertRequest.DigiCert.ProfileID, *createdCA.ProfileID)
 		require.NotNil(t, createdCA.CertificateCommonName)
 		assert.Equal(t, createDigicertRequest.DigiCert.CertificateCommonName, *createdCA.CertificateCommonName)
-		assert.ElementsMatch(t, createDigicertRequest.DigiCert.CertificateUserPrincipalNames, *createdCA.CertificateUserPrincipalNames)
+		require.NotNil(t, createdCA.CertificateUserPrincipalNames)
+		assert.Equal(t, createDigicertRequest.DigiCert.CertificateUserPrincipalNames, *createdCA.CertificateUserPrincipalNames)
 		require.NotNil(t, createdCA.CertificateSeatID)
 		assert.Equal(t, createDigicertRequest.DigiCert.CertificateSeatID, *createdCA.CertificateSeatID)
-		verifyNilFieldsForType(t, createdCA)
+		t.Logf("created DigiCert config: CN=%q UPN=%q seat ID=%q", *createdCA.CertificateCommonName, *createdCA.CertificateUserPrincipalNames, *createdCA.CertificateSeatID)
 	})
 
 	t.Run("Create DigiCert CA - Happy path with no UPNs", func(t *testing.T) {
@@ -359,6 +380,29 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		require.NotNil(t, createdCA.CertificateSeatID)
 		assert.Equal(t, createDigicertRequest.DigiCert.CertificateSeatID, *createdCA.CertificateSeatID)
 		verifyNilFieldsForType(t, createdCA)
+	})
+
+	t.Run("Create DigiCert CA - rejects custom variables", func(t *testing.T) {
+		for _, value := range []string{"$FLEET_SECRET_CERTIFICATE_ID", "$FLEET_HOST_VITAL_ASSET_TAG"} {
+			t.Run(value, func(t *testing.T) {
+				svc, ctx := baseSetupForCATests()
+				createDigicertRequest := fleet.CertificateAuthorityPayload{
+					DigiCert: &fleet.DigiCertCA{
+						Name:                          "DigicertWIFI",
+						URL:                           digicertURL,
+						APIToken:                      "digicert_api_token",
+						ProfileID:                     "digicert_profile_id",
+						CertificateCommonName:         value,
+						CertificateUserPrincipalNames: []string{value},
+						CertificateSeatID:             value,
+					},
+				}
+
+				_, err := svc.NewCertificateAuthority(ctx, createDigicertRequest)
+				require.Error(t, err)
+				require.Empty(t, createdCAs)
+			})
+		}
 	})
 
 	t.Run("Create Hydrant CA - Happy path", func(t *testing.T) {
@@ -1346,18 +1390,23 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 		})
 
 		t.Run("Allows variable for certificate related fields", func(t *testing.T) {
-			svc, ctx := baseSetupForCATests()
+			fleetVars := append([]fleet.FleetVarName{fleet.FleetVarHostHardwareSerial}, fleet.IDPFleetVariables...)
+			for _, fleetVar := range fleetVars {
+				t.Run(string(fleetVar), func(t *testing.T) {
+					svc, ctx := baseSetupForCATests()
+					value := fleetVar.WithPrefix()
+					payload := fleet.CertificateAuthorityUpdatePayload{
+						DigiCertCAUpdatePayload: &fleet.DigiCertCAUpdatePayload{
+							CertificateCommonName:         &value,
+							CertificateUserPrincipalNames: &[]string{value},
+							CertificateSeatID:             &value,
+						},
+					}
 
-			payload := fleet.CertificateAuthorityUpdatePayload{
-				DigiCertCAUpdatePayload: &fleet.DigiCertCAUpdatePayload{
-					CertificateCommonName:         ptr.String("$FLEET_VAR_HOST_HARDWARE_SERIAL"),
-					CertificateUserPrincipalNames: &[]string{"$FLEET_VAR_HOST_HARDWARE_SERIAL"},
-					CertificateSeatID:             ptr.String("$FLEET_VAR_HOST_HARDWARE_SERIAL"),
-				},
+					err := svc.UpdateCertificateAuthority(ctx, digicertID, payload)
+					require.EqualError(t, err, "mock error to avoid NewActivity panic")
+				})
 			}
-
-			err := svc.UpdateCertificateAuthority(ctx, digicertID, payload)
-			require.Error(t, err, "mock error to avoid NewActivity panic")
 		})
 
 		t.Run("Fails updating URL if no api token", func(t *testing.T) {

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -292,8 +292,7 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 	})
 
 	t.Run("Create DigiCert CA - Happy path with variables", func(t *testing.T) {
-		fleetVars := append([]fleet.FleetVarName{fleet.FleetVarHostHardwareSerial}, fleet.IDPFleetVariables...)
-		for _, fleetVar := range fleetVars {
+		for _, fleetVar := range fleet.FleetVarsSupportedInDigiCert {
 			t.Run(string(fleetVar), func(t *testing.T) {
 				svc, ctx := baseSetupForCATests()
 				value := fleetVar.WithPrefix()
@@ -1390,8 +1389,7 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 		})
 
 		t.Run("Allows variable for certificate related fields", func(t *testing.T) {
-			fleetVars := append([]fleet.FleetVarName{fleet.FleetVarHostHardwareSerial}, fleet.IDPFleetVariables...)
-			for _, fleetVar := range fleetVars {
+			for _, fleetVar := range fleet.FleetVarsSupportedInDigiCert {
 				t.Run(string(fleetVar), func(t *testing.T) {
 					svc, ctx := baseSetupForCATests()
 					value := fleetVar.WithPrefix()

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -368,11 +370,37 @@ func (ds *Datastore) BatchApplyCertificateAuthorities(ctx context.Context, ops f
 	upserts = append(upserts, ops.Update...)
 
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		var digiCertCAsToRefresh []string
+		for _, ca := range ops.Update {
+			if ca.Type == string(fleet.CATypeDigiCert) && ca.Name != nil {
+				if err := lockDigiCertProfileVariableAssociations(ctx, tx); err != nil {
+					return err
+				}
+				break
+			}
+		}
+		for _, ca := range ops.Update {
+			if ca.Type != string(fleet.CATypeDigiCert) || ca.Name == nil {
+				continue
+			}
+			oldCA, err := getDigiCertCAForProfileVariables(ctx, tx, *ca.Name, true)
+			if err != nil {
+				return err
+			}
+			if digiCertProfileVariableFieldsChanged(ca, oldCA) {
+				digiCertCAsToRefresh = append(digiCertCAsToRefresh, *ca.Name)
+			}
+		}
 		if err := batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts); err != nil {
 			return err
 		}
 		if err := batchDeleteCertificateAuthorities(ctx, tx, ops.Delete); err != nil {
 			return err
+		}
+		for _, caName := range digiCertCAsToRefresh {
+			if err := ds.refreshDigiCertProfileVariableAssociations(ctx, tx, caName); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -445,14 +473,265 @@ func (ds *Datastore) UpdateCertificateAuthorityByID(ctx context.Context, certifi
 	WHERE id = ?
 	`, setStmt)
 
-	_, err = ds.writer(ctx).ExecContext(ctx, stmt, updateArgs...)
-	if err != nil {
-		if strings.Contains(err.Error(), "idx_ca_type_name") {
-			return fleet.ConflictError{Message: "a certificate authority with this name already exists"}
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		var currentCA *fleet.CertificateAuthority
+		if digiCertUpdateMayAffectProfileVariables(ca) {
+			if err := lockDigiCertProfileVariableAssociations(ctx, tx); err != nil {
+				return err
+			}
+			currentCA, err = getDigiCertCAByIDForProfileVariables(ctx, tx, certificateAuthorityID)
+			if err != nil {
+				return err
+			}
 		}
-		return ctxerr.Wrapf(ctx, err, "updating certificate authority with id %d", certificateAuthorityID)
+		_, err = tx.ExecContext(ctx, stmt, updateArgs...)
+		if err != nil {
+			if strings.Contains(err.Error(), "idx_ca_type_name") {
+				return fleet.ConflictError{Message: "a certificate authority with this name already exists"}
+			}
+			return ctxerr.Wrapf(ctx, err, "updating certificate authority with id %d", certificateAuthorityID)
+		}
+
+		if currentCA != nil && digiCertProfileVariableFieldsChanged(ca, currentCA) {
+			if err := ds.refreshDigiCertProfileVariableAssociations(ctx, tx, *currentCA.Name); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func digiCertUpdateMayAffectProfileVariables(ca *fleet.CertificateAuthority) bool {
+	return ca.Type == string(fleet.CATypeDigiCert) &&
+		ca.Name == nil &&
+		(ca.CertificateCommonName != nil || ca.CertificateUserPrincipalNames != nil || ca.CertificateSeatID != nil)
+}
+
+func digiCertProfileVariableFieldsChanged(ca, oldCA *fleet.CertificateAuthority) bool {
+	return ca.CertificateCommonName != nil && (oldCA.CertificateCommonName == nil || *ca.CertificateCommonName != *oldCA.CertificateCommonName) ||
+		ca.CertificateUserPrincipalNames != nil && (oldCA.CertificateUserPrincipalNames == nil || !slices.Equal(*ca.CertificateUserPrincipalNames, *oldCA.CertificateUserPrincipalNames)) ||
+		ca.CertificateSeatID != nil && (oldCA.CertificateSeatID == nil || *ca.CertificateSeatID != *oldCA.CertificateSeatID)
+}
+
+type digiCertProfileVariables struct {
+	Name                          string `db:"name"`
+	CertificateCommonName         string `db:"certificate_common_name"`
+	CertificateUserPrincipalNames []byte `db:"certificate_user_principal_names"`
+	CertificateSeatID             string `db:"certificate_seat_id"`
+}
+
+func lockDigiCertProfileVariableAssociations(ctx context.Context, tx sqlx.ExtContext) error {
+	var id uint
+	if err := sqlx.GetContext(ctx, tx, &id, `
+		SELECT id
+		FROM fleet_variables
+		WHERE name = ?
+		FOR UPDATE
+	`, "FLEET_VAR_"+string(fleet.FleetVarDigiCertDataPrefix)); err != nil {
+		return ctxerr.Wrap(ctx, err, "locking DigiCert profile variable associations")
+	}
+	return nil
+}
+
+func getDigiCertCAForProfileVariables(ctx context.Context, tx sqlx.ExtContext, caName string, forUpdate bool) (*fleet.CertificateAuthority, error) {
+	var ca digiCertProfileVariables
+	stmt := `
+		SELECT name, certificate_common_name, certificate_user_principal_names, certificate_seat_id
+		FROM certificate_authorities
+		WHERE type = 'digicert' AND name = ?
+	`
+	if forUpdate {
+		stmt += " FOR UPDATE"
+	}
+	if err := sqlx.GetContext(ctx, tx, &ca, stmt, caName); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting DigiCert certificate authority for profile variable associations")
+	}
+	return certificateAuthorityFromDigiCertProfileVariables(ctx, ca)
+}
+
+func getDigiCertCAByIDForProfileVariables(ctx context.Context, tx sqlx.ExtContext, caID uint) (*fleet.CertificateAuthority, error) {
+	var ca digiCertProfileVariables
+	if err := sqlx.GetContext(ctx, tx, &ca, `
+		SELECT name, certificate_common_name, certificate_user_principal_names, certificate_seat_id
+		FROM certificate_authorities
+		WHERE type = 'digicert' AND id = ?
+		FOR UPDATE
+	`, caID); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting DigiCert certificate authority for profile variable associations")
+	}
+	return certificateAuthorityFromDigiCertProfileVariables(ctx, ca)
+}
+
+func certificateAuthorityFromDigiCertProfileVariables(ctx context.Context, ca digiCertProfileVariables) (*fleet.CertificateAuthority, error) {
+	var upns []string
+	if err := json.Unmarshal(ca.CertificateUserPrincipalNames, &upns); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "unmarshalling DigiCert certificate user principal names for profile variable associations")
+	}
+	return &fleet.CertificateAuthority{
+		Name:                          &ca.Name,
+		CertificateCommonName:         &ca.CertificateCommonName,
+		CertificateUserPrincipalNames: &upns,
+		CertificateSeatID:             &ca.CertificateSeatID,
+	}, nil
+}
+
+func getDigiCertCAsForProfileVariables(ctx context.Context, tx sqlx.ExtContext) ([]fleet.DigiCertCA, error) {
+	var caRows []digiCertProfileVariables
+	if err := sqlx.SelectContext(ctx, tx, &caRows, `
+		SELECT name, certificate_common_name, certificate_user_principal_names, certificate_seat_id
+		FROM certificate_authorities
+		WHERE type = 'digicert'
+		FOR SHARE
+	`); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting DigiCert certificate authorities for profile variable associations")
 	}
 
+	digiCertCAs := make([]fleet.DigiCertCA, 0, len(caRows))
+	for _, caRow := range caRows {
+		ca, err := certificateAuthorityFromDigiCertProfileVariables(ctx, caRow)
+		if err != nil {
+			return nil, err
+		}
+		digiCertCAs = append(digiCertCAs, fleet.DigiCertCA{
+			Name:                          *ca.Name,
+			CertificateCommonName:         *ca.CertificateCommonName,
+			CertificateUserPrincipalNames: *ca.CertificateUserPrincipalNames,
+			CertificateSeatID:             *ca.CertificateSeatID,
+		})
+	}
+	return digiCertCAs, nil
+}
+
+func resolveDigiCertProfileVariableAssociationsDB(
+	ctx context.Context,
+	tx sqlx.ExtContext,
+	profileVariablesByUUID []fleet.MDMProfileUUIDFleetVariables,
+) ([]fleet.MDMProfileUUIDFleetVariables, error) {
+	usesDigiCert := false
+	for _, profileVariables := range profileVariablesByUUID {
+		for _, fleetVar := range profileVariables.FleetVariables {
+			if strings.HasPrefix(string(fleetVar), string(fleet.FleetVarDigiCertDataPrefix)) ||
+				strings.HasPrefix(string(fleetVar), string(fleet.FleetVarDigiCertPasswordPrefix)) {
+				usesDigiCert = true
+				break
+			}
+		}
+		if usesDigiCert {
+			break
+		}
+	}
+	if !usesDigiCert {
+		return profileVariablesByUUID, nil
+	}
+
+	if err := lockDigiCertProfileVariableAssociations(ctx, tx); err != nil {
+		return nil, err
+	}
+	digiCertCAs, err := getDigiCertCAsForProfileVariables(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedProfiles := make([]fleet.MDMProfileUUIDFleetVariables, 0, len(profileVariablesByUUID))
+	for _, profileVariables := range profileVariablesByUUID {
+		usesDigiCert := false
+		for _, fleetVar := range profileVariables.FleetVariables {
+			if strings.HasPrefix(string(fleetVar), string(fleet.FleetVarDigiCertDataPrefix)) ||
+				strings.HasPrefix(string(fleetVar), string(fleet.FleetVarDigiCertPasswordPrefix)) {
+				usesDigiCert = true
+				break
+			}
+		}
+		if !usesDigiCert {
+			resolvedProfiles = append(resolvedProfiles, profileVariables)
+			continue
+		}
+
+		var mobileconfig []byte
+		if err := sqlx.GetContext(ctx, tx, &mobileconfig, `
+			SELECT mobileconfig
+			FROM mdm_apple_configuration_profiles
+			WHERE profile_uuid = ?
+		`, profileVariables.ProfileUUID); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting Apple profile for DigiCert profile variable associations")
+		}
+		resolved := fleet.ResolveDigiCertProfileFleetVariables(variables.Find(string(mobileconfig)), digiCertCAs)
+		fleetVars := make([]fleet.FleetVarName, len(resolved))
+		for i, fleetVar := range resolved {
+			fleetVars[i] = fleet.FleetVarName(fleetVar)
+		}
+		resolvedProfiles = append(resolvedProfiles, fleet.MDMProfileUUIDFleetVariables{
+			ProfileUUID:    profileVariables.ProfileUUID,
+			FleetVariables: fleetVars,
+		})
+	}
+	return resolvedProfiles, nil
+}
+
+func (ds *Datastore) refreshDigiCertProfileVariableAssociations(ctx context.Context, tx sqlx.ExtContext, caName string) error {
+	digiCertCAs, err := getDigiCertCAsForProfileVariables(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	type profileRow struct {
+		ProfileUUID  string `db:"profile_uuid"`
+		Mobileconfig []byte `db:"mobileconfig"`
+	}
+	var profiles []profileRow
+	if err := sqlx.SelectContext(ctx, tx, &profiles, `
+		SELECT macp.profile_uuid, macp.mobileconfig
+		FROM mdm_apple_configuration_profiles macp
+		WHERE EXISTS (
+			SELECT 1
+			FROM mdm_configuration_profile_variables mcpv
+			JOIN fleet_variables fv ON fv.id = mcpv.fleet_variable_id
+			WHERE mcpv.apple_profile_uuid = macp.profile_uuid AND fv.name IN (?, ?)
+		)
+	`, "FLEET_VAR_"+string(fleet.FleetVarDigiCertDataPrefix), "FLEET_VAR_"+string(fleet.FleetVarDigiCertPasswordPrefix)); err != nil {
+		return ctxerr.Wrap(ctx, err, "getting Apple profiles with DigiCert variables")
+	}
+
+	profileVariables := make([]fleet.MDMProfileUUIDFleetVariables, 0, len(profiles))
+	for _, profile := range profiles {
+		fleetVarsInProfile := variables.Find(string(profile.Mobileconfig))
+		if !slices.Contains(fleetVarsInProfile, string(fleet.FleetVarDigiCertDataPrefix)+caName) &&
+			!slices.Contains(fleetVarsInProfile, string(fleet.FleetVarDigiCertPasswordPrefix)+caName) {
+			continue
+		}
+		if err := sqlx.GetContext(ctx, tx, &profile.Mobileconfig, `
+			SELECT mobileconfig
+			FROM mdm_apple_configuration_profiles
+			WHERE profile_uuid = ?
+			FOR UPDATE SKIP LOCKED
+		`, profile.ProfileUUID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return ctxerr.Wrap(ctx, err, "locking Apple profile for DigiCert profile variable associations")
+		}
+		fleetVarsInProfile = variables.Find(string(profile.Mobileconfig))
+		if !slices.Contains(fleetVarsInProfile, string(fleet.FleetVarDigiCertDataPrefix)+caName) &&
+			!slices.Contains(fleetVarsInProfile, string(fleet.FleetVarDigiCertPasswordPrefix)+caName) {
+			continue
+		}
+		resolved := fleet.ResolveDigiCertProfileFleetVariables(fleetVarsInProfile, digiCertCAs)
+		fleetVars := make([]fleet.FleetVarName, len(resolved))
+		for i, fleetVar := range resolved {
+			fleetVars[i] = fleet.FleetVarName(fleetVar)
+		}
+		profileVariables = append(profileVariables, fleet.MDMProfileUUIDFleetVariables{
+			ProfileUUID:    profile.ProfileUUID,
+			FleetVariables: fleetVars,
+		})
+	}
+
+	if len(profileVariables) == 0 {
+		return nil
+	}
+	if _, err := setVariableAssociationsForColumnDB(ctx, tx, profileVariables, "apple_profile_uuid"); err != nil {
+		return ctxerr.Wrap(ctx, err, "refreshing DigiCert profile variable associations")
+	}
 	return nil
 }
 

--- a/server/datastore/mysql/certificate_authorities_test.go
+++ b/server/datastore/mysql/certificate_authorities_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +26,7 @@ func TestCertificateAuthority(t *testing.T) {
 		{"CreateCertificateAuthority", testCreateCertificateAuthority},
 		{"Delete", testDeleteCertificateAuthority},
 		{"UpdateCertificateAuthorityByID", testUpdateCertificateAuthorityByID},
+		{"UpdateDigiCertProfileVariableAssociations", testUpdateDigiCertProfileVariableAssociations},
 	}
 
 	for _, c := range cases {
@@ -616,6 +619,277 @@ func testUpdateCertificateAuthorityByID(t *testing.T, ds *Datastore) {
 		require.Equal(t, "updated-username", *updatedCA.Username)
 		require.Equal(t, "updated-password", *updatedCA.Password)
 	})
+}
+
+func testUpdateDigiCertProfileVariableAssociations(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	caName := "digicert_ca"
+	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
+		Type:                          string(fleet.CATypeDigiCert),
+		Name:                          &caName,
+		URL:                           new("https://example.com"),
+		APIToken:                      new("token"),
+		ProfileID:                     new("profile"),
+		CertificateCommonName:         new(fleet.FleetVarHostEndUserIDPUsername.WithPrefix()),
+		CertificateUserPrincipalNames: &[]string{},
+		CertificateSeatID:             new("seat"),
+	})
+	require.NoError(t, err)
+
+	profileInput := generateAppleCP("digicert", "digicert", 0)
+	profileInput.Mobileconfig = []byte(
+		fleet.FleetVarDigiCertDataPrefix.WithPrefix() + caName + " " + fleet.FleetVarHostEndUserIDPFullname.WithPrefix(),
+	)
+	profile, err := ds.NewMDMAppleConfigProfile(ctx, *profileInput, []fleet.FleetVarName{
+		fleet.FleetVarName(string(fleet.FleetVarDigiCertDataPrefix) + caName),
+		fleet.FleetVarHostEndUserIDPUsername,
+		fleet.FleetVarHostEndUserIDPFullname,
+	})
+	require.NoError(t, err)
+
+	otherCAName := "other_digicert_ca"
+	_, err = ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
+		Type:                          string(fleet.CATypeDigiCert),
+		Name:                          &otherCAName,
+		URL:                           new("https://example.com"),
+		APIToken:                      new("other-token"),
+		ProfileID:                     new("other-profile"),
+		CertificateCommonName:         new(fleet.FleetVarHostEndUserIDPUsernameLocalPart.WithPrefix()),
+		CertificateUserPrincipalNames: &[]string{},
+		CertificateSeatID:             new("other-seat"),
+	})
+	require.NoError(t, err)
+	otherProfileInput := generateAppleCP("other-digicert", "other-digicert", 0)
+	otherProfileInput.Mobileconfig = []byte(fleet.FleetVarDigiCertPasswordPrefix.WithPrefix() + otherCAName)
+	otherProfile, err := ds.NewMDMAppleConfigProfile(ctx, *otherProfileInput, []fleet.FleetVarName{
+		fleet.FleetVarName(string(fleet.FleetVarDigiCertPasswordPrefix) + otherCAName),
+		fleet.FleetVarHostEndUserIDPUsernameLocalPart,
+	})
+	require.NoError(t, err)
+	combinedProfileInput := generateAppleCP("combined-digicert", "combined-digicert", 0)
+	combinedProfileInput.Mobileconfig = []byte(
+		fleet.FleetVarDigiCertDataPrefix.WithPrefix() + caName + " " + fleet.FleetVarDigiCertPasswordPrefix.WithPrefix() + otherCAName,
+	)
+	combinedProfile, err := ds.NewMDMAppleConfigProfile(ctx, *combinedProfileInput, []fleet.FleetVarName{
+		fleet.FleetVarName(string(fleet.FleetVarDigiCertDataPrefix) + caName),
+		fleet.FleetVarName(string(fleet.FleetVarDigiCertPasswordPrefix) + otherCAName),
+		fleet.FleetVarHostEndUserIDPUsername,
+		fleet.FleetVarHostEndUserIDPUsernameLocalPart,
+	})
+	require.NoError(t, err)
+
+	getVariables := func(profileUUID string) map[string]uint {
+		var rows []struct {
+			ID   uint   `db:"id"`
+			Name string `db:"name"`
+		}
+		err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, `
+			SELECT mcpv.id, fv.name
+			FROM mdm_configuration_profile_variables mcpv
+			JOIN fleet_variables fv ON fv.id = mcpv.fleet_variable_id
+			WHERE mcpv.apple_profile_uuid = ?
+			ORDER BY fv.name
+		`, profileUUID)
+		require.NoError(t, err)
+		actual := make(map[string]uint, len(rows))
+		for _, row := range rows {
+			actual[row.Name] = row.ID
+		}
+		return actual
+	}
+	checkVariables := func(profileUUID string, expected []string) {
+		actual := getVariables(profileUUID)
+		for _, name := range expected {
+			require.Contains(t, actual, name)
+		}
+		require.Len(t, actual, len(expected))
+	}
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsername),
+	})
+	checkVariables(otherProfile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_PASSWORD_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsernameLocalPart),
+	})
+	checkVariables(combinedProfile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_DIGICERT_PASSWORD_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsername),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsernameLocalPart),
+	})
+	otherProfileVariables := getVariables(otherProfile.ProfileUUID)
+	profileVariablesBeforeRename := getVariables(profile.ProfileUUID)
+
+	renamedCA := "renamed_digicert_ca"
+	require.NoError(t, ds.UpdateCertificateAuthorityByID(ctx, ca.ID, &fleet.CertificateAuthority{
+		Type: string(fleet.CATypeDigiCert),
+		Name: &renamedCA,
+	}))
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsername),
+	})
+	require.Equal(t, profileVariablesBeforeRename, getVariables(profile.ProfileUUID))
+	require.Equal(t, otherProfileVariables, getVariables(otherProfile.ProfileUUID))
+	require.NoError(t, ds.UpdateCertificateAuthorityByID(ctx, ca.ID, &fleet.CertificateAuthority{
+		Type: string(fleet.CATypeDigiCert),
+		Name: &caName,
+	}))
+	require.Equal(t, profileVariablesBeforeRename, getVariables(profile.ProfileUUID))
+
+	department := fleet.FleetVarHostEndUserIDPDepartment.WithPrefix()
+	require.NoError(t, ds.UpdateCertificateAuthorityByID(ctx, ca.ID, &fleet.CertificateAuthority{
+		Type:                  string(fleet.CATypeDigiCert),
+		CertificateCommonName: &department,
+	}))
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPDepartment),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+	})
+	checkVariables(combinedProfile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_DIGICERT_PASSWORD_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPDepartment),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsernameLocalPart),
+	})
+	require.Equal(t, otherProfileVariables, getVariables(otherProfile.ProfileUUID))
+
+	groups := fleet.FleetVarHostEndUserIDPGroups.WithPrefix()
+	require.NoError(t, ds.BatchApplyCertificateAuthorities(ctx, fleet.CertificateAuthoritiesBatchOperations{
+		Update: []*fleet.CertificateAuthority{{
+			Type:                          string(fleet.CATypeDigiCert),
+			Name:                          &caName,
+			URL:                           new("https://example.com"),
+			APIToken:                      new("token"),
+			ProfileID:                     new("profile"),
+			CertificateCommonName:         &groups,
+			CertificateUserPrincipalNames: &[]string{},
+			CertificateSeatID:             new("seat"),
+		}},
+	}))
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPGroups),
+	})
+	checkVariables(combinedProfile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_DIGICERT_PASSWORD_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPGroups),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPUsernameLocalPart),
+	})
+	require.Equal(t, otherProfileVariables, getVariables(otherProfile.ProfileUUID))
+
+	profileVariables := getVariables(profile.ProfileUUID)
+	require.NoError(t, ds.UpdateCertificateAuthorityByID(ctx, ca.ID, &fleet.CertificateAuthority{
+		Type:      string(fleet.CATypeDigiCert),
+		ProfileID: new("updated-profile"),
+	}))
+	require.Equal(t, profileVariables, getVariables(profile.ProfileUUID))
+	require.NoError(t, ds.UpdateCertificateAuthorityByID(ctx, ca.ID, &fleet.CertificateAuthority{
+		Type:                  string(fleet.CATypeDigiCert),
+		CertificateCommonName: &groups,
+	}))
+	require.Equal(t, profileVariables, getVariables(profile.ProfileUUID))
+	require.NoError(t, ds.BatchApplyCertificateAuthorities(ctx, fleet.CertificateAuthoritiesBatchOperations{
+		Update: []*fleet.CertificateAuthority{{
+			Type:                          string(fleet.CATypeDigiCert),
+			Name:                          &caName,
+			URL:                           new("https://updated.example.com"),
+			APIToken:                      new("updated-token"),
+			ProfileID:                     new("updated-profile"),
+			CertificateCommonName:         &groups,
+			CertificateUserPrincipalNames: &[]string{},
+			CertificateSeatID:             new("seat"),
+		}},
+	}))
+	require.Equal(t, profileVariables, getVariables(profile.ProfileUUID))
+
+	profileVariablesBeforeDelete := getVariables(profile.ProfileUUID)
+	_, err = ds.DeleteCertificateAuthority(ctx, ca.ID)
+	require.NoError(t, err)
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPGroups),
+	})
+	require.Equal(t, profileVariablesBeforeDelete, getVariables(profile.ProfileUUID))
+	require.Equal(t, otherProfileVariables, getVariables(otherProfile.ProfileUUID))
+
+	recreatedCA, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
+		Type:                          string(fleet.CATypeDigiCert),
+		Name:                          &caName,
+		URL:                           new("https://example.com"),
+		APIToken:                      new("token"),
+		ProfileID:                     new("profile"),
+		CertificateCommonName:         new(fleet.FleetVarHostEndUserIDPUsernameLocalPart.WithPrefix()),
+		CertificateUserPrincipalNames: &[]string{},
+		CertificateSeatID:             new("seat"),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, recreatedCA.ID)
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPGroups),
+	})
+	require.Equal(t, profileVariablesBeforeDelete, getVariables(profile.ProfileUUID))
+	require.Equal(t, otherProfileVariables, getVariables(otherProfile.ProfileUUID))
+
+	caTx, err := ds.writer(ctx).BeginTxx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = caTx.Rollback() })
+	require.NoError(t, lockDigiCertProfileVariableAssociations(ctx, caTx))
+	_, err = getDigiCertCAByIDForProfileVariables(ctx, caTx, recreatedCA.ID)
+	require.NoError(t, err)
+	_, err = caTx.ExecContext(ctx, `
+		UPDATE certificate_authorities
+		SET certificate_common_name = ?
+		WHERE id = ?
+	`, department, recreatedCA.ID)
+	require.NoError(t, err)
+
+	profileTx, err := ds.writer(ctx).BeginTxx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = profileTx.Rollback() })
+	_, err = profileTx.ExecContext(ctx, `
+		UPDATE mdm_apple_configuration_profiles
+		SET mobileconfig = mobileconfig
+		WHERE profile_uuid = ?
+	`, profile.ProfileUUID)
+	require.NoError(t, err)
+
+	profileAssociationResult := make(chan error, 1)
+	go func() {
+		_, err := batchSetProfileVariableAssociationsDB(ctx, profileTx, []fleet.MDMProfileUUIDFleetVariables{{
+			ProfileUUID: profile.ProfileUUID,
+			FleetVariables: []fleet.FleetVarName{
+				fleet.FleetVarName(string(fleet.FleetVarDigiCertDataPrefix) + caName),
+				fleet.FleetVarHostEndUserIDPGroups,
+				fleet.FleetVarHostEndUserIDPFullname,
+			},
+		}}, "darwin", false)
+		profileAssociationResult <- err
+	}()
+	require.NoError(t, ds.refreshDigiCertProfileVariableAssociations(ctx, caTx, caName))
+	require.NoError(t, caTx.Commit())
+	select {
+	case err := <-profileAssociationResult:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for profile variable associations")
+	}
+	require.NoError(t, profileTx.Commit())
+	checkVariables(profile.ProfileUUID, []string{
+		"FLEET_VAR_DIGICERT_DATA_",
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPDepartment),
+		"FLEET_VAR_" + string(fleet.FleetVarHostEndUserIDPFullname),
+	})
+	require.Equal(t, otherProfileVariables, getVariables(otherProfile.ProfileUUID))
 }
 
 // // TODO(hca): refactor old app config test to cover new implementations

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2406,6 +2406,12 @@ func batchSetProfileVariableAssociationsDB(
 	if len(profileVariablesByUUID) == 0 {
 		return false, nil
 	}
+	if platform == "darwin" && !forAppleDeclarations {
+		profileVariablesByUUID, err = resolveDigiCertProfileVariableAssociationsDB(ctx, tx, profileVariablesByUUID)
+		if err != nil {
+			return false, err
+		}
+	}
 
 	var columnName string
 	switch {

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -164,6 +164,7 @@ var (
 		FleetVarHostEndUserIDPDepartment,
 		FleetVarHostEndUserIDPFullname,
 	}
+	FleetVarsSupportedInDigiCert = slices.Concat([]FleetVarName{FleetVarHostEndUserEmailIDP}, FleetVarsSupportedInScripts)
 )
 
 type AppleMDM struct {

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	mdm_types "github.com/fleetdm/fleet/v4/server/mdm"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/google/uuid"
 )
 
@@ -166,6 +167,30 @@ var (
 	}
 	FleetVarsSupportedInDigiCert = slices.Concat([]FleetVarName{FleetVarHostEndUserEmailIDP}, FleetVarsSupportedInScripts)
 )
+
+func ResolveDigiCertProfileFleetVariables(fleetVars []string, digiCertCAs []DigiCertCA) []string {
+	resolvedFleetVars := slices.Clone(fleetVars)
+	for _, fleetVar := range fleetVars {
+		if !strings.HasPrefix(fleetVar, string(FleetVarDigiCertDataPrefix)) && !strings.HasPrefix(fleetVar, string(FleetVarDigiCertPasswordPrefix)) {
+			continue
+		}
+		caName := strings.TrimPrefix(strings.TrimPrefix(fleetVar, string(FleetVarDigiCertDataPrefix)), string(FleetVarDigiCertPasswordPrefix))
+		for _, ca := range digiCertCAs {
+			if ca.Name != caName {
+				continue
+			}
+			caContents := strings.Join(append([]string{ca.CertificateCommonName, ca.CertificateSeatID}, ca.CertificateUserPrincipalNames...), "\n")
+			for _, caFleetVar := range variables.Find(caContents) {
+				if slices.Contains(IDPFleetVariables, FleetVarName(caFleetVar)) {
+					resolvedFleetVars = append(resolvedFleetVars, caFleetVar)
+				}
+			}
+			break
+		}
+	}
+
+	return variables.Dedupe(resolvedFleetVars)
+}
 
 type AppleMDM struct {
 	CommonName   string    `json:"common_name"`

--- a/server/fleet/mdm_test.go
+++ b/server/fleet/mdm_test.go
@@ -22,6 +22,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResolveDigiCertProfileFleetVariables(t *testing.T) {
+	profileVars := make([]string, 0, 6)
+	profileVars = append(profileVars,
+		string(fleet.FleetVarHostEndUserIDPUsername),
+		string(fleet.FleetVarDigiCertDataPrefix)+"first",
+		string(fleet.FleetVarDigiCertPasswordPrefix)+"second",
+	)
+	digiCertCAs := []fleet.DigiCertCA{
+		{
+			Name:                          "first",
+			CertificateCommonName:         fleet.FleetVarHostEndUserIDPUsername.WithPrefix(),
+			CertificateUserPrincipalNames: []string{fleet.FleetVarHostEndUserIDPDepartment.WithBraces()},
+			CertificateSeatID:             "literal-seat",
+		},
+		{
+			Name:                          "second",
+			CertificateCommonName:         "literal-common-name",
+			CertificateUserPrincipalNames: []string{"literal-upn"},
+			CertificateSeatID:             fleet.FleetVarHostEndUserIDPFullname.WithPrefix(),
+		},
+		{
+			Name:                  "unreferenced",
+			CertificateCommonName: fleet.FleetVarHostEndUserIDPGroups.WithPrefix(),
+		},
+	}
+
+	require.Equal(t, []string{
+		"HOST_END_USER_IDP_USERNAME",
+		"DIGICERT_DATA_first",
+		"DIGICERT_PASSWORD_second",
+		"HOST_END_USER_IDP_DEPARTMENT",
+		"HOST_END_USER_IDP_FULL_NAME",
+	}, fleet.ResolveDigiCertProfileFleetVariables(profileVars, digiCertCAs))
+	require.Equal(t, []string{
+		"HOST_END_USER_IDP_USERNAME",
+		"DIGICERT_DATA_first",
+		"DIGICERT_PASSWORD_second",
+		"", "", "",
+	}, profileVars[:cap(profileVars)])
+}
+
 func TestDEPClient(t *testing.T) {
 	rxToken := regexp.MustCompile(`oauth_token="(\w+)"`)
 	const (

--- a/server/mdm/apple/profile_processor.go
+++ b/server/mdm/apple/profile_processor.go
@@ -600,7 +600,7 @@ func preprocessProfileContents(
 					}
 					ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateSeatID, hostIDForUUIDCache, variablesUpdatedAt, onMismatchedHostCount)
 					if err != nil {
-						return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA common name")
+						return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA seat ID")
 					}
 					if !ok {
 						failed = true
@@ -610,7 +610,7 @@ func preprocessProfileContents(
 						for i := range caCopy.CertificateUserPrincipalNames {
 							ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateUserPrincipalNames[i], hostIDForUUIDCache, variablesUpdatedAt, onMismatchedHostCount)
 							if err != nil {
-								return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA common name")
+								return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA user principal name")
 							}
 							if !ok {
 								failed = true
@@ -761,6 +761,9 @@ func getFirstIDPEmail(ctx context.Context, ds fleet.Datastore, target *fleet.Cmd
 func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *fleet.CmdTarget, hostLite fleet.Host, caVarsCache map[string]string, item *string, hostIDForUUIDCache map[string]uint, variablesUpdatedAt *time.Time, onMismatchedHostCount func(int) error) (bool, error) {
 	caFleetVars := variables.Find(*item)
 	for _, caVar := range caFleetVars {
+		if !slices.Contains(fleet.FleetVarsSupportedInDigiCert, fleet.FleetVarName(caVar)) {
+			return false, ctxerr.Errorf(ctx, "unsupported DigiCert Fleet variable FLEET_VAR_%s", caVar)
+		}
 		switch {
 		case caVar == string(fleet.FleetVarHostEndUserEmailIDP):
 			email, ok := caVarsCache[string(fleet.FleetVarHostEndUserEmailIDP)]
@@ -810,6 +813,9 @@ func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *flee
 				caVarsCache[string(fleet.FleetVarHostPlatform)] = platform
 			}
 			*item = profiles.ReplaceFleetVariableInXML(fleet.FleetVarHostPlatformRegexp, *item, platform)
+		case caVar == string(fleet.FleetVarHostUUID):
+			*item = strings.ReplaceAll(*item, fleet.FleetVarHostUUID.WithPrefix(), hostLite.UUID)
+			*item = strings.ReplaceAll(*item, fleet.FleetVarHostUUID.WithBraces(), hostLite.UUID)
 		case slices.Contains(fleet.IDPFleetVariables, fleet.FleetVarName(caVar)):
 			value, ok := caVarsCache[caVar]
 			if !ok {
@@ -835,8 +841,6 @@ func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *flee
 			fleetVar := fleet.FleetVarName(caVar)
 			*item = strings.ReplaceAll(*item, fleetVar.WithPrefix(), value)
 			*item = strings.ReplaceAll(*item, fleetVar.WithBraces(), value)
-		default:
-			return false, ctxerr.Errorf(ctx, "unsupported DigiCert Fleet variable FLEET_VAR_%s", caVar)
 		}
 	}
 	return true, nil

--- a/server/mdm/apple/profile_processor.go
+++ b/server/mdm/apple/profile_processor.go
@@ -590,7 +590,7 @@ func preprocessProfileContents(
 					// Populate Fleet vars in the CA fields
 					caVarsCache := make(map[string]string)
 
-					ok, err := replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateCommonName, onMismatchedHostCount)
+					ok, err := replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateCommonName, hostIDForUUIDCache, variablesUpdatedAt, onMismatchedHostCount)
 					if err != nil {
 						return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA common name")
 					}
@@ -598,7 +598,7 @@ func preprocessProfileContents(
 						failed = true
 						break fleetVarLoop
 					}
-					ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateSeatID, onMismatchedHostCount)
+					ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateSeatID, hostIDForUUIDCache, variablesUpdatedAt, onMismatchedHostCount)
 					if err != nil {
 						return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA common name")
 					}
@@ -608,7 +608,7 @@ func preprocessProfileContents(
 					}
 					if len(caCopy.CertificateUserPrincipalNames) > 0 {
 						for i := range caCopy.CertificateUserPrincipalNames {
-							ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateUserPrincipalNames[i], onMismatchedHostCount)
+							ok, err = replaceFleetVarInItem(ctx, ds, target, hostLite, caVarsCache, &caCopy.CertificateUserPrincipalNames[i], hostIDForUUIDCache, variablesUpdatedAt, onMismatchedHostCount)
 							if err != nil {
 								return ctxerr.Wrap(ctx, err, "populating Fleet variables in DigiCert CA common name")
 							}
@@ -758,11 +758,11 @@ func getFirstIDPEmail(ctx context.Context, ds fleet.Datastore, target *fleet.Cmd
 	return emails[0], true, nil
 }
 
-func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *fleet.CmdTarget, hostLite fleet.Host, caVarsCache map[string]string, item *string, onMismatchedHostCount func(int) error) (bool, error) {
+func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *fleet.CmdTarget, hostLite fleet.Host, caVarsCache map[string]string, item *string, hostIDForUUIDCache map[string]uint, variablesUpdatedAt *time.Time, onMismatchedHostCount func(int) error) (bool, error) {
 	caFleetVars := variables.Find(*item)
 	for _, caVar := range caFleetVars {
-		switch caVar {
-		case string(fleet.FleetVarHostEndUserEmailIDP):
+		switch {
+		case caVar == string(fleet.FleetVarHostEndUserEmailIDP):
 			email, ok := caVarsCache[string(fleet.FleetVarHostEndUserEmailIDP)]
 			if !ok {
 				var err error
@@ -776,7 +776,7 @@ func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *flee
 				caVarsCache[string(fleet.FleetVarHostEndUserEmailIDP)] = email
 			}
 			*item = profiles.ReplaceFleetVariableInXML(fleetVarHostEndUserEmailIDPRegexp, *item, email)
-		case string(fleet.FleetVarHostHardwareSerial):
+		case caVar == string(fleet.FleetVarHostHardwareSerial):
 			hardwareSerial, ok := caVarsCache[string(fleet.FleetVarHostHardwareSerial)]
 			if !ok {
 				var err error
@@ -791,7 +791,7 @@ func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *flee
 				caVarsCache[string(fleet.FleetVarHostHardwareSerial)] = hostLite.HardwareSerial
 			}
 			*item = profiles.ReplaceFleetVariableInXML(fleet.FleetVarHostHardwareSerialRegexp, *item, hardwareSerial)
-		case string(fleet.FleetVarHostPlatform):
+		case caVar == string(fleet.FleetVarHostPlatform):
 			platform, ok := caVarsCache[string(fleet.FleetVarHostPlatform)]
 			if !ok {
 				var err error
@@ -810,8 +810,33 @@ func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *flee
 				caVarsCache[string(fleet.FleetVarHostPlatform)] = platform
 			}
 			*item = profiles.ReplaceFleetVariableInXML(fleet.FleetVarHostPlatformRegexp, *item, platform)
+		case slices.Contains(fleet.IDPFleetVariables, fleet.FleetVarName(caVar)):
+			value, ok := caVarsCache[caVar]
+			if !ok {
+				var err error
+				value, _, ok, err = profiles.ResolveHostEndUserIDPValue(ctx, ds, caVar, hostLite.UUID, hostIDForUUIDCache, func(errMsg string) error {
+					return ds.UpdateOrDeleteHostMDMAppleProfile(ctx, &fleet.HostMDMAppleProfile{
+						CommandUUID:        target.CmdUUID,
+						HostUUID:           hostLite.UUID,
+						Status:             &fleet.MDMDeliveryFailed,
+						Detail:             errMsg,
+						OperationType:      fleet.MDMOperationTypeInstall,
+						VariablesUpdatedAt: variablesUpdatedAt,
+					})
+				})
+				if err != nil {
+					return false, ctxerr.Wrap(ctx, err, "resolving host end user IDP variable")
+				}
+				if !ok {
+					return false, nil
+				}
+				caVarsCache[caVar] = value
+			}
+			fleetVar := fleet.FleetVarName(caVar)
+			*item = strings.ReplaceAll(*item, fleetVar.WithPrefix(), value)
+			*item = strings.ReplaceAll(*item, fleetVar.WithBraces(), value)
 		default:
-			// We should not reach this since we validated the variables when saving app config
+			return false, ctxerr.Errorf(ctx, "unsupported DigiCert Fleet variable FLEET_VAR_%s", caVar)
 		}
 	}
 	return true, nil

--- a/server/mdm/apple/profile_processor_test.go
+++ b/server/mdm/apple/profile_processor_test.go
@@ -669,10 +669,16 @@ func TestPreprocessProfileContentsDigiCertCertificateEnrollmentWithFleetVariable
 	t.Logf("issued DigiCert config: CN=%q UPN=%q seat ID=%q", issuedConfig.CertificateCommonName, issuedConfig.CertificateUserPrincipalNames, issuedConfig.CertificateSeatID)
 }
 
-func TestReplaceFleetVarInItemIDPVariables(t *testing.T) {
+func TestReplaceFleetVarInItem(t *testing.T) {
 	ds := new(mock.Store)
+	ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+		return []*fleet.Host{{ID: 1, UUID: "host", HardwareSerial: "serial", Platform: "darwin"}}, nil
+	}
 	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, idents []string) ([]uint, error) {
 		return []uint{1}, nil
+	}
+	ds.GetHostEmailsFunc = func(ctx context.Context, hostUUID string, source string) ([]string, error) {
+		return []string{"legacy@example.com"}, nil
 	}
 	ds.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
 		return &fleet.ScimUser{
@@ -684,19 +690,24 @@ func TestReplaceFleetVarInItemIDPVariables(t *testing.T) {
 		}, nil
 	}
 	ds.ListHostDeviceMappingFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostDeviceMapping, error) {
-		return nil, nil
+		return []*fleet.HostDeviceMapping{{Email: "legacy@example.com"}}, nil
 	}
 
 	tests := []struct {
 		fleetVar fleet.FleetVarName
 		expected string
 	}{
+		{fleet.FleetVarHostEndUserEmailIDP, "legacy@example.com"},
+		{fleet.FleetVarHostHardwareSerial, "serial"},
+		{fleet.FleetVarHostUUID, "host"},
+		{fleet.FleetVarHostPlatform, "macos"},
 		{fleet.FleetVarHostEndUserIDPUsername, "user@example.com"},
 		{fleet.FleetVarHostEndUserIDPUsernameLocalPart, "user"},
 		{fleet.FleetVarHostEndUserIDPGroups, "Engineering,IT"},
 		{fleet.FleetVarHostEndUserIDPDepartment, "Engineering & IT"},
 		{fleet.FleetVarHostEndUserIDPFullname, "R&D User"},
 	}
+	require.Len(t, tests, len(fleet.FleetVarsSupportedInDigiCert))
 	for _, tt := range tests {
 		t.Run(string(tt.fleetVar), func(t *testing.T) {
 			item := "prefix-" + tt.fleetVar.WithBraces() + "-suffix"

--- a/server/mdm/apple/profile_processor_test.go
+++ b/server/mdm/apple/profile_processor_test.go
@@ -546,6 +546,168 @@ func TestPreprocessProfileContentsDigiCertUPNIsUniqueForMultipleHosts(t *testing
 	assert.Equal(t, host2Serial+"@example.com", upnByHostUUID[host2UUID], "host 2 UPN should contain its own serial")
 }
 
+func TestPreprocessProfileContentsDigiCertCertificateEnrollmentWithFleetVariables(t *testing.T) {
+	ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+	logger := slog.New(slog.DiscardHandler)
+	appCfg := &fleet.AppConfig{}
+	appCfg.ServerSettings.ServerURL = "https://test.example.com"
+	appCfg.MDM.EnabledAndConfigured = true
+	ds := new(mock.Store)
+	svc := scep.NewSCEPConfigService(logger, nil)
+
+	const caName = "myCA"
+	const hostUUID = "host-uuid"
+	const hardwareSerial = "SERIAL-123"
+	const username = "test.user@example.com"
+	const usernameLocalPart = "test.user"
+
+	var issuedConfig fleet.DigiCertCA
+	mockDigiCert := &digicert_mock.Service{}
+	mockDigiCert.GetCertificateFunc = func(ctx context.Context, config fleet.DigiCertCA) (*fleet.DigiCertCertificate, error) {
+		issuedConfig = config
+		now := time.Now()
+		return &fleet.DigiCertCertificate{
+			PfxData:        []byte("fake-pfx"),
+			Password:       "fake-password",
+			NotValidBefore: now,
+			NotValidAfter:  now.Add(365 * 24 * time.Hour),
+			SerialNumber:   "certificate-serial",
+		}, nil
+	}
+
+	targets := map[string]*fleet.CmdTarget{
+		"p1": {
+			CmdUUID:           "cmd-uuid",
+			ProfileIdentifier: "com.apple.security.pkcs12",
+			EnrollmentIDs:     []string{hostUUID},
+		},
+	}
+	pending := fleet.MDMDeliveryPending
+	hostProfilesToInstallMap := map[fleet.HostProfileUUID]*fleet.MDMAppleBulkUpsertHostProfilePayload{
+		{HostUUID: hostUUID, ProfileUUID: "p1"}: {
+			ProfileUUID:       "p1",
+			ProfileIdentifier: "com.apple.security.pkcs12",
+			HostUUID:          hostUUID,
+			OperationType:     fleet.MDMOperationTypeInstall,
+			Status:            &pending,
+			CommandUUID:       "cmd-uuid",
+			Scope:             fleet.PayloadScopeSystem,
+		},
+	}
+	profileContents := map[string]mobileconfig.Mobileconfig{
+		"p1": []byte("<string>$FLEET_VAR_" + string(fleet.FleetVarDigiCertPasswordPrefix) + caName + "</string><data>$FLEET_VAR_" + string(fleet.FleetVarDigiCertDataPrefix) + caName + "</data>"),
+	}
+	groupedCAs := &fleet.GroupedCertificateAuthorities{
+		DigiCert: []fleet.DigiCertCA{
+			{
+				Name:                          caName,
+				URL:                           "https://digicert.example.com",
+				APIToken:                      "api-token",
+				ProfileID:                     "profile-id",
+				CertificateCommonName:         fleet.FleetVarHostHardwareSerial.WithPrefix(),
+				CertificateUserPrincipalNames: []string{fleet.FleetVarHostEndUserIDPUsername.WithPrefix()},
+				CertificateSeatID:             fleet.FleetVarHostEndUserIDPUsernameLocalPart.WithPrefix(),
+			},
+		},
+	}
+	ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+		assert.Equal(t, []string{hostUUID}, uuids)
+		return []*fleet.Host{{ID: 1, UUID: hostUUID, HardwareSerial: hardwareSerial}}, nil
+	}
+	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, identifiers []string) ([]uint, error) {
+		assert.Equal(t, []string{hostUUID}, identifiers)
+		return []uint{1}, nil
+	}
+	ds.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		assert.EqualValues(t, 1, hostID)
+		return &fleet.ScimUser{UserName: username}, nil
+	}
+	ds.ListHostDeviceMappingFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+	var hostProfileUpdates []*fleet.MDMAppleBulkUpsertHostProfilePayload
+	ds.BulkUpsertMDMAppleHostProfilesFunc = func(ctx context.Context, payload []*fleet.MDMAppleBulkUpsertHostProfilePayload) error {
+		hostProfileUpdates = payload
+		return nil
+	}
+	var managedCertificates []*fleet.MDMManagedCertificate
+	ds.BulkUpsertMDMManagedCertificatesFunc = func(ctx context.Context, payload []*fleet.MDMManagedCertificate) error {
+		managedCertificates = payload
+		return nil
+	}
+
+	err := preprocessProfileContents(ctx, appCfg, ds, svc, mockDigiCert, logger, targets, profileContents, hostProfilesToInstallMap, make(map[string]string), groupedCAs)
+	require.NoError(t, err)
+	require.True(t, mockDigiCert.GetCertificateFuncInvoked)
+	assert.Equal(t, hardwareSerial, issuedConfig.CertificateCommonName)
+	assert.Equal(t, []string{username}, issuedConfig.CertificateUserPrincipalNames)
+	assert.Equal(t, usernameLocalPart, issuedConfig.CertificateSeatID)
+	require.Len(t, hostProfileUpdates, 1)
+	assert.Equal(t, "p1", hostProfileUpdates[0].ProfileUUID)
+	assert.Equal(t, hostUUID, hostProfileUpdates[0].HostUUID)
+	assert.Equal(t, fleet.MDMOperationTypeInstall, hostProfileUpdates[0].OperationType)
+	require.NotNil(t, hostProfileUpdates[0].Status)
+	assert.Equal(t, fleet.MDMDeliveryPending, *hostProfileUpdates[0].Status)
+	assert.NotEqual(t, "cmd-uuid", hostProfileUpdates[0].CommandUUID)
+	require.Len(t, managedCertificates, 1)
+	assert.Equal(t, hostUUID, managedCertificates[0].HostUUID)
+	assert.Equal(t, "p1", managedCertificates[0].ProfileUUID)
+	assert.Equal(t, fleet.CAConfigDigiCert, managedCertificates[0].Type)
+	assert.Equal(t, caName, managedCertificates[0].CAName)
+	require.NotNil(t, managedCertificates[0].Serial)
+	assert.Equal(t, "certificate-serial", *managedCertificates[0].Serial)
+	require.NotNil(t, managedCertificates[0].NotValidBefore)
+	require.NotNil(t, managedCertificates[0].NotValidAfter)
+	require.Len(t, targets, 1)
+	for profileUUID, target := range targets {
+		assert.Equal(t, profileUUID, target.CmdUUID)
+		assert.Equal(t, hostProfileUpdates[0].CommandUUID, target.CmdUUID)
+		contents, ok := profileContents[profileUUID]
+		require.True(t, ok)
+		assert.Equal(t, "<string>fake-password</string><data>ZmFrZS1wZng=</data>", string(contents))
+	}
+	t.Logf("issued DigiCert config: CN=%q UPN=%q seat ID=%q", issuedConfig.CertificateCommonName, issuedConfig.CertificateUserPrincipalNames, issuedConfig.CertificateSeatID)
+}
+
+func TestReplaceFleetVarInItemIDPVariables(t *testing.T) {
+	ds := new(mock.Store)
+	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, idents []string) ([]uint, error) {
+		return []uint{1}, nil
+	}
+	ds.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
+		return &fleet.ScimUser{
+			UserName:   "user@example.com",
+			GivenName:  new("R&D"),
+			FamilyName: new("User"),
+			Department: new("Engineering & IT"),
+			Groups:     []fleet.ScimUserGroup{{DisplayName: "Engineering"}, {DisplayName: "IT"}},
+		}, nil
+	}
+	ds.ListHostDeviceMappingFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+
+	tests := []struct {
+		fleetVar fleet.FleetVarName
+		expected string
+	}{
+		{fleet.FleetVarHostEndUserIDPUsername, "user@example.com"},
+		{fleet.FleetVarHostEndUserIDPUsernameLocalPart, "user"},
+		{fleet.FleetVarHostEndUserIDPGroups, "Engineering,IT"},
+		{fleet.FleetVarHostEndUserIDPDepartment, "Engineering & IT"},
+		{fleet.FleetVarHostEndUserIDPFullname, "R&D User"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.fleetVar), func(t *testing.T) {
+			item := "prefix-" + tt.fleetVar.WithBraces() + "-suffix"
+			ok, err := replaceFleetVarInItem(t.Context(), ds, &fleet.CmdTarget{CmdUUID: "command"}, fleet.Host{UUID: "host"}, make(map[string]string), &item, make(map[string]uint), nil, func(int) error { return nil })
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, "prefix-"+tt.expected+"-suffix", item)
+		})
+	}
+}
+
 func TestPreprocessProfileContentsEndUserIDP(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -574,26 +574,7 @@ func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo
 		return nil, err
 	}
 
-	for _, fleetVar := range fleetVars {
-		if !strings.HasPrefix(fleetVar, string(fleet.FleetVarDigiCertDataPrefix)) && !strings.HasPrefix(fleetVar, string(fleet.FleetVarDigiCertPasswordPrefix)) {
-			continue
-		}
-		caName := strings.TrimPrefix(strings.TrimPrefix(fleetVar, string(fleet.FleetVarDigiCertDataPrefix)), string(fleet.FleetVarDigiCertPasswordPrefix))
-		for _, ca := range groupedCAs.DigiCert {
-			if ca.Name != caName {
-				continue
-			}
-			caContents := ca.CertificateCommonName + ca.CertificateSeatID + strings.Join(ca.CertificateUserPrincipalNames, "")
-			for _, caFleetVar := range variables.Find(caContents) {
-				if slices.Contains(fleet.IDPFleetVariables, fleet.FleetVarName(caFleetVar)) {
-					fleetVars = append(fleetVars, caFleetVar)
-				}
-			}
-			break
-		}
-	}
-
-	return variables.Dedupe(fleetVars), nil
+	return fleet.ResolveDigiCertProfileFleetVariables(fleetVars, groupedCAs.DigiCert), nil
 }
 
 // extensibleSSOProfileContent is the subset of an Apple configuration profile

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -574,7 +574,26 @@ func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo
 		return nil, err
 	}
 
-	return fleetVars, nil
+	for _, fleetVar := range fleetVars {
+		if !strings.HasPrefix(fleetVar, string(fleet.FleetVarDigiCertDataPrefix)) && !strings.HasPrefix(fleetVar, string(fleet.FleetVarDigiCertPasswordPrefix)) {
+			continue
+		}
+		caName := strings.TrimPrefix(strings.TrimPrefix(fleetVar, string(fleet.FleetVarDigiCertDataPrefix)), string(fleet.FleetVarDigiCertPasswordPrefix))
+		for _, ca := range groupedCAs.DigiCert {
+			if ca.Name != caName {
+				continue
+			}
+			caContents := ca.CertificateCommonName + ca.CertificateSeatID + strings.Join(ca.CertificateUserPrincipalNames, "")
+			for _, caFleetVar := range variables.Find(caContents) {
+				if slices.Contains(fleet.IDPFleetVariables, fleet.FleetVarName(caFleetVar)) {
+					fleetVars = append(fleetVars, caFleetVar)
+				}
+			}
+			break
+		}
+	}
+
+	return variables.Dedupe(fleetVars), nil
 }
 
 // extensibleSSOProfileContent is the subset of an Apple configuration profile

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -9100,9 +9100,13 @@ func TestValidatePSSORegistrationTokenVariable(t *testing.T) {
 
 func TestValidateConfigProfileFleetVariables(t *testing.T) {
 	t.Parallel()
+	digiCertCA := newMockDigicertCA("https://example.com", "caName")
+	digiCertCA.CertificateCommonName = fleet.FleetVarHostEndUserIDPFullname.WithPrefix()
+	digiCertCA.CertificateUserPrincipalNames = []string{fleet.FleetVarHostEndUserIDPUsername.WithBraces()}
+	digiCertCA.CertificateSeatID = fleet.FleetVarHostEndUserIDPDepartment.WithPrefix()
 	groupedCAs := &fleet.GroupedCertificateAuthorities{
 		DigiCert: []fleet.DigiCertCA{
-			newMockDigicertCA("https://example.com", "caName"),
+			digiCertCA,
 			newMockDigicertCA("https://example.com", "caName2"),
 		},
 		CustomScepProxy: []fleet.CustomSCEPProxyCA{
@@ -9144,7 +9148,10 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 			profile: digiCertForValidation("${FLEET_VAR_DIGICERT_PASSWORD_caName}", "${FLEET_VAR_DIGICERT_DATA_caName}", "Name",
 				"com.apple.security.pkcs12"),
 			errMsg: "",
-			vars:   []string{"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName"},
+			vars: []string{
+				"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName", "HOST_END_USER_IDP_FULL_NAME",
+				"HOST_END_USER_IDP_USERNAME", "HOST_END_USER_IDP_DEPARTMENT",
+			},
 		},
 		{
 			name: "DigiCert 2 profiles with swapped variables",
@@ -9157,7 +9164,10 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 			profile: digiCertForValidation2("${FLEET_VAR_DIGICERT_PASSWORD_caName}", "${FLEET_VAR_DIGICERT_DATA_caName}",
 				"$FLEET_VAR_DIGICERT_PASSWORD_caName2", "$FLEET_VAR_DIGICERT_DATA_caName2"),
 			errMsg: "",
-			vars:   []string{"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName", "DIGICERT_PASSWORD_caName2", "DIGICERT_DATA_caName2"},
+			vars: []string{
+				"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName", "DIGICERT_PASSWORD_caName2", "DIGICERT_DATA_caName2",
+				"HOST_END_USER_IDP_FULL_NAME", "HOST_END_USER_IDP_USERNAME", "HOST_END_USER_IDP_DEPARTMENT",
+			},
 		},
 		{
 			name: "Custom SCEP renewal ID shows up in the wrong place",
@@ -9214,7 +9224,10 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 			name:    "Custom SCEP and DigiCert profiles happy path",
 			profile: customSCEPDigiCertForValidation("${FLEET_VAR_CUSTOM_SCEP_CHALLENGE_scepName}", "${FLEET_VAR_CUSTOM_SCEP_PROXY_URL_scepName}"),
 			errMsg:  "",
-			vars:    []string{"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName", "CUSTOM_SCEP_CHALLENGE_scepName", "CUSTOM_SCEP_PROXY_URL_scepName", "SCEP_RENEWAL_ID"},
+			vars: []string{
+				"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName", "CUSTOM_SCEP_CHALLENGE_scepName", "CUSTOM_SCEP_PROXY_URL_scepName", "SCEP_RENEWAL_ID",
+				"HOST_END_USER_IDP_FULL_NAME", "HOST_END_USER_IDP_USERNAME", "HOST_END_USER_IDP_DEPARTMENT",
+			},
 		},
 		{
 			name:    "Custom profile with IdP variables and unknown variable",
@@ -9298,7 +9311,7 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 			errMsg:  "",
 			vars: []string{
 				"DIGICERT_PASSWORD_caName", "DIGICERT_DATA_caName", "NDES_SCEP_CHALLENGE", "NDES_SCEP_PROXY_URL",
-				"SCEP_RENEWAL_ID",
+				"SCEP_RENEWAL_ID", "HOST_END_USER_IDP_FULL_NAME", "HOST_END_USER_IDP_USERNAME", "HOST_END_USER_IDP_DEPARTMENT",
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52368

# Summary
DigiCert CA CN, Seat ID and UPN fields are documented to support built-in Fleet Variables, but in practice they were not updated to support Modern IDP Vars.

Updated DigiCert CA to support modern IDP Vars while keeping legacy Email Var as I am not sure if it has been fully deprecated yes (in the case, can be removed completly).

In addition, to keep Fleet's contract and promise to automatically update certificates on IDP changes or var changes, updated the flow to track IDP values change and DigiCert CA CN, Seat. ID and UPN fields mapping to trigger certificate enrollment on change.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DigiCert certificate enrollment now supports additional Fleet variables, including host UUID, platform, hardware serial, and identity-provider details.
  * Fleet variables referenced within DigiCert certificate fields are automatically resolved in Apple configuration profiles.
  * DigiCert profile associations stay synchronized when certificate authorities are created, updated, renamed, or deleted.

* **Bug Fixes**
  * Unsupported Fleet variables in DigiCert certificate fields are now rejected with clear validation errors.
  * Error messages identify the affected certificate field accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->