### PR TITLE
Add a missing period to the live report tooltip

### DIFF
--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
@@ -245,7 +245,7 @@ describe("EditQueryForm - component", () => {
 
     expect(
       await screen.findByText(
-        /live reports are disabled in organization settings/i
+        /live reports are disabled in organization settings\./i
       )
     ).toBeInTheDocument();
   });

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -564,7 +564,7 @@ const EditQueryForm = ({
         <div className={`button-wrap ${baseClass}__button-wrap--new-query`}>
           <TooltipWrapper
             className="live-query-button-tooltip"
-            tipContent="Live reports are disabled in organization settings"
+            tipContent="Live reports are disabled in organization settings."
             disableTooltip={!disabledLiveQuery}
             position="top"
             showArrow
@@ -856,7 +856,7 @@ const EditQueryForm = ({
             )}
             <TooltipWrapper
               className="live-query-button-tooltip"
-              tipContent="Live reports are disabled in organization settings"
+              tipContent="Live reports are disabled in organization settings."
               disableTooltip={!disabledLiveQuery}
               position="top"
               showArrow


### PR DESCRIPTION
# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

---

Before:

<img width="188" height="112" alt="Screenshot 2026-09-03 at 14 57 49" src="https://github.com/user-attachments/assets/4f5dcb05-46cf-400f-9b7e-59a64a49281e" />

And after:

<img width="207" height="123" alt="Screenshot 2026-09-03 at 14 56 07" src="https://github.com/user-attachments/assets/d530af14-4141-47a8-96b8-79a32a158072" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected punctuation in the “Live reports are disabled in organization settings.” tooltip message.
  * Updated the related validation to match the revised message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->