### PR TITLE
Cherry-pick: Revert WSTEP ROBO certificate renewal fix (#51468)

### DIFF
--- a/changes/fix-wstep-robo-renewal
+++ b/changes/fix-wstep-robo-renewal
@@ -1,1 +1,0 @@
-- Fixed a bug where Windows hosts showed a failed enrollment state after the MDM certificate renewal window opened.

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -235,11 +235,9 @@ const (
 	// Provisioning Doc Certificate Renewal Period (365 days)
 	WstepCertRenewalPeriodInDays = "365"
 
-	// WstepROBOSupport tells Windows whether Fleet supports ROBO auto
-	// certificate renewal. Set to "false" because Fleet does not implement
-	// the renewal endpoint. Advertising "true" causes Windows to attempt
-	// renewal, fail, and set EnrollmentState=3 on the host. See #50611.
-	WstepROBOSupport = "false"
+	// Provisioning Doc Server supports ROBO auto certificate renewal
+	// TODO: Add renewal support
+	WstepROBOSupport = "true"
 
 	// Provisioning Doc Server retry interval
 	WstepRenewRetryInterval = "4"

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -81,19 +81,6 @@ func TestRequestSecurityTokenResponseCollectionSoapResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, outXML)
 	require.Contains(t, string(outXML), fmt.Sprintf("base64binary\">%s</BinarySecurityToken>", provisionedToken))
-
-	// Verify the provisioning doc advertises ROBOSupport=false. Fleet does
-	// not implement WSTEP ROBO renewal; advertising "true" causes Windows
-	// to attempt renewal, fail, and set EnrollmentState=3. See #50611.
-	certStore := NewCertStoreProvisioningData("Device", "AA", []byte("id"), "BB", []byte("sc"))
-	appCfg := NewApplicationProvisioningData("https://example.com/mdm", "dev", "pw")
-	provDoc := NewProvisioningDoc(certStore, appCfg, NewDMClientProvisioningData())
-	encoded, err := provDoc.GetEncodedB64Representation()
-	require.NoError(t, err)
-	raw, err := base64.StdEncoding.DecodeString(encoded)
-	require.NoError(t, err)
-	require.Contains(t, string(raw), `name="ROBOSupport" value="false"`)
-	require.NotContains(t, string(raw), `name="ROBOSupport" value="true"`)
 }
 
 func TestGetPoliciesResponseSoapResponse(t *testing.T) {


### PR DESCRIPTION
**Related issue:** #50611, #52492

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Summary

Cherry-picks the revert of #51468 into the 4.92.0 RC. The original fix (setting `ROBOSupport=false`) does not prevent Windows from attempting certificate renewal when enrolled via Entra, and the real root cause is certificate backdating in `wstep.go`. See #52492 for the correct fix.

## Testing

- [x] QA'd all new/changed functionality manually

Clean cherry-pick of d22b09fa57f from main.

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

Generated by Claude on behalf of Sharon FDM