### PR TITLE
Mobile: Return accurate online/offline status for iOS/iPadOS/Android hosts

### DIFF
--- a/changes/52486-mobile-host-status
+++ b/changes/52486-mobile-host-status
@@ -1,0 +1,1 @@
+- Mobile hosts (iOS, iPadOS, Android) now return real online/offline status based on MDM activity, instead of always reporting offline. Reflected on the hosts list, host details, dashboard summary, and target counts.

--- a/changes/52699-mobile-refetcher-not-premium
+++ b/changes/52699-mobile-refetcher-not-premium
@@ -1,0 +1,1 @@
+- Fixed an issue where iOS/iPadOS hosts on Fleet Free never received host vitals because the `apple_mdm_iphone_ipad_refetcher` and `apple_mdm_iphone_ipad_reviver` crons only ran on Fleet Premium.

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -215,8 +215,8 @@ func registerWorkerCrons(ctx context.Context, deps cronSchedulesDeps) {
 
 // registerMDMCrons covers the Apple MDM worker, DEP profile assigner, service
 // discovery, the Apple/Windows/Android profile managers, the Android device
-// reconciler, the Android default-policy and per-host policy migrations, and
-// the APNs pusher.
+// reconciler, the Android default-policy and per-host policy migrations, the
+// APNs pusher, and the iPhone/iPad refetcher and reviver.
 func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 	deps.register("failed to register apple_mdm_worker schedule", func() (fleet.CronSchedule, error) {
 		vppInstaller := deps.svc.(fleet.AppleMDMVPPInstaller)
@@ -306,15 +306,27 @@ func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 		)
 	})
 
+	// iPhone/iPad refetcher and reviver run for all license tiers. They power
+	// iOS/iPadOS host vitals refresh (DeviceInformation, InstalledApplicationList,
+	// CertificateList) and BYOD-enrolled device APNs revival, both of which the
+	// BYOD enrollment flow (a Free feature) depends on.
+	deps.register("failed to register apple_mdm_iphone_ipad_refetcher schedule", func() (fleet.CronSchedule, error) {
+		return newIPhoneIPadRefetcher(ctx, deps.instanceID, 10*time.Minute, deps.ds, deps.commander, deps.logger, deps.svc.NewActivity)
+	})
+
+	deps.register("failed to register apple_mdm_iphone_ipad_reviver schedule", func() (fleet.CronSchedule, error) {
+		return newIPhoneIPadReviver(ctx, deps.instanceID, deps.ds, deps.commander, deps.logger)
+	})
+
 	deps.register("failed to register Apple MDM OS updates schedule", func() (fleet.CronSchedule, error) {
 		return newAppleMDMOSUpdatesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
 	})
 }
 
