### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.162.0",
+      "version": "1.163.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.162.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.163.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'company.thebrowser.Browser' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.162.0-86046.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.163.0-86417.zip",
       "install_script_ref": "cbf109ae",
       "uninstall_script_ref": "a19b04fa",
-      "sha256": "d8f4299200c16bde5c0f413976fb92397613706eb6fff855d02dcd9e9c3f1aa1",
+      "sha256": "f0e9ca1e2c9e78a7df6f27e19f971620ab9d8e8d0b1d1c2b94e7210fb11796cd",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.901.20858",
+      "version": "26.901.22334",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.901.20858') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.901.22334') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.openai.chat' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.901.20858.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.901.22334.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "c8cab4ba07ff1852b5eeb11a7e077adba48e28fe8faada158eaa5edca90f0062",
+      "sha256": "b2e671d34269789fd1747072018295f48f486cfac2cf0c6b6a8e15fc218b06f0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.18.25",
+      "version": "3.19.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.18.25') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.19.7') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.cursor.com/production/280eca2911f1774689696e5f1efa5a4f97a87af3/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/90de2327392570a5f5f625c656c6749d228e6437/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "1ae48b55",
       "uninstall_script_ref": "03b9aece",
-      "sha256": "9b12b8e0d0fcc124f474d95e0fd79692485f2b4aa58a123ea4959186725da948",
+      "sha256": "7eff6b6e511c24a03152bb7730ca5ed11457dfc1feb3288c57f05426dd04013d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dayflow/darwin.json
+++ b/ee/maintained-apps/outputs/dayflow/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.1.1",
+      "version": "2.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.1.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.2.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'teleportlabs.com.Dayflow' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.1.1/Dayflow.dmg",
+      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.2.0/Dayflow.dmg",
       "install_script_ref": "9ec4db9b",
       "uninstall_script_ref": "8672edfc",
-      "sha256": "db36cd15929f3ef24f13ee24a7d6dde1a00baa6f8f581b632787174df4db8be2",
+      "sha256": "8ac78be890b590fa3b260b30d22c95b83dfe43b62cffda3ecf9214c05cd37bd5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dockdoor/darwin.json
+++ b/ee/maintained-apps/outputs/dockdoor/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.39.5",
+      "version": "1.40.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor' AND version_compare(bundle_short_version, '1.39.5') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor' AND version_compare(bundle_short_version, '1.40.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.ethanbills.DockDoor' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/ejbills/DockDoor/releases/download/1.39.5/DockDoor.dmg",
+      "installer_url": "https://github.com/ejbills/DockDoor/releases/download/1.40.0/DockDoor.dmg",
       "install_script_ref": "8a8c0b06",
       "uninstall_script_ref": "0e456379",
-      "sha256": "2c3c06027f2a2e74375d1c4c95d2133b6bf7e88843cc7026c4c40d5e84c56d40",
+      "sha256": "7d05e25a68ff9d9ff8d11a05c4e9fe9be42a56ae3428bfc0e4b55fc1938f90f0",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/figma/darwin.json
+++ b/ee/maintained-apps/outputs/figma/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "126.8.16",
+      "version": "126.8.18",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.8.16') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop' AND version_compare(bundle_short_version, '126.8.18') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.figma.Desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.8.16.zip",
+      "installer_url": "https://desktop.figma.com/mac-arm/Figma-126.8.18.zip",
       "install_script_ref": "cea5222a",
       "uninstall_script_ref": "ffdf9bc3",
-      "sha256": "991ba930194147ee6272031f404c356a7747ef47e4f0079fa8e426b92f026b49",
+      "sha256": "b35e1f5827d6933b15f52fda1dad8e65067c9e6f31a486ca4dc1f3b00a17bb05",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "152.0.7977.76",
+      "version": "152.0.7977.83",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '152.0.7977.76') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '152.0.7977.83') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.google.Chrome' AND a.bundle_executable != '');"
       },
       "installer_url": "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg",

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.372.0",
+      "version": "0.373.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.372.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.373.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.loom.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.372.0-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.373.2-arm64.dmg",
       "install_script_ref": "53e2b898",
       "uninstall_script_ref": "1a901a1f",
-      "sha256": "f1fb883c3639b2c12776f4ade0feafd70f5ace30e9ba841eb482f758a605f5fe",
+      "sha256": "7562a378d4082540dca21f45e826a553b68a1e3df4815530f38683885da9d12c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ollama/windows.json
+++ b/ee/maintained-apps/outputs/ollama/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.33.2",
+      "version": "0.33.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.33.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.33.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) IN ('ollama.exe','ollama app.exe'));"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.33.2/OllamaSetup.exe",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.33.3/OllamaSetup.exe",
       "install_script_ref": "e14c71ee",
       "uninstall_script_ref": "3f049b5d",
-      "sha256": "5a91c1cf92480e28a84cd99e437219be719df5a50d5fa0fd5fe5b5c4a122f506",
+      "sha256": "32cdcb1da477bc7fffbf1c1cdeeb99b1db003af094db56dd3c156abd04d34f8e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/signal/windows.json
+++ b/ee/maintained-apps/outputs/signal/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.25.0",
+      "version": "8.26.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Signal %' AND publisher = 'Signal Messenger, LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Signal %' AND publisher = 'Signal Messenger, LLC' AND version_compare(version, '8.25.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Signal %' AND publisher = 'Signal Messenger, LLC' AND version_compare(version, '8.26.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'signal.exe');"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-win-8.25.0.exe",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-win-8.26.0.exe",
       "install_script_ref": "97ea8e76",
       "uninstall_script_ref": "3fc7779f",
-      "sha256": "312c12c41461be3a6da003f75ae6d1c4c688d7f2a9ecbe85843f252f0cafc022",
+      "sha256": "13d4c18023a57f23f3fa262de0ab1555a928889822c5ee12230a55616195c16b",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/windows.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.136.0",
+      "version": "1.136.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation' AND version_compare(version, '1.136.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation' AND version_compare(version, '1.136.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'code.exe');"
       },
-      "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/520fb30b2d3d324b4cb2342f6e88e2cd93751de1/VSCodeSetup-x64-1.136.0.exe",
+      "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/a44adf7f53e00964ab890f9f8758a334f1fc15bc/VSCodeSetup-x64-1.136.1.exe",
       "install_script_ref": "49122823",
       "uninstall_script_ref": "e09509e2",
-      "sha256": "a973b24b3f4479bf54ba2693a9f9e50e7254deab147220ea0e15ef974a66b098",
+      "sha256": "f88c83afd2acda9cbfffbd89e1ebe35a88162616f7cb2014ab11118ef91c3bfe",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS app packages for Arc, ChatGPT, Cursor, Dayflow, DockDoor, Figma, Google Chrome, and Loom to their latest listed releases.
  * Updated Windows app packages for Ollama, Signal, and Visual Studio Code.
  * Refreshed download sources and integrity checks to match the new versions, ensuring installations use the corresponding release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->