### PR TITLE
Clarify Require IdP authentication is per-fleet for manual enrollment links

### DIFF
--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -32,6 +32,8 @@ You can require IdP authentication during automatic enrollment (ADE) for Apple (
 
 4. In Fleet, configure your IdP by heading to **Settings > Integrations > Authentication (SSO) > End users**. Then, enable IdP authentication by heading to **Controls > Setup experience > Require IdP authentication**. Alternatively, you can use [Fleet's GitOps workflow](https://fleetdm.com/docs/configuration/yaml-files) to configure your IdP integration and enable IdP authentication.
 
+> **Require IdP authentication** is configured per fleet. When manually enrolling a host using a secret-based enrollment link (e.g. `https://<your_fleet_url>/enroll?enroll_secret=<SECRET>`), make sure the `enroll_secret` belongs to the fleet where you turned on **Require IdP authentication**. An enroll secret for "All fleets," or for a fleet where this setting is off, won't require IdP authentication, even if it's enabled for another fleet.
+
 > If you've already configured [single sign-on
 > (SSO)](https://fleetdm.com/docs/deploy/single-sign-on-sso) in Fleet, you still want to create a
 > new SAML app for IdP authentication. This way, only Fleet users can log in to Fleet.

--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -32,7 +32,7 @@ You can require IdP authentication during automatic enrollment (ADE) for Apple (
 
 4. In Fleet, configure your IdP by heading to **Settings > Integrations > Authentication (SSO) > End users**. Then, enable IdP authentication by heading to **Controls > Setup experience > Require IdP authentication**. Alternatively, you can use [Fleet's GitOps workflow](https://fleetdm.com/docs/configuration/yaml-files) to configure your IdP integration and enable IdP authentication.
 
-> **Require IdP authentication** is configured per fleet. When manually enrolling a host using a secret-based enrollment link (e.g. `https://<your_fleet_url>/enroll?enroll_secret=<SECRET>`), make sure the `enroll_secret` belongs to the fleet where you turned on **Require IdP authentication**. An enroll secret for "All fleets," or for a fleet where this setting is off, won't require IdP authentication, even if it's enabled for another fleet.
+> **Require IdP authentication** is configured per fleet. When [enrolling mobile devices](https://fleetdm.com/guides/enroll-hosts#mobile-devices) using an enrollment link, make sure the `enroll_secret` in the link's URL belongs to the fleet where you turned on **Require IdP authentication**.
 
 > If you've already configured [single sign-on
 > (SSO)](https://fleetdm.com/docs/deploy/single-sign-on-sso) in Fleet, you still want to create a


### PR DESCRIPTION
# Checklist for submitter

Docs-only change (guide copy); no code, tests, migrations, or settings affected, and no CHANGELOG entry needed, so the rest of the template's checklist doesn't apply.

## Why

A customer manually enrolling a macOS host via a secret-based link
(`https://<fleet_url>/enroll?enroll_secret=<SECRET>`) wasn't prompted for IdP
authentication even though **Require IdP authentication** was turned on for
their fleet. Root cause (confirmed in Slack, and in
`pkg/mdm/ota_enroll.go`'s `RequiresEnrollOTAAuthentication`): the setting is
looked up per-fleet based on the enroll secret's team. They'd grabbed the
enroll secret from **All fleets** instead of the specific fleet with the
setting enabled, so Fleet fell back to the "no team" IdP setting.

## What changed

Added a clarifying note to the **End user authentication** section of the
[Setup experience guide](https://fleetdm.com/guides/setup-experience#end-user-authentication)
explaining that the enroll secret used in a manual enrollment link must
belong to the fleet where **Require IdP authentication** is enabled.
