### PR TITLE
Stop the Android mock from reporting an enterprise as deleted (#52507)

### DIFF
--- a/cmd/android-amapi-mock/bench_test.go
+++ b/cmd/android-amapi-mock/bench_test.go
@@ -18,6 +18,9 @@ func BenchmarkDeviceGetParallel(b *testing.B) {
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
+		// RunParallel calls this once per worker, so the request below belongs to one
+		// goroutine. It is built outside the loop deliberately: the point of measurement is
+		// lock contention on the store, not request construction.
 		req := httptest.NewRequest("GET", path, nil)
 		for pb.Next() {
 			mux.ServeHTTP(httptest.NewRecorder(), req)

--- a/cmd/android-amapi-mock/bench_test.go
+++ b/cmd/android-amapi-mock/bench_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// BenchmarkDeviceGetParallel drives the device lookup route, the mock's hot path under load.
+// It is a read on the store, so concurrent callers must not serialize: anything that puts a
+// store-wide writer on this path costs the load test throughput.
+func BenchmarkDeviceGetParallel(b *testing.B) {
+	store := newDeviceStore()
+	mux := newMux(store, nil, 0, 0)
+	path := "/v1/enterprises/" + testEnterpriseID + "/devices/fakedevice"
+
+	// Prime the enterprise so this measures steady state rather than first sight.
+	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", path, nil))
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		req := httptest.NewRequest("GET", path, nil)
+		for pb.Next() {
+			mux.ServeHTTP(httptest.NewRecorder(), req)
+		}
+	})
+}

--- a/cmd/android-amapi-mock/handlers.go
+++ b/cmd/android-amapi-mock/handlers.go
@@ -379,17 +379,22 @@ func handleWebAppsCreate() http.HandlerFunc {
 
 func handleEnterprisesList(store *deviceStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		store.mu.RLock()
-		seen := make(map[string]bool)
-		for _, d := range store.byESID {
-			if d.EnterpriseID != "" {
-				seen[d.EnterpriseID] = true
-			}
-		}
-		store.mu.RUnlock()
+		known := store.knownEnterprises()
 
-		enterprises := make([]map[string]string, 0, len(seen))
-		for id := range seen {
+		// An empty list is not "no enterprises exist", it is "this mock has not been told about
+		// any yet" — it holds no state across restarts and learns enterprises only from traffic.
+		// Fleet treats a successful list that omits its enterprise as confirmation the
+		// enterprise was deleted, so answering with an empty list here would have it delete its
+		// enterprise records, turn Android MDM off and unenroll every Android host. A failed
+		// list is explicitly treated as a technical problem instead, which is what an unknown
+		// state should look like.
+		if len(known) == 0 {
+			http.Error(w, "mock has not observed any enterprise yet", http.StatusServiceUnavailable)
+			return
+		}
+
+		enterprises := make([]map[string]string, 0, len(known))
+		for _, id := range known {
 			enterprises = append(enterprises, map[string]string{"name": "enterprises/" + id})
 		}
 

--- a/cmd/android-amapi-mock/handlers.go
+++ b/cmd/android-amapi-mock/handlers.go
@@ -381,13 +381,9 @@ func handleEnterprisesList(store *deviceStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		known := store.knownEnterprises()
 
-		// An empty list is not "no enterprises exist", it is "this mock has not been told about
-		// any yet" — it holds no state across restarts and learns enterprises only from traffic.
-		// Fleet treats a successful list that omits its enterprise as confirmation the
-		// enterprise was deleted, so answering with an empty list here would have it delete its
-		// enterprise records, turn Android MDM off and unenroll every Android host. A failed
-		// list is explicitly treated as a technical problem instead, which is what an unknown
-		// state should look like.
+		// Fleet unenrolls every Android host and turns Android MDM off when its enterprise is
+		// absent from a successful list. An empty list here only means nothing has been observed
+		// yet, and a failed list is already treated as a technical problem, which is what it is.
 		if len(known) == 0 {
 			http.Error(w, "mock has not observed any enterprise yet", http.StatusServiceUnavailable)
 			return

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -559,6 +559,10 @@ func TestStoreConcurrentAccess(t *testing.T) {
 		func() *http.Request {
 			return httptest.NewRequest("POST", policyActionPath, bytes.NewReader(certBody))
 		},
+		// Reads the enterprise set the policy routes above are writing to.
+		func() *http.Request {
+			return httptest.NewRequest("GET", "/v1/enterprises", nil)
+		},
 	}
 
 	var wg sync.WaitGroup
@@ -585,6 +589,72 @@ func TestGetStateUnknownDeviceReturns404(t *testing.T) {
 
 // TestDevicesListIncludesFakeDevices pins what the reconciler reads: a registered device must
 // be listed, since Fleet marks any enrolled device missing from this list as unenrolled.
+// Fleet reads its enterprise missing from a successful GET /v1/enterprises as proof the
+// enterprise was deleted, and reacts by deleting its enterprise records, turning Android MDM
+// off and unenrolling every Android host. The mock must never produce that answer from a state
+// that only means it has not been told about the enterprise yet.
+func TestEnterprisesListReportsEnterpriseWithoutRegisteredDevices(t *testing.T) {
+	mux, _ := newTestMux(t)
+
+	// Any request naming the enterprise is enough; none of these register a device.
+	for _, req := range []*http.Request{
+		httptest.NewRequest("POST", "/v1/enterprises/"+testEnterpriseID+"/enrollmentTokens",
+			bytes.NewReader([]byte(`{}`))),
+		httptest.NewRequest("GET", "/v1/enterprises/"+testEnterpriseID+"/devices", nil),
+	} {
+		t.Run(req.Method+" "+req.URL.Path, func(t *testing.T) {
+			mux, store := newTestMux(t)
+			mux.ServeHTTP(httptest.NewRecorder(), req)
+			require.Empty(t, store.byESID, "this request must not register a device")
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/enterprises", nil))
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			var resp androidmanagement.ListEnterprisesResponse
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+			require.Len(t, resp.Enterprises, 1)
+			assert.Equal(t, "enterprises/"+testEnterpriseID, resp.Enterprises[0].Name)
+		})
+	}
+
+	// A registered device still reports its enterprise, as before.
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/enterprises", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp androidmanagement.ListEnterprisesResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Enterprises, 1)
+	assert.Equal(t, "enterprises/"+testEnterpriseID, resp.Enterprises[0].Name)
+}
+
+// With nothing observed, the honest answer is "unknown", not "empty". Fleet treats a failed
+// list as a technical problem and leaves its enterprise alone; an empty one it would act on.
+func TestEnterprisesListRefusesToConfirmAnEmptyListItCannotKnow(t *testing.T) {
+	mux, _ := newTestMux(t)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/enterprises", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+// The enterprise an addressed request names is recorded even when that request fails, so a
+// device call for an unknown device does not leave the enterprise unreported.
+func TestEnterprisesListRecordsEnterpriseFromFailedDeviceRequest(t *testing.T) {
+	mux, store := newTestMux(t)
+
+	mux.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET",
+		"/v1/enterprises/"+testEnterpriseID+"/devices/nope", nil))
+	require.Empty(t, store.byESID)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/enterprises", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "enterprises/"+testEnterpriseID)
+}
+
 func TestDevicesListIncludesFakeDevices(t *testing.T) {
 	mux, _ := newTestMux(t)
 	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -589,10 +589,10 @@ func TestGetStateUnknownDeviceReturns404(t *testing.T) {
 
 // TestDevicesListIncludesFakeDevices pins what the reconciler reads: a registered device must
 // be listed, since Fleet marks any enrolled device missing from this list as unenrolled.
-// Fleet reads its enterprise missing from a successful GET /v1/enterprises as proof the
-// enterprise was deleted, and reacts by deleting its enterprise records, turning Android MDM
-// off and unenrolling every Android host. The mock must never produce that answer from a state
-// that only means it has not been told about the enterprise yet.
+// TestEnterprisesListReportsEnterpriseWithoutRegisteredDevices checks that an enterprise in
+// use is reported even with no fake device registered against it. Fleet reads its enterprise
+// missing from a successful list as proof of deletion, and reacts by deleting its enterprise
+// records, turning Android MDM off and unenrolling every Android host.
 func TestEnterprisesListReportsEnterpriseWithoutRegisteredDevices(t *testing.T) {
 	mux, _ := newTestMux(t)
 
@@ -630,8 +630,9 @@ func TestEnterprisesListReportsEnterpriseWithoutRegisteredDevices(t *testing.T) 
 	assert.Equal(t, "enterprises/"+testEnterpriseID, resp.Enterprises[0].Name)
 }
 
-// With nothing observed, the honest answer is "unknown", not "empty". Fleet treats a failed
-// list as a technical problem and leaves its enterprise alone; an empty one it would act on.
+// TestEnterprisesListRefusesToConfirmAnEmptyListItCannotKnow checks that with nothing observed
+// the answer is "unknown", not "empty". Fleet treats a failed list as a technical problem and
+// leaves its enterprise alone; an empty one it would act on.
 func TestEnterprisesListRefusesToConfirmAnEmptyListItCannotKnow(t *testing.T) {
 	mux, _ := newTestMux(t)
 
@@ -640,8 +641,9 @@ func TestEnterprisesListRefusesToConfirmAnEmptyListItCannotKnow(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
 }
 
-// The enterprise an addressed request names is recorded even when that request fails, so a
-// device call for an unknown device does not leave the enterprise unreported.
+// TestEnterprisesListRecordsEnterpriseFromFailedDeviceRequest checks that the enterprise an
+// addressed request names is recorded even when that request fails, so a call for an unknown
+// device does not leave the enterprise unreported.
 func TestEnterprisesListRecordsEnterpriseFromFailedDeviceRequest(t *testing.T) {
 	mux, store := newTestMux(t)
 
@@ -653,6 +655,25 @@ func TestEnterprisesListRecordsEnterpriseFromFailedDeviceRequest(t *testing.T) {
 	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/enterprises", nil))
 	require.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "enterprises/"+testEnterpriseID)
+}
+
+// TestNoteEnterpriseIsBounded checks that enterprise IDs taken from request paths cannot grow
+// the set without limit, and that an enterprise recorded before the limit is still reported.
+func TestNoteEnterpriseIsBounded(t *testing.T) {
+	store := newDeviceStore()
+
+	store.noteEnterprise(testEnterpriseID)
+	for i := range maxTrackedEnterprises + 100 {
+		store.noteEnterprise(fmt.Sprintf("junk-%d", i))
+	}
+
+	store.entMu.RLock()
+	got := len(store.enterprises)
+	store.entMu.RUnlock()
+	assert.Equal(t, maxTrackedEnterprises, got)
+
+	// The enterprise seen first is still there, so the report Fleet depends on is unaffected.
+	assert.Contains(t, store.knownEnterprises(), testEnterpriseID)
 }
 
 func TestDevicesListIncludesFakeDevices(t *testing.T) {

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -657,6 +657,21 @@ func TestEnterprisesListRecordsEnterpriseFromFailedDeviceRequest(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "enterprises/"+testEnterpriseID)
 }
 
+// TestNoteEnterpriseIgnoresEmptyID checks that an empty path value is not recorded as an
+// enterprise. Recording it would leave the set non-empty and holding a meaningless ID, which
+// would both report "enterprises/" to Fleet and stop the unknown state from answering 503.
+func TestNoteEnterpriseIgnoresEmptyID(t *testing.T) {
+	store := newDeviceStore()
+	store.noteEnterprise("")
+
+	assert.Empty(t, store.knownEnterprises())
+
+	mux := newMux(store, nil, 0, 0)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/v1/enterprises", nil))
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
 // TestNoteEnterpriseIsBounded checks that enterprise IDs taken from request paths cannot grow
 // the set without limit, and that an enterprise recorded before the limit is still reported.
 func TestNoteEnterpriseIsBounded(t *testing.T) {

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -66,7 +66,10 @@ type deviceStore struct {
 	deletedNames map[string]struct{}
 
 	// enterprises records every enterprise this mock has been addressed about, so that
-	// GET /v1/enterprises can report one that has no registered fake device.
+	// GET /v1/enterprises can report one that has no registered fake device. It has its own
+	// lock because it is touched by nearly every AMAPI request: sharing mu would put a
+	// store-wide writer in front of every concurrent device lookup.
+	entMu       sync.RWMutex
 	enterprises map[string]struct{}
 
 	// policyVersions tracks the latest version for each policy name.
@@ -95,24 +98,39 @@ func (ds *deviceStore) noteEnterprise(id string) {
 	if id == "" {
 		return
 	}
-	ds.mu.Lock()
-	defer ds.mu.Unlock()
+
+	// The set is effectively write-once — a load test addresses one enterprise for its whole
+	// run — so keep the common case on the read lock and only write on first sight.
+	ds.entMu.RLock()
+	_, known := ds.enterprises[id]
+	ds.entMu.RUnlock()
+	if known {
+		return
+	}
+
+	ds.entMu.Lock()
+	defer ds.entMu.Unlock()
 	ds.enterprises[id] = struct{}{}
 }
 
 // knownEnterprises returns every enterprise the mock has seen, either addressed directly or
 // through a registered fake device.
 func (ds *deviceStore) knownEnterprises() []string {
-	ds.mu.RLock()
-	defer ds.mu.RUnlock()
-
+	// Taken one after the other rather than nested, so this never holds two of the store's
+	// locks at once.
+	ds.entMu.RLock()
 	seen := make(map[string]struct{}, len(ds.enterprises))
 	maps.Copy(seen, ds.enterprises)
+	ds.entMu.RUnlock()
+
+	ds.mu.RLock()
 	for _, d := range ds.byESID {
 		if d.EnterpriseID != "" {
 			seen[d.EnterpriseID] = struct{}{}
 		}
 	}
+	ds.mu.RUnlock()
+
 	return slices.Collect(maps.Keys(seen))
 }
 

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -65,11 +65,8 @@ type deviceStore struct {
 	deletedESIDs map[string]struct{}
 	deletedNames map[string]struct{}
 
-	// enterprises records every enterprise this mock has been asked about, whether or not a
-	// fake device was ever registered against it. GET /v1/enterprises answers from this rather
-	// than from the registered devices alone: Fleet reads its enterprise missing from that
-	// list as proof the enterprise was deleted, and responds by deleting its own enterprise
-	// records, turning Android MDM off and unenrolling every Android host.
+	// enterprises records every enterprise this mock has been addressed about, so that
+	// GET /v1/enterprises can report one that has no registered fake device.
 	enterprises map[string]struct{}
 
 	// policyVersions tracks the latest version for each policy name.

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -68,7 +68,8 @@ type deviceStore struct {
 	// enterprises records every enterprise this mock has been addressed about, so that
 	// GET /v1/enterprises can report one that has no registered fake device. It has its own
 	// lock because it is touched by nearly every AMAPI request: sharing mu would put a
-	// store-wide writer in front of every concurrent device lookup.
+	// store-wide writer in front of every concurrent device lookup. Capped at
+	// maxTrackedEnterprises, since the IDs come from request paths.
 	entMu       sync.RWMutex
 	enterprises map[string]struct{}
 
@@ -93,6 +94,12 @@ func newDeviceStore() *deviceStore {
 	}
 }
 
+// maxTrackedEnterprises bounds the set noteEnterprise fills. The IDs are taken from request
+// paths, so an unbounded set would grow with junk from anything that can reach the mock. A load
+// test addresses one enterprise, and the one Fleet is using is recorded on its first request,
+// long before a limit this size is reached.
+const maxTrackedEnterprises = 1000
+
 // noteEnterprise records an enterprise the mock has been addressed about.
 func (ds *deviceStore) noteEnterprise(id string) {
 	if id == "" {
@@ -110,6 +117,9 @@ func (ds *deviceStore) noteEnterprise(id string) {
 
 	ds.entMu.Lock()
 	defer ds.entMu.Unlock()
+	if len(ds.enterprises) >= maxTrackedEnterprises {
+		return
+	}
 	ds.enterprises[id] = struct{}{}
 }
 

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -18,8 +18,10 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -63,6 +65,13 @@ type deviceStore struct {
 	deletedESIDs map[string]struct{}
 	deletedNames map[string]struct{}
 
+	// enterprises records every enterprise this mock has been asked about, whether or not a
+	// fake device was ever registered against it. GET /v1/enterprises answers from this rather
+	// than from the registered devices alone: Fleet reads its enterprise missing from that
+	// list as proof the enterprise was deleted, and responds by deleting its own enterprise
+	// records, turning Android MDM off and unenrolling every Android host.
+	enterprises map[string]struct{}
+
 	// policyVersions tracks the latest version for each policy name.
 	// Fleet uses per-device policies named enterprises/{id}/policies/{hostUUID}.
 	// policyVersion is the counter versions are issued from; it is guarded by policyMu so
@@ -78,9 +87,36 @@ func newDeviceStore() *deviceStore {
 		byName:         make(map[string]*fakeDevice),
 		deletedESIDs:   make(map[string]struct{}),
 		deletedNames:   make(map[string]struct{}),
+		enterprises:    make(map[string]struct{}),
 		policyVersions: make(map[string]int64),
 		policyVersion:  1,
 	}
+}
+
+// noteEnterprise records an enterprise the mock has been addressed about.
+func (ds *deviceStore) noteEnterprise(id string) {
+	if id == "" {
+		return
+	}
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	ds.enterprises[id] = struct{}{}
+}
+
+// knownEnterprises returns every enterprise the mock has seen, either addressed directly or
+// through a registered fake device.
+func (ds *deviceStore) knownEnterprises() []string {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+
+	seen := make(map[string]struct{}, len(ds.enterprises))
+	maps.Copy(seen, ds.enterprises)
+	for _, d := range ds.byESID {
+		if d.EnterpriseID != "" {
+			seen[d.EnterpriseID] = struct{}{}
+		}
+	}
+	return slices.Collect(maps.Keys(seen))
 }
 
 // nextPolicyVersion issues the next version and records it as the current version of
@@ -279,22 +315,32 @@ func newMux(store *deviceStore, google *googleForwarder, latencyMean time.Durati
 		return simulateLatencyAndErrors(latencyMean, errorRate, h)
 	}
 
+	// noteEnt records the enterprise a request addresses before handling it, so that an
+	// enterprise Fleet is actively using is reported by GET /v1/enterprises even when no fake
+	// device has been registered against it.
+	noteEnt := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			store.noteEnterprise(r.PathValue("eid"))
+			h(w, r)
+		}
+	}
+
 	// ---- AMAPI: Devices ----
 	fwd := forwardForRealDevice(store, google)
-	mux.HandleFunc("GET /v1/enterprises/{eid}/devices/{did}", fwd(sim(handleDevicesGet(store))))
-	mux.HandleFunc("PATCH /v1/enterprises/{eid}/devices/{did}", fwd(sim(handleDevicesPatch(store))))
-	mux.HandleFunc("DELETE /v1/enterprises/{eid}/devices/{did}", fwd(sim(handleDevicesDelete(store))))
-	mux.HandleFunc("POST /v1/enterprises/{eid}/devices/{did}", fwd(sim(handleIssueCommand(store))))
-	mux.HandleFunc("GET /v1/enterprises/{eid}/devices", sim(handleDevicesList(store, google)))
+	mux.HandleFunc("GET /v1/enterprises/{eid}/devices/{did}", noteEnt(fwd(sim(handleDevicesGet(store)))))
+	mux.HandleFunc("PATCH /v1/enterprises/{eid}/devices/{did}", noteEnt(fwd(sim(handleDevicesPatch(store)))))
+	mux.HandleFunc("DELETE /v1/enterprises/{eid}/devices/{did}", noteEnt(fwd(sim(handleDevicesDelete(store)))))
+	mux.HandleFunc("POST /v1/enterprises/{eid}/devices/{did}", noteEnt(fwd(sim(handleIssueCommand(store)))))
+	mux.HandleFunc("GET /v1/enterprises/{eid}/devices", noteEnt(sim(handleDevicesList(store, google))))
 
 	// ---- AMAPI: Policies ----
-	mux.HandleFunc("PATCH /v1/enterprises/{eid}/policies/{pid}", sim(handlePoliciesPatch(store, google)))
-	mux.HandleFunc("POST /v1/enterprises/{eid}/policies/{pid}", sim(handlePolicyAction(store)))
+	mux.HandleFunc("PATCH /v1/enterprises/{eid}/policies/{pid}", noteEnt(sim(handlePoliciesPatch(store, google))))
+	mux.HandleFunc("POST /v1/enterprises/{eid}/policies/{pid}", noteEnt(sim(handlePolicyAction(store))))
 
 	// ---- AMAPI: Other ----
-	mux.HandleFunc("POST /v1/enterprises/{eid}/enrollmentTokens", sim(forwardOrMock(google, handleEnrollmentTokenCreate())))
-	mux.HandleFunc("GET /v1/enterprises/{eid}/applications/{pkg}", sim(forwardOrMock(google, handleApplicationsGet())))
-	mux.HandleFunc("POST /v1/enterprises/{eid}/webApps", sim(forwardOrMock(google, handleWebAppsCreate())))
+	mux.HandleFunc("POST /v1/enterprises/{eid}/enrollmentTokens", noteEnt(sim(forwardOrMock(google, handleEnrollmentTokenCreate()))))
+	mux.HandleFunc("GET /v1/enterprises/{eid}/applications/{pkg}", noteEnt(sim(forwardOrMock(google, handleApplicationsGet()))))
+	mux.HandleFunc("POST /v1/enterprises/{eid}/webApps", noteEnt(sim(forwardOrMock(google, handleWebAppsCreate()))))
 	mux.HandleFunc("GET /v1/enterprises", sim(forwardOrMock(google, handleEnterprisesList(store))))
 
 	// Catch-all for unmatched /v1/ requests


### PR DESCRIPTION
**Related issue:** Resolves #52507

## What

`GET /v1/enterprises` on the mock built its answer from the registered fake devices only:

```go
for _, d := range store.byESID {
    if d.EnterpriseID != "" { seen[d.EnterpriseID] = true }
}
```

So a mock started without `--google-credentials` and without registered devices answered `{"enterprises":[]}` — a successful, empty list.

Fleet reads that as confirmation. `verifyEnterpriseExistsWithGoogle` checks whether its own enterprise appears in the list, and when it doesn't, `cleanupDeletedEnterprise` runs: it deletes the local enterprise records, calls the proxy's delete endpoint, sets `mdm.android_enabled_and_configured` to false, unenrolls every Android host, and fails all pending Android VPP installs. The `cleanup_android_enterprise` cron fires hourly, so pointing a dev Fleet at a fresh mock quietly dismantles its Android setup within the hour, with nothing in the audit log.

## The fix

Two parts, because there are two ways the mock ends up not knowing about an enterprise.

**It has seen the enterprise, just not a device on it.** Every AMAPI route under `/v1/enterprises/{eid}/...` now records the enterprise it addresses, and the list answers from that set unioned with the device-derived one. An enterprise Fleet is actively using — enrollment tokens, policy patches, device calls — is reported whether or not a fake device was ever registered against it. Recording happens before the handler runs, so a request that fails still counts; a device call for an unknown device is still evidence the enterprise exists.

**It has seen nothing at all.** Then an empty list would be a claim the mock is not in a position to make: it holds no state across restarts and learns enterprises only from traffic, so "no enterprises" and "nobody has told me yet" look identical from inside. It now answers 503. Fleet already distinguishes these — a *failed* list is treated as a technical problem and explicitly leaves the enterprise alone, with a comment saying so — so this routes the unknown state to the path that was built for it rather than adding a new one.

This is deliberately asymmetric. Under-reporting an enterprise destroys state that a load test cannot get back; over-reporting one costs nothing.

## Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes — no route or payload shape changed.

No changes file: this is a load-testing tool under `cmd/`, with no user-visible behavior change.

## Testing

- [x] Added/updated automated tests

- `TestEnterprisesListReportsEnterpriseWithoutRegisteredDevices` — an enrollment-token request and a device-list request each make the enterprise reportable on their own, with an assertion that neither registered a device; a registered device still reports its enterprise as before.
- `TestEnterprisesListRefusesToConfirmAnEmptyListItCannotKnow` — nothing observed gives 503, not an empty 200.
- `TestEnterprisesListRecordsEnterpriseFromFailedDeviceRequest` — a call for a device that doesn't exist still records the enterprise.

All three fail against the unmodified handler, where the response is `{"enterprises":[]}`. The rest of the package's tests pass unchanged.

`TestStoreConcurrentAccess` already drove two of the newly wrapped routes concurrently; I added a concurrent `GET /v1/enterprises` so the read side is covered too. `go test -race -count=5` is clean.

- [ ] QA'd all new/changed functionality manually — not done end-to-end; I don't have an Android enterprise connected through the hosted proxy to watch the cron act on. The tests cover the mock's side of the contract, and the Fleet-side behavior they protect against is the existing `cleanupDeletedEnterprise` path.

## A note for the reviewer

The 503 is the part worth a second opinion. It makes the mock unable to represent a genuinely empty AMAPI account, which real Google can. That seemed clearly the right trade for a load-testing mock given what the alternative costs, but if you'd rather the mock stay literal and have Fleet's cleanup require stronger evidence than one empty list, I'm happy to move it there instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Android management API mock now reports observed enterprises through `GET /v1/enterprises`.
  * Enterprise information is recorded from enterprise-related requests, including requests made before any devices are registered.
  * Enterprise listings reflect enterprises observed across device, policy, and other management API requests.

* **Bug Fixes**
  * The enterprise list no longer returns an empty successful response when no enterprise is known; it now returns HTTP 503 Service Unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->