### PR TITLE
Fix "Could not transfer hosts" when transferring over 65,535 hosts

### DIFF
--- a/changes/44858-transfer-hosts-too-many-placeholders
+++ b/changes/44858-transfer-hosts-too-many-placeholders
@@ -1,0 +1,1 @@
+* Fixed a "Could not transfer hosts" error when transferring more than 65,535 hosts to a fleet at once. The hosts were reassigned, but the follow-up work on the transfer (MDM profile, Android device, and Apple Business Manager bookkeeping) exceeded MySQL's per-statement placeholder limit and failed the request. Those queries are now batched.

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -439,15 +439,17 @@ func (ds *Datastore) UpdateTeamIDOnAndroidDevices(ctx context.Context, hostUUIDs
 	if len(hostUUIDs) == 0 {
 		return nil
 	}
-	query, args, err := sqlx.In(
-		`UPDATE android_devices ad JOIN hosts h ON ad.host_id = h.id SET ad.team_id = ? WHERE h.uuid IN (?)`,
-		teamID, hostUUIDs,
-	)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "build update android_devices team_id query")
-	}
-	if _, err := ds.writer(ctx).ExecContext(ctx, query, args...); err != nil {
-		return ctxerr.Wrap(ctx, err, "update android_devices team_id")
+	for batch := range slices.Chunk(hostUUIDs, hostIDsFanoutBatchSize) {
+		query, args, err := sqlx.In(
+			`UPDATE android_devices ad JOIN hosts h ON ad.host_id = h.id SET ad.team_id = ? WHERE h.uuid IN (?)`,
+			teamID, batch,
+		)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "build update android_devices team_id query")
+		}
+		if _, err := ds.writer(ctx).ExecContext(ctx, query, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "update android_devices team_id")
+		}
 	}
 	return nil
 }
@@ -2780,22 +2782,25 @@ WHERE
 	h.platform = 'android'
 `
 
-	stmt, args, err := sqlx.In(stmt, hostIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "prepare statement arguments")
-	}
-
-	var rows []struct {
-		ID   uint   `db:"id"`
-		UUID string `db:"uuid"`
-	}
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list mdm android uuids to host ids")
-	}
-
-	results := make(map[string]uint, len(rows))
-	for _, r := range rows {
-		results[r.UUID] = r.ID
+	results := make(map[string]uint)
+	if err := common_mysql.BatchProcessSimple(hostIDs, hostIDsFanoutBatchSize, func(batch []uint) error {
+		inStmt, args, err := sqlx.In(stmt, batch)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "prepare statement arguments")
+		}
+		var rows []struct {
+			ID   uint   `db:"id"`
+			UUID string `db:"uuid"`
+		}
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, inStmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "list mdm android uuids to host ids")
+		}
+		for _, r := range rows {
+			results[r.UUID] = r.ID
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return results, nil

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -4379,14 +4379,20 @@ WHERE
 	hda.deleted_at IS NULL
 `
 
