### PR TITLE
Decode vulnerability feeds with encoding/json/v2

### DIFF
--- a/changes/52466-vuln-feed-decode-jsonv2
+++ b/changes/52466-vuln-feed-decode-jsonv2
@@ -1,0 +1,1 @@
+- Sped up decoding of NVD and OSV vulnerability feed files during vulnerability processing by streaming them with `encoding/json/v2`.

--- a/server/vulnerabilities/nvd/sync/cve_syncer.go
+++ b/server/vulnerabilities/nvd/sync/cve_syncer.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"errors"
 	"fmt"
 	"io"
@@ -649,7 +650,7 @@ func (s *CVE) fetchVulnCheckDownloadURL(ctx context.Context, baseURL string) (st
 	defer resp.Body.Close()
 
 	var vcResponse VulnCheckBackupResponse
-	if err := json.NewDecoder(resp.Body).Decode(&vcResponse); err != nil {
+	if err := jsonv2.UnmarshalRead(resp.Body, &vcResponse); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "error decoding response")
 	}
 
@@ -741,7 +742,7 @@ func (s *CVE) processVulnCheckFile(ctx context.Context, fileName string) error {
 		}
 
 		var data VulnCheckBackupDataFile
-		if err := json.NewDecoder(gReader).Decode(&data); err != nil {
+		if err := jsonv2.UnmarshalRead(gReader, &data); err != nil {
 			return fmt.Errorf("error decoding JSON from file %s: %w", file.Name, err)
 		}
 
@@ -859,7 +860,7 @@ func readCVEsLegacyFormat(dbDir string, year int) (*schema.NVDCVEFeedJSON10, err
 	defer file.Close()
 
 	var cveFeed schema.NVDCVEFeedJSON10
-	if err := json.NewDecoder(file).Decode(&cveFeed); err != nil {
+	if err := jsonv2.UnmarshalRead(file, &cveFeed); err != nil {
 		return nil, err
 	}
 

--- a/server/vulnerabilities/nvd/tools/cvefeed/feed.go
+++ b/server/vulnerabilities/nvd/tools/cvefeed/feed.go
@@ -22,7 +22,7 @@ import (
 	"bufio"
 	"compress/bzip2"
 	"compress/gzip"
-	"encoding/json"
+	"encoding/json/v2"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -55,7 +55,7 @@ func getFeed(in io.Reader) (*schema.NVDCVEFeedJSON10, error) {
 	defer reader.Close()
 
 	var feed schema.NVDCVEFeedJSON10
-	if err := json.NewDecoder(reader).Decode(&feed); err != nil {
+	if err := json.UnmarshalRead(reader, &feed); err != nil {
 		return nil, err
 	}
 	return &feed, nil

--- a/server/vulnerabilities/osv/analyzer.go
+++ b/server/vulnerabilities/osv/analyzer.go
@@ -3,7 +3,7 @@ package osv
 import (
 	"compress/gzip"
 	"context"
-	"encoding/json"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -274,7 +274,7 @@ func loadOSVArtifact(ctx context.Context, ver fleet.OSVersion, vulnPath string, 
 	defer gz.Close()
 
 	var artifact OSVArtifact
-	if err := json.NewDecoder(gz).Decode(&artifact); err != nil {
+	if err := json.UnmarshalRead(gz, &artifact); err != nil {
 		return nil, fmt.Errorf("decoding OSV artifact: %w", err)
 	}
 
@@ -651,7 +651,7 @@ func loadRHELOSVArtifact(ctx context.Context, ver fleet.OSVersion, vulnPath stri
 	defer gz.Close()
 
 	var artifact RHELOSVArtifact
-	if err := json.NewDecoder(gz).Decode(&artifact); err != nil {
+	if err := json.UnmarshalRead(gz, &artifact); err != nil {
 		return nil, fmt.Errorf("decoding RHEL OSV artifact: %w", err)
 	}
 


### PR DESCRIPTION
Resolves #52466

Go 1.27's encoding/json runs on json/v2, but its v1 Decoder still buffers the whole document before unmarshaling. For the 100MB+ NVD and OSV feeds that makes -race builds ~15x slower (206s vs 13s per NVD file) and times out the nightly vuln tests.

json.UnmarshalRead streams the value instead: 8.6s under -race, and faster than v1 without it. Switch the NVD feed loader, the OSV Ubuntu/RHEL artifact loaders, and the VulnCheck/legacy feed reads in the syncer. The legacy feed writer stays on the v1 encoder so output bytes are unchanged. Decoded structs were verified identical to v1 against real NVD, OSV, and VulnCheck data.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved vulnerability feed processing speed when decoding NVD and OSV data.
  * Streamlined handling of vulnerability feeds and compressed artifact data while preserving existing validation and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->