### PR TITLE
Explain "Never" in the Hosts list "Last fetched" column

### DIFF
--- a/changes/44155-last-fetched-never-tooltip
+++ b/changes/44155-last-fetched-never-tooltip
@@ -1,0 +1,1 @@
+- Added a tooltip explaining why the "Last fetched" column on the Hosts page reads "Never" for a host that has checked in but has not yet reported vitals.

--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tests.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tests.tsx
@@ -9,6 +9,7 @@ import {
 
 const EMPTY_STRING = "Unavailable";
 const INVALID_STRING = "Invalid date";
+const NEVER_TOOLTIP = "This host has not reported vitals yet.";
 
 describe("HumanTimeDiffWithDateTip - component", () => {
   it("renders tooltip on hover", async () => {
@@ -43,5 +44,31 @@ describe("HumanTimeDiffWithDateTip - component", () => {
     );
 
     expect(screen.getByText(/never/i)).toBeInTheDocument();
+  });
+
+  it("explains 'Never' on hover when given a never tooltip", async () => {
+    const { user } = renderWithSetup(
+      <HumanTimeDiffWithFleetLaunchCutoff
+        timeString="1970-01-02T00:00:00Z"
+        neverTooltip={NEVER_TOOLTIP}
+      />
+    );
+
+    await user.hover(screen.getByText(/never/i));
+
+    expect(await screen.findByText(NEVER_TOOLTIP)).toBeInTheDocument();
+  });
+
+  it("ignores the never tooltip when the date is after Fleet was created", async () => {
+    const { user } = renderWithSetup(
+      <HumanTimeDiffWithFleetLaunchCutoff
+        timeString="2024-04-27T12:00:00Z"
+        neverTooltip={NEVER_TOOLTIP}
+      />
+    );
+
+    await user.hover(screen.getByText(/years ago/i));
+
+    expect(screen.queryByText(NEVER_TOOLTIP)).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tests.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tests.tsx
@@ -54,6 +54,8 @@ describe("HumanTimeDiffWithDateTip - component", () => {
       />
     );
 
+    expect(screen.queryByText(NEVER_TOOLTIP)).not.toBeInTheDocument();
+
     await user.hover(screen.getByText(/never/i));
 
     expect(await screen.findByText(NEVER_TOOLTIP)).toBeInTheDocument();

--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tsx
@@ -4,11 +4,16 @@ import { uniqueId } from "lodash";
 import { humanLastSeen, internationalTimeFormat } from "utilities/helpers";
 import { INITIAL_FLEET_DATE } from "utilities/constants";
 import ReactTooltip, { Place } from "react-tooltip";
+import TooltipWrapper from "components/TooltipWrapper";
 
 interface IHumanTimeDiffWithDateTip {
   timeString: string;
   cutoffBeforeFleetLaunch?: boolean;
   tooltipPosition?: Place;
+  /** Content for a tooltip on the "Never" value, explaining to the caller's
+   * audience why the date is missing. Ignored unless the value renders as
+   * "Never". */
+  neverTooltip?: React.ReactNode;
 }
 
 /** Returns "Unavailable" if date is empty string or "Unavailable"
@@ -19,6 +24,7 @@ export const HumanTimeDiffWithDateTip = ({
   timeString,
   cutoffBeforeFleetLaunch = false,
   tooltipPosition = "top",
+  neverTooltip,
 }: IHumanTimeDiffWithDateTip): JSX.Element => {
   const id = uniqueId();
 
@@ -29,7 +35,18 @@ export const HumanTimeDiffWithDateTip = ({
   // There are cases where dates are set in Fleet to be the "zero date" which
   // serves as an indicator that a particular date isn't set.
   if (cutoffBeforeFleetLaunch && timeString < INITIAL_FLEET_DATE) {
-    return <span>Never</span>;
+    if (!neverTooltip) {
+      return <span>Never</span>;
+    }
+    return (
+      <TooltipWrapper
+        tipContent={neverTooltip}
+        position={tooltipPosition}
+        showArrow
+      >
+        Never
+      </TooltipWrapper>
+    );
   }
 
   try {
@@ -63,11 +80,13 @@ export const HumanTimeDiffWithDateTip = ({
 export const HumanTimeDiffWithFleetLaunchCutoff = ({
   timeString,
   tooltipPosition = "top",
+  neverTooltip,
 }: IHumanTimeDiffWithDateTip): JSX.Element => {
   return (
     <HumanTimeDiffWithDateTip
       timeString={timeString}
       tooltipPosition={tooltipPosition}
+      neverTooltip={neverTooltip}
       cutoffBeforeFleetLaunch
     />
   );

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tests.tsx
@@ -9,6 +9,10 @@ import {
   getPrimaryDeviceUser,
 } from "./HostTableConfig";
 
+// react-table's `Column` union includes group columns, which carry no `Cell`,
+// so the property isn't reachable through that type alone.
+type IColumnWithCell = Column<IHost> & { Cell?: React.ElementType };
+
 describe("getPrimaryDeviceUser", () => {
   it("returns no primary email, no suffix, and no tooltip lines when there are no emails", () => {
     expect(getPrimaryDeviceUser([])).toEqual({
@@ -151,7 +155,7 @@ describe("HostTableConfig - User email column", () => {
     });
     const column = columns.find(
       (c) => (c as Column<IHost>).id === "device_mapping"
-    ) as Column<IHost> | undefined;
+    ) as IColumnWithCell | undefined;
     if (!column) throw new Error("device_mapping column not found");
     return column;
   };
@@ -214,7 +218,7 @@ describe("HostTableConfig - Serial number column", () => {
 
   const serialColumn = headers.find(
     (h) => (h as Column<IHost>).id === "hardware_serial"
-  ) as Column<IHost> | undefined;
+  ) as IColumnWithCell | undefined;
 
   if (!serialColumn || typeof serialColumn.Cell !== "function") {
     throw new Error("hardware_serial column or Cell not found");

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -58,6 +58,9 @@ type ISelectionCellProps = CellProps<IHost>;
 type IIssuesCellProps = CellProps<IHost, IHost["issues"]>;
 type IDeviceUserCellProps = CellProps<IHost, IHost["device_mapping"]>;
 
+const NEVER_FETCHED_TOOLTIP =
+  "This host has not reported vitals yet, even if it has checked in.";
+
 // Max number of individual email lines shown in the tooltip before the
 // remainder collapses into a single "+N more" line.
 const MAX_EMAILS_BEFORE_MORE_LINE = 5;
@@ -349,8 +352,12 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     Cell: (cellProps: IHostTableStringCellProps) => (
       // TODO(android): android doesn't support refetch?
       <TextCell
-        value={{ timeString: cellProps.cell.value }}
-        formatter={HumanTimeDiffWithFleetLaunchCutoff}
+        value={
+          <HumanTimeDiffWithFleetLaunchCutoff
+            timeString={cellProps.cell.value}
+            neverTooltip={NEVER_FETCHED_TOOLTIP}
+          />
+        }
       />
     ),
   },


### PR DESCRIPTION

<img width="2032" height="1080" alt="Screenshot 2026-09-04 at 7 14 28 AM" src="https://github.com/user-attachments/assets/2b0db015-7e50-4546-a7da-9ee0dd2ae738" />


Relates to #44155

A host that enrolls but never returns detail queries keeps the server's NeverTimestamp sentinel in detail_updated_at, so "Last fetched" reads "Never" beside a real "Last seen" date. Add a tooltip on that cell stating the host has not reported vitals yet.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tooltip to the Hosts page explaining why “Last fetched” may display “Never” when a host has checked in but has not reported vitals.

* **Tests**
  * Added coverage for displaying the tooltip only when the host’s date predates Fleet’s creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->