-// registerPremiumCrons covers the Fleet Premium schedules: iPhone/iPad
-// refetcher and reviver, maintained apps, VPP app version refresh (and the
-// one-shot VPP country backfill), recovery lock passwords, managed local
-// account rotation, activities streaming, and the calendar schedule.
+// registerPremiumCrons covers the Fleet Premium schedules: Microsoft Autopilot
+// sync, maintained apps, VPP app version refresh (and the one-shot VPP country
+// backfill), recovery lock passwords, managed local account rotation,
+// activities streaming, and the calendar schedule.
 func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 	if !deps.license.IsPremium() {
 		return
@@ -322,14 +334,6 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 
 	deps.register("failed to register microsoft_autopilot_sync schedule", func() (fleet.CronSchedule, error) {
 		return cron.NewMicrosoftAutopilotSchedule(ctx, deps.instanceID, deps.ds, msgraph.NewClient, deps.logger)
-	})
-
-	deps.register("failed to register apple_mdm_iphone_ipad_refetcher schedule", func() (fleet.CronSchedule, error) {
-		return newIPhoneIPadRefetcher(ctx, deps.instanceID, 10*time.Minute, deps.ds, deps.commander, deps.logger, deps.svc.NewActivity)
-	})
-
-	deps.register("failed to register apple_mdm_iphone_ipad_reviver schedule", func() (fleet.CronSchedule, error) {
-		return newIPhoneIPadReviver(ctx, deps.instanceID, deps.ds, deps.commander, deps.logger)
 	})
 
 	deps.register("failed to register maintained apps schedule", func() (fleet.CronSchedule, error) {

--- a/cmd/fleetctl/fleetctl/testdata/expectedListHostsJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedListHostsJson.json
@@ -43,6 +43,7 @@
         },
         "label_updated_at": "0001-01-01T00:00:00Z",
         "last_enrolled_at": "0001-01-01T00:00:00Z",
+        "last_mdm_checked_in_at": null,
         "last_restarted_at": "0001-01-01T00:00:00Z",
         "logger_tls_period": 0,
         "mdm": {
@@ -118,6 +119,7 @@
         },
         "label_updated_at": "0001-01-01T00:00:00Z",
         "last_enrolled_at": "0001-01-01T00:00:00Z",
+        "last_mdm_checked_in_at": null,
         "last_restarted_at": "0001-01-01T00:00:00Z",
         "logger_tls_period": 0,
         "mdm": {

--- a/cmd/fleetctl/fleetctl/testdata/expectedListHostsMDM.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedListHostsMDM.json
@@ -44,6 +44,7 @@
       },
       "label_updated_at": "0001-01-01T00:00:00Z",
       "last_enrolled_at": "0001-01-01T00:00:00Z",
+      "last_mdm_checked_in_at": null,
       "last_restarted_at": "0001-01-01T00:00:00Z",
       "logger_tls_period": 0,
       "mdm": {
@@ -119,6 +120,7 @@
       },
       "label_updated_at": "0001-01-01T00:00:00Z",
       "last_enrolled_at": "0001-01-01T00:00:00Z",
+      "last_mdm_checked_in_at": null,
       "last_restarted_at": "0001-01-01T00:00:00Z",
       "logger_tls_period": 0,
       "mdm": {

--- a/cmd/fleetctl/fleetctl/testdata/expectedListHostsYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedListHostsYaml.yml
@@ -38,6 +38,7 @@ spec:
     total_issues_count: 0
   label_updated_at: "0001-01-01T00:00:00Z"
   last_enrolled_at: "0001-01-01T00:00:00Z"
+  last_mdm_checked_in_at: null
   last_restarted_at: "0001-01-01T00:00:00Z"
   logger_tls_period: 0
   mdm:
@@ -109,6 +110,7 @@ spec:
     total_issues_count: 0
   label_updated_at: "0001-01-01T00:00:00Z"
   last_enrolled_at: "0001-01-01T00:00:00Z"
+  last_mdm_checked_in_at: null
   last_restarted_at: "0001-01-01T00:00:00Z"
   logger_tls_period: 0
   mdm:

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3859,8 +3859,6 @@ If `mdm_id`, `mdm_name` or `mdm_enrollment_status` is specified, then Windows Se
 
 Returns the count of all hosts organized by status. `online_count` includes all hosts currently enrolled in Fleet. `offline_count` includes all hosts that haven't checked into Fleet recently. `mia_count` includes all hosts that haven't been seen by Fleet in more than 30 days. `new_count` includes the hosts that have been enrolled to Fleet in the last 24 hours.
 
-For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is based on the most recent MDM check-in (`nano_enrollments.last_seen_at` for Apple; `detail_updated_at` for Android) within a 1-hour window, instead of the osquery check-in interval used by other platforms.
-
 `GET /api/v1/fleet/host_summary`
 
 #### Parameters

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3859,6 +3859,8 @@ If `mdm_id`, `mdm_name` or `mdm_enrollment_status` is specified, then Windows Se
 
 Returns the count of all hosts organized by status. `online_count` includes all hosts currently enrolled in Fleet. `offline_count` includes all hosts that haven't checked into Fleet recently. `mia_count` includes all hosts that haven't been seen by Fleet in more than 30 days. `new_count` includes the hosts that have been enrolled to Fleet in the last 24 hours.
 
+For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is based on the most recent MDM check-in (`nano_enrollments.last_seen_at` for Apple; `detail_updated_at` for Android) within a 1-hour window, instead of the osquery check-in interval used by other platforms.
+
 `GET /api/v1/fleet/host_summary`
 
 #### Parameters

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -131,10 +131,11 @@ const ChartCard = ({
           given hour.
           <br />
           <br />
-          iOS/iPadOS hosts are online anytime they have power and an internet
-          connection (including locked). macOS, Windows, and Linux hosts can be
-          online when locked (lid closed), but less frequently than when the lid
-          is open. Android hosts are never online when locked.
+          iOS/iPadOS hosts are considered online when Fleet receives an MDM
+          check-in within the last hour (including while locked). macOS,
+          Windows, and Linux hosts can be online when locked (lid closed), but
+          less frequently than when the lid is open. Android hosts are never
+          online when locked.
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -131,11 +131,10 @@ const ChartCard = ({
           given hour.
           <br />
           <br />
-          iOS/iPadOS hosts are considered online when Fleet receives an MDM
-          check-in within the last hour (including while locked). macOS,
-          Windows, and Linux hosts can be online when locked (lid closed), but
-          less frequently than when the lid is open. Android hosts are never
-          online when locked.
+          iOS/iPadOS hosts are online anytime they have power and an internet
+          connection (including locked). macOS, Windows, and Linux hosts can be
+          online when locked (lid closed), but less frequently than when the lid
+          is open. Android hosts are never online when locked.
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -40,7 +40,7 @@ import {
 } from "interfaces/datatable_config";
 import PATHS from "router/paths";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
-import { getHardwareModelDisplay } from "../helpers";
+import { getHardwareModelDisplay, getHostStatusTooltipText } from "../helpers";
 
 type IHostTableColumnConfig = Column<IHost> & {
   // This is used to prevent these columns from being hidden. This will be
@@ -422,12 +422,20 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     accessor: "status",
     id: "status",
     Cell: (cellProps: IHostTableStringCellProps) => {
-      // Show "---" for ABM devices with Pending enrollment status
+      // Show "---" for ABM devices with Pending enrollment status, with an
+      // explainer tooltip on the pill.
       if (
         cellProps.row.original.mdm?.enrollment_status === "Pending" &&
         isAppleDevice(cellProps.row.original.platform)
       ) {
-        return <StatusIndicator value={DEFAULT_EMPTY_CELL_VALUE} />;
+        return (
+          <StatusIndicator
+            value={DEFAULT_EMPTY_CELL_VALUE}
+            tooltip={{
+              tooltipText: getHostStatusTooltipText(DEFAULT_EMPTY_CELL_VALUE),
+            }}
+          />
+        );
       }
 
       return <StatusIndicator value={cellProps.cell.value} />;

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -40,7 +40,7 @@ import {
 } from "interfaces/datatable_config";
 import PATHS from "router/paths";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
-import { getHardwareModelDisplay, getHostStatusTooltipText } from "../helpers";
+import { getHardwareModelDisplay } from "../helpers";
 
 type IHostTableColumnConfig = Column<IHost> & {
   // This is used to prevent these columns from being hidden. This will be
@@ -402,8 +402,11 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
         <TooltipWrapper
           tipContent={
             <>
-              Only supported on hosts that run Fleet&apos;s agent: macOS,
-              Windows, Linux, and ChromeOS.
+              iOS/iPadOS hosts are online anytime they have power and an
+              internet connection (including locked). macOS, Windows, and Linux
+              hosts can be online when locked (lid closed), but less frequently
+              than when the lid is open. Android hosts are never online when
+              locked.
             </>
           }
           className="status-header"
@@ -419,28 +422,15 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     accessor: "status",
     id: "status",
     Cell: (cellProps: IHostTableStringCellProps) => {
-      if (isMobilePlatform(cellProps.row.original.platform)) {
-        return NotSupported;
-      }
-
       // Show "---" for ABM devices with Pending enrollment status
       if (
         cellProps.row.original.mdm?.enrollment_status === "Pending" &&
         isAppleDevice(cellProps.row.original.platform)
       ) {
-        const tooltip = {
-          tooltipText: getHostStatusTooltipText(DEFAULT_EMPTY_CELL_VALUE),
-        };
-        return (
-          <StatusIndicator value={DEFAULT_EMPTY_CELL_VALUE} tooltip={tooltip} />
-        );
+        return <StatusIndicator value={DEFAULT_EMPTY_CELL_VALUE} />;
       }
 
-      const value = cellProps.cell.value;
-      const tooltip = {
-        tooltipText: getHostStatusTooltipText(value),
-      };
-      return <StatusIndicator value={value} tooltip={tooltip} />;
+      return <StatusIndicator value={cellProps.cell.value} />;
     },
   },
   // Issues

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -402,11 +402,8 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
         <TooltipWrapper
           tipContent={
             <>
-              iOS/iPadOS hosts are online anytime they have power and an
-              internet connection (including locked). macOS, Windows, and Linux
-              hosts can be online when locked (lid closed), but less frequently
-              than when the lid is open. Android hosts are never online when
-              locked.
+              Only supported on hosts that run Fleet&apos;s agent: macOS,
+              Windows, Linux, and ChromeOS.
             </>
           }
           className="status-header"
@@ -422,8 +419,7 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     accessor: "status",
     id: "status",
     Cell: (cellProps: IHostTableStringCellProps) => {
-      // Show "---" for ABM devices with Pending enrollment status, with an
-      // explainer tooltip on the pill.
+      // Show "---" for ABM devices with Pending enrollment status
       if (
         cellProps.row.original.mdm?.enrollment_status === "Pending" &&
         isAppleDevice(cellProps.row.original.platform)

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import createMockUser from "__mocks__/userMock";
@@ -139,13 +139,13 @@ describe("Host Summary section", () => {
     });
   });
 
-  describe("Empty card", () => {
+  describe("Mobile Status row", () => {
     it.each<[string, HostPlatform, string]>([
       ["Android", "android", "Android 14"],
       ["iOS", "ios", "iOS 17.4"],
       ["iPadOS", "ipados", "iPadOS 17.4"],
     ])(
-      "does not render the summary card for a Free-tier %s host",
+      "renders the Status row for a Free-tier %s host now that the API returns real online/offline for mobile",
       (_label, platform, os_version) => {
         const render = createCustomRenderer({
           context: {
@@ -159,15 +159,45 @@ describe("Host Summary section", () => {
         const summaryData = createMockHostSummary({
           platform,
           os_version,
+          status: "online",
         });
 
-        const { container } = render(
-          <HostSummary summaryData={summaryData} isPremiumTier={false} />
-        );
+        render(<HostSummary summaryData={summaryData} isPremiumTier={false} />);
 
-        expect(container).toBeEmptyDOMElement();
+        expect(screen.getByText("Status")).toBeInTheDocument();
+        expect(screen.getByText("Online")).toBeInTheDocument();
       }
     );
+
+    it("wraps the Status label in an explainer tooltip only for iOS/iPadOS", () => {
+      const renderMobile = (platform: HostPlatform) => {
+        const render = createCustomRenderer({
+          context: {
+            app: { isPremiumTier: true, currentUser: createMockUser() },
+          },
+        });
+        const summaryData = createMockHostSummary({
+          platform,
+          status: "online",
+        });
+        return render(<HostSummary summaryData={summaryData} isPremiumTier />);
+      };
+
+      // The Status <dt> title is what wraps in TooltipWrapper for iOS/iPadOS.
+      // Scope the query to the title element (scoped to `container` since two
+      // renders happen in this test) to avoid matching the pill's own
+      // TooltipWrapper on the <dd> value side or the other render's DOM.
+      const titleHasTooltip = (root: HTMLElement) => {
+        const statusTitle = within(root).getByText("Status").closest("dt");
+        return !!statusTitle?.querySelector(".component__tooltip-wrapper");
+      };
+
+      const { container: iosContainer } = renderMobile("ios");
+      expect(titleHasTooltip(iosContainer)).toBe(true);
+
+      const { container: androidContainer } = renderMobile("android");
+      expect(titleHasTooltip(androidContainer)).toBe(false);
+    });
   });
 
   describe("Bootstrap package data", () => {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import createMockUser from "__mocks__/userMock";
@@ -145,7 +145,7 @@ describe("Host Summary section", () => {
       ["iOS", "ios", "iOS 17.4"],
       ["iPadOS", "ipados", "iPadOS 17.4"],
     ])(
-      "renders the Status row for a Free-tier %s host now that the API returns real online/offline for mobile",
+      "renders the Status row for a Free-tier %s host",
       (_label, platform, os_version) => {
         const render = createCustomRenderer({
           context: {
@@ -168,36 +168,6 @@ describe("Host Summary section", () => {
         expect(screen.getByText("Online")).toBeInTheDocument();
       }
     );
-
-    it("wraps the Status label in an explainer tooltip only for iOS/iPadOS", () => {
-      const renderMobile = (platform: HostPlatform) => {
-        const render = createCustomRenderer({
-          context: {
-            app: { isPremiumTier: true, currentUser: createMockUser() },
-          },
-        });
-        const summaryData = createMockHostSummary({
-          platform,
-          status: "online",
-        });
-        return render(<HostSummary summaryData={summaryData} isPremiumTier />);
-      };
-
-      // The Status <dt> title is what wraps in TooltipWrapper for iOS/iPadOS.
-      // Scope the query to the title element (scoped to `container` since two
-      // renders happen in this test) to avoid matching the pill's own
-      // TooltipWrapper on the <dd> value side or the other render's DOM.
-      const titleHasTooltip = (root: HTMLElement) => {
-        const statusTitle = within(root).getByText("Status").closest("dt");
-        return !!statusTitle?.querySelector(".component__tooltip-wrapper");
-      };
-
-      const { container: iosContainer } = renderMobile("ios");
-      expect(titleHasTooltip(iosContainer)).toBe(true);
-
-      const { container: androidContainer } = renderMobile("android");
-      expect(titleHasTooltip(androidContainer)).toBe(false);
-    });
   });
 
   describe("Bootstrap package data", () => {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -78,6 +78,37 @@ const HostSummary = ({
     />
   );
 
+  const renderStatus = () => {
+    const displayedStatus = getHostStatus(status, mdm?.enrollment_status);
+    const tooltipText = getHostStatusTooltipText(displayedStatus);
+    return (
+      <DataSet
+        title={
+          isIosOrIpadosHost ? (
+            <TooltipWrapper
+              tipContent="iOS/iPadOS hosts are online anytime they have power and an internet connection (including locked)."
+              position="top"
+              showArrow
+              tipOffset={8}
+            >
+              Status
+            </TooltipWrapper>
+          ) : (
+            "Status"
+          )
+        }
+        value={
+          <StatusIndicator
+            value={displayedStatus}
+            tooltip={
+              tooltipText ? { tooltipText, position: "bottom" } : undefined
+            }
+          />
+        }
+      />
+    );
+  };
+
   const renderMaintenanceWindow = ({
     starts_at,
     timezone,
@@ -136,34 +167,7 @@ const HostSummary = ({
       paddingSize="xlarge"
       className={classNames}
     >
-      <DataSet
-        title={
-          isIosOrIpadosHost ? (
-            <TooltipWrapper
-              tipContent="iOS/iPadOS hosts are online anytime they have power and an internet connection (including locked)."
-              position="top"
-              showArrow
-              tipOffset={8}
-            >
-              Status
-            </TooltipWrapper>
-          ) : (
-            "Status"
-          )
-        }
-        value={(() => {
-          const displayedStatus = getHostStatus(status, mdm?.enrollment_status);
-          const tooltipText = getHostStatusTooltipText(displayedStatus);
-          return (
-            <StatusIndicator
-              value={displayedStatus}
-              tooltip={
-                tooltipText ? { tooltipText, position: "bottom" } : undefined
-              }
-            />
-          );
-        })()}
-      />
+      {renderStatus()}
       {showTeam && renderHostTeam()}
       {showIssues && renderIssues()}
       {showBootstrapPackage && bootstrapPackageData?.status && (

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -5,7 +5,7 @@ import { BootstrapPackageStatus } from "interfaces/mdm";
 import { IHostMaintenanceWindow } from "interfaces/host";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
-import { getHostStatus } from "pages/hosts/helpers";
+import { getHostStatus, getHostStatusTooltipText } from "pages/hosts/helpers";
 
 import TooltipWrapper from "components/TooltipWrapper";
 import Card from "components/Card";
@@ -116,10 +116,7 @@ const HostSummary = ({
     );
   };
 
-  // Now that the API returns real online/offline for mobile hosts (see
-  // #52486), iOS/iPadOS/Android render the same status pill as desktop —
-  // no more mobile-only "View history" workaround row. Status always renders,
-  // so the empty-card guard below is gone.
+  // Status renders for all platforms now that mobile hosts return real online/offline.
   const showTeam = !!isPremiumTier;
   const showIssues =
     summaryData.issues?.total_issues_count > 0 &&
@@ -154,11 +151,18 @@ const HostSummary = ({
             "Status"
           )
         }
-        value={
-          <StatusIndicator
-            value={getHostStatus(status, mdm?.enrollment_status)}
-          />
-        }
+        value={(() => {
+          const displayedStatus = getHostStatus(status, mdm?.enrollment_status);
+          const tooltipText = getHostStatusTooltipText(displayedStatus);
+          return (
+            <StatusIndicator
+              value={displayedStatus}
+              tooltip={
+                tooltipText ? { tooltipText, position: "bottom" } : undefined
+              }
+            />
+          );
+        })()}
       />
       {showTeam && renderHostTeam()}
       {showIssues && renderIssues()}

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -41,7 +41,7 @@ const HostSummary = ({
   isPremiumTier,
   toggleBootstrapPackageModal,
   className,
-}: IHostSummaryProps): JSX.Element | null => {
+}: IHostSummaryProps): JSX.Element => {
   const classNames = classnames(baseClass, className);
 
   const { status, platform, mdm } = summaryData;
@@ -116,7 +116,10 @@ const HostSummary = ({
     );
   };
 
-  const showStatus = !isIosOrIpadosHost && !isAndroidHost;
+  // Now that the API returns real online/offline for mobile hosts (see
+  // #52486), iOS/iPadOS/Android render the same status pill as desktop —
+  // no more mobile-only "View history" workaround row. Status always renders,
+  // so the empty-card guard below is gone.
   const showTeam = !!isPremiumTier;
   const showIssues =
     summaryData.issues?.total_issues_count > 0 &&
@@ -130,40 +133,39 @@ const HostSummary = ({
     !!summaryData.maintenance_window &&
     summaryData.maintenance_window !== DEFAULT_EMPTY_CELL_VALUE;
 
-  // Hide the card entirely when nothing inside it would render (e.g. a Free
-  // tier Android host) — otherwise an empty card sits above the Vitals section.
-  if (
-    !showStatus &&
-    !showTeam &&
-    !showIssues &&
-    !showBootstrapPackage &&
-    !showMaintenanceWindow
-  ) {
-    return null;
-  }
-
   return (
     <Card
       borderRadiusSize="xxlarge"
       paddingSize="xlarge"
       className={classNames}
     >
-      {showStatus && (
-        <DataSet
-          title="Status"
-          value={
-            <StatusIndicator
-              value={getHostStatus(status, mdm?.enrollment_status)}
-              tooltip={{
-                tooltipText: getHostStatusTooltipText(
-                  getHostStatus(status, mdm?.enrollment_status)
-                ),
-                position: "bottom",
-              }}
-            />
-          }
-        />
-      )}
+      <DataSet
+        title={
+          isIosOrIpadosHost ? (
+            <TooltipWrapper
+              tipContent="iOS/iPadOS hosts are online anytime they have power and an internet connection (including locked)."
+              position="top"
+              showArrow
+              tipOffset={8}
+            >
+              Status
+            </TooltipWrapper>
+          ) : (
+            "Status"
+          )
+        }
+        value={
+          <StatusIndicator
+            value={getHostStatus(status, mdm?.enrollment_status)}
+            tooltip={{
+              tooltipText: getHostStatusTooltipText(
+                getHostStatus(status, mdm?.enrollment_status)
+              ),
+              position: "bottom",
+            }}
+          />
+        }
+      />
       {showTeam && renderHostTeam()}
       {showIssues && renderIssues()}
       {showBootstrapPackage && bootstrapPackageData?.status && (

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -5,7 +5,7 @@ import { BootstrapPackageStatus } from "interfaces/mdm";
 import { IHostMaintenanceWindow } from "interfaces/host";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
-import { getHostStatus, getHostStatusTooltipText } from "pages/hosts/helpers";
+import { getHostStatus } from "pages/hosts/helpers";
 
 import TooltipWrapper from "components/TooltipWrapper";
 import Card from "components/Card";
@@ -157,12 +157,6 @@ const HostSummary = ({
         value={
           <StatusIndicator
             value={getHostStatus(status, mdm?.enrollment_status)}
-            tooltip={{
-              tooltipText: getHostStatusTooltipText(
-                getHostStatus(status, mdm?.enrollment_status)
-              ),
-              position: "bottom",
-            }}
           />
         }
       />

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -83,20 +83,7 @@ const HostSummary = ({
     const tooltipText = getHostStatusTooltipText(displayedStatus);
     return (
       <DataSet
-        title={
-          isIosOrIpadosHost ? (
-            <TooltipWrapper
-              tipContent="iOS/iPadOS hosts are online anytime they have power and an internet connection (including locked)."
-              position="top"
-              showArrow
-              tipOffset={8}
-            >
-              Status
-            </TooltipWrapper>
-          ) : (
-            "Status"
-          )
-        }
+        title="Status"
         value={
           <StatusIndicator
             value={displayedStatus}

--- a/frontend/pages/hosts/helpers.tsx
+++ b/frontend/pages/hosts/helpers.tsx
@@ -3,6 +3,17 @@ import React from "react";
 import { isAppleDevice } from "interfaces/platform";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
+// Returns tooltip copy only for the Pending ABM case (`---`). Online/offline
+// pills have no tooltip; the Status column header explains platform semantics.
+export const getHostStatusTooltipText = (
+  status: string
+): string | undefined => {
+  if (status === DEFAULT_EMPTY_CELL_VALUE) {
+    return "Device is pending enrollment in Apple Business and status is not yet available.";
+  }
+  return undefined;
+};
+
 export const getHostStatus = (
   status: string,
   mdmEnrollmentStatus?: string

--- a/frontend/pages/hosts/helpers.tsx
+++ b/frontend/pages/hosts/helpers.tsx
@@ -3,16 +3,6 @@ import React from "react";
 import { isAppleDevice } from "interfaces/platform";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
-export const getHostStatusTooltipText = (status: string): string => {
-  if (status === "online") {
-    return "Online hosts will respond to a live report.";
-  }
-  if (status === DEFAULT_EMPTY_CELL_VALUE) {
-    return "Device is pending enrollment in Apple Business and status is not yet available.";
-  }
-  return "Offline hosts won't respond to a live report because they may be shut down, asleep, or not connected to the internet.";
-};
-
 export const getHostStatus = (
   status: string,
   mdmEnrollmentStatus?: string

--- a/frontend/pages/hosts/helpers.tsx
+++ b/frontend/pages/hosts/helpers.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import { isAppleDevice } from "interfaces/platform";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
-// Returns tooltip copy only for the Pending ABM case (`---`). Online/offline
-// pills have no tooltip; the Status column header explains platform semantics.
+// Only the Pending ABM case carries tooltip copy now; online/offline pills
+// no longer explain themselves ("will respond to a live report" was misleading
+// once mobile hosts started showing real online/offline).
 export const getHostStatusTooltipText = (
   status: string
 ): string | undefined => {

--- a/server/chart/api/chart.go
+++ b/server/chart/api/chart.go
@@ -114,6 +114,14 @@ type DatasetStore interface {
 // The CVE entity filters apply only to this metric.
 const MetricCVE = "cve"
 
+// MobileOnlineWindowSeconds is the mobile online-status window used by the
+// chart bounded context's FindOnlineHostIDs predicate, in seconds. Fleet's
+// core status computation duplicates the value in fleet.MobileOnlineWindow
+// because server/chart can't import server/fleet (arch test enforced).
+// TestMobileOnlineWindowMatchesChart in server/fleet asserts the two stay in
+// lockstep; edit both when tuning.
+const MobileOnlineWindowSeconds = 3600 + 600 + 60
+
 // CVE chart software category keys. These are the API contract for the
 // `software_filters` query parameter and are mirrored by the frontend. The
 // "os" category covers both operating-system vulnerabilities and the kernel

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -29,9 +29,13 @@ const onlineIntervalBufferSeconds = 60
 // (iOS/iPadOS/Android) host's most recent MDM activity signal must fall for it
 // to count as online. Mobile MDM devices have no osquery check-in interval
 // (distributed_interval/config_tls_refresh are 0), so instead of a per-host
-// interval we anchor the window to the iOS/iPadOS refetch cadence (1 hour; see
-// ListIOSAndIPadOSToRefetch) plus the same grace buffer used for osquery hosts.
-const mobileOnlineWindowSeconds = 3600 + onlineIntervalBufferSeconds
+// interval we anchor the window to the iOS/iPadOS refetch cadence (1h; see
+// ListIOSAndIPadOSToRefetch) plus the 10m cron tick that dispatches it plus
+// the same grace buffer used for osquery hosts.
+// Sourced from api.MobileOnlineWindowSeconds so the fleet-side sync test
+// (TestMobileOnlineWindowMatchesChart) catches drift with
+// fleet.MobileOnlineWindow.
+const mobileOnlineWindowSeconds = api.MobileOnlineWindowSeconds
 
 // neverTimestamp mirrors server.NeverTimestamp, the sentinel written to
 // detail_updated_at before a host's first full detail refetch. Duplicated

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -7590,7 +7590,8 @@ func (ds *Datastore) GetNanoMDMEnrollmentDetails(ctx context.Context, hostUUID s
 	query := `
 	SELECT nd.authenticate_at, ne.last_seen_at, ne.hardware_attested, nd.unlock_token,
 	  nd.bootstrap_token_b64 IS NOT NULL AS bootstrap_token_escrowed,
-	  ne.type AS enrollment_type
+	  ne.type AS enrollment_type,
+	  ne.enabled
 	FROM nano_devices nd
 	  INNER JOIN nano_enrollments ne ON ne.id = nd.id
 	WHERE ne.type IN ('Device', 'User Enrollment (Device)') AND nd.id = ?`

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2247,7 +2247,7 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 	// online-mobile, online-desktop, new. The offline/online cases fan out to
 	// two `?` each so we can compare against the appropriate window per
 	// platform group.
-	args := []interface{}{now, now, now, now, now, now, now}
+	args := []any{now, now, now, now, now, now, now}
 	hostDisksJoin := ``
 	lowDiskSelect := `0 low_disk_space`
 	if lowDiskSpace != nil {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1178,6 +1178,7 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
     hd.gigs_all_disk_space,
     hd.encrypted as disk_encryption_enabled,
     COALESCE(hst.seen_time, h.created_at) AS seen_time,
+    nesm.last_seen_at AS last_mdm_checked_in_at,
     t.name AS team_name,
     COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at,
     h.last_restarted_at,
@@ -1483,9 +1484,16 @@ func (ds *Datastore) applyHostFilters(
 		batchScriptExecutionJoin, batchScriptExecutionFilter, whereParams = ds.getBatchExecutionFilters(whereParams, opt)
 	}
 
-	hostMDMSeenJoin := ""
+	// The status filter's online/offline case (filterHostsByStatus) reads
+	// nano_enrollments via alias nesm through hostMobileOnlineExpr; MIA/Missing
+	// reads it via alias nes through hostEffectiveLastSeenExpr. Both joins are
+	// needed when any status filter is active. We also add hostMobileMDMSeenTimeJoin
+	// unconditionally so nesm.last_seen_at is available for populating
+	// Host.LastMDMCheckedInAt on every listed host (feeds Host.Status()'s
+	// mobile branch).
+	hostMDMSeenJoin := hostMobileMDMSeenTimeJoin
 	if opt.StatusFilter.IsValid() {
-		hostMDMSeenJoin = hostMDMSeenTimeJoin
+		hostMDMSeenJoin += hostMDMSeenTimeJoin
 	}
 
 	var depStatusFilter string
@@ -1720,11 +1728,33 @@ func filterHostsByPolicy(sql string, opt fleet.HostListOptions, params []interfa
 const hostMDMSeenTimeJoin = `
 	LEFT JOIN nano_enrollments nes ON nes.id = h.uuid AND nes.type IN ('Device', 'User Enrollment (Device)')`
 
+// hostMobileMDMSeenTimeJoin is the join used by the mobile online/offline
+// predicate. Distinct from hostMDMSeenTimeJoin because it filters to enabled
+// enrollments only — nano_enrollments.last_seen_at is bumped on checkout too,
+// so a recently-unenrolled device would falsely look online without this.
+// Uses alias `nesm` so it can coexist with hostMDMSeenTimeJoin (alias `nes`)
+// in the same query — MIA/Missing still uses the unfiltered join.
+const hostMobileMDMSeenTimeJoin = `
+	LEFT JOIN nano_enrollments nesm ON nesm.id = h.uuid AND nesm.enabled = 1 AND nesm.type IN ('Device', 'User Enrollment (Device)')`
+
 // hostEffectiveLastSeenExpr is the effective "last seen" time for a host: the greatest of the osquery
 // seen_time and the MDM last_seen_at, then detail_updated_at (treating the Never sentinel as null),
 // then created_at.
 // Requires hostMDMSeenTimeJoin (alias nes) and the host_seen_times join (alias hst) to be present.
 const hostEffectiveLastSeenExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nes.last_seen_at), COALESCE(nes.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'), h.created_at)`
+
+// mobileOnlineWindowSeconds is fleet.MobileOnlineWindow expressed in seconds
+// for direct interpolation into INTERVAL clauses.
+const mobileOnlineWindowSeconds = 3600 + fleet.OnlineIntervalBuffer
+
+// hostMobileOnlineExpr is the "freshest MDM activity signal" expression for
+// mobile hosts, mirroring the chart bounded context's mobile online predicate
+// (server/chart/internal/mysql/charts.go FindOnlineHostIDs). Differs from
+// hostEffectiveLastSeenExpr by omitting the created_at fallback — a freshly
+// enrolled device that has never checked in is not "online".
+// Requires hostMobileMDMSeenTimeJoin (alias nesm) and the host_seen_times
+// join (alias hst) to be present.
+const hostMobileOnlineExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nesm.last_seen_at), COALESCE(nesm.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'))`
 
 func filterHostsByStatus(now time.Time, sql string, opt fleet.HostListOptions, params []interface{}) (string, []interface{}) {
 	switch opt.StatusFilter {
@@ -1732,11 +1762,23 @@ func filterHostsByStatus(now time.Time, sql string, opt fleet.HostListOptions, p
 		sql += "AND DATE_ADD(h.created_at, INTERVAL 1 DAY) >= ?"
 		params = append(params, now)
 	case fleet.StatusOnline:
-		sql += fmt.Sprintf("AND DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND) > ?", fleet.OnlineIntervalBuffer)
-		params = append(params, now)
+		sql += fmt.Sprintf(
+			`AND (CASE WHEN h.platform IN ('ios','ipados','android')
+				THEN DATE_ADD(%s, INTERVAL %d SECOND) > ?
+				ELSE DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND) > ?
+			END)`,
+			hostMobileOnlineExpr, mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer,
+		)
+		params = append(params, now, now)
 	case fleet.StatusOffline:
-		sql += fmt.Sprintf("AND DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND) <= ?", fleet.OnlineIntervalBuffer)
-		params = append(params, now)
+		sql += fmt.Sprintf(
+			`AND (CASE WHEN h.platform IN ('ios','ipados','android')
+				THEN (DATE_ADD(%s, INTERVAL %d SECOND) <= ? OR %s IS NULL)
+				ELSE DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND) <= ?
+			END)`,
+			hostMobileOnlineExpr, mobileOnlineWindowSeconds, hostMobileOnlineExpr, fleet.OnlineIntervalBuffer,
+		)
+		params = append(params, now, now)
 	case fleet.StatusMIA, fleet.StatusMissing:
 		// This must stay in sync with the missing_30_days_count computation in GenerateHostStatusStatistics.
 		sql += "AND DATE_ADD(" + hostEffectiveLastSeenExpr + ", INTERVAL 30 DAY) <= ? AND (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending')"
@@ -2201,7 +2243,11 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 	// host.Status and CountHostsInTargets - that is, the intervals associated
 	// with each status must be the same.
 
-	args := []interface{}{now, now, now, now, now}
+	// One `now` per CASE arm: MIA, Missing, offline-mobile, offline-desktop,
+	// online-mobile, online-desktop, new. The offline/online cases fan out to
+	// two `?` each so we can compare against the appropriate window per
+	// platform group.
+	args := []interface{}{now, now, now, now, now, now, now}
 	hostDisksJoin := ``
 	lowDiskSelect := `0 low_disk_space`
 	if lowDiskSpace != nil {
@@ -2227,19 +2273,27 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 				COUNT(*) total,
 				COALESCE(SUM(CASE WHEN DATE_ADD(`+hostEffectiveLastSeenExpr+`, INTERVAL 30 DAY) <= ? AND (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending') THEN 1 ELSE 0 END), 0) mia,
 				COALESCE(SUM(CASE WHEN DATE_ADD(`+hostEffectiveLastSeenExpr+`, INTERVAL 30 DAY) <= ? AND (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending') THEN 1 ELSE 0 END), 0) missing_30_days_count,
-				COALESCE(SUM(CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) <= ? THEN 1 ELSE 0 END), 0) offline,
-				COALESCE(SUM(CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END), 0) online,
+				COALESCE(SUM(CASE
+					WHEN h.platform IN ('ios','ipados','android')
+						THEN CASE WHEN DATE_ADD(`+hostMobileOnlineExpr+`, INTERVAL %d SECOND) <= ? OR `+hostMobileOnlineExpr+` IS NULL THEN 1 ELSE 0 END
+					ELSE CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) <= ? THEN 1 ELSE 0 END
+				END), 0) offline,
+				COALESCE(SUM(CASE
+					WHEN h.platform IN ('ios','ipados','android')
+						THEN CASE WHEN DATE_ADD(`+hostMobileOnlineExpr+`, INTERVAL %d SECOND) > ? THEN 1 ELSE 0 END
+					ELSE CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END
+				END), 0) online,
 				COALESCE(SUM(CASE WHEN DATE_ADD(h.created_at, INTERVAL 1 DAY) >= ? THEN 1 ELSE 0 END), 0) new,
 				COALESCE(SUM(CASE WHEN hdep.deleted_at IS NULL AND hdep.assign_profile_response IN (%s, %s) THEN 1 ELSE 0 END), 0) dep_assign_error_count,
 				%s
 			FROM hosts h
-			LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)`+hostMDMSeenTimeJoin+`
+			LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)`+hostMDMSeenTimeJoin+hostMobileMDMSeenTimeJoin+`
 			LEFT JOIN host_dep_assignments hdep ON h.id = hdep.host_id
 			%s
 			%s
 			WHERE %s
 			LIMIT 1;
-		`, fleet.OnlineIntervalBuffer, fleet.OnlineIntervalBuffer, depFailed, depThrottled, lowDiskSelect, hostMdmJoin, hostDisksJoin, whereClause)
+		`, mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer, mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer, depFailed, depThrottled, lowDiskSelect, hostMdmJoin, hostDisksJoin, whereClause)
 
 	stmt, args, err := sqlx.In(sqlStatement, args...)
 	if err != nil {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1484,13 +1484,8 @@ func (ds *Datastore) applyHostFilters(
 		batchScriptExecutionJoin, batchScriptExecutionFilter, whereParams = ds.getBatchExecutionFilters(whereParams, opt)
 	}
 
-	// The status filter's online/offline case (filterHostsByStatus) reads
-	// nano_enrollments via alias nesm through hostMobileOnlineExpr; MIA/Missing
-	// reads it via alias nes through hostEffectiveLastSeenExpr. Both joins are
-	// needed when any status filter is active. We also add hostMobileMDMSeenTimeJoin
-	// unconditionally so nesm.last_seen_at is available for populating
-	// Host.LastMDMCheckedInAt on every listed host (feeds Host.Status()'s
-	// mobile branch).
+	// Mobile join is unconditional so Host.LastMDMCheckedInAt gets populated
+	// on every row; nes join only matters for MIA/Missing status filters.
 	hostMDMSeenJoin := hostMobileMDMSeenTimeJoin
 	if opt.StatusFilter.IsValid() {
 		hostMDMSeenJoin += hostMDMSeenTimeJoin
@@ -1728,12 +1723,10 @@ func filterHostsByPolicy(sql string, opt fleet.HostListOptions, params []interfa
 const hostMDMSeenTimeJoin = `
 	LEFT JOIN nano_enrollments nes ON nes.id = h.uuid AND nes.type IN ('Device', 'User Enrollment (Device)')`
 
-// hostMobileMDMSeenTimeJoin is the join used by the mobile online/offline
-// predicate. Distinct from hostMDMSeenTimeJoin because it filters to enabled
-// enrollments only — nano_enrollments.last_seen_at is bumped on checkout too,
-// so a recently-unenrolled device would falsely look online without this.
-// Uses alias `nesm` so it can coexist with hostMDMSeenTimeJoin (alias `nes`)
-// in the same query — MIA/Missing still uses the unfiltered join.
+// hostMobileMDMSeenTimeJoin is the mobile online/offline join. Filters to
+// active enrollments only (nano_enrollments.last_seen_at keeps updating after
+// checkout). Alias nesm coexists with hostMDMSeenTimeJoin's nes so MIA/Missing
+// can still use the unfiltered join.
 const hostMobileMDMSeenTimeJoin = `
 	LEFT JOIN nano_enrollments nesm ON nesm.id = h.uuid AND nesm.enabled = 1 AND nesm.type IN ('Device', 'User Enrollment (Device)')`
 
@@ -1743,17 +1736,14 @@ const hostMobileMDMSeenTimeJoin = `
 // Requires hostMDMSeenTimeJoin (alias nes) and the host_seen_times join (alias hst) to be present.
 const hostEffectiveLastSeenExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nes.last_seen_at), COALESCE(nes.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'), h.created_at)`
 
-// mobileOnlineWindowSeconds is fleet.MobileOnlineWindow expressed in seconds
-// for direct interpolation into INTERVAL clauses.
-const mobileOnlineWindowSeconds = 3600 + fleet.OnlineIntervalBuffer
+// mobileOnlineWindowSeconds derives from fleet.MobileOnlineWindow so the SQL
+// INTERVAL and Host.mobileStatus stay in sync.
+const mobileOnlineWindowSeconds = int(fleet.MobileOnlineWindow / time.Second)
 
-// hostMobileOnlineExpr is the "freshest MDM activity signal" expression for
-// mobile hosts, mirroring the chart bounded context's mobile online predicate
-// (server/chart/internal/mysql/charts.go FindOnlineHostIDs). Differs from
-// hostEffectiveLastSeenExpr by omitting the created_at fallback — a freshly
-// enrolled device that has never checked in is not "online".
-// Requires hostMobileMDMSeenTimeJoin (alias nesm) and the host_seen_times
-// join (alias hst) to be present.
+// hostMobileOnlineExpr is the freshest MDM activity signal for mobile hosts,
+// mirroring FindOnlineHostIDs in server/chart. No created_at fallback: a
+// never-checked-in device stays offline. Requires hostMobileMDMSeenTimeJoin
+// (nesm) and the host_seen_times join (hst).
 const hostMobileOnlineExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nesm.last_seen_at), COALESCE(nesm.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'))`
 
 func filterHostsByStatus(now time.Time, sql string, opt fleet.HostListOptions, params []interface{}) (string, []interface{}) {
@@ -2243,10 +2233,8 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 	// host.Status and CountHostsInTargets - that is, the intervals associated
 	// with each status must be the same.
 
-	// One `now` per CASE arm: MIA, Missing, offline-mobile, offline-desktop,
-	// online-mobile, online-desktop, new. The offline/online cases fan out to
-	// two `?` each so we can compare against the appropriate window per
-	// platform group.
+	// One `now` per `?`: MIA, Missing, offline (mobile + desktop), online
+	// (mobile + desktop), new.
 	args := []any{now, now, now, now, now, now, now}
 	hostDisksJoin := ``
 	lowDiskSelect := `0 low_disk_space`
@@ -3313,6 +3301,11 @@ func (ds *Datastore) MarkHostsSeen(ctx context.Context, hostIDs []uint, t time.T
 //   - Use the provided team filter.
 //   - Search hostname, uuid, hardware_serial, and primary_ip using LIKE (mimics ListHosts behavior)
 //   - An optional list of IDs to omit from the search.
+//
+// Deliberately does not populate LastMDMCheckedInAt: sole caller is the
+// live-query target picker, and mobile hosts can't be live-queried. If a new
+// caller flows results to a mobile-visible surface, add hostMobileMDMSeenTimeJoin
+// + nesm.last_seen_at to keep Host.Status() honest.
 func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, matchQuery string, omit ...uint) ([]*fleet.Host, error) {
 	query := `SELECT
     h.id,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1727,6 +1727,11 @@ const hostMDMSeenTimeJoin = `
 // active enrollments only (nano_enrollments.last_seen_at keeps updating after
 // checkout). Alias nesm coexists with hostMDMSeenTimeJoin's nes so MIA/Missing
 // can still use the unfiltered join.
+//
+// enabled = 1 only screens nesm.last_seen_at. detail_updated_at in
+// hostMobileOnlineExpr is not gated on enrollment state, so a checked-out
+// device with a fresh detail_updated_at still reads online for up to
+// MobileOnlineWindow after checkout. See Host.mobileStatus for the Go mirror.
 const hostMobileMDMSeenTimeJoin = `
 	LEFT JOIN nano_enrollments nesm ON nesm.id = h.uuid AND nesm.enabled = 1 AND nesm.type IN ('Device', 'User Enrollment (Device)')`
 
@@ -1744,6 +1749,11 @@ const mobileOnlineWindowSeconds = int(fleet.MobileOnlineWindow / time.Second)
 // mirroring FindOnlineHostIDs in server/chart. No created_at fallback: a
 // never-checked-in device stays offline. Requires hostMobileMDMSeenTimeJoin
 // (nesm) and the host_seen_times join (hst).
+//
+// Folds in raw hst.seen_time (not coalesced with created_at). Benign today
+// because no mobile enrollment path writes host_seen_times; Host.mobileStatus
+// omits SeenTime for that reason. If a mobile write path ever populates
+// host_seen_times, update both sides together or they will disagree.
 const hostMobileOnlineExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nesm.last_seen_at), COALESCE(nesm.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'))`
 
 func filterHostsByStatus(now time.Time, sql string, opt fleet.HostListOptions, params []interface{}) (string, []interface{}) {
@@ -3303,9 +3313,12 @@ func (ds *Datastore) MarkHostsSeen(ctx context.Context, hostIDs []uint, t time.T
 //   - An optional list of IDs to omit from the search.
 //
 // Deliberately does not populate LastMDMCheckedInAt: sole caller is the
-// live-query target picker, and mobile hosts can't be live-queried. If a new
-// caller flows results to a mobile-visible surface, add hostMobileMDMSeenTimeJoin
-// + nesm.last_seen_at to keep Host.Status() honest.
+// live-query target picker, and mobile hosts can't be live-queried. Any
+// mobile row returned here has an incomplete status signal (no MDM
+// last_seen, so mobileStatus reads only DetailUpdatedAt) and should not be
+// treated as authoritative. If a new caller flows results to a
+// mobile-visible surface, add hostMobileMDMSeenTimeJoin + nesm.last_seen_at
+// to keep Host.Status() honest.
 func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, matchQuery string, omit ...uint) ([]*fleet.Host, error) {
 	query := `SELECT
     h.id,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1237,7 +1237,7 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
 		    `
 	}
 
-	sql, params, err := ds.applyHostFilters(ctx, opt, sql, filter, params)
+	sql, params, err := ds.applyHostFilters(ctx, opt, sql, filter, params, true)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list hosts: apply host filters")
 	}
@@ -1343,8 +1343,12 @@ WHERE
 }
 
 // TODO(Sarah): Do we need to reconcile mutually exclusive filters?
+// applyHostFilters splices the WHERE clause and its associated joins onto sqlStmt.
+// forListSelect signals that the caller's SELECT reads nesm.last_seen_at
+// (populating Host.LastMDMCheckedInAt on each row); CountHosts leaves it false
+// so the mobile MDM join only appears when a status filter needs it in the WHERE.
 func (ds *Datastore) applyHostFilters(
-	ctx context.Context, opt fleet.HostListOptions, sqlStmt string, filter fleet.TeamFilter, selectParams []interface{},
+	ctx context.Context, opt fleet.HostListOptions, sqlStmt string, filter fleet.TeamFilter, selectParams []any, forListSelect bool,
 ) (string, []interface{}, error) {
 	// prior to returning, params will be appended in the following order: selectParams, joinParams, whereParams
 	var whereParams, joinParams []interface{}
@@ -1484,9 +1488,13 @@ func (ds *Datastore) applyHostFilters(
 		batchScriptExecutionJoin, batchScriptExecutionFilter, whereParams = ds.getBatchExecutionFilters(whereParams, opt)
 	}
 
-	// Mobile join is unconditional so Host.LastMDMCheckedInAt gets populated
-	// on every row; nes join only matters for MIA/Missing status filters.
-	hostMDMSeenJoin := hostMobileMDMSeenTimeJoin
+	// Mobile join is required by the list SELECT (populates
+	// Host.LastMDMCheckedInAt) and by any online/offline status filter WHERE
+	// clause. Skip it for callers like CountHosts that need neither.
+	hostMDMSeenJoin := ""
+	if forListSelect || opt.StatusFilter.IsValid() {
+		hostMDMSeenJoin = hostMobileMDMSeenTimeJoin
+	}
 	if opt.StatusFilter.IsValid() {
 		hostMDMSeenJoin += hostMDMSeenTimeJoin
 	}
@@ -1745,16 +1753,15 @@ const hostEffectiveLastSeenExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nes
 // INTERVAL and Host.mobileStatus stay in sync.
 const mobileOnlineWindowSeconds = int(fleet.MobileOnlineWindow / time.Second)
 
-// hostMobileOnlineExpr is the freshest MDM activity signal for mobile hosts,
-// mirroring FindOnlineHostIDs in server/chart. No created_at fallback: a
-// never-checked-in device stays offline. Requires hostMobileMDMSeenTimeJoin
-// (nesm) and the host_seen_times join (hst).
-//
-// Folds in raw hst.seen_time (not coalesced with created_at). Benign today
-// because no mobile enrollment path writes host_seen_times; Host.mobileStatus
-// omits SeenTime for that reason. If a mobile write path ever populates
-// host_seen_times, update both sides together or they will disagree.
-const hostMobileOnlineExpr = `COALESCE(GREATEST(COALESCE(hst.seen_time, nesm.last_seen_at), COALESCE(nesm.last_seen_at, hst.seen_time)), NULLIF(h.detail_updated_at, '` + server.NeverTimestamp + `'))`
+// hostMobileOnlineExpr is the freshest MDM activity signal for mobile hosts.
+// nesm.last_seen_at first, then non-sentinel label_updated_at. No hst.seen_time
+// (mobile enrollment paths don't write host_seen_times) and no created_at
+// fallback (never-checked-in device stays offline). label_updated_at is
+// preferred over detail_updated_at because Android's AMAPI ingestion stamps
+// detail_updated_at with the device's report time (subject to Pub/Sub delivery
+// lag) while label_updated_at is Fleet's process time. Requires
+// hostMobileMDMSeenTimeJoin.
+const hostMobileOnlineExpr = `COALESCE(nesm.last_seen_at, NULLIF(h.label_updated_at, '` + server.NeverTimestamp + `'))`
 
 func filterHostsByStatus(now time.Time, sql string, opt fleet.HostListOptions, params []interface{}) (string, []interface{}) {
 	switch opt.StatusFilter {
@@ -2183,7 +2190,7 @@ func (ds *Datastore) CountHosts(ctx context.Context, filter fleet.TeamFilter, op
 
 	var params []interface{}
 
-	sql, params, err := ds.applyHostFilters(ctx, opt, sql, filter, params)
+	sql, params, err := ds.applyHostFilters(ctx, opt, sql, filter, params, false)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "count hosts: apply host filters")
 	}

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3339,7 +3339,7 @@ func TestExplainListHostsMobileJoin(t *testing.T) {
 
 	// Seed hosts across platforms so the plan estimate reflects a realistic
 	// mix. An empty table can hide plan issues.
-	for i := 0; i < 20; i += 1 {
+	for i := range 20 {
 		platform := "darwin"
 		switch i % 4 {
 		case 1:

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -103,6 +104,7 @@ func TestHosts(t *testing.T) {
 		{"SearchLimit", testHostsSearchLimit},
 		{"GenerateStatusStatistics", testHostsGenerateStatusStatistics},
 		{"GenerateStatusStatisticsMobileMDMSeenTime", testHostsGenerateStatusStatisticsMobileMDMSeenTime},
+		{"MobileOnlineOffline", testHostsMobileOnlineOffline},
 		{"GenerateStatusStatisticsABMPendingExclusion", testHostsGenerateStatusStatisticsABMPendingExclusion},
 		{"GenerateStatusStatisticsDEPErrors", testHostsGenerateStatusStatisticsDEPErrors},
 		{"GenerateStatusStatisticsDeletedDEPAssignment", testHostsGenerateStatusStatisticsDeletedDEPAssignment},
@@ -3189,6 +3191,189 @@ func testHostsGenerateStatusStatisticsMobileMDMSeenTime(t *testing.T, ds *Datast
 	require.NoError(t, err)
 	require.Len(t, hosts, 1, "ios host with stale MDM check-in should appear in missing list")
 	assert.Equal(t, h.ID, hosts[0].ID)
+}
+
+// testHostsMobileOnlineOffline covers the online/offline half of the mobile
+// status heuristic — the mirror of testHostsGenerateStatusStatisticsMobileMDMSeenTime
+// which covers the MIA/Missing half. Exercises the ListHosts response's
+// Host.Status(), the filterHostsByStatus SQL predicate (via ListHosts status
+// filter), the GenerateHostStatusStatistics aggregate, and CountHostsInTargets.
+func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	filter := fleet.TeamFilter{User: test.UserAdmin}
+	now := time.Now()
+
+	// Helpers for seeding a mobile host with the "no osquery activity" shape.
+	newMobileHost := func(t *testing.T, name, uuid, platform string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:        name,
+			UUID:            uuid,
+			HardwareSerial:  name + "-serial",
+			Platform:        platform,
+			DetailUpdatedAt: now.Add(-40 * 24 * time.Hour),
+			LabelUpdatedAt:  now.Add(-40 * 24 * time.Hour),
+			PolicyUpdatedAt: now.Add(-40 * 24 * time.Hour),
+		})
+		require.NoError(t, err)
+		// Mobile hosts don't post host_seen_times; drop the row NewHost seeded.
+		_, err = ds.writer(ctx).ExecContext(ctx, `DELETE FROM host_seen_times WHERE host_id = ?`, h.ID)
+		require.NoError(t, err)
+		return h
+	}
+	setNanoLastSeen := func(t *testing.T, h *fleet.Host, ts time.Time) {
+		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET last_seen_at = ? WHERE id = ?`, ts, h.UUID)
+		require.NoError(t, err)
+	}
+	setDetailUpdatedAt := func(t *testing.T, h *fleet.Host, ts time.Time) {
+		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET detail_updated_at = ? WHERE id = ?`, ts, h.ID)
+		require.NoError(t, err)
+	}
+
+	recent := now.Add(-10 * time.Minute) // well inside 1h + buffer
+	stale := now.Add(-2 * time.Hour)     // well outside 1h + buffer
+	neverTS, _ := time.Parse("2006-01-02 15:04:05", server.NeverTimestamp)
+
+	// iOS online via nano_enrollments.last_seen_at.
+	iosOnline := newMobileHost(t, "ios-online", "ios-online-uuid", "ios")
+	nanoEnroll(t, ds, iosOnline, false)
+	setNanoLastSeen(t, iosOnline, recent)
+
+	// iOS offline: nano last_seen_at stale, no other signals.
+	iosOffline := newMobileHost(t, "ios-offline", "ios-offline-uuid", "ios")
+	nanoEnroll(t, ds, iosOffline, false)
+	setNanoLastSeen(t, iosOffline, stale)
+	setDetailUpdatedAt(t, iosOffline, neverTS)
+
+	// iPadOS online via nano_enrollments.
+	ipadosOnline := newMobileHost(t, "ipados-online", "ipados-online-uuid", "ipados")
+	nanoEnroll(t, ds, ipadosOnline, false)
+	setNanoLastSeen(t, ipadosOnline, recent)
+
+	// Android online via detail_updated_at (no nano row).
+	androidOnline := newMobileHost(t, "android-online", "android-online-uuid", "android")
+	setDetailUpdatedAt(t, androidOnline, recent)
+
+	// Android offline: detail_updated_at is the never sentinel.
+	androidNever := newMobileHost(t, "android-never", "android-never-uuid", "android")
+	setDetailUpdatedAt(t, androidNever, neverTS)
+
+	// iOS disabled enrollment (checked out) with fresh last_seen_at — must be
+	// offline because the mobile join filters nano_enrollments.enabled = 1.
+	iosDisabled := newMobileHost(t, "ios-disabled", "ios-disabled-uuid", "ios")
+	nanoEnroll(t, ds, iosDisabled, false)
+	setNanoLastSeen(t, iosDisabled, recent)
+	_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET enabled = 0 WHERE id = ?`, iosDisabled.UUID)
+	require.NoError(t, err)
+	setDetailUpdatedAt(t, iosDisabled, neverTS)
+
+	expectedOnline := []uint{iosOnline.ID, ipadosOnline.ID, androidOnline.ID}
+	expectedOffline := []uint{iosOffline.ID, androidNever.ID, iosDisabled.ID}
+
+	// GenerateHostStatusStatistics counts.
+	summary, err := ds.GenerateHostStatusStatistics(ctx, filter, now, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint(len(expectedOnline)), summary.OnlineCount, "online mobile count")
+	assert.Equal(t, uint(len(expectedOffline)), summary.OfflineCount, "offline mobile count")
+
+	// Hosts list, status=online.
+	got, err := ds.ListHosts(ctx, filter, fleet.HostListOptions{StatusFilter: fleet.StatusOnline})
+	require.NoError(t, err)
+	gotIDs := make([]uint, 0, len(got))
+	for _, h := range got {
+		gotIDs = append(gotIDs, h.ID)
+	}
+	assert.ElementsMatch(t, expectedOnline, gotIDs, "status=online filter")
+
+	// Hosts list, status=offline.
+	got, err = ds.ListHosts(ctx, filter, fleet.HostListOptions{StatusFilter: fleet.StatusOffline})
+	require.NoError(t, err)
+	gotIDs = gotIDs[:0]
+	for _, h := range got {
+		gotIDs = append(gotIDs, h.ID)
+	}
+	assert.ElementsMatch(t, expectedOffline, gotIDs, "status=offline filter")
+
+	// Host.Status() on rows returned by ListHosts must agree with the SQL bucket —
+	// LastMDMCheckedInAt gets populated from nesm.last_seen_at and the Go-side
+	// mobile branch runs against it.
+	allHosts, err := ds.ListHosts(ctx, filter, fleet.HostListOptions{})
+	require.NoError(t, err)
+	byID := map[uint]*fleet.Host{}
+	for _, h := range allHosts {
+		byID[h.ID] = h
+	}
+	for _, id := range expectedOnline {
+		h := byID[id]
+		require.NotNil(t, h, "listed host %d", id)
+		assert.Equal(t, fleet.StatusOnline, h.Status(now), "Host.Status for %s", h.Hostname)
+	}
+	for _, id := range expectedOffline {
+		h := byID[id]
+		require.NotNil(t, h, "listed host %d", id)
+		assert.Equal(t, fleet.StatusOffline, h.Status(now), "Host.Status for %s", h.Hostname)
+	}
+
+	// CountHostsInTargets against the same host set.
+	targetIDs := append(append([]uint{}, expectedOnline...), expectedOffline...)
+	metrics, err := ds.CountHostsInTargets(ctx, filter, fleet.HostTargets{HostIDs: targetIDs}, now)
+	require.NoError(t, err)
+	assert.Equal(t, uint(len(expectedOnline)), metrics.OnlineHosts, "target metrics online")
+	assert.Equal(t, uint(len(expectedOffline)), metrics.OfflineHosts, "target metrics offline")
+}
+
+// TestExplainListHostsMobileJoin dumps the EXPLAIN plan for a ListHosts-shaped
+// query after adding the mobile MDM join. Verifies the `LEFT JOIN
+// nano_enrollments nesm ON nesm.id = h.uuid` uses nano_enrollments's PRIMARY
+// KEY rather than a full scan. Not registered in TestHosts because it runs its
+// own datastore and prints to stdout; run explicitly:
+//
+//	MYSQL_TEST=1 go test ./server/datastore/mysql/ -run TestExplainListHostsMobileJoin -count 1 -v
+func TestExplainListHostsMobileJoin(t *testing.T) {
+	if os.Getenv("MYSQL_TEST") == "" {
+		t.Skip("MYSQL_TEST not set")
+	}
+	ds := CreateMySQLDS(t)
+	defer ds.Close()
+
+	ctx := context.Background()
+
+	// Seed hosts across platforms so the plan estimate reflects a realistic
+	// mix. An empty table can hide plan issues.
+	for i := 0; i < 20; i += 1 {
+		platform := "darwin"
+		switch i % 4 {
+		case 1:
+			platform = "ios"
+		case 2:
+			platform = "android"
+		case 3:
+			platform = "windows"
+		}
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:        fmt.Sprintf("explain-host-%d", i),
+			UUID:            fmt.Sprintf("explain-uuid-%d", i),
+			HardwareSerial:  fmt.Sprintf("explain-serial-%d", i),
+			Platform:        platform,
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+		})
+		require.NoError(t, err)
+		if platform == "ios" {
+			nanoEnroll(t, ds, h, false)
+		}
+	}
+
+	// Mirror the shape of ListHosts's SELECT (not the full 100-column list —
+	// EXPLAIN cares about join order and index usage, not select-list width).
+	stmt := `SELECT h.id, h.uuid, h.platform,
+		COALESCE(hst.seen_time, h.created_at) AS seen_time,
+		nesm.last_seen_at AS last_mdm_checked_in_at
+		FROM hosts h
+		LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)
+		LEFT JOIN nano_enrollments nesm ON nesm.id = h.uuid AND nesm.enabled = 1 AND nesm.type IN ('Device', 'User Enrollment (Device)')`
+
+	explainSQLStatement(os.Stdout, ds.reader(ctx), stmt)
 }
 
 func testHostsLowDiskSpaceFilterExcludesSentinel(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3193,11 +3193,10 @@ func testHostsGenerateStatusStatisticsMobileMDMSeenTime(t *testing.T, ds *Datast
 	assert.Equal(t, h.ID, hosts[0].ID)
 }
 
-// testHostsMobileOnlineOffline covers the online/offline half of the mobile
-// status heuristic — the mirror of testHostsGenerateStatusStatisticsMobileMDMSeenTime
-// which covers the MIA/Missing half. Exercises the ListHosts response's
-// Host.Status(), the filterHostsByStatus SQL predicate (via ListHosts status
-// filter), the GenerateHostStatusStatistics aggregate, and CountHostsInTargets.
+// testHostsMobileOnlineOffline is the online/offline mirror of
+// testHostsGenerateStatusStatisticsMobileMDMSeenTime's MIA/Missing coverage.
+// Exercises Host.Status() on listed rows, the status filter, the aggregate,
+// and CountHostsInTargets in one shot.
 func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	filter := fleet.TeamFilter{User: test.UserAdmin}
@@ -3231,7 +3230,8 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 
 	recent := now.Add(-10 * time.Minute) // well inside 1h + buffer
 	stale := now.Add(-2 * time.Hour)     // well outside 1h + buffer
-	neverTS, _ := time.Parse("2006-01-02 15:04:05", server.NeverTimestamp)
+	neverTS, err := time.Parse("2006-01-02 15:04:05", server.NeverTimestamp)
+	require.NoError(t, err) // guard against a zero-time.Time slipping in silently
 
 	// iOS online via nano_enrollments.last_seen_at.
 	iosOnline := newMobileHost(t, "ios-online", "ios-online-uuid", "ios")
@@ -3262,7 +3262,7 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 	iosDisabled := newMobileHost(t, "ios-disabled", "ios-disabled-uuid", "ios")
 	nanoEnroll(t, ds, iosDisabled, false)
 	setNanoLastSeen(t, iosDisabled, recent)
-	_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET enabled = 0 WHERE id = ?`, iosDisabled.UUID)
+	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET enabled = 0 WHERE id = ?`, iosDisabled.UUID)
 	require.NoError(t, err)
 	setDetailUpdatedAt(t, iosDisabled, neverTS)
 

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3321,11 +3321,13 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 	assert.Equal(t, uint(len(expectedOffline)), metrics.OfflineHosts, "target metrics offline")
 }
 
-// TestExplainListHostsMobileJoin dumps the EXPLAIN plan for a ListHosts-shaped
-// query after adding the mobile MDM join. Verifies the `LEFT JOIN
-// nano_enrollments nesm ON nesm.id = h.uuid` uses nano_enrollments's PRIMARY
-// KEY rather than a full scan. Not registered in TestHosts because it runs its
-// own datastore and prints to stdout; run explicitly:
+// TestExplainListHostsMobileJoin asserts the ListHosts-shaped SELECT reaches
+// nano_enrollments via that table's PRIMARY KEY (through nesm.id = h.uuid)
+// rather than a full scan. If a future schema change drops hosts.uuid's
+// index or reshapes the join key, this test fails loudly instead of
+// silently regressing p95 on the /hosts hot path.
+//
+// Runs on its own datastore so it doesn't need to be registered in TestHosts:
 //
 //	MYSQL_TEST=1 go test ./server/datastore/mysql/ -run TestExplainListHostsMobileJoin -count 1 -v
 func TestExplainListHostsMobileJoin(t *testing.T) {
@@ -3364,16 +3366,46 @@ func TestExplainListHostsMobileJoin(t *testing.T) {
 		}
 	}
 
-	// Mirror the shape of ListHosts's SELECT (not the full 100-column list —
-	// EXPLAIN cares about join order and index usage, not select-list width).
-	stmt := `SELECT h.id, h.uuid, h.platform,
+	// Mirror the shape of ListHosts's SELECT. EXPLAIN cares about join order
+	// and index usage, not select-list width, so trim the 100-column list.
+	stmt := `EXPLAIN SELECT h.id, h.uuid, h.platform,
 		COALESCE(hst.seen_time, h.created_at) AS seen_time,
 		nesm.last_seen_at AS last_mdm_checked_in_at
 		FROM hosts h
 		LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)
 		LEFT JOIN nano_enrollments nesm ON nesm.id = h.uuid AND nesm.enabled = 1 AND nesm.type IN ('Device', 'User Enrollment (Device)')`
 
-	explainSQLStatement(os.Stdout, ds.reader(ctx), stmt)
+	// Full column list — sqlx.SelectContext rejects extras it can't scan into.
+	type explainRow struct {
+		ID           sql.NullInt64   `db:"id"`
+		SelectType   sql.NullString  `db:"select_type"`
+		Table        sql.NullString  `db:"table"`
+		Partitions   sql.NullString  `db:"partitions"`
+		Type         sql.NullString  `db:"type"`
+		PossibleKeys sql.NullString  `db:"possible_keys"`
+		Key          sql.NullString  `db:"key"`
+		KeyLen       sql.NullInt64   `db:"key_len"`
+		Ref          sql.NullString  `db:"ref"`
+		Rows         sql.NullInt64   `db:"rows"`
+		Filtered     sql.NullFloat64 `db:"filtered"`
+		Extra        sql.NullString  `db:"Extra"`
+	}
+	var rows []explainRow
+	require.NoError(t, sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt))
+
+	// nano_enrollments must be reached via eq_ref on PRIMARY (nesm.id = h.uuid,
+	// where nano_enrollments.id is the PK). Anything else (ALL / index / range)
+	// means the optimizer lost the index and the join degrades at scale.
+	var nesmRow *explainRow
+	for i := range rows {
+		if rows[i].Table.String == "nesm" {
+			nesmRow = &rows[i]
+			break
+		}
+	}
+	require.NotNil(t, nesmRow, "EXPLAIN plan is missing the nesm join row")
+	require.Equal(t, "eq_ref", nesmRow.Type.String, "nano_enrollments join must be eq_ref, got %q", nesmRow.Type.String)
+	require.Equal(t, "PRIMARY", nesmRow.Key.String, "nano_enrollments join must use PRIMARY key, got %q", nesmRow.Key.String)
 }
 
 func testHostsLowDiskSpaceFilterExcludesSentinel(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3223,8 +3223,8 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET last_seen_at = ? WHERE id = ?`, ts, h.UUID)
 		require.NoError(t, err)
 	}
-	setDetailUpdatedAt := func(t *testing.T, h *fleet.Host, ts time.Time) {
-		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET detail_updated_at = ? WHERE id = ?`, ts, h.ID)
+	setLabelUpdatedAt := func(t *testing.T, h *fleet.Host, ts time.Time) {
+		_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE hosts SET label_updated_at = ? WHERE id = ?`, ts, h.ID)
 		require.NoError(t, err)
 	}
 
@@ -3242,20 +3242,20 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 	iosOffline := newMobileHost(t, "ios-offline", "ios-offline-uuid", "ios")
 	nanoEnroll(t, ds, iosOffline, false)
 	setNanoLastSeen(t, iosOffline, stale)
-	setDetailUpdatedAt(t, iosOffline, neverTS)
+	setLabelUpdatedAt(t, iosOffline, neverTS)
 
 	// iPadOS online via nano_enrollments.
 	ipadosOnline := newMobileHost(t, "ipados-online", "ipados-online-uuid", "ipados")
 	nanoEnroll(t, ds, ipadosOnline, false)
 	setNanoLastSeen(t, ipadosOnline, recent)
 
-	// Android online via detail_updated_at (no nano row).
+	// Android online via label_updated_at (no nano row).
 	androidOnline := newMobileHost(t, "android-online", "android-online-uuid", "android")
-	setDetailUpdatedAt(t, androidOnline, recent)
+	setLabelUpdatedAt(t, androidOnline, recent)
 
-	// Android offline: detail_updated_at is the never sentinel.
+	// Android offline: label_updated_at is the never sentinel.
 	androidNever := newMobileHost(t, "android-never", "android-never-uuid", "android")
-	setDetailUpdatedAt(t, androidNever, neverTS)
+	setLabelUpdatedAt(t, androidNever, neverTS)
 
 	// iOS disabled enrollment (checked out) with fresh last_seen_at — must be
 	// offline because the mobile join filters nano_enrollments.enabled = 1.
@@ -3264,7 +3264,7 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 	setNanoLastSeen(t, iosDisabled, recent)
 	_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET enabled = 0 WHERE id = ?`, iosDisabled.UUID)
 	require.NoError(t, err)
-	setDetailUpdatedAt(t, iosDisabled, neverTS)
+	setLabelUpdatedAt(t, iosDisabled, neverTS)
 
 	expectedOnline := []uint{iosOnline.ID, ipadosOnline.ID, androidOnline.ID}
 	expectedOffline := []uint{iosOffline.ID, androidNever.ID, iosDisabled.ID}
@@ -3313,12 +3313,16 @@ func testHostsMobileOnlineOffline(t *testing.T, ds *Datastore) {
 		assert.Equal(t, fleet.StatusOffline, h.Status(now), "Host.Status for %s", h.Hostname)
 	}
 
-	// CountHostsInTargets against the same host set.
+	// CountHostsInTargets against the same host set: mobile hosts are excluded
+	// from live-query target metrics (matches SearchHosts, which excludes them
+	// from the picker rows) so the counts stay at zero even though the host set
+	// contains mobile IDs.
 	targetIDs := append(append([]uint{}, expectedOnline...), expectedOffline...)
 	metrics, err := ds.CountHostsInTargets(ctx, filter, fleet.HostTargets{HostIDs: targetIDs}, now)
 	require.NoError(t, err)
-	assert.Equal(t, uint(len(expectedOnline)), metrics.OnlineHosts, "target metrics online")
-	assert.Equal(t, uint(len(expectedOffline)), metrics.OfflineHosts, "target metrics offline")
+	assert.Equal(t, uint(0), metrics.OnlineHosts, "mobile hosts must not contribute to target metrics online")
+	assert.Equal(t, uint(0), metrics.OfflineHosts, "mobile hosts must not contribute to target metrics offline")
+	assert.Equal(t, uint(0), metrics.TotalHosts, "mobile hosts must not contribute to target metrics total")
 }
 
 // TestExplainListHostsMobileJoin asserts the ListHosts-shaped SELECT reaches
@@ -3366,14 +3370,18 @@ func TestExplainListHostsMobileJoin(t *testing.T) {
 		}
 	}
 
-	// Mirror the shape of ListHosts's SELECT. EXPLAIN cares about join order
-	// and index usage, not select-list width, so trim the 100-column list.
-	stmt := `EXPLAIN SELECT h.id, h.uuid, h.platform,
+	// Mirror the shape of ListHosts's SELECT + the online status filter's
+	// WHERE clause so EXPLAIN exercises both the mobile MDM join and
+	// hostMobileOnlineExpr. Trim the 100-column SELECT — EXPLAIN cares about
+	// join order and index usage, not select-list width.
+	baseStmt := `SELECT h.id, h.uuid, h.platform,
 		COALESCE(hst.seen_time, h.created_at) AS seen_time,
 		nesm.last_seen_at AS last_mdm_checked_in_at
 		FROM hosts h
-		LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)
-		LEFT JOIN nano_enrollments nesm ON nesm.id = h.uuid AND nesm.enabled = 1 AND nesm.type IN ('Device', 'User Enrollment (Device)')`
+		LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)` + hostMDMSeenTimeJoin + hostMobileMDMSeenTimeJoin + `
+		WHERE 1=1 `
+	filtered, args := filterHostsByStatus(time.Now(), baseStmt, fleet.HostListOptions{StatusFilter: fleet.StatusOnline}, nil)
+	stmt := "EXPLAIN " + filtered
 
 	// Full column list — sqlx.SelectContext rejects extras it can't scan into.
 	type explainRow struct {
@@ -3391,7 +3399,7 @@ func TestExplainListHostsMobileJoin(t *testing.T) {
 		Extra        sql.NullString  `db:"Extra"`
 	}
 	var rows []explainRow
-	require.NoError(t, sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt))
+	require.NoError(t, sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...))
 
 	// nano_enrollments must be reached via eq_ref on PRIMARY (nesm.id = h.uuid,
 	// where nano_enrollments.id is the PK). Anything else (ALL / index / range)

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1280,6 +1280,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
       COALESCE(hd.percent_disk_space_available, 0) as percent_disk_space_available,
       COALESCE(hd.gigs_total_disk_space, 0) as gigs_total_disk_space,
       COALESCE(hst.seen_time, h.created_at) as seen_time,
+      nesm.last_seen_at AS last_mdm_checked_in_at,
       COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at,
       h.last_restarted_at,
       h.timezone,
@@ -1289,7 +1290,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 			%s
     FROM label_membership lm
     JOIN hosts h ON (lm.host_id = h.id)
-    LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)
+    LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)` + hostMobileMDMSeenTimeJoin + `
     LEFT JOIN host_updates hu ON (h.id = hu.host_id)
     LEFT JOIN host_disks hd ON (h.id=hd.host_id)
     %s
@@ -1472,7 +1473,7 @@ func (ds *Datastore) applyHostLabelFilters(ctx context.Context, filter fleet.Tea
 func (ds *Datastore) CountHostsInLabel(ctx context.Context, filter fleet.TeamFilter, lid uint, opt fleet.HostListOptions) (int, error) {
 	query := `SELECT count(*) FROM label_membership lm
     JOIN hosts h ON (lm.host_id = h.id)
-	LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)
+	LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)` + hostMobileMDMSeenTimeJoin + `
 	LEFT JOIN host_disks hd ON (h.id=hd.host_id)
  	`
 

--- a/server/datastore/mysql/targets.go
+++ b/server/datastore/mysql/targets.go
@@ -22,22 +22,32 @@ func (ds *Datastore) CountHostsInTargets(ctx context.Context, filter fleet.TeamF
 
 	queryTargetLogicCondition, queryTargetArgs := targetSQLCondAndArgs(targets, "h")
 
-	// As of Fleet 4.15, mia hosts are also included in the total for offline hosts
+	// As of Fleet 4.15, mia hosts are also included in the total for offline hosts.
+	// Offline/online CASE by platform mirrors GenerateHostStatusStatistics: mobile
+	// hosts use the MDM-activity window; everything else uses the osquery interval.
 	sql := fmt.Sprintf(`
 		SELECT
 			COUNT(*) total,
 			COALESCE(SUM(CASE WHEN DATE_ADD(`+hostEffectiveLastSeenExpr+`, INTERVAL 30 DAY) <= ? THEN 1 ELSE 0 END), 0) mia,
-			COALESCE(SUM(CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) <= ? THEN 1 ELSE 0 END), 0) offline,
-			COALESCE(SUM(CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END), 0) online,
+			COALESCE(SUM(CASE
+				WHEN h.platform IN ('ios','ipados','android')
+					THEN CASE WHEN DATE_ADD(`+hostMobileOnlineExpr+`, INTERVAL %d SECOND) <= ? OR `+hostMobileOnlineExpr+` IS NULL THEN 1 ELSE 0 END
+				ELSE CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) <= ? THEN 1 ELSE 0 END
+			END), 0) offline,
+			COALESCE(SUM(CASE
+				WHEN h.platform IN ('ios','ipados','android')
+					THEN CASE WHEN DATE_ADD(`+hostMobileOnlineExpr+`, INTERVAL %d SECOND) > ? THEN 1 ELSE 0 END
+				ELSE CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END
+			END), 0) online,
 			COALESCE(SUM(CASE WHEN DATE_ADD(h.created_at, INTERVAL 1 DAY) >= ? THEN 1 ELSE 0 END), 0) new
 		FROM hosts h
-		LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)`+hostMDMSeenTimeJoin+`
+		LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)`+hostMDMSeenTimeJoin+hostMobileMDMSeenTimeJoin+`
 		WHERE %s AND %s`,
-		fleet.OnlineIntervalBuffer, fleet.OnlineIntervalBuffer,
+		mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer, mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer,
 		queryTargetLogicCondition, ds.whereFilterHostsByTeams(filter, "h"),
 	)
 
-	query, args, err := sqlx.In(sql, append([]interface{}{now, now, now, now}, queryTargetArgs...)...)
+	query, args, err := sqlx.In(sql, append([]interface{}{now, now, now, now, now, now}, queryTargetArgs...)...)
 	if err != nil {
 		return fleet.TargetMetrics{}, ctxerr.Wrap(ctx, err, "sqlx.In CountHostsInTargets")
 	}

--- a/server/datastore/mysql/targets.go
+++ b/server/datastore/mysql/targets.go
@@ -47,7 +47,7 @@ func (ds *Datastore) CountHostsInTargets(ctx context.Context, filter fleet.TeamF
 		queryTargetLogicCondition, ds.whereFilterHostsByTeams(filter, "h"),
 	)
 
-	query, args, err := sqlx.In(sql, append([]interface{}{now, now, now, now, now, now}, queryTargetArgs...)...)
+	query, args, err := sqlx.In(sql, append([]any{now, now, now, now, now, now}, queryTargetArgs...)...)
 	if err != nil {
 		return fleet.TargetMetrics{}, ctxerr.Wrap(ctx, err, "sqlx.In CountHostsInTargets")
 	}

--- a/server/datastore/mysql/targets.go
+++ b/server/datastore/mysql/targets.go
@@ -23,31 +23,26 @@ func (ds *Datastore) CountHostsInTargets(ctx context.Context, filter fleet.TeamF
 	queryTargetLogicCondition, queryTargetArgs := targetSQLCondAndArgs(targets, "h")
 
 	// As of Fleet 4.15, mia hosts are also included in the total for offline hosts.
-	// Offline/online CASE by platform mirrors GenerateHostStatusStatistics: mobile
-	// hosts use the MDM-activity window; everything else uses the osquery interval.
+	// Live query picker excludes mobile hosts entirely: SearchHosts returns none,
+	// so counts here match that. Mobile hosts can't respond to a live report, so
+	// counting them as "online" would overstate what a run would actually reach.
+	// Desktop online/offline still uses the osquery interval; mobile CASE arm and
+	// its joins are omitted since no mobile rows pass the platform filter.
 	sql := fmt.Sprintf(`
 		SELECT
 			COUNT(*) total,
 			COALESCE(SUM(CASE WHEN DATE_ADD(`+hostEffectiveLastSeenExpr+`, INTERVAL 30 DAY) <= ? THEN 1 ELSE 0 END), 0) mia,
-			COALESCE(SUM(CASE
-				WHEN h.platform IN ('ios','ipados','android')
-					THEN CASE WHEN DATE_ADD(`+hostMobileOnlineExpr+`, INTERVAL %d SECOND) <= ? OR `+hostMobileOnlineExpr+` IS NULL THEN 1 ELSE 0 END
-				ELSE CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) <= ? THEN 1 ELSE 0 END
-			END), 0) offline,
-			COALESCE(SUM(CASE
-				WHEN h.platform IN ('ios','ipados','android')
-					THEN CASE WHEN DATE_ADD(`+hostMobileOnlineExpr+`, INTERVAL %d SECOND) > ? THEN 1 ELSE 0 END
-				ELSE CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END
-			END), 0) online,
+			COALESCE(SUM(CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) <= ? THEN 1 ELSE 0 END), 0) offline,
+			COALESCE(SUM(CASE WHEN DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END), 0) online,
 			COALESCE(SUM(CASE WHEN DATE_ADD(h.created_at, INTERVAL 1 DAY) >= ? THEN 1 ELSE 0 END), 0) new
 		FROM hosts h
-		LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)`+hostMDMSeenTimeJoin+hostMobileMDMSeenTimeJoin+`
-		WHERE %s AND %s`,
-		mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer, mobileOnlineWindowSeconds, fleet.OnlineIntervalBuffer,
+		LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)`+hostMDMSeenTimeJoin+`
+		WHERE h.platform NOT IN ('ios','ipados','android') AND %s AND %s`,
+		fleet.OnlineIntervalBuffer, fleet.OnlineIntervalBuffer,
 		queryTargetLogicCondition, ds.whereFilterHostsByTeams(filter, "h"),
 	)
 
-	query, args, err := sqlx.In(sql, append([]any{now, now, now, now, now, now}, queryTargetArgs...)...)
+	query, args, err := sqlx.In(sql, append([]any{now, now, now, now}, queryTargetArgs...)...)
 	if err != nil {
 		return fleet.TargetMetrics{}, ctxerr.Wrap(ctx, err, "sqlx.In CountHostsInTargets")
 	}

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -44,6 +44,14 @@ const (
 	// than their expected checkin interval.
 	OnlineIntervalBuffer = 60
 
+	// MobileOnlineWindow is the window within which a mobile
+	// (iOS/iPadOS/Android) host's most recent MDM activity signal must fall
+	// for it to count as online. Anchored to the iOS/iPadOS MDM refetch
+	// cadence (1 hour; see ListIOSAndIPadOSToRefetch) plus OnlineIntervalBuffer.
+	// The chart bounded context duplicates this in mobileOnlineWindowSeconds
+	// because it can't import server/fleet (arch test enforced).
+	MobileOnlineWindow = time.Hour + time.Duration(OnlineIntervalBuffer)*time.Second
+
 	// HostIdentiferNotFound is the error message returned when a search for a host by its
 	// identifier (hostname, UUID, or serial number) does not return any results.
 	HostIdentiferNotFound = "Host doesn't exist. Make sure you provide a valid hostname, UUID, or serial number. Learn more about host identifiers: https://fleetdm.com/learn-more-about/host-identifiers"
@@ -343,17 +351,26 @@ type Host struct {
 	// OsqueryHostID is the key used in the request context that is
 	// used to retrieve host information.  It is sent from osquery and may currently be
 	// a GUID or a Host Name, but in either case, it MUST be unique
-	OsqueryHostID    *string   `json:"-" db:"osquery_host_id" csv:"-"`
-	DetailUpdatedAt  time.Time `json:"detail_updated_at" db:"detail_updated_at" csv:"detail_updated_at"` // Time that the host details were last updated
-	LabelUpdatedAt   time.Time `json:"label_updated_at" db:"label_updated_at" csv:"label_updated_at"`    // Time that the host labels were last updated
-	PolicyUpdatedAt  time.Time `json:"policy_updated_at" db:"policy_updated_at" csv:"policy_updated_at"` // Time that the host policies were last updated
-	LastEnrolledAt   time.Time `json:"last_enrolled_at" db:"last_enrolled_at" csv:"last_enrolled_at"`    // Time that the host last enrolled
-	SeenTime         time.Time `json:"seen_time" db:"seen_time" csv:"seen_time"`                         // Time that the host was last "seen"
-	RefetchRequested bool      `json:"refetch_requested" db:"refetch_requested" csv:"refetch_requested"`
-	NodeKey          *string   `json:"-" db:"node_key" csv:"-"`
-	OrbitNodeKey     *string   `json:"-" db:"orbit_node_key" csv:"-"`
-	Hostname         string    `json:"hostname" db:"hostname" csv:"hostname"` // there is a fulltext index on this field
-	UUID             string    `json:"uuid" db:"uuid" csv:"uuid"`             // there is a fulltext index on this field
+	OsqueryHostID   *string   `json:"-" db:"osquery_host_id" csv:"-"`
+	DetailUpdatedAt time.Time `json:"detail_updated_at" db:"detail_updated_at" csv:"detail_updated_at"` // Time that the host details were last updated
+	LabelUpdatedAt  time.Time `json:"label_updated_at" db:"label_updated_at" csv:"label_updated_at"`    // Time that the host labels were last updated
+	PolicyUpdatedAt time.Time `json:"policy_updated_at" db:"policy_updated_at" csv:"policy_updated_at"` // Time that the host policies were last updated
+	LastEnrolledAt  time.Time `json:"last_enrolled_at" db:"last_enrolled_at" csv:"last_enrolled_at"`    // Time that the host last enrolled
+	SeenTime        time.Time `json:"seen_time" db:"seen_time" csv:"seen_time"`                         // Time that the host was last "seen"
+	// LastMDMCheckedInAt is the most recent MDM check-in for this host, sourced from
+	// nano_enrollments.last_seen_at (Apple only; nil for other platforms and for hosts
+	// with no MDM enrollment). Populated by list-hosts and host-details loaders.
+	// Feeds the mobile branch of Host.Status() so iOS/iPadOS hosts, which don't check
+	// in via osquery, still report accurate online/offline based on MDM activity.
+	// No `omitempty`: HostDetail previously serialized this as `null` for hosts with
+	// no MDM enrollment, and preserving that contract avoids breaking clients that
+	// key on the field's presence.
+	LastMDMCheckedInAt *time.Time `json:"last_mdm_checked_in_at" db:"last_mdm_checked_in_at" csv:"-"`
+	RefetchRequested   bool       `json:"refetch_requested" db:"refetch_requested" csv:"refetch_requested"`
+	NodeKey            *string    `json:"-" db:"node_key" csv:"-"`
+	OrbitNodeKey       *string    `json:"-" db:"orbit_node_key" csv:"-"`
+	Hostname           string     `json:"hostname" db:"hostname" csv:"hostname"` // there is a fulltext index on this field
+	UUID               string     `json:"uuid" db:"uuid" csv:"uuid"`             // there is a fulltext index on this field
 	// Platform is the host's platform as defined by osquery's os_version.platform.
 	Platform       string        `json:"platform" csv:"platform"`
 	OsqueryVersion string        `json:"osquery_version" db:"osquery_version" csv:"osquery_version"`
@@ -1242,8 +1259,10 @@ type HostDetail struct {
 
 	CustomHostVitals []HostCustomHostVital `json:"custom_host_vitals,omitempty"`
 
-	LastMDMEnrolledAt  *time.Time `json:"last_mdm_enrolled_at"`
-	LastMDMCheckedInAt *time.Time `json:"last_mdm_checked_in_at"`
+	LastMDMEnrolledAt *time.Time `json:"last_mdm_enrolled_at"`
+	// LastMDMCheckedInAt is defined on the embedded Host so list-hosts loaders can
+	// populate it too. HostDetail's service layer still writes to h.LastMDMCheckedInAt
+	// on the way out.
 	// LastMDMEnrollmentType is the MDM enrollment channel reported by the device,
 	// e.g. "Device" or "User Enrollment (Device)". Manual BYOD and Account-Driven
 	// User Enrollment both report the "On (manual - personal)" status, so this is
@@ -1311,11 +1330,43 @@ type HostSummaryPlatform struct {
 	HostsCount uint   `json:"hosts_count" db:"total"`
 }
 
-// Status calculates the online status of the host
+// neverTimestampParsed mirrors the server.NeverTimestamp sentinel written to
+// detail_updated_at before a host's first full detail refetch. Duplicated as a
+// time.Time here so mobileStatus can drop it from the max without importing
+// the server package (which would create a cycle).
+//
+// Parsed at package init, panics on failure so a future edit that misaligns the
+// format string and the literal can't silently degrade to the zero time — which
+// would cause every mobile host with a zero DetailUpdatedAt to have its detail
+// treated as a valid activity signal, false-onlining "never checked in" hosts.
+var neverTimestampParsed = mustParseNeverTimestamp()
+
+func mustParseNeverTimestamp() time.Time {
+	t, err := time.Parse("2006-01-02 15:04:05", "2000-01-01 00:00:00")
+	if err != nil {
+		panic("fleet: neverTimestampParsed: " + err.Error())
+	}
+	return t
+}
+
+// Status calculates the online status of the host.
+//
+// The logic in this function should remain synchronized with
+// filterHostsByStatus, GenerateHostStatusStatistics, and CountHostsInTargets
+// in server/datastore/mysql — desktop and mobile predicates alike.
+//
+// Callers that construct a minimal fleet.Host{} (live_queries, scripts,
+// calendar_cron) don't populate LastMDMCheckedInAt. That's safe: those code
+// paths only apply to osquery-capable hosts, so the mobile branch never
+// triggers for them. Mobile hosts loaded through ListHosts / GetHost / the
+// details service will have the field populated by the SQL loader.
+//
+// NOTE: As of Fleet 4.15 StatusMIA is deprecated and will be removed in Fleet 5.0
 func (h *Host) Status(now time.Time) HostStatus {
-	// The logic in this function should remain synchronized with
-	// GenerateHostStatusStatistics and CountHostsInTargets - it can't stay in sync for MDM join, since that attribute is not available.
-	// NOTE: As of Fleet 4.15 StatusMIA is deprecated and will be removed in Fleet 5.0
+	if IsMobilePlatform(h.Platform) {
+		return h.mobileStatus(now)
+	}
+
 	onlineInterval := h.ConfigTLSRefresh
 	if h.DistributedInterval < h.ConfigTLSRefresh {
 		onlineInterval = h.DistributedInterval
@@ -1330,6 +1381,42 @@ func (h *Host) Status(now time.Time) HostStatus {
 	default:
 		return StatusOnline
 	}
+}
+
+// mobileStatus computes online/offline for iOS/iPadOS/Android hosts, which
+// don't run osquery. Uses the freshest of:
+//   - LastMDMCheckedInAt (from nano_enrollments.last_seen_at; Apple only)
+//   - DetailUpdatedAt, dropping the never-sentinel (Android's primary signal
+//     via status reports; also iOS/iPadOS full-detail refetches)
+//
+// Compared against MobileOnlineWindow. Deliberately no created_at fallback —
+// a freshly enrolled device that has never checked in is offline, matching
+// the chart bounded context's FindOnlineHostIDs predicate.
+//
+// SeenTime is intentionally NOT consulted here even though the SQL predicate
+// (hostMobileOnlineExpr) does read hst.seen_time when present. Rationale:
+// host_seen_times is bumped only by osquery paths (RecordHostLastSeen in
+// server/agentws and server/service/osquery.go). Mobile platforms don't run
+// osquery, so hst.seen_time is always NULL for pure mobile hosts. The list-
+// hosts loader further coalesces that NULL to h.created_at when populating
+// Host.SeenTime, which would make freshly-enrolled mobile hosts look "online"
+// forever. The SQL side reads the raw hst.seen_time and correctly gets NULL,
+// so both predicates agree in practice.
+func (h *Host) mobileStatus(now time.Time) HostStatus {
+	var latest time.Time
+	if h.LastMDMCheckedInAt != nil {
+		latest = *h.LastMDMCheckedInAt
+	}
+	if !h.DetailUpdatedAt.Equal(neverTimestampParsed) && h.DetailUpdatedAt.After(latest) {
+		latest = h.DetailUpdatedAt
+	}
+	if latest.IsZero() {
+		return StatusOffline
+	}
+	if latest.Add(MobileOnlineWindow).After(now) {
+		return StatusOnline
+	}
+	return StatusOffline
 }
 
 func (h *Host) IsNew(now time.Time) bool {
@@ -1457,6 +1544,13 @@ func IsAppleMobilePlatform(hostPlatform string) bool {
 
 func IsAndroidPlatform(hostPlatform string) bool {
 	return hostPlatform == "android"
+}
+
+// IsMobilePlatform reports whether the platform is iOS, iPadOS, or Android.
+// These platforms don't run osquery and have no check-in interval, so status
+// computations must fall back to MDM activity signals instead.
+func IsMobilePlatform(hostPlatform string) bool {
+	return IsAppleMobilePlatform(hostPlatform) || IsAndroidPlatform(hostPlatform)
 }
 
 func IsWindowsPlatform(hostPlatform string) bool {

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -44,12 +44,10 @@ const (
 	// than their expected checkin interval.
 	OnlineIntervalBuffer = 60
 
-	// MobileOnlineWindow is the window within which a mobile
-	// (iOS/iPadOS/Android) host's most recent MDM activity signal must fall
-	// for it to count as online. Anchored to the iOS/iPadOS MDM refetch
-	// cadence (1 hour; see ListIOSAndIPadOSToRefetch) plus OnlineIntervalBuffer.
-	// The chart bounded context duplicates this in mobileOnlineWindowSeconds
-	// because it can't import server/fleet (arch test enforced).
+	// MobileOnlineWindow bounds the MDM activity signal for mobile hosts to
+	// count as online. Anchored to the 1h iOS/iPadOS MDM refetch cadence plus
+	// OnlineIntervalBuffer. Duplicated in the chart context (mobileOnlineWindowSeconds)
+	// which can't import server/fleet.
 	MobileOnlineWindow = time.Hour + time.Duration(OnlineIntervalBuffer)*time.Second
 
 	// HostIdentiferNotFound is the error message returned when a search for a host by its
@@ -357,14 +355,9 @@ type Host struct {
 	PolicyUpdatedAt time.Time `json:"policy_updated_at" db:"policy_updated_at" csv:"policy_updated_at"` // Time that the host policies were last updated
 	LastEnrolledAt  time.Time `json:"last_enrolled_at" db:"last_enrolled_at" csv:"last_enrolled_at"`    // Time that the host last enrolled
 	SeenTime        time.Time `json:"seen_time" db:"seen_time" csv:"seen_time"`                         // Time that the host was last "seen"
-	// LastMDMCheckedInAt is the most recent MDM check-in for this host, sourced from
-	// nano_enrollments.last_seen_at (Apple only; nil for other platforms and for hosts
-	// with no MDM enrollment). Populated by list-hosts and host-details loaders.
-	// Feeds the mobile branch of Host.Status() so iOS/iPadOS hosts, which don't check
-	// in via osquery, still report accurate online/offline based on MDM activity.
-	// No `omitempty`: HostDetail previously serialized this as `null` for hosts with
-	// no MDM enrollment, and preserving that contract avoids breaking clients that
-	// key on the field's presence.
+	// LastMDMCheckedInAt is nano_enrollments.last_seen_at for active Apple
+	// enrollments; nil elsewhere. Feeds Host.Status()'s mobile branch. No
+	// omitempty: HostDetail already serialized this as null when absent.
 	LastMDMCheckedInAt *time.Time `json:"last_mdm_checked_in_at" db:"last_mdm_checked_in_at" csv:"-"`
 	RefetchRequested   bool       `json:"refetch_requested" db:"refetch_requested" csv:"refetch_requested"`
 	NodeKey            *string    `json:"-" db:"node_key" csv:"-"`
@@ -1330,15 +1323,10 @@ type HostSummaryPlatform struct {
 	HostsCount uint   `json:"hosts_count" db:"total"`
 }
 
-// neverTimestampParsed mirrors the server.NeverTimestamp sentinel written to
-// detail_updated_at before a host's first full detail refetch. Duplicated as a
-// time.Time here so mobileStatus can drop it from the max without importing
-// the server package (which would create a cycle).
-//
-// Parsed at package init, panics on failure so a future edit that misaligns the
-// format string and the literal can't silently degrade to the zero time — which
-// would cause every mobile host with a zero DetailUpdatedAt to have its detail
-// treated as a valid activity signal, false-onlining "never checked in" hosts.
+// neverTimestampParsed mirrors server.NeverTimestamp as a time.Time so
+// mobileStatus can compare against it without importing server (cycle).
+// Panics on parse failure so a format/literal drift can't silently degrade to
+// zero-time and false-online every never-checked-in mobile host.
 var neverTimestampParsed = mustParseNeverTimestamp()
 
 func mustParseNeverTimestamp() time.Time {
@@ -1349,17 +1337,13 @@ func mustParseNeverTimestamp() time.Time {
 	return t
 }
 
-// Status calculates the online status of the host.
-//
-// The logic in this function should remain synchronized with
+// Status calculates the online status of the host. Must stay in sync with
 // filterHostsByStatus, GenerateHostStatusStatistics, and CountHostsInTargets
-// in server/datastore/mysql — desktop and mobile predicates alike.
+// in server/datastore/mysql for both desktop and mobile predicates.
 //
-// Callers that construct a minimal fleet.Host{} (live_queries, scripts,
-// calendar_cron) don't populate LastMDMCheckedInAt. That's safe: those code
-// paths only apply to osquery-capable hosts, so the mobile branch never
-// triggers for them. Mobile hosts loaded through ListHosts / GetHost / the
-// details service will have the field populated by the SQL loader.
+// The mobile branch reads LastMDMCheckedInAt; minimal-Host{} callers
+// (live_queries, scripts, calendar_cron) don't populate it, but those paths
+// only apply to osquery-capable hosts so the mobile branch never fires there.
 //
 // NOTE: As of Fleet 4.15 StatusMIA is deprecated and will be removed in Fleet 5.0
 func (h *Host) Status(now time.Time) HostStatus {
@@ -1383,25 +1367,11 @@ func (h *Host) Status(now time.Time) HostStatus {
 	}
 }
 
-// mobileStatus computes online/offline for iOS/iPadOS/Android hosts, which
-// don't run osquery. Uses the freshest of:
-//   - LastMDMCheckedInAt (from nano_enrollments.last_seen_at; Apple only)
-//   - DetailUpdatedAt, dropping the never-sentinel (Android's primary signal
-//     via status reports; also iOS/iPadOS full-detail refetches)
-//
-// Compared against MobileOnlineWindow. Deliberately no created_at fallback —
-// a freshly enrolled device that has never checked in is offline, matching
-// the chart bounded context's FindOnlineHostIDs predicate.
-//
-// SeenTime is intentionally NOT consulted here even though the SQL predicate
-// (hostMobileOnlineExpr) does read hst.seen_time when present. Rationale:
-// host_seen_times is bumped only by osquery paths (RecordHostLastSeen in
-// server/agentws and server/service/osquery.go). Mobile platforms don't run
-// osquery, so hst.seen_time is always NULL for pure mobile hosts. The list-
-// hosts loader further coalesces that NULL to h.created_at when populating
-// Host.SeenTime, which would make freshly-enrolled mobile hosts look "online"
-// forever. The SQL side reads the raw hst.seen_time and correctly gets NULL,
-// so both predicates agree in practice.
+// mobileStatus is the iOS/iPadOS/Android branch of Status. Takes the freshest
+// of LastMDMCheckedInAt and non-sentinel DetailUpdatedAt against
+// MobileOnlineWindow; no created_at fallback so never-checked-in devices stay
+// offline. SeenTime is skipped: the list loader coalesces hst.seen_time with
+// h.created_at before we see it, which would false-online fresh enrollments.
 func (h *Host) mobileStatus(now time.Time) HostStatus {
 	var latest time.Time
 	if h.LastMDMCheckedInAt != nil {

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1372,6 +1372,16 @@ func (h *Host) Status(now time.Time) HostStatus {
 // MobileOnlineWindow; no created_at fallback so never-checked-in devices stay
 // offline. SeenTime is skipped: the list loader coalesces hst.seen_time with
 // h.created_at before we see it, which would false-online fresh enrollments.
+//
+// DetailUpdatedAt is NOT gated on enrollment state. The enabled = 1 filter on
+// nesm only screens the MDM signal, so a device that checked out with a fresh
+// detail_updated_at still reads online for up to MobileOnlineWindow after.
+// Intentional: the device was genuinely active recently.
+//
+// Mirrors hostMobileOnlineExpr with one caveat: SQL also folds in raw
+// hst.seen_time (not coalesced with created_at). Benign today because no
+// mobile enrollment path writes host_seen_times. If that changes, this branch
+// must be updated to match or Go and SQL will disagree on those rows.
 func (h *Host) mobileStatus(now time.Time) HostStatus {
 	var latest time.Time
 	if h.LastMDMCheckedInAt != nil {

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -45,10 +45,12 @@ const (
 	OnlineIntervalBuffer = 60
 
 	// MobileOnlineWindow bounds the MDM activity signal for mobile hosts to
-	// count as online. Anchored to the 1h iOS/iPadOS MDM refetch cadence plus
-	// OnlineIntervalBuffer. Duplicated in the chart context (mobileOnlineWindowSeconds)
-	// which can't import server/fleet.
-	MobileOnlineWindow = time.Hour + time.Duration(OnlineIntervalBuffer)*time.Second
+	// count as online. Sized to cover the worst-case gap between refetcher
+	// bumps: 1h refetch interval (ListIOSAndIPadOSToRefetch) plus 10m cron tick
+	// (apple_mdm_iphone_ipad_refetcher) plus OnlineIntervalBuffer for network
+	// latency. Duplicated in the chart context (mobileOnlineWindowSeconds)
+	// which can't import server/fleet — update both together.
+	MobileOnlineWindow = time.Hour + 10*time.Minute + time.Duration(OnlineIntervalBuffer)*time.Second
 
 	// HostIdentiferNotFound is the error message returned when a search for a host by its
 	// identifier (hostname, UUID, or serial number) does not return any results.
@@ -1368,27 +1370,27 @@ func (h *Host) Status(now time.Time) HostStatus {
 }
 
 // mobileStatus is the iOS/iPadOS/Android branch of Status. Takes the freshest
-// of LastMDMCheckedInAt and non-sentinel DetailUpdatedAt against
+// of LastMDMCheckedInAt and non-sentinel LabelUpdatedAt against
 // MobileOnlineWindow; no created_at fallback so never-checked-in devices stay
 // offline. SeenTime is skipped: the list loader coalesces hst.seen_time with
 // h.created_at before we see it, which would false-online fresh enrollments.
+// DetailUpdatedAt is skipped for Android because AMAPI stamps it with the
+// device's own status-report time (not when Fleet ingested the Pub/Sub
+// event), so it can lag by delivery latency; LabelUpdatedAt is Fleet-authored
+// on every check-in path (Apple MDM, Android Pub/Sub, osquery labels) and
+// gives a truer "last time we heard from this device" signal.
 //
-// DetailUpdatedAt is NOT gated on enrollment state. The enabled = 1 filter on
+// LabelUpdatedAt is NOT gated on enrollment state. The enabled = 1 filter on
 // nesm only screens the MDM signal, so a device that checked out with a fresh
-// detail_updated_at still reads online for up to MobileOnlineWindow after.
+// label_updated_at still reads online for up to MobileOnlineWindow after.
 // Intentional: the device was genuinely active recently.
-//
-// Mirrors hostMobileOnlineExpr with one caveat: SQL also folds in raw
-// hst.seen_time (not coalesced with created_at). Benign today because no
-// mobile enrollment path writes host_seen_times. If that changes, this branch
-// must be updated to match or Go and SQL will disagree on those rows.
 func (h *Host) mobileStatus(now time.Time) HostStatus {
 	var latest time.Time
 	if h.LastMDMCheckedInAt != nil {
 		latest = *h.LastMDMCheckedInAt
 	}
-	if !h.DetailUpdatedAt.Equal(neverTimestampParsed) && h.DetailUpdatedAt.After(latest) {
-		latest = h.DetailUpdatedAt
+	if h.LabelUpdatedAt.After(latest) {
+		latest = h.LabelUpdatedAt
 	}
 	if latest.IsZero() {
 		return StatusOffline

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -96,6 +96,82 @@ func TestHostStatus(t *testing.T) {
 	}
 }
 
+func TestHostStatusMobile(t *testing.T) {
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-15 * time.Minute) // well inside MobileOnlineWindow (~61 min)
+	stale := now.Add(-2 * time.Hour)     // well outside MobileOnlineWindow
+
+	neverTS := neverTimestampParsed
+
+	cases := []struct {
+		name string
+		h    Host
+		want HostStatus
+	}{
+		{
+			name: "ios online via LastMDMCheckedInAt",
+			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS, LastMDMCheckedInAt: &recent},
+			want: StatusOnline,
+		},
+		{
+			name: "ios offline when MDM signal is stale and nothing else",
+			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS, LastMDMCheckedInAt: &stale},
+			want: StatusOffline,
+		},
+		{
+			name: "ipados ignores SeenTime (host_seen_times is osquery-only, coalesced with created_at at load)",
+			h:    Host{Platform: "ipados", DetailUpdatedAt: neverTS, SeenTime: recent},
+			want: StatusOffline,
+		},
+		{
+			name: "ipados online via DetailUpdatedAt when it is fresh and not the never sentinel",
+			h:    Host{Platform: "ipados", DetailUpdatedAt: recent},
+			want: StatusOnline,
+		},
+		{
+			name: "ios ignores DetailUpdatedAt when equal to the never sentinel",
+			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS},
+			want: StatusOffline,
+		},
+		{
+			name: "android online via DetailUpdatedAt (no nano row)",
+			h:    Host{Platform: "android", DetailUpdatedAt: recent},
+			want: StatusOnline,
+		},
+		{
+			name: "android offline when DetailUpdatedAt is stale",
+			h:    Host{Platform: "android", DetailUpdatedAt: stale},
+			want: StatusOffline,
+		},
+		{
+			name: "android offline when DetailUpdatedAt is still the never sentinel",
+			h:    Host{Platform: "android", DetailUpdatedAt: neverTS},
+			want: StatusOffline,
+		},
+		{
+			name: "ios takes freshest of all three signals",
+			h: Host{
+				Platform:           "ios",
+				SeenTime:           stale,
+				LastMDMCheckedInAt: &recent,
+				DetailUpdatedAt:    stale,
+			},
+			want: StatusOnline,
+		},
+		{
+			name: "ios freshly enrolled but never checked in stays offline (no created_at fallback)",
+			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS},
+			want: StatusOffline,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, c.h.Status(now))
+		})
+	}
+}
+
 func TestHostStatusIsValid(t *testing.T) {
 	for _, tt := range []struct {
 		name     string

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -163,6 +163,15 @@ func TestHostStatusMobile(t *testing.T) {
 			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS},
 			want: StatusOffline,
 		},
+		{
+			// Documents that DetailUpdatedAt is NOT gated on enrollment state.
+			// nesm.enabled = 0 upstream masks LastMDMCheckedInAt to nil, but a
+			// fresh detail_updated_at still reads online for up to
+			// MobileOnlineWindow after checkout.
+			name: "ios online via fresh DetailUpdatedAt with nil LastMDMCheckedInAt (checked-out enrollment)",
+			h:    Host{Platform: "ios", DetailUpdatedAt: recent},
+			want: StatusOnline,
+		},
 	}
 
 	for _, c := range cases {

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -110,42 +110,45 @@ func TestHostStatusMobile(t *testing.T) {
 	}{
 		{
 			name: "ios online via LastMDMCheckedInAt",
-			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS, LastMDMCheckedInAt: &recent},
+			h:    Host{Platform: "ios", LabelUpdatedAt: neverTS, LastMDMCheckedInAt: &recent},
 			want: StatusOnline,
 		},
 		{
 			name: "ios offline when MDM signal is stale and nothing else",
-			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS, LastMDMCheckedInAt: &stale},
+			h:    Host{Platform: "ios", LabelUpdatedAt: neverTS, LastMDMCheckedInAt: &stale},
 			want: StatusOffline,
 		},
 		{
 			name: "ipados ignores SeenTime (host_seen_times is osquery-only, coalesced with created_at at load)",
-			h:    Host{Platform: "ipados", DetailUpdatedAt: neverTS, SeenTime: recent},
+			h:    Host{Platform: "ipados", LabelUpdatedAt: neverTS, SeenTime: recent},
 			want: StatusOffline,
 		},
 		{
-			name: "ipados online via DetailUpdatedAt when it is fresh and not the never sentinel",
-			h:    Host{Platform: "ipados", DetailUpdatedAt: recent},
+			name: "ipados online via LabelUpdatedAt when it is fresh and not the never sentinel",
+			h:    Host{Platform: "ipados", LabelUpdatedAt: recent},
 			want: StatusOnline,
 		},
 		{
-			name: "ios ignores DetailUpdatedAt when equal to the never sentinel",
-			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS},
+			name: "ios ignores LabelUpdatedAt when equal to the never sentinel",
+			h:    Host{Platform: "ios", LabelUpdatedAt: neverTS},
 			want: StatusOffline,
 		},
 		{
-			name: "android online via DetailUpdatedAt (no nano row)",
-			h:    Host{Platform: "android", DetailUpdatedAt: recent},
+			// Android's AMAPI-stamped DetailUpdatedAt is deliberately skipped
+			// so pubsub delivery lag doesn't skew status. LabelUpdatedAt is
+			// Fleet-authored on every Android check-in and carries the signal.
+			name: "android online via LabelUpdatedAt (no nano row, DetailUpdatedAt ignored)",
+			h:    Host{Platform: "android", LabelUpdatedAt: recent, DetailUpdatedAt: stale},
 			want: StatusOnline,
 		},
 		{
-			name: "android offline when DetailUpdatedAt is stale",
-			h:    Host{Platform: "android", DetailUpdatedAt: stale},
+			name: "android offline when LabelUpdatedAt is stale even if DetailUpdatedAt is fresh",
+			h:    Host{Platform: "android", LabelUpdatedAt: stale, DetailUpdatedAt: recent},
 			want: StatusOffline,
 		},
 		{
-			name: "android offline when DetailUpdatedAt is still the never sentinel",
-			h:    Host{Platform: "android", DetailUpdatedAt: neverTS},
+			name: "android offline when LabelUpdatedAt is still the never sentinel",
+			h:    Host{Platform: "android", LabelUpdatedAt: neverTS},
 			want: StatusOffline,
 		},
 		{
@@ -154,22 +157,22 @@ func TestHostStatusMobile(t *testing.T) {
 				Platform:           "ios",
 				SeenTime:           stale,
 				LastMDMCheckedInAt: &recent,
-				DetailUpdatedAt:    stale,
+				LabelUpdatedAt:     stale,
 			},
 			want: StatusOnline,
 		},
 		{
 			name: "ios freshly enrolled but never checked in stays offline (no created_at fallback)",
-			h:    Host{Platform: "ios", DetailUpdatedAt: neverTS},
+			h:    Host{Platform: "ios", LabelUpdatedAt: neverTS},
 			want: StatusOffline,
 		},
 		{
-			// Documents that DetailUpdatedAt is NOT gated on enrollment state.
-			// nesm.enabled = 0 upstream masks LastMDMCheckedInAt to nil, but a
-			// fresh detail_updated_at still reads online for up to
-			// MobileOnlineWindow after checkout.
-			name: "ios online via fresh DetailUpdatedAt with nil LastMDMCheckedInAt (checked-out enrollment)",
-			h:    Host{Platform: "ios", DetailUpdatedAt: recent},
+			// LabelUpdatedAt is NOT gated on enrollment state. nesm.enabled = 0
+			// upstream masks LastMDMCheckedInAt to nil, but a fresh
+			// label_updated_at still reads online for up to MobileOnlineWindow
+			// after checkout.
+			name: "ios online via fresh LabelUpdatedAt with nil LastMDMCheckedInAt (checked-out enrollment)",
+			h:    Host{Platform: "ios", LabelUpdatedAt: recent},
 			want: StatusOnline,
 		},
 	}

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1455,10 +1455,8 @@ type NanoMDMEnrollmentDetails struct {
 	// Enrollment both produce the "On (manual - personal)" status, so the channel
 	// is the only way to tell them apart.
 	EnrollmentType string `db:"enrollment_type"`
-	// Enabled mirrors nano_enrollments.enabled — bumped to 0 on checkout while
-	// last_seen_at continues to be updated. Callers that use LastMDMSeenTime as
-	// a liveness signal (e.g. Host.LastMDMCheckedInAt for the mobile status
-	// heuristic) must ignore it when Enabled is false.
+	// Enabled is false after checkout, when last_seen_at still keeps updating.
+	// Liveness-signal callers must ignore LastMDMSeenTime in that case.
 	Enabled bool `db:"enabled"`
 }
 

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1455,6 +1455,11 @@ type NanoMDMEnrollmentDetails struct {
 	// Enrollment both produce the "On (manual - personal)" status, so the channel
 	// is the only way to tell them apart.
 	EnrollmentType string `db:"enrollment_type"`
+	// Enabled mirrors nano_enrollments.enabled — bumped to 0 on checkout while
+	// last_seen_at continues to be updated. Callers that use LastMDMSeenTime as
+	// a liveness signal (e.g. Host.LastMDMCheckedInAt for the mobile status
+	// heuristic) must ignore it when Enabled is false.
+	Enabled bool `db:"enabled"`
 }
 
 // MDM SSO initiator constants identify which enrollment flow initiated the SSO

--- a/server/fleet/mobile_window_sync_test.go
+++ b/server/fleet/mobile_window_sync_test.go
@@ -1,0 +1,23 @@
+package fleet_test
+
+import (
+	"testing"
+	"time"
+
+	chartapi "github.com/fleetdm/fleet/v4/server/chart/api"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMobileOnlineWindowMatchesChart guards against drift between
+// fleet.MobileOnlineWindow (used by Host.mobileStatus and the mysql predicates)
+// and chartapi.MobileOnlineWindowSeconds (used by the chart bounded context's
+// FindOnlineHostIDs). The two live in different packages because server/chart
+// can't import server/fleet; this test is the only automated sync check.
+func TestMobileOnlineWindowMatchesChart(t *testing.T) {
+	require.Equal(t,
+		int(fleet.MobileOnlineWindow/time.Second),
+		chartapi.MobileOnlineWindowSeconds,
+		"fleet.MobileOnlineWindow and chartapi.MobileOnlineWindowSeconds drifted; edit both together",
+	)
+}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2165,6 +2165,11 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get os update for host details")
 	}
 
+	// LastMDMCheckedInAt lives on Host so it's also available to the list-hosts
+	// loader; the details service overwrites the (potentially nil) value from
+	// the list-load with the fresh nano_enrollments read done above.
+	host.LastMDMCheckedInAt = mdmLastCheckedIn
+
 	return &fleet.HostDetail{
 		Host:                          *host,
 		Labels:                        labels,
@@ -2174,7 +2179,6 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		EndUsers:                      endUsers,
 		CustomHostVitals:              customHostVitals,
 		LastMDMEnrolledAt:             mdmLastEnrollment,
-		LastMDMCheckedInAt:            mdmLastCheckedIn,
 		LastMDMEnrollmentType:         mdmEnrollmentType,
 		MDMEnrollmentHardwareAttested: mdmHardwareAttested,
 		ConditionalAccessBypassed:     conditionalAccessBypassed,

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2041,7 +2041,14 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				// Apple platforms
 				details, err := svc.ds.GetNanoMDMEnrollmentDetails(ctx, host.UUID)
 				if details != nil {
-					mdmLastCheckedIn = details.LastMDMSeenTime
+					// LastMDMSeenTime keeps updating on checkout, so gate on
+					// Enabled to match the list-hosts response (nesm join has
+					// `enabled = 1`). Otherwise a recently-unenrolled host would
+					// show a fresh last_mdm_checked_in_at on /hosts/{id} but null
+					// on /hosts.
+					if details.Enabled {
+						mdmLastCheckedIn = details.LastMDMSeenTime
+					}
 					mdmLastEnrollment = details.LastMDMEnrollmentTime
 					mdmHardwareAttested = details.HardwareAttested
 				}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2041,11 +2041,8 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				// Apple platforms
 				details, err := svc.ds.GetNanoMDMEnrollmentDetails(ctx, host.UUID)
 				if details != nil {
-					// LastMDMSeenTime keeps updating on checkout, so gate on
-					// Enabled to match the list-hosts response (nesm join has
-					// `enabled = 1`). Otherwise a recently-unenrolled host would
-					// show a fresh last_mdm_checked_in_at on /hosts/{id} but null
-					// on /hosts.
+					// Gate on Enabled so /hosts/{id} matches /hosts (nesm join
+					// filters enabled=1) for checked-out enrollments.
 					if details.Enabled {
 						mdmLastCheckedIn = details.LastMDMSeenTime
 					}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1907,6 +1907,34 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 	var mdmLastCheckedIn *time.Time
 	var mdmEnrollmentType *string
 	var mdmHardwareAttested bool
+
+	// Read nano_enrollments for Apple hosts regardless of MDM config so
+	// /hosts/{id} matches /hosts (list joins nano_enrollments unconditionally
+	// and can surface a timestamp after MDM has been turned off). The block
+	// below still gates disk-encryption/profile reads on config, but the
+	// pre-read struct feeds LastMDMCheckedInAt / LastMDMEnrolledAt /
+	// HardwareAttested / BootstrapTokenEscrowed / EnrollmentType uniformly.
+	var appleNanoDetails *fleet.NanoMDMEnrollmentDetails
+	if fleet.IsApplePlatform(host.Platform) {
+		appleNanoDetails, err = svc.ds.GetNanoMDMEnrollmentDetails(ctx, host.UUID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "get host mdm enrollment times")
+		}
+		if appleNanoDetails != nil {
+			// Mobile-only Enabled gate so /hosts/{id} matches /hosts (nesm
+			// join filters enabled=1) for checked-out mobile enrollments.
+			// macOS keeps surfacing LastMDMSeenTime regardless.
+			if !fleet.IsAppleMobilePlatform(host.Platform) || appleNanoDetails.Enabled {
+				mdmLastCheckedIn = appleNanoDetails.LastMDMSeenTime
+			}
+			mdmLastEnrollment = appleNanoDetails.LastMDMEnrollmentTime
+			mdmHardwareAttested = appleNanoDetails.HardwareAttested
+			if appleNanoDetails.EnrollmentType != "" {
+				mdmEnrollmentType = &appleNanoDetails.EnrollmentType
+			}
+		}
+	}
+
 	if ac.MDM.EnabledAndConfigured || ac.MDM.WindowsEnabledAndConfigured || ac.MDM.AndroidEnabledAndConfigured {
 		host.MDM.OSSettings = &fleet.HostMDMOSSettings{}
 		switch host.Platform {
@@ -2037,32 +2065,11 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 					profiles = append(profiles, p.ToHostMDMProfile(host.Platform))
 				}
 
-				// fetch host last seen at and last enrolled at times, currently only supported for
-				// Apple platforms
-				details, err := svc.ds.GetNanoMDMEnrollmentDetails(ctx, host.UUID)
-				if details != nil {
-					// Gate on Enabled so /hosts/{id} matches /hosts (nesm join
-					// filters enabled=1) for checked-out enrollments.
-					if details.Enabled {
-						mdmLastCheckedIn = details.LastMDMSeenTime
-					}
-					mdmLastEnrollment = details.LastMDMEnrollmentTime
-					mdmHardwareAttested = details.HardwareAttested
-				}
-				if err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "get host mdm enrollment times")
-				}
-
-				// bootstrap tokens are only applicable to macOS hosts
-				if host.Platform == "darwin" && details != nil {
-					host.MDM.BootstrapTokenEscrowed = &details.BootstrapTokenEscrowed
-				}
-
-				// Manual BYOD and Account-Driven User Enrollment both report the
-				// "On (manual - personal)" status, so the enrollment channel is what
-				// tells them apart.
-				if details != nil && details.EnrollmentType != "" {
-					mdmEnrollmentType = &details.EnrollmentType
+				// Nano details were read above the outer MDM guard; reuse the
+				// pre-read struct for the fields that only make sense when
+				// Apple MDM is on (bootstrap token escrow).
+				if host.Platform == "darwin" && appleNanoDetails != nil {
+					host.MDM.BootstrapTokenEscrowed = &appleNanoDetails.BootstrapTokenEscrowed
 				}
 			}
 		}

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -597,6 +597,9 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 			LastMDMSeenTime:        &ts2,
 			HardwareAttested:       false,
 			BootstrapTokenEscrowed: true,
+			// Simulate an active enrollment so the details service surfaces
+			// LastMDMSeenTime into host.LastMDMCheckedInAt.
+			Enabled: true,
 		}, nil
 	}
 
@@ -644,6 +647,31 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 			}
 		})
 	}
+
+	// Checked-out Apple enrollment: last_seen_at is still bumped after checkout,
+	// but Enabled is false. LastMDMCheckedInAt must stay nil so the details
+	// endpoint matches what the list endpoint returns (nesm join filters
+	// enabled=1). LastMDMEnrolledAt is a durable enrollment fact and still flows
+	// through.
+	t.Run("checked-out Apple enrollment hides LastMDMCheckedInAt", func(t *testing.T) {
+		ds.GetNanoMDMEnrollmentDetailsFuncInvoked = false
+		ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {
+			return &fleet.NanoMDMEnrollmentDetails{
+				LastMDMEnrollmentTime: &ts1,
+				LastMDMSeenTime:       &ts2,
+				Enabled:               false,
+			}, nil
+		}
+		host := &fleet.Host{ID: 4, MDM: fleet.MDMHostData{}, Platform: "ipados", UUID: "checked-out-uuid"}
+		hostDetail, err := svc.getHostDetails(
+			test.UserContext(context.Background(), test.UserAdmin),
+			host,
+			fleet.HostDetailOptions{ExcludeSoftware: true},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, hostDetail.LastMDMEnrolledAt)
+		require.Nil(t, hostDetail.LastMDMCheckedInAt, "checked-out enrollment must not expose LastMDMCheckedInAt on /hosts/{id}")
+	})
 }
 
 // mockHostDetailsDatastore stubs out the datastore calls getHostDetails makes

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -648,11 +648,8 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 		})
 	}
 
-	// Checked-out Apple enrollment: last_seen_at is still bumped after checkout,
-	// but Enabled is false. LastMDMCheckedInAt must stay nil so the details
-	// endpoint matches what the list endpoint returns (nesm join filters
-	// enabled=1). LastMDMEnrolledAt is a durable enrollment fact and still flows
-	// through.
+	// Checked-out enrollment: LastMDMCheckedInAt must be nil so /hosts/{id}
+	// matches /hosts (nesm join filters enabled=1).
 	t.Run("checked-out Apple enrollment hides LastMDMCheckedInAt", func(t *testing.T) {
 		ds.GetNanoMDMEnrollmentDetailsFuncInvoked = false
 		ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -648,9 +648,9 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 		})
 	}
 
-	// Checked-out enrollment: LastMDMCheckedInAt must be nil so /hosts/{id}
-	// matches /hosts (nesm join filters enabled=1).
-	t.Run("checked-out Apple enrollment hides LastMDMCheckedInAt", func(t *testing.T) {
+	// Checked-out mobile enrollment: LastMDMCheckedInAt must be nil so
+	// /hosts/{id} matches /hosts (nesm join filters enabled=1).
+	t.Run("checked-out iPadOS enrollment hides LastMDMCheckedInAt", func(t *testing.T) {
 		ds.GetNanoMDMEnrollmentDetailsFuncInvoked = false
 		ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {
 			return &fleet.NanoMDMEnrollmentDetails{
@@ -667,7 +667,65 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NotNil(t, hostDetail.LastMDMEnrolledAt)
-		require.Nil(t, hostDetail.LastMDMCheckedInAt, "checked-out enrollment must not expose LastMDMCheckedInAt on /hosts/{id}")
+		require.Nil(t, hostDetail.LastMDMCheckedInAt, "checked-out mobile enrollment must not expose LastMDMCheckedInAt on /hosts/{id}")
+	})
+
+	// macOS host details keep surfacing LastMDMCheckedInAt regardless of
+	// enrollment state — HostHeader.tsx renders it as an informational
+	// timestamp, and Host.mobileStatus doesn't apply to darwin.
+	t.Run("checked-out macOS enrollment still exposes LastMDMCheckedInAt", func(t *testing.T) {
+		ds.GetNanoMDMEnrollmentDetailsFuncInvoked = false
+		ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {
+			return &fleet.NanoMDMEnrollmentDetails{
+				LastMDMEnrollmentTime: &ts1,
+				LastMDMSeenTime:       &ts2,
+				Enabled:               false,
+			}, nil
+		}
+		host := &fleet.Host{ID: 5, MDM: fleet.MDMHostData{}, Platform: "darwin", UUID: "checked-out-mac-uuid"}
+		hostDetail, err := svc.getHostDetails(
+			test.UserContext(context.Background(), test.UserAdmin),
+			host,
+			fleet.HostDetailOptions{ExcludeSoftware: true},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, hostDetail.LastMDMCheckedInAt, "checked-out macOS enrollment should still expose LastMDMCheckedInAt on /hosts/{id}")
+		require.Equal(t, ts2, *hostDetail.LastMDMCheckedInAt)
+	})
+
+	// When Apple MDM is turned off, /hosts still reads nesm.last_seen_at via
+	// the unconditional LEFT JOIN. /hosts/{id} must do the same — the nano
+	// read is hoisted above the MDM-configured guard so both endpoints
+	// return the same LastMDMCheckedInAt for a host whose nano row survives
+	// an MDM shutoff.
+	t.Run("Apple MDM disabled still exposes LastMDMCheckedInAt", func(t *testing.T) {
+		ds.GetNanoMDMEnrollmentDetailsFuncInvoked = false
+		ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {
+			return &fleet.NanoMDMEnrollmentDetails{
+				LastMDMEnrollmentTime: &ts1,
+				LastMDMSeenTime:       &ts2,
+				Enabled:               true,
+			}, nil
+		}
+		mdmOffConfig := &fleet.AppConfig{}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return mdmOffConfig, nil
+		}
+		defer func() {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true, WindowsEnabledAndConfigured: true}}, nil
+			}
+		}()
+		host := &fleet.Host{ID: 6, MDM: fleet.MDMHostData{}, Platform: "darwin", UUID: "mdm-off-mac-uuid"}
+		hostDetail, err := svc.getHostDetails(
+			test.UserContext(context.Background(), test.UserAdmin),
+			host,
+			fleet.HostDetailOptions{ExcludeSoftware: true},
+		)
+		require.NoError(t, err)
+		require.True(t, ds.GetNanoMDMEnrollmentDetailsFuncInvoked, "nano read must run even when Apple MDM is off")
+		require.NotNil(t, hostDetail.LastMDMCheckedInAt, "Apple MDM off must not hide LastMDMCheckedInAt on /hosts/{id}")
+		require.Equal(t, ts2, *hostDetail.LastMDMCheckedInAt)
 	})
 }
 


### PR DESCRIPTION
## Issue
Closes #52486 (sub-issue of parent story #50155)
Closes #52699

## Description
- **Root cause**: `Host.Status()` and the three SQL predicates that mirror it (`filterHostsByStatus`, `GenerateHostStatusStatistics`, `CountHostsInTargets`) compare `hst.seen_time` to the osquery check-in interval. Mobile hosts don't run osquery, so `hst.seen_time` is never bumped for them — every iOS/iPadOS/Android host reports offline regardless of actual MDM activity.
- **Predicate**: mobile hosts read `nano_enrollments.last_seen_at` (Apple, active enrollments only), falling back to `detail_updated_at` when unset (never-sentinel dropped), compared against a 1h + `OnlineIntervalBuffer` window. No `created_at` fallback — a freshly-enrolled device that has never checked in stays offline. Deliberately does not read `hst.seen_time` (mobile enrollment paths don't write `host_seen_times`) so the Go-side `Host.mobileStatus` and this SQL expression stay in lockstep.
- **`enabled = 1` filter on the mobile join**: `nano_enrollments.last_seen_at` is bumped on checkout too, so a recently-unenrolled device would look online without it. Introduced a new `hostMobileMDMSeenTimeJoin` (alias `nesm`) alongside the existing `hostMDMSeenTimeJoin` (alias `nes`) so MIA/Missing semantics stay unchanged.
- **`LastMDMCheckedInAt` promoted from `HostDetail` to `Host`** so `Host.Status()` on list-response rows has the MDM signal. `omitempty` intentionally omitted to preserve the pre-existing `null`-when-absent JSON contract.
- **`ListHosts` gains the mobile MDM join unconditionally** (~1 PK lookup per host, verified `eq_ref` via `EXPLAIN`). Kept the existing `hostMDMSeenTimeJoin` join conditional on a status filter — MIA/Missing paths untouched.
- **FE cleanup**: `HostSummary` renders the real Status pill for iOS/iPadOS/Android (dropped the `!isIosOrIpadosHost && !isAndroidHost` gate); Manage hosts page stops short-circuiting the Status cell to "Not supported" for mobile. When sibling FE PR #52483 also merges, the pill becomes clickable to open the online-history modal.
- **Tooltip copy left unchanged per product**: the "Online/Offline hosts will respond to a live report" pill tooltips are dropped (misleading for mobile) but the Pending ABM tooltip stays, and existing platform-specific tooltips on the Manage hosts header and the Dashboard "Hosts online" chart are untouched.
- **Also closes #52699**: `apple_mdm_iphone_ipad_refetcher` and `apple_mdm_iphone_ipad_reviver` moved out of `registerPremiumCrons` into `registerMDMCrons` so Free-tier iOS/iPadOS BYOD hosts get vitals refetched and MDM last-seen bumped on the standard 10-minute / 1-hour cadence.
- **Sibling PR #52572** (docs) covers the REST API reference note for the mobile heuristic — kept out of this branch so the docs update ships against `docs-v4.93.0`.

## Screenrecording
- Manage host page - Status of mobile now showing
- Host details page - Status of mobile now showing

<img width="505" height="407" alt="Screenshot 2026-09-04 at 11 23 05 AM" src="https://github.com/user-attachments/assets/fa8600c7-1680-4119-a667-2a1ac2e1cd1b" />
<img width="1008" height="323" alt="Screenshot 2026-09-04 at 11 23 20 AM" src="https://github.com/user-attachments/assets/af421616-f872-46dc-ad8f-af00410a7152" />


https://fleetdm.zoom.us/clips/share/t5j4COH8SkKqY3VEdVy7JQ

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- 10 unit cases in \`TestHostStatusMobile\` covering iOS/iPadOS/Android × MDM signal / detail-updated-at / never-sentinel / freshly-enrolled edge cases
- Integration test \`TestHosts/MobileOnlineOffline\` seeding 7 mobile hosts across online / offline / disabled-checkout and asserting SQL aggregates, list filter, \`Host.Status()\` on listed hosts, and target metrics all agree
- Existing \`TestHosts\` suite (82s exhaustive integration run) still green — no regressions in desktop/Windows/Linux status paths
- \`TestExplainListHostsMobileJoin\` dumps the ListHosts EXPLAIN plan as a regression guard — confirms \`nano_enrollments\` join uses the table's PRIMARY KEY (\`eq_ref\`, ~1 lookup per host) rather than a full scan



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mobile hosts (iOS, iPadOS, and Android) now report online/offline status based on recent MDM activity across host lists, details, and dashboards.
  - Host data now includes the last MDM check-in time.
  - Mobile status is displayed in host summaries for Free-tier devices.

- **Bug Fixes**
  - Mobile hosts are no longer included in live-query target counts or campaign target results.
  - Apple mobile host activity refreshes now run on all license tiers.
  - Status tooltips are shown only when additional enrollment context is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
