### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/amie/darwin.json
+++ b/ee/maintained-apps/outputs/amie/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "260831.0.0",
+      "version": "260903.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app' AND version_compare(bundle_short_version, '260831.0.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app' AND version_compare(bundle_short_version, '260903.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'so.amie.electron-app' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/amieso/electron-releases/releases/download/v260831.0.0/Amie-260831.0.0-arm64-mac.zip",
+      "installer_url": "https://github.com/amieso/electron-releases/releases/download/v260903.0.0/Amie-260903.0.0-arm64-mac.zip",
       "install_script_ref": "be47fa85",
       "uninstall_script_ref": "44125419",
-      "sha256": "024f3b4ab668585c772e94668183d1de8f84904ed6901b2a1026af65a1433372",
+      "sha256": "973952b3b6c5752ff97543096a3cc4bf8a2a7a483636d3675e8edaf47fe58b1b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/antigravity/darwin.json
+++ b/ee/maintained-apps/outputs/antigravity/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.12.0",
+      "version": "2.12.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.12.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.12.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.google.antigravity' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.12.0-5051501534642176/darwin-arm/Antigravity.dmg",
+      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.12.2-6298742303883264/darwin-arm/Antigravity.dmg",
       "install_script_ref": "b60a046d",
       "uninstall_script_ref": "5e1a08b9",
-      "sha256": "cd1cca7ce2a64f6df0c3bcc13e54bf80644440f5dc8df22a8b21ddd22ef1c415",
+      "sha256": "9f22b1f7a444d3c0c99483528963381f45e287237e3ba18bedc8bf47935b3d18",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/aws-sam-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-sam-cli/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.166.0",
+      "version": "1.166.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.166.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.166.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'aws sam command line interface.exe');"
       },
-      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.166.0/AWS_SAM_CLI_64_PY3.msi",
+      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.166.1/AWS_SAM_CLI_64_PY3.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "a3074b39",
-      "sha256": "be19604c6a883e249acf4041b834157375563e0b5df18866c11f29e0a64cb344",
+      "sha256": "4bf6752fe33871eeafce666c2048c376dd474fa1db87fe5da7b95e73f2f24c6c",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.46388.0",
+      "version": "1.46388.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.46388.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.46388.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.anthropic.claudefordesktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.46388.0/Claude-88d4ea2fdadb149723ebab39764c160d03d9ee82.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.46388.1/Claude-2dfd5f2c40e82ccf388f5dc1d3f1ce93a3671b03.zip",
       "install_script_ref": "98321e4d",
       "uninstall_script_ref": "421baa98",
-      "sha256": "b813afc8a067dd29d24ce04dd0a78d4c3189dc892fa05ecbfc4aedee9d91ebee",
+      "sha256": "894de7f1b18941af9459c07d1dc344e8b503ee38e839617ae1e09013a1132514",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the available macOS version of Amie to 260903.0.0.
  * Updated the available macOS version of Antigravity to 2.12.2.
  * Updated the available Windows version of AWS SAM CLI to 1.166.1.
  * Updated the available macOS version of Claude Desktop to 1.46388.1.
  * Refreshed download details and verification checksums for each application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->