-	stmt, args, err := sqlx.In(stmt, hostIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "prepare statement arguments")
-	}
-
 	var serials []string
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &serials, stmt, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list mdm apple dep serials")
+	if err := common_mysql.BatchProcessSimple(hostIDs, hostIDsFanoutBatchSize, func(batch []uint) error {
+		inStmt, args, err := sqlx.In(stmt, batch)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "prepare statement arguments")
+		}
+		var batchSerials []string
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &batchSerials, inStmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "list mdm apple dep serials")
+		}
+		serials = append(serials, batchSerials...)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return serials, nil
 }

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3485,14 +3485,24 @@ SELECT
 FROM hosts
 WHERE id IN (?)`
 
-	stmt, args, err := sqlx.In(stmt, ids)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "building query to select hosts by id")
-	}
+	// Callers build per-host work from these rows, so batching must not return a
+	// host twice for a repeated id.
+	uniqueIDs := slices.Compact(slices.Sorted(slices.Values(ids)))
 
 	var hosts []*fleet.Host
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, stmt, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "select hosts by id")
+	if err := common_mysql.BatchProcessSimple(uniqueIDs, hostIDsFanoutBatchSize, func(batch []uint) error {
+		inStmt, args, err := sqlx.In(stmt, batch)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "building query to select hosts by id")
+		}
+		var batchHosts []*fleet.Host
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &batchHosts, inStmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "select hosts by id")
+		}
+		hosts = append(hosts, batchHosts...)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return hosts, nil

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1133,16 +1133,40 @@ func (ds *Datastore) bulkSetPendingMDMHostProfilesDB(
 
 	switch {
 	case len(hostUUIDs) > 0:
-		// TODO: if a very large number (~65K) of uuids was provided, could
-		// result in too many placeholders (not an immediate concern).
-		uuidStmt = `SELECT uuid, platform FROM hosts WHERE uuid IN (?)`
-		args = append(args, hostUUIDs)
+		// Batched: a team transfer or bulk operation can pass more host
+		// identifiers than MySQL allows placeholders for in one statement. No
+		// dedupe needed here: a repeated identifier only costs a duplicate entry
+		// in androidHosts below, which the caller uses solely as a non-empty check.
+		if err := common_mysql.BatchProcessSimple(hostUUIDs, hostIDsFanoutBatchSize, func(batch []string) error {
+			inStmt, args, err := sqlx.In(`SELECT uuid, platform FROM hosts WHERE uuid IN (?)`, batch)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "prepare query to load host UUIDs")
+			}
+			var batchHosts []fleet.Host
+			if err := sqlx.SelectContext(ctx, tx, &batchHosts, inStmt, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "execute query to load host UUIDs")
+			}
+			hosts = append(hosts, batchHosts...)
+			return nil
+		}); err != nil {
+			return updates, err
+		}
 
 	case len(hostIDs) > 0:
-		// TODO: if a very large number (~65K) of uuids was provided, could
-		// result in too many placeholders (not an immediate concern).
-		uuidStmt = `SELECT uuid, platform FROM hosts WHERE id IN (?)`
-		args = append(args, hostIDs)
+		if err := common_mysql.BatchProcessSimple(hostIDs, hostIDsFanoutBatchSize, func(batch []uint) error {
+			inStmt, args, err := sqlx.In(`SELECT uuid, platform FROM hosts WHERE id IN (?)`, batch)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "prepare query to load host UUIDs")
+			}
+			var batchHosts []fleet.Host
+			if err := sqlx.SelectContext(ctx, tx, &batchHosts, inStmt, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "execute query to load host UUIDs")
+			}
+			hosts = append(hosts, batchHosts...)
+			return nil
+		}); err != nil {
+			return updates, err
+		}
 
 	case len(teamIDs) > 0:
 		// TODO: if a very large number (~65K) of team IDs was provided, could

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -43,6 +43,11 @@ import (
 const (
 	mySQLTimestampFormat = "2006-01-02 15:04:05" // %Y/%m/%d %H:%M:%S
 
+	// hostIDsFanoutBatchSize bounds how many host IDs (or UUIDs) go into one
+	// `IN (?)` statement, well under MySQL's 65,535 placeholder limit. It
+	// matches the batch size AddHostsToTeam uses for the writes on the same path.
+	hostIDsFanoutBatchSize = 10_000
+
 	// Migration IDs needed for fixing broken migrations that some customers encountered with fleet v4.73.2
 	// See https://github.com/fleetdm/fleet/issues/33562
 	fleet4732BadMigrationID1  = 20250918154557 // was 20250918154557_AddKernelHostCountsIndexForVulnQueries.go


### PR DESCRIPTION
Fixes #44858

AddHostsToTeam batches its writes at 10k, but the service layer then passed the full host list to several more queries, each expanding to one placeholder per host. Above 65,535 hosts they failed with MySQL error 1390 - after the reassignment had already committed, which is why the UI errored on a transfer that had actually moved the hosts.

This was fixed by batching the subsequent operations.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed host transfers involving more than 65,535 hosts, which could previously fail after hosts were reassigned.
  * Large host transfer operations now process related device, MDM, and Apple Business Manager updates in batches, avoiding database query limits.
  * Improved reliability for large-scale fleet transfers and ensures associated device records remain updated successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->