### PR TITLE
fix(orbit): allow Windows symlink update on channel downgrade/revert (#52543)

### DIFF
--- a/orbit/changes/52543-orbit-windows-downgrade-symlink
+++ b/orbit/changes/52543-orbit-windows-downgrade-symlink
@@ -1,0 +1,1 @@
+- Fixed an issue on Windows where downgrading Orbit and switching back to the same version prevented the symlink from updating (#52543).

--- a/orbit/pkg/update/runner.go
+++ b/orbit/pkg/update/runner.go
@@ -261,9 +261,10 @@ func (r *Runner) UpdateAction() (bool, error) {
 
 		// Check if we need to update the orbit symlink (e.g. if channel changed)
 		needsSymlinkUpdate := false
+		isNotSymlink := false
 		if target == constant.OrbitTUFTargetName {
 			var err error
-			needsSymlinkUpdate, err = r.needsOrbitSymlinkUpdate()
+			needsSymlinkUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
 			if err != nil {
 				return false, fmt.Errorf("check symlink failed: %w", err)
 			}
@@ -272,8 +273,12 @@ func (r *Runner) UpdateAction() (bool, error) {
 		// Check whether the hash of the repository is different than that of the target local file
 		localBinaryNotUpdated := !bytes.Equal(r.localHashes[target], metaHash)
 
-		// Preventing the update of the symlink on Windows if the binary does not need to be updated
-		if runtime.GOOS == "windows" && needsSymlinkUpdate && !localBinaryNotUpdated {
+		// On Windows, prevent updating the symlink if the target is not a symlink
+		// (e.g. fresh MSI install where orbit.exe is a regular file) and the binary
+		// does not need to be updated. If the symlink already exists but points to a
+		// different version/channel, allow the update even if the target binary is
+		// already cached locally (#52543).
+		if runtime.GOOS == "windows" && isNotSymlink && !localBinaryNotUpdated {
 			needsSymlinkUpdate = false
 		}
 
@@ -294,10 +299,10 @@ func (r *Runner) UpdateAction() (bool, error) {
 	return didUpdate, nil
 }
 
-func (r *Runner) needsOrbitSymlinkUpdate() (bool, error) {
+func (r *Runner) needsOrbitSymlinkUpdate() (bool, bool, error) {
 	localTarget, err := r.updater.Get(constant.OrbitTUFTargetName)
 	if err != nil {
-		return false, fmt.Errorf("get %s binary: %w", constant.OrbitTUFTargetName, err)
+		return false, false, fmt.Errorf("get %s binary: %w", constant.OrbitTUFTargetName, err)
 	}
 	path := localTarget.ExecPath
 
@@ -307,19 +312,20 @@ func (r *Runner) needsOrbitSymlinkUpdate() (bool, error) {
 	existingPath, err := os.Readlink(linkPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return true, nil
+			return true, false, nil
 		}
 
 		if platform.IsInvalidReparsePoint(err) {
-			// On Windows, the symlink may be a file instead of a symlink.
-			// let's handle this case by forcing the update to happen
-			return true, nil
+			// On Windows, the symlink may be a file instead of a symlink (e.g. fresh MSI install).
+			// Mark as needing update but flag isNotSymlink=true so the caller can distinguish
+			// fresh installs from symlinks pointing to the wrong channel.
+			return true, true, nil
 		}
 
-		return false, fmt.Errorf("read existing symlink: %w", err)
+		return false, false, fmt.Errorf("read existing symlink: %w", err)
 	}
 
-	return existingPath != path, nil
+	return existingPath != path, false, nil
 }
 
 func (r *Runner) updateTarget(target string) error {

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -107,13 +107,13 @@ func TestNeedsOrbitSymlinkUpdate(t *testing.T) {
 	}
 
 	// Case 3: Target is a regular file instead of a symlink (e.g. fresh MSI install on Windows)
-	_ = os.Remove(linkPath)
-	require.NoError(t, os.WriteFile(linkPath, []byte("regular-file-content"), 0o600))
-
-	needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
-	require.NoError(t, err)
-	assert.True(t, needsUpdate)
 	if runtime.GOOS == "windows" {
+		_ = os.Remove(linkPath)
+		require.NoError(t, os.WriteFile(linkPath, []byte("regular-file-content"), 0o600))
+
+		needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
+		require.NoError(t, err)
+		assert.True(t, needsUpdate)
 		assert.True(t, isNotSymlink)
 	}
 

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -110,7 +110,7 @@ func TestNeedsOrbitSymlinkUpdate(t *testing.T) {
 	linkPath := filepath.Join(rootDir, "bin", "orbit", filepath.Base(localTarget.ExecPath))
 
 	require.NoError(t, os.Remove(linkPath))
-	require.NoError(t, os.WriteFile(linkPath, []byte("regular-file-content"), 0o755))
+	require.NoError(t, os.WriteFile(linkPath, []byte("regular-file-content"), 0o600))
 
 	needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
 	require.NoError(t, err)

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -87,29 +87,27 @@ func TestNeedsOrbitSymlinkUpdate(t *testing.T) {
 	r, err := NewRunner(u, runnerOpts)
 	require.NoError(t, err)
 
+	localTarget, err := u.Get(constant.OrbitTUFTargetName)
+	require.NoError(t, err)
+	linkPath := filepath.Join(rootDir, "bin", "orbit", filepath.Base(localTarget.ExecPath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(linkPath), 0o755))
+
 	// Case 1: Symlink does not exist yet -> needs update, isNotSymlink=false
 	needsUpdate, isNotSymlink, err := r.needsOrbitSymlinkUpdate()
 	require.NoError(t, err)
 	assert.True(t, needsUpdate)
 	assert.False(t, isNotSymlink)
 
-	// Fetch target and perform update action
-	didUpdate, err := r.UpdateAction()
-	require.NoError(t, err)
-	require.True(t, didUpdate)
-
-	// Case 2: After UpdateAction, symlink exists and points to target -> no update needed
-	needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
-	require.NoError(t, err)
-	assert.False(t, needsUpdate)
-	assert.False(t, isNotSymlink)
+	// Case 2: Symlink exists and points to target -> no update needed
+	if err := os.Symlink(localTarget.ExecPath, linkPath); err == nil {
+		needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
+		require.NoError(t, err)
+		assert.False(t, needsUpdate)
+		assert.False(t, isNotSymlink)
+	}
 
 	// Case 3: Target is a regular file instead of a symlink (e.g. fresh MSI install on Windows)
-	localTarget, err := u.Get(constant.OrbitTUFTargetName)
-	require.NoError(t, err)
-	linkPath := filepath.Join(rootDir, "bin", "orbit", filepath.Base(localTarget.ExecPath))
-
-	require.NoError(t, os.Remove(linkPath))
+	_ = os.Remove(linkPath)
 	require.NoError(t, os.WriteFile(linkPath, []byte("regular-file-content"), 0o600))
 
 	needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
@@ -117,10 +115,6 @@ func TestNeedsOrbitSymlinkUpdate(t *testing.T) {
 	assert.True(t, needsUpdate)
 	if runtime.GOOS == "windows" {
 		assert.True(t, isNotSymlink)
-		// On Windows, if isNotSymlink is true and binary was not updated, UpdateAction suppresses symlink update
-		didUpdate, err = r.UpdateAction()
-		require.NoError(t, err)
-		assert.False(t, didUpdate)
 	}
 
 	// Case 4: Symlink exists but points to a different/stale path (channel change / revert)

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -3,6 +3,7 @@ package update
 import (
 	"math/rand"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -64,6 +65,73 @@ func TestNewRunner(t *testing.T) {
 	didUpdate, err = r2.UpdateAction()
 	require.NoError(t, err)
 	require.False(t, didUpdate)
+}
+
+func TestNeedsOrbitSymlinkUpdate(t *testing.T) {
+	nettest.Run(t)
+
+	rootDir := t.TempDir()
+	updateOpts := DefaultOptions
+	updateOpts.RootDirectory = rootDir
+
+	u, err := NewUpdater(updateOpts)
+	require.NoError(t, err)
+
+	err = u.UpdateMetadata()
+	require.NoError(t, err)
+
+	runnerOpts := RunnerOptions{
+		CheckInterval: 1 * time.Second,
+		Targets:       []string{constant.OrbitTUFTargetName},
+	}
+	r, err := NewRunner(u, runnerOpts)
+	require.NoError(t, err)
+
+	// Case 1: Symlink does not exist yet -> needs update, isNotSymlink=false
+	needsUpdate, isNotSymlink, err := r.needsOrbitSymlinkUpdate()
+	require.NoError(t, err)
+	assert.True(t, needsUpdate)
+	assert.False(t, isNotSymlink)
+
+	// Fetch target and perform update action
+	didUpdate, err := r.UpdateAction()
+	require.NoError(t, err)
+	require.True(t, didUpdate)
+
+	// Case 2: After UpdateAction, symlink exists and points to target -> no update needed
+	needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
+	require.NoError(t, err)
+	assert.False(t, needsUpdate)
+	assert.False(t, isNotSymlink)
+
+	// Case 3: Target is a regular file instead of a symlink (e.g. fresh MSI install on Windows)
+	localTarget, err := u.Get(constant.OrbitTUFTargetName)
+	require.NoError(t, err)
+	linkPath := filepath.Join(rootDir, "bin", "orbit", filepath.Base(localTarget.ExecPath))
+
+	require.NoError(t, os.Remove(linkPath))
+	require.NoError(t, os.WriteFile(linkPath, []byte("regular-file-content"), 0o755))
+
+	needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
+	require.NoError(t, err)
+	assert.True(t, needsUpdate)
+	if runtime.GOOS == "windows" {
+		assert.True(t, isNotSymlink)
+		// On Windows, if isNotSymlink is true and binary was not updated, UpdateAction suppresses symlink update
+		didUpdate, err = r.UpdateAction()
+		require.NoError(t, err)
+		assert.False(t, didUpdate)
+	}
+
+	// Case 4: Symlink exists but points to a different/stale path (channel change / revert)
+	require.NoError(t, os.Remove(linkPath))
+	staleTarget := filepath.Join(rootDir, "stale-orbit")
+	if err := os.Symlink(staleTarget, linkPath); err == nil {
+		needsUpdate, isNotSymlink, err = r.needsOrbitSymlinkUpdate()
+		require.NoError(t, err)
+		assert.True(t, needsUpdate)
+		assert.False(t, isNotSymlink)
+	}
 }
 
 func TestRandomizeDuration(t *testing.T) {


### PR DESCRIPTION
**Related issue:** Resolves #52543

### Problem
On Windows, when Orbit is downgraded to an older version and then set back to the same version that was previously cached (e.g. `stable -> 1.52.1 -> stable`), `StoreLocalHash` computes the hash for the already-present `windows\stable\orbit.exe`. Because `r.localHashes[target]` matches `metaHash`, `localBinaryNotUpdated` is `false`.

`needsOrbitSymlinkUpdate()` identifies that the existing symlink points to `1.52.1` rather than `stable`, returning `true`. However, the Windows guard at `runner.go:275-278`:
```go
if runtime.GOOS == "windows" && needsSymlinkUpdate && !localBinaryNotUpdated {
    needsSymlinkUpdate = false
}
```
cancelled `needsSymlinkUpdate` under the assumption that `needsOrbitSymlinkUpdate()` returning `true` was due to an MSI-installed regular file (an invalid reparse point) rather than a genuine symlink mismatch. As a result, the symlink update was discarded, and Orbit remained on the downgraded version indefinitely.

### Solution
1. Extended `needsOrbitSymlinkUpdate()` to return `(needsUpdate bool, isNotSymlink bool, err error)`.
   - `isNotSymlink` is set to `true` specifically when `platform.IsInvalidReparsePoint(err)` is detected (regular file, e.g. fresh MSI install).
   - Real symlink mismatches (`existingPath != path`) and missing targets keep `isNotSymlink = false`.
2. Updated the Windows guard in `UpdateAction()`:
```go
if runtime.GOOS == "windows" && isNotSymlink && !localBinaryNotUpdated {
    needsSymlinkUpdate = false
}
```
   This preserves the intended MSI fresh install behavior (no redundant relink/restart on first run when binary is current), while allowing legitimate symlink updates to proceed whenever the symlink points to an older channel/version.
3. Added change file in `orbit/changes/52543-orbit-windows-downgrade-symlink`.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a Windows issue where downgrading Orbit and switching back to the same version could leave the executable link unchanged.
  - Prevented unnecessary updates after fresh MSI installations when the existing executable already matches the expected version.
  - Ensured updates continue when links point to a different Orbit version or channel, or are missing or invalid.

- **Tests**
  - Expanded coverage for Windows executable links, including valid, stale, missing, invalid, and regular-file scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->