### PR TITLE
OAB: Block manual endpoints + SCEP when both configured

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -991,6 +991,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			appCfg.ServerSettings.ServerURL,
 			config,
 			svc,
+			ds,
 		); err != nil {
 			initFatal(err, "setup mdm apple services")
 		}

--- a/ee/server/service/apple_mdm.go
+++ b/ee/server/service/apple_mdm.go
@@ -28,6 +28,11 @@ func (svc *Service) GetMDMAccountDrivenEnrollmentSSOURL(ctx context.Context, enr
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err)
 	}
+
+	if appConfig.MDM.OnlyAllowAppleBusinessEnrollment {
+		return "", &fleet.ABOnlyEnrollmentForbiddenError{}
+	}
+
 	url := appConfig.MDMUrl() + "/mdm/apple/account_driven_enroll/sso"
 
 	if enrollmentToken != "" {
@@ -41,6 +46,15 @@ func (svc *Service) GetMDMAppleAccountEnrollmentProfile(ctx context.Context, enr
 	// skipauth: This enrollment endpoint is authenticated only by the enrollment reference.
 	svc.authz.SkipAuthorization(ctx)
 
+	appConfig, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err)
+	}
+
+	if appConfig.MDM.OnlyAllowAppleBusinessEnrollment {
+		return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+	}
+
 	enrollChallenge, err := svc.ds.ConsumeADUEEnrollmentChallenge(ctx, enrollRef)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "consuming account driven enrollment challenge")
@@ -52,11 +66,6 @@ func (svc *Service) GetMDMAppleAccountEnrollmentProfile(ctx context.Context, enr
 	idpAccount, err := svc.ds.GetMDMIdPAccountByUUID(ctx, enrollChallenge.IdPAccountUUID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting MDM IdP account by UUID")
-	}
-
-	appConfig, err := svc.ds.AppConfig(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err)
 	}
 
 	topic, err := apple_mdm.MDMPushCertTopic(ctx, svc.ds)

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1679,6 +1679,10 @@ func (svc *Service) GetMDMManualEnrollmentProfile(ctx context.Context, personal 
 		return nil, ctxerr.Wrap(ctx, err)
 	}
 
+	if appConfig.MDM.OnlyAllowAppleBusinessEnrollment {
+		return nil, &fleet.BadRequestError{Message: fleet.AdminOnlyEnrollmentForbiddenErrMsg}
+	}
+
 	topic, err := assets.APNSTopic(ctx, svc.ds)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "extracting topic from APNs cert")

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -578,6 +578,7 @@
       // using string comparison to satisfy the linter.
       const ANDROID_MDM_ENABLED = "{{.AndroidMDMEnabled}}" === "true";
       const MAC_MDM_ENABLED = "{{.MacMDMEnabled}}" == "true";
+      const IS_APPLE_MANUAL_ENROLLMENT_BLOCKED = "{{.AppleManualEnrollmentBlocked}}" == "true";
       const ERROR_MESSAGE = "{{.ErrorMessage}}";
       const IDP_UUID = "{{.IdpUUID}}";
       const isFullyManaged = new URLSearchParams(window.location.search).has(
@@ -948,6 +949,13 @@
 
         // handle rendering for macos
         if (platform === "macos") {
+          if (IS_APPLE_MANUAL_ENROLLMENT_BLOCKED) {
+            renderError(
+              "This URL is invalid or expired.",
+              "IT blocked manual enrollments. Please reach out to your IT admin."
+            );
+            return;
+          }
           if (!MAC_MDM_ENABLED) {
             renderError(
               "Apple MDM is turned off.",
@@ -965,6 +973,13 @@
 
         // handle rendering for ios and ipad
         if (platform === "ios" || platform === "ipad") {
+          if (IS_APPLE_MANUAL_ENROLLMENT_BLOCKED) {
+            renderError(
+              "This URL is invalid or expired.",
+              "IT blocked manual enrollments. Please reach out to your IT admin."
+            );
+            return;
+          }
           if (!MAC_MDM_ENABLED) {
             const description = `To enroll your ${
               platform === "ios" ? "iPhone" : "iPad"

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -345,7 +345,7 @@ type MDM struct {
 	/////////////////////////////////////////////////////////////////
 }
 
-// IsAppleMDMSCEPBlocked reports whether Apple MDM SCEP endpoints is blocked all together, this blocks enrollments
+// IsAppleMDMSCEPBlocked reports whether Apple MDM SCEP endpoints are blocked altogether. This blocks enrollments
 // and renewals, plus those that might have a valid profile lying around with the static SCEP can't enroll.
 func (m MDM) IsAppleMDMSCEPBlocked() bool {
 	return m.OnlyAllowAppleBusinessEnrollment && m.AppleRequireHardwareAttestation

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -2476,8 +2476,9 @@ type DeviceGlobalConfig struct {
 // DeviceGlobalMDMConfig is a subset of AppConfig.MDM with information used by
 // the device endpoints
 type DeviceGlobalMDMConfig struct {
-	EnabledAndConfigured bool `json:"enabled_and_configured"`
-	RequireAllSoftware   bool `json:"require_all_software_macos"`
+	EnabledAndConfigured             bool `json:"enabled_and_configured"`
+	RequireAllSoftware               bool `json:"require_all_software_macos"`
+	OnlyAllowAppleBusinessEnrollment bool `json:"only_allow_apple_business_enrollment"`
 }
 
 // DeviceFeatures is a subset of AppConfig.Features with information used by

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -345,6 +345,12 @@ type MDM struct {
 	/////////////////////////////////////////////////////////////////
 }
 
+// IsMDMSCEPBlocked reports whether MDM SCEP endpoints is blocked all together, this blocks enrollments
+// and renewals, plus those that might have a valid profile lying around with the static SCEP can't enroll.
+func (m MDM) IsMDMSCEPBlocked() bool {
+	return m.OnlyAllowAppleBusinessEnrollment && m.AppleRequireHardwareAttestation
+}
+
 type DiskEncryptionConfig struct {
 	// MacOSEnabled indicates if FileVault enforcement is enabled for macOS hosts.
 	MacOSEnabled bool

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -345,9 +345,9 @@ type MDM struct {
 	/////////////////////////////////////////////////////////////////
 }
 
-// IsMDMSCEPBlocked reports whether MDM SCEP endpoints is blocked all together, this blocks enrollments
+// IsAppleMDMSCEPBlocked reports whether Apple MDM SCEP endpoints is blocked all together, this blocks enrollments
 // and renewals, plus those that might have a valid profile lying around with the static SCEP can't enroll.
-func (m MDM) IsMDMSCEPBlocked() bool {
+func (m MDM) IsAppleMDMSCEPBlocked() bool {
 	return m.OnlyAllowAppleBusinessEnrollment && m.AppleRequireHardwareAttestation
 }
 

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -637,3 +637,5 @@ func (e *ABOnlyEnrollmentForbiddenError) Internal() string {
 	}
 	return ""
 }
+
+const AdminOnlyEnrollmentForbiddenErrMsg = "Manual enrollment is not available because only Apple Business enrollment is allowed for this organization."

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -617,3 +617,23 @@ type VPPIconAvailable struct {
 func (e *VPPIconAvailable) Error() string {
 	return fmt.Sprintf("VPP icon available at: %s", e.IconURL)
 }
+
+// ABOnlyEnrollmentForbiddenError is returned by device-facing enrollment
+// endpoints when only Apple Business enrollment is allowed.
+type ABOnlyEnrollmentForbiddenError struct {
+	ErrorWithUUID
+	InternalErr error
+}
+
+func (e *ABOnlyEnrollmentForbiddenError) Error() string {
+	return "Manual enrollment is not available. Only devices assigned through Apple Business can enroll. Please contact your IT administrator."
+}
+
+func (e *ABOnlyEnrollmentForbiddenError) StatusCode() int { return http.StatusForbidden }
+
+func (e *ABOnlyEnrollmentForbiddenError) Internal() string {
+	if e.InternalErr != nil {
+		return e.InternalErr.Error()
+	}
+	return ""
+}

--- a/server/mdm/scep/server/endpoint.go
+++ b/server/mdm/scep/server/endpoint.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"os"
 	"strings"
@@ -272,23 +271,3 @@ type SCEPResponse struct {
 }
 
 func (r SCEPResponse) scepOperation() string { return r.operation }
-
-// EndpointLoggingMiddleware returns an endpoint middleware that logs the
-// duration of each invocation, and the resulting error, if any.
-func EndpointLoggingMiddleware(logger *slog.Logger) endpoint.Middleware {
-	return func(next endpoint.Endpoint) endpoint.Endpoint {
-		return func(ctx context.Context, request any) (response any, err error) {
-			var attrs []slog.Attr
-			if oper, ok := request.(interface {
-				scepOperation() string
-			}); ok {
-				attrs = append(attrs, slog.String("op", oper.scepOperation()))
-			}
-			defer func(begin time.Time) {
-				attrs = append(attrs, slog.Any("error", err), slog.Duration("took", time.Since(begin)))
-				logger.LogAttrs(ctx, slog.LevelInfo, "scep endpoint", attrs...)
-			}(time.Now())
-			return next(ctx, request)
-		}
-	}
-}

--- a/server/mdm/scep/server/middleware.go
+++ b/server/mdm/scep/server/middleware.go
@@ -20,7 +20,7 @@ func ACMEOnlyEnrollmentMiddleware(appCfgGetter fleet.GetsAppConfig) endpoint.Mid
 			if err != nil {
 				return nil, fmt.Errorf("loading app config for SCEP enrollment policy: %w", err)
 			}
-			if cfg.MDM.IsMDMSCEPBlocked() {
+			if cfg.MDM.IsAppleMDMSCEPBlocked() {
 				return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
 			}
 			return next(ctx, request)

--- a/server/mdm/scep/server/middleware.go
+++ b/server/mdm/scep/server/middleware.go
@@ -1,0 +1,55 @@
+package scepserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/go-kit/kit/endpoint"
+)
+
+// acmeOnlyEnrollmentMiddleware refuses all SCEP issuance when only
+// ACME-attested Apple Business enrollment is allowed. Fleet never solicits
+// SCEP renewals in that mode, so any PKIOperation is stale or hostile.
+func ACMEOnlyEnrollmentMiddleware(appCfgGetter fleet.GetsAppConfig) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request any) (response any, err error) {
+			cfg, err := appCfgGetter.AppConfig(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("loading app config for SCEP enrollment policy: %w", err)
+			}
+			if cfg.MDM.IsMDMSCEPBlocked() {
+				return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+			}
+			return next(ctx, request)
+		}
+	}
+}
+
+// EndpointLoggingMiddleware returns an endpoint middleware that logs the
+// duration of each invocation, and the resulting error, if any.
+func EndpointLoggingMiddleware(logger *slog.Logger) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request any) (response any, err error) {
+			var attrs []slog.Attr
+			if oper, ok := request.(interface {
+				scepOperation() string
+			}); ok {
+				attrs = append(attrs, slog.String("op", oper.scepOperation()))
+			}
+			defer func(begin time.Time) {
+				logErr := err
+				if logErr == nil {
+					if resp, ok := response.(SCEPResponse); ok {
+						logErr = resp.Err
+					}
+				}
+				attrs = append(attrs, slog.Any("error", logErr), slog.Duration("took", time.Since(begin)))
+				logger.LogAttrs(ctx, slog.LevelInfo, "scep endpoint", attrs...)
+			}(time.Now())
+			return next(ctx, request)
+		}
+	}
+}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -8607,6 +8607,10 @@ func (svc *Service) GetOTAProfile(ctx context.Context, enrollSecret, idpUUID str
 		return nil, ctxerr.Wrap(ctx, err, "getting app config to get org name")
 	}
 
+	if cfg.MDM.OnlyAllowAppleBusinessEnrollment {
+		return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+	}
+
 	requiresIDPUUID, err := shared_mdm.RequiresEnrollOTAAuthentication(ctx, svc.ds, enrollSecret, cfg.MDM.MacOSSetup.EnableEndUserAuthentication)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "checking if IDP UUID is required for OTA enrollment")

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -8766,6 +8766,15 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 	// authorization is performed via the enroll secret and the provided certificates
 	svc.authz.SkipAuthorization(ctx)
 
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "reading app config")
+	}
+
+	if appCfg.MDM.OnlyAllowAppleBusinessEnrollment {
+		return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+	}
+
 	if len(certificates) == 0 {
 		return nil, authz.ForbiddenWithInternal("no certificates provided", nil, nil, nil)
 	}
@@ -8790,11 +8799,6 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, fmt.Errorf("loading SCEP challenge from the database: %w", err)
 	}
 	scepChallenge := string(assets[fleet.MDMAssetSCEPChallenge].Value)
-
-	appCfg, err := svc.ds.AppConfig(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "reading app config")
-	}
 
 	mdmURL := appCfg.MDMUrl()
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4948,6 +4948,12 @@ func certIsFromNewEnrollment(cert *x509.Certificate) bool {
 //
 // [1]: https://developer.apple.com/documentation/devicemanagement/authenticate
 func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm.Authenticate) error {
+	// AB-only enrollment enforcement lives in abOnlyEnrollmentCheckinService, which wraps
+	// this service (see handler.go). This service is dispatched as a "sub service" of
+	// multi.New alongside nanomdm's core service — its returned errors are only logged, not
+	// surfaced to the device (see MultiService.runOthers) — so a check here cannot actually
+	// block enrollment.
+
 	var scepRenewalInProgress bool
 	existingDeviceInfo, err := svc.ds.GetHostMDMCheckinInfo(r.Context, r.ID)
 	if err != nil {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2975,16 +2975,15 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err, "extracting topic from APNs cert")
 	}
 
-	var depAssignments []*fleet.HostDEPAssignment
+	depAssignments, err := svc.ds.GetHostDEPAssignmentsBySerial(ctx, machineInfo.Serial)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting DEP assignments by serial")
+	}
+
 	if appConfig.MDM.OnlyAllowAppleBusinessEnrollment {
 		if machineInfo.Serial == "" {
 			// adue enrollment does not have a serial, so fail fast
 			return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
-		}
-
-		depAssignments, err = svc.ds.GetHostDEPAssignmentsBySerial(ctx, machineInfo.Serial)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting DEP assignments by serial")
 		}
 
 		// No DEP assignment for this serial, so we fail.

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2975,21 +2975,42 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err, "extracting topic from APNs cert")
 	}
 
+	var depAssignments []*fleet.HostDEPAssignment
+	if appConfig.MDM.OnlyAllowAppleBusinessEnrollment {
+		if machineInfo.Serial == "" {
+			// adue enrollment does not have a serial, so fail fast
+			return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+		}
+
+		depAssignments, err = svc.ds.GetHostDEPAssignmentsBySerial(ctx, machineInfo.Serial)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting DEP assignments by serial")
+		}
+
+		// No DEP assignment for this serial, so we fail.
+		if len(depAssignments) == 0 {
+			return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+		}
+	}
+
 	var requireACME bool
 	if appConfig.MDM.AppleRequireHardwareAttestation {
-		requireACME, err = svc.isMDMAppleACMERequired(ctx, machineInfo)
+		requireACME, err = svc.isMDMAppleACMERequired(ctx, machineInfo, depAssignments)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "checking if ACME enrollment is required")
 		}
 
 		svc.logger.InfoContext(ctx, "hardware attestastion required", "require_acme", requireACME, "product", machineInfo.Product, "serial", machineInfo.Serial)
-
 	}
 
 	var enrollProf []byte
 	if requireACME {
 		enrollProf, err = svc.generateMDMAppleACMEEnrollProfile(ctx, machineInfo.Serial, appConfig.OrgInfo.OrgName, mdmURL, topic)
 	} else {
+		if appConfig.MDM.IsAppleMDMSCEPBlocked() {
+			// do not allow falling through to SCEP when it's blocked via both require acme and only AB enrollments.
+			return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+		}
 		enrollProf, err = svc.generateMDMAppleSCEPEnrollProfile(ctx, appConfig.OrgInfo.OrgName, mdmURL, topic)
 	}
 
@@ -3023,7 +3044,7 @@ func (svc *Service) NewACMEEnrollment(ctx context.Context, hardwareSerial string
 	return svc.acmeSvc.NewACMEEnrollment(ctx, hardwareSerial)
 }
 
-func (svc *Service) isMDMAppleACMERequired(ctx context.Context, machineInfo *fleet.MDMAppleMachineInfo) (bool, error) {
+func (svc *Service) isMDMAppleACMERequired(ctx context.Context, machineInfo *fleet.MDMAppleMachineInfo, depAssignments []*fleet.HostDEPAssignment) (bool, error) {
 	if machineInfo == nil {
 		return false, ctxerr.New(ctx, "machine info is nil")
 	}
@@ -3043,13 +3064,9 @@ func (svc *Service) isMDMAppleACMERequired(ctx context.Context, machineInfo *fle
 	}
 
 	// we only require ACME if the serial is DEP-assigned to Fleet
-	assignments, err := svc.ds.GetHostDEPAssignmentsBySerial(ctx, machineInfo.Serial)
-	if err != nil {
-		return false, ctxerr.Wrap(ctx, err, "checking DEP assignment status")
-	}
-	svc.logger.InfoContext(ctx, "checking DEP assignment status for ACME requirement", "serial", machineInfo.Serial, "dep_assignments_count", len(assignments))
+	svc.logger.InfoContext(ctx, "checking DEP assignment status for ACME requirement", "serial", machineInfo.Serial, "dep_assignments_count", len(depAssignments))
 
-	return len(assignments) > 0, nil
+	return len(depAssignments) > 0, nil
 }
 
 // isACMESupported checks if the device is supported for ACME enrollment. Fleet supports:

--- a/server/service/apple_mdm_abonly_checkin.go
+++ b/server/service/apple_mdm_abonly_checkin.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	nano_service "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/service"
+)
+
+// abOnlyEnrollmentCheckinService wraps the full MDM checkin/command service chain
+// (nanomdm's core service plus Fleet's own, dispatched together via multi.New) so that
+// rejecting an Authenticate actually reaches the device.
+//
+// multi.New treats every service after the first as a "sub service": their errors are only
+// logged (see MultiService.runOthers), never returned to the HTTP caller — only the first
+// service's return value determines the response. Fleet's own checkin service is registered
+// as a sub service on purpose (its many side effects — host creation, activity logging —
+// must not fail the live MDM protocol handshake if e.g. a DB write has a transient error), so
+// a business rule that needs to actually block enrollment cannot live there. This wrapper is
+// placed around the whole chain instead (same spot certauth.New wraps it), so its Authenticate
+// return value is what the HTTP handler sees.
+type abOnlyEnrollmentCheckinService struct {
+	nano_service.CheckinAndCommandService
+	ds     fleet.Datastore
+	logger *slog.Logger
+}
+
+// newABOnlyEnrollmentCheckinService wraps next with the Apple Business-only enrollment check.
+func newABOnlyEnrollmentCheckinService(next nano_service.CheckinAndCommandService, ds fleet.Datastore, logger *slog.Logger) nano_service.CheckinAndCommandService {
+	return &abOnlyEnrollmentCheckinService{CheckinAndCommandService: next, ds: ds, logger: logger}
+}
+
+func (s *abOnlyEnrollmentCheckinService) Authenticate(r *mdm.Request, m *mdm.Authenticate) error {
+	appCfg, err := s.ds.AppConfig(r.Context)
+	if err != nil {
+		return ctxerr.Wrap(r.Context, err, "loading app config for AB-only enrollment check")
+	}
+	if appCfg.MDM.OnlyAllowAppleBusinessEnrollment {
+		assignments, err := s.ds.GetHostDEPAssignmentsBySerial(r.Context, m.SerialNumber)
+		if err != nil {
+			return ctxerr.Wrap(r.Context, err, "checking DEP assignment for AB-only enrollment")
+		}
+		if len(assignments) == 0 {
+			// r.EnrollID is nil here: this wrapper runs before nanomdm's core service, which
+			// is what populates it (see the "critical" ordering note on multi.New's call
+			// site in handler.go). Log the identifiers available directly on the message
+			// instead of the usual r.ID.
+			s.logger.InfoContext(r.Context, "rejecting enrollment: serial not assigned in Apple Business",
+				"udid", m.UDID, "serial", m.SerialNumber,
+			)
+			returnErr := fleet.ABOnlyEnrollmentForbiddenError{}
+			return nano_service.NewHTTPStatusError(returnErr.StatusCode(), &returnErr)
+		}
+	}
+	return s.CheckinAndCommandService.Authenticate(r, m)
+}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -266,6 +266,9 @@ func setupAppleMDMService(t *testing.T, license *fleet.LicenseInfo, tweakCfg ...
 	ds.InsertAppleSoftwareUpdateDeviceIDFunc = func(ctx context.Context, hostUUID, updateDeviceID string) error {
 		return nil
 	}
+	ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+		return nil, nil
+	}
 
 	return svc, ctx, ds, opts
 }
@@ -10360,6 +10363,95 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 		})
 	})
 
+	t.Run("AB only enrollment", func(t *testing.T) {
+		depAssignedMI := fleet.MDMAppleMachineInfo{
+			Product:   "MacBookPro18,3", // Apple Silicon
+			Serial:    "ABONLYSERIAL",
+			UDID:      "ab-only-udid",
+			OSVersion: "13.6.0", // < 14 so ACME is never required, isolating the AB-only/SCEP-block behavior
+		}
+
+		t.Run("device without a serial is forbidden", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+					MDM:            fleet.MDM{EnabledAndConfigured: true, OnlyAllowAppleBusinessEnrollment: true},
+				}, nil
+			}
+			// DEP assignments are always fetched regardless of AB-only, so return none for
+			// the empty serial -- the missing serial alone must still be forbidden.
+			ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+				return []*fleet.HostDEPAssignment{}, nil
+			}
+			noSerialMI := depAssignedMI
+			noSerialMI.Serial = ""
+
+			_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &noSerialMI)
+			var abErr *fleet.ABOnlyEnrollmentForbiddenError
+			require.ErrorAs(t, err, &abErr)
+		})
+
+		t.Run("device not DEP assigned is forbidden", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+					MDM:            fleet.MDM{EnabledAndConfigured: true, OnlyAllowAppleBusinessEnrollment: true},
+				}, nil
+			}
+			ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+				return []*fleet.HostDEPAssignment{}, nil
+			}
+
+			_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &depAssignedMI)
+			var abErr *fleet.ABOnlyEnrollmentForbiddenError
+			require.ErrorAs(t, err, &abErr)
+		})
+
+		t.Run("DEP assigned device without hardware attestation gets SCEP", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+					MDM:            fleet.MDM{EnabledAndConfigured: true, OnlyAllowAppleBusinessEnrollment: true},
+				}, nil
+			}
+			ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+				return []*fleet.HostDEPAssignment{{HostID: 1}}, nil
+			}
+
+			profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &depAssignedMI)
+			require.NoError(t, err)
+			assertSCEPProfile(t, decodeSignedEnrollmentProfile(t, profile))
+		})
+
+		t.Run("DEP assigned device that falls through to SCEP is blocked when hardware attestation is also required", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+					MDM: fleet.MDM{
+						EnabledAndConfigured:             true,
+						OnlyAllowAppleBusinessEnrollment: true,
+						AppleRequireHardwareAttestation:  true,
+					},
+				}, nil
+			}
+			ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+				return []*fleet.HostDEPAssignment{{HostID: 1}}, nil
+			}
+
+			// depAssignedMI is on macOS 13, so isMDMAppleACMERequired returns false and the
+			// code falls through to the SCEP branch -- with both AB-only and hardware
+			// attestation configured, that fallback must be blocked rather than silently
+			// issuing a SCEP profile.
+			_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &depAssignedMI)
+			var abErr *fleet.ABOnlyEnrollmentForbiddenError
+			require.ErrorAs(t, err, &abErr)
+		})
+	})
+
 	t.Run("miscellaneous error handling", func(t *testing.T) {
 		// For these tests we can just use a single device type since we're not asserting on the
 		// profile content, just that errors are handled and returned properly.
@@ -10422,22 +10514,20 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 					ds.GetHostDEPAssignmentsBySerialFuncInvoked = false // reset invocation flag
 
 					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &machineInfo)
-					if hardwareAttestationRequired {
-						// when hardware attestation is required, DEP assignment is checked before deciding on ACME vs SCEP, so an error here should be returned
-						require.True(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
-						require.Error(t, err)
-						require.Contains(t, err.Error(), "checking DEP assignment")
-					} else {
-						// when hardware attestation is not required, DEP assignment is not relevant since we always return SCEP, so an error here should not be returned
-						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
-						require.NoError(t, err)
-					}
+
+					// DEP assignment is always fetched.
+					require.True(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "getting DEP assignments by serial")
 				})
 
 				t.Run("invalid OS version for Apple Silicon Mac returns error", func(t *testing.T) {
 					// restore foundProfileFunc in case a previous sub-test left a different func
 					ds.GetMDMAppleEnrollmentProfileByTokenFunc = foundProfileFunc
 					ds.GetHostDEPAssignmentsBySerialFuncInvoked = false // reset invocation flag
+					ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+						return nil, nil
+					}
 					invalidOSMI := fleet.MDMAppleMachineInfo{
 						Product:   "MacBookPro18,3", // Apple Silicon — reaches the OSVersion check
 						Serial:    "MACSILSERIAL",
@@ -10446,13 +10536,13 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 					}
 					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &invalidOSMI)
 					if hardwareAttestationRequired {
-						// isMDMAppleACMERequired is called and fails at the OSVersion check — DEP check is never reached
-						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+						// isMDMAppleACMERequired is called and fails at the OSVersion check — DEP check is always reached as it is outside and also used for AB only.
+						require.True(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
 						require.Error(t, err)
 						require.Contains(t, err.Error(), "checking if device is less than macOS 14")
 					} else {
 						// isMDMAppleACMERequired is never called, so OSVersion is irrelevant — SCEP is always returned
-						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+						require.True(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
 						require.NoError(t, err)
 					}
 				})

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -286,8 +286,9 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 			// TODO(mna): It currently only returns the Apple enabled and configured,
 			// regardless of the platform of the device. See
 			// https://github.com/fleetdm/fleet/pull/19304#discussion_r1618792410.
-			EnabledAndConfigured: ac.MDM.EnabledAndConfigured,
-			RequireAllSoftware:   requireAllSoftware,
+			EnabledAndConfigured:             ac.MDM.EnabledAndConfigured,
+			RequireAllSoftware:               requireAllSoftware,
+			OnlyAllowAppleBusinessEnrollment: ac.MDM.OnlyAllowAppleBusinessEnrollment,
 		},
 		Features: fleet.DeviceFeatures{
 			EnableSoftwareInventory:       softwareInventoryEnabled,

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -923,6 +923,10 @@ func (svc *Service) GetDeviceMDMAppleEnrollmentProfile(ctx context.Context) (*ur
 		return nil, ctxerr.Wrap(ctx, err, "fetching app config")
 	}
 
+	if cfg.MDM.OnlyAllowAppleBusinessEnrollment {
+		return nil, &fleet.ABOnlyEnrollmentForbiddenError{}
+	}
+
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -118,10 +118,11 @@ func ServeEndUserEnrollOTA(
 			herr(ctx, w, "load appconfig err: "+err.Error())
 			return
 		}
+		appleManualEnrollmentBlocked := appCfg.MDM.OnlyAllowAppleBusinessEnrollment
 
 		errorMsg := r.URL.Query().Get("error")
 		if errorMsg != "" {
-			if err := renderEnrollPage(w, appCfg, urlPrefix, "", errorMsg, nonce, ""); err != nil {
+			if err := renderEnrollPage(w, appCfg, urlPrefix, "", errorMsg, nonce, "", appleManualEnrollmentBlocked); err != nil {
 				herr(ctx, w, err.Error())
 			}
 			return
@@ -129,7 +130,7 @@ func ServeEndUserEnrollOTA(
 
 		enrollSecret := r.URL.Query().Get("enroll_secret")
 		if enrollSecret == "" {
-			if err := renderEnrollPage(w, appCfg, urlPrefix, "", "This URL is invalid. : Enroll secret is invalid. Please contact your IT admin.", nonce, ""); err != nil {
+			if err := renderEnrollPage(w, appCfg, urlPrefix, "", "This URL is invalid. : Enroll secret is invalid. Please contact your IT admin.", nonce, "", appleManualEnrollmentBlocked); err != nil {
 				herr(ctx, w, err.Error())
 			}
 			return
@@ -189,7 +190,7 @@ func ServeEndUserEnrollOTA(
 			})
 		}
 
-		if err := renderEnrollPage(w, appCfg, urlPrefix, enrollSecret, "", nonce, idpUUID); err != nil {
+		if err := renderEnrollPage(w, appCfg, urlPrefix, enrollSecret, "", nonce, idpUUID, appleManualEnrollmentBlocked); err != nil {
 			herr(ctx, w, err.Error())
 			return
 		}
@@ -213,7 +214,7 @@ func generateEnrollOTAURL(fleetURL string, enrollSecret string) (string, error) 
 	return enrollURL.String(), nil
 }
 
-func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSecret, errorMessage, nonce, idpUUID string) error {
+func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSecret, errorMessage, nonce, idpUUID string, appleManualEnrollmentBlocked bool) error {
 	fs := newBinaryFileSystem("/frontend")
 	file, err := fs.Open("templates/enroll-ota.html")
 	if err != nil {
@@ -235,23 +236,25 @@ func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSec
 		return fmt.Errorf("generate enroll ota url: %w", err)
 	}
 	if err := t.Execute(w, struct {
-		EnrollURL             string
-		URLPrefix             string
-		ErrorMessage          string
-		AndroidMDMEnabled     bool
-		MacMDMEnabled         bool
-		AndroidFeatureEnabled bool
-		CSPNonce              string
-		IdpUUID               string
+		EnrollURL                    string
+		URLPrefix                    string
+		ErrorMessage                 string
+		AndroidMDMEnabled            bool
+		MacMDMEnabled                bool
+		AndroidFeatureEnabled        bool
+		CSPNonce                     string
+		IdpUUID                      string
+		AppleManualEnrollmentBlocked bool
 	}{
-		URLPrefix:             urlPrefix,
-		EnrollURL:             enrollURL,
-		ErrorMessage:          errorMessage,
-		AndroidMDMEnabled:     appCfg.MDM.AndroidEnabledAndConfigured,
-		MacMDMEnabled:         appCfg.MDM.EnabledAndConfigured,
-		AndroidFeatureEnabled: true,
-		CSPNonce:              nonce,
-		IdpUUID:               idpUUID,
+		URLPrefix:                    urlPrefix,
+		EnrollURL:                    enrollURL,
+		ErrorMessage:                 errorMessage,
+		AndroidMDMEnabled:            appCfg.MDM.AndroidEnabledAndConfigured,
+		MacMDMEnabled:                appCfg.MDM.EnabledAndConfigured,
+		AndroidFeatureEnabled:        true,
+		CSPNonce:                     nonce,
+		IdpUUID:                      idpUUID,
+		AppleManualEnrollmentBlocked: appleManualEnrollmentBlocked,
 	}); err != nil {
 		return fmt.Errorf("execute react template: %w", err)
 	}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1434,10 +1434,9 @@ func registerMDMServiceDiscovery(
 	serviceDiscoveryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appCfg, err := appCfgGetter.AppConfig(r.Context())
 		if err != nil {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			serviceDiscoveryLogger.ErrorContext(r.Context(), "error loading app config for service discovery", "err", err)
 			return
-		}
-		if appCfg.MDM.OnlyAllowAppleBusinessEnrollment {
+		} else if appCfg.MDM.OnlyAllowAppleBusinessEnrollment {
 			err := &fleet.ABOnlyEnrollmentForbiddenError{}
 			http.Error(w, err.Error(), err.StatusCode())
 			return

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1406,8 +1406,9 @@ func RegisterAppleMDMProtocolServices(
 	serverURLPrefix string,
 	fleetConfig config.FleetConfig,
 	svc fleet.Service,
+	ds fleet.Datastore,
 ) error {
-	if err := registerSCEP(mux, scepConfig, scepStorage, mdmStorage, logger, fleetConfig); err != nil {
+	if err := registerSCEP(mux, scepConfig, scepStorage, mdmStorage, logger, fleetConfig, ds); err != nil {
 		return fmt.Errorf("scep: %w", err)
 	}
 	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger, fleetConfig); err != nil {
@@ -1479,6 +1480,7 @@ func registerSCEP(
 	mdmStorage fleet.MDMAppleStore,
 	logger *slog.Logger,
 	fleetConfig config.FleetConfig,
+	appCfgGetter fleet.GetsAppConfig,
 ) error {
 	var signer scepserver.CSRSignerContext = scepserver.SignCSRAdapter(scep_depot.NewSigner(
 		scepStorage,
@@ -1504,8 +1506,11 @@ func registerSCEP(
 
 	scepSlogLogger := logger.With("component", "http-mdm-apple-scep")
 	e := scepserver.MakeServerEndpoints(scepService)
+	e.GetEndpoint = scepserver.ACMEOnlyEnrollmentMiddleware(appCfgGetter)(e.GetEndpoint)
+	e.PostEndpoint = scepserver.ACMEOnlyEnrollmentMiddleware(appCfgGetter)(e.PostEndpoint)
 	e.GetEndpoint = scepserver.EndpointLoggingMiddleware(scepSlogLogger)(e.GetEndpoint)
 	e.PostEndpoint = scepserver.EndpointLoggingMiddleware(scepSlogLogger)(e.PostEndpoint)
+
 	scepHandler := scepserver.MakeHTTPHandler(e, scepService, scepSlogLogger)
 	mux.Handle(apple_mdm.SCEPPath, otel.WrapHandler(scepHandler, apple_mdm.SCEPPath, fleetConfig))
 	return nil

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1411,7 +1411,7 @@ func RegisterAppleMDMProtocolServices(
 	if err := registerSCEP(mux, scepConfig, scepStorage, mdmStorage, logger, fleetConfig, ds); err != nil {
 		return fmt.Errorf("scep: %w", err)
 	}
-	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger, fleetConfig); err != nil {
+	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger, fleetConfig, ds); err != nil {
 		return fmt.Errorf("mdm: %w", err)
 	}
 	if err := registerMDMServiceDiscovery(mux, logger, serverURLPrefix, fleetConfig, ds); err != nil {
@@ -1588,6 +1588,7 @@ func registerMDM(
 	profileService nanomdm_service.ProfileService,
 	logger *slog.Logger,
 	fleetConfig config.FleetConfig,
+	ds fleet.Datastore,
 ) error {
 	certVerifier := mdmcrypto.NewSCEPVerifier(mdmStorage)
 	mdmLogger := NewNanoMDMLogger(logger.With("component", "http-mdm-apple-mdm"))
@@ -1609,6 +1610,10 @@ func registerMDM(
 	var mdmService nanomdm_service.CheckinAndCommandService = multi.New(mdmLogger, coreMDMService, checkinAndCommandService)
 
 	mdmService = certauth.New(mdmService, mdmStorage, certauth.WithLogger(mdmLogger.With("handler", "cert-auth")))
+	// Wraps the whole chain above (not a multi.New sub-service) so a rejection here is what
+	// the HTTP handler actually returns to the device. See abOnlyEnrollmentCheckinService's
+	// doc comment for why this can't live inside checkinAndCommandService itself.
+	mdmService = newABOnlyEnrollmentCheckinService(mdmService, ds, logger.With("component", "http-mdm-apple-mdm", "handler", "ab-only-enrollment"))
 	var mdmHandler http.Handler = httpmdm.CheckinAndCommandHandler(mdmService, mdmLogger.With("handler", "checkin-command"))
 	verifyDisable, exists := os.LookupEnv("FLEET_MDM_APPLE_SCEP_VERIFY_DISABLE")
 	if exists && (strings.EqualFold(verifyDisable, "true") || verifyDisable == "1") {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1414,7 +1414,7 @@ func RegisterAppleMDMProtocolServices(
 	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger, fleetConfig); err != nil {
 		return fmt.Errorf("mdm: %w", err)
 	}
-	if err := registerMDMServiceDiscovery(mux, logger, serverURLPrefix, fleetConfig); err != nil {
+	if err := registerMDMServiceDiscovery(mux, logger, serverURLPrefix, fleetConfig, ds); err != nil {
 		return fmt.Errorf("service discovery: %w", err)
 	}
 	if err := registerPSSO(mux, svc, logger, fleetConfig); err != nil {
@@ -1428,9 +1428,21 @@ func registerMDMServiceDiscovery(
 	logger *slog.Logger,
 	serverURLPrefix string,
 	fleetConfig config.FleetConfig,
+	appCfgGetter fleet.GetsAppConfig,
 ) error {
 	serviceDiscoveryLogger := logger.With("component", "mdm-apple-service-discovery")
 	serviceDiscoveryHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appCfg, err := appCfgGetter.AppConfig(r.Context())
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		if appCfg.MDM.OnlyAllowAppleBusinessEnrollment {
+			err := &fleet.ABOnlyEnrollmentForbiddenError{}
+			http.Error(w, err.Error(), err.StatusCode())
+			return
+		}
+
 		var mdmEnrollmentURL string
 		token := r.PathValue("token")
 		if token != "" {
@@ -1444,7 +1456,7 @@ func registerMDMServiceDiscovery(
 		serviceDiscoveryLogger.InfoContext(ctx, "serving MDM service discovery response", "url", mdmEnrollmentURL)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintf(w, `{"Servers":[{"Version": "mdm-byod", "BaseURL": "%s"}]}`, mdmEnrollmentURL)
+		_, err = fmt.Fprintf(w, `{"Servers":[{"Version": "mdm-byod", "BaseURL": "%s"}]}`, mdmEnrollmentURL)
 		if err != nil {
 			serviceDiscoveryLogger.ErrorContext(ctx, "error writing service discovery response", "err", err)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3499,23 +3499,23 @@ func (s *integrationMDMTestSuite) TestABOnlyEnrollmentBlocksAuthenticateForNonDE
 		encoder := json.NewEncoder(w)
 		switch r.URL.Path {
 		case "/session":
-			require.NoError(t, encoder.Encode(map[string]string{"auth_session_token": "xyz"}))
+			assert.NoError(t, encoder.Encode(map[string]string{"auth_session_token": "xyz"}))
 		case "/profile":
-			require.NoError(t, encoder.Encode(godep.ProfileResponse{ProfileUUID: uuid.New().String()}))
+			assert.NoError(t, encoder.Encode(godep.ProfileResponse{ProfileUUID: uuid.New().String()}))
 		case "/server/devices":
-			require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: []godep.Device{depDevice}}))
+			assert.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: []godep.Device{depDevice}}))
 		case "/devices/sync":
-			require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: []godep.Device{depDevice}, Cursor: "foo"}))
+			assert.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: []godep.Device{depDevice}, Cursor: "foo"}))
 		case "/profile/devices":
 			b, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			var prof profileAssignmentReq
-			require.NoError(t, json.Unmarshal(b, &prof))
+			assert.NoError(t, json.Unmarshal(b, &prof))
 			resp := godep.ProfileResponse{ProfileUUID: prof.ProfileUUID, Devices: make(map[string]string, len(prof.Devices))}
 			for _, serial := range prof.Devices {
 				resp.Devices[serial] = string(fleet.DEPAssignProfileResponseSuccess)
 			}
-			require.NoError(t, encoder.Encode(resp))
+			assert.NoError(t, encoder.Encode(resp))
 		default:
 			_, _ = w.Write([]byte(`{}`))
 		}
@@ -3525,11 +3525,11 @@ func (s *integrationMDMTestSuite) TestABOnlyEnrollmentBlocksAuthenticateForNonDE
 
 	origAppCfg, err := s.ds.AppConfig(t.Context())
 	require.NoError(t, err)
-	t.Cleanup(func() { s.ds.SaveAppConfig(context.Background(), origAppCfg) })
+	t.Cleanup(func() { require.NoError(t, s.ds.SaveAppConfig(context.Background(), origAppCfg)) })
 	appCfg, err := s.ds.AppConfig(t.Context())
 	require.NoError(t, err)
 	appCfg.MDM.OnlyAllowAppleBusinessEnrollment = true
-	require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
+	require.NoError(t, s.ds.SaveAppConfig(t.Context(), appCfg))
 
 	// The DEP-assigned device has a row in host_dep_assignments for its serial (populated by
 	// the DEP sync above), so the full enroll flow — profile fetch, SCEP, Authenticate,
@@ -3548,8 +3548,8 @@ func (s *integrationMDMTestSuite) TestABOnlyEnrollmentBlocksAuthenticateForNonDE
 	}, "MacBookPro16,1")
 	err = rogueDevice.Enroll()
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "authenticate:")
-	assert.ErrorContains(t, err, fmt.Sprintf("%d", http.StatusForbidden))
+	require.ErrorContains(t, err, "authenticate:")
+	require.ErrorContains(t, err, fmt.Sprintf("%d", http.StatusForbidden))
 
 	// Rejected at Authenticate, so no host record should have been created for it.
 	listHostsRes := listHostsResponse{}
@@ -3735,7 +3735,7 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 	originalAppCfg, err := s.ds.AppConfig(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		s.ds.SaveAppConfig(context.Background(), originalAppCfg)
+		require.NoError(t, s.ds.SaveAppConfig(context.Background(), originalAppCfg))
 	})
 
 	getUserStatusCode := func(isBlocked bool, unblockedStatus int) int {
@@ -3791,7 +3791,7 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 	require.NoError(t, err)
 
 	// setup host so we can do device authenticated endpoints
-	host, err := s.ds.NewHost(t.Context(), &fleet.Host{TeamID: ptr.Uint(1)})
+	host, err := s.ds.NewHost(t.Context(), &fleet.Host{TeamID: new(uint(1))})
 	require.NoError(t, err)
 
 	// Mint a fresh device auth token
@@ -3800,12 +3800,13 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 	require.NoError(t, err)
 
 	// setup automatic enrollment profile to get a token
-	depProfileToken := "fake-dep-token"
-	s.ds.NewMDMAppleEnrollmentProfile(t.Context(), fleet.MDMAppleEnrollmentProfilePayload{
+	depProfileToken := "fake-dep-token" // nolint:gosec // test credential
+	_, err = s.ds.NewMDMAppleEnrollmentProfile(t.Context(), fleet.MDMAppleEnrollmentProfilePayload{
 		Type:       fleet.MDMAppleEnrollmentTypeAutomatic,
 		DEPProfile: new(json.RawMessage(`{}`)),
 		Token:      depProfileToken,
 	})
+	require.NoError(t, err)
 
 	for _, isBlocked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("blocked=%v", isBlocked), func(t *testing.T) {
@@ -3815,7 +3816,7 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			appCfg.MDM.AppleRequireHardwareAttestation = isBlocked
 			appCfg.MDM.OnlyAllowAppleBusinessEnrollment = isBlocked
 			require.Equal(t, isBlocked, appCfg.MDM.IsAppleMDMSCEPBlocked())
-			require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
+			require.NoError(t, s.ds.SaveAppConfig(t.Context(), appCfg))
 
 			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.
 			// PKIOperation requires additional setup to verify, but it's under the same middleware.
@@ -3866,7 +3867,7 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 
 			// hit /enroll page and verify on the returned enroll page.
 			resp = s.DoRawNoAuth("GET", "/enroll", nil, http.StatusOK)
-			require.Equal(t, resp.Header.Get("Content-Type"), "text/html; charset=utf-8")
+			require.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
 			// assert it contains the content we expect
 			defer resp.Body.Close()
 			bodyBytes, err := io.ReadAll(resp.Body)

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3488,6 +3488,87 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	assert.True(t, hostResp.Host.MDMEnrollmentHardwareAttested)
 }
 
+// TestABOnlyEnrollmentBlocksAuthenticateForNonDEPHosts covers the AB-only enforcement in
+// MDMAppleCheckinAndCommandService.Authenticate directly, independent of the enrollment-profile
+// and SCEP layers that also enforce it. That matters because a device can reach the raw MDM
+// checkin endpoint without going through Fleet's profile-issuance endpoint at all — e.g. it
+// obtained a profile before AB-only was turned on, or via some other channel — so Authenticate
+// is the last line of defense and needs its own coverage rather than relying on the
+// profile-fetch block to catch every case.
+func (s *integrationMDMTestSuite) TestABOnlyEnrollmentBlocksAuthenticateForNonDEPHosts() {
+	t := s.T()
+	s.enableABM(t.Name())
+	s.setSkipWorkerJobs(t)
+
+	depDevice := godep.Device{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"}
+	s.mockDEPResponse(t.Name(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		encoder := json.NewEncoder(w)
+		switch r.URL.Path {
+		case "/session":
+			require.NoError(t, encoder.Encode(map[string]string{"auth_session_token": "xyz"}))
+		case "/profile":
+			require.NoError(t, encoder.Encode(godep.ProfileResponse{ProfileUUID: uuid.New().String()}))
+		case "/server/devices":
+			require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: []godep.Device{depDevice}}))
+		case "/devices/sync":
+			require.NoError(t, encoder.Encode(godep.DeviceResponse{Devices: []godep.Device{depDevice}, Cursor: "foo"}))
+		case "/profile/devices":
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var prof profileAssignmentReq
+			require.NoError(t, json.Unmarshal(b, &prof))
+			resp := godep.ProfileResponse{ProfileUUID: prof.ProfileUUID, Devices: make(map[string]string, len(prof.Devices))}
+			for _, serial := range prof.Devices {
+				resp.Devices[serial] = string(fleet.DEPAssignProfileResponseSuccess)
+			}
+			require.NoError(t, encoder.Encode(resp))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	s.runDEPSchedule()
+	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
+
+	// Only OnlyAllowAppleBusinessEnrollment, not AppleRequireHardwareAttestation: SCEP
+	// blocking (IsAppleMDMSCEPBlocked) requires both, and we want SCEP to succeed here so
+	// the non-DEP device actually reaches Authenticate instead of being turned away earlier.
+	origAppCfg, err := s.ds.AppConfig(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { s.ds.SaveAppConfig(context.Background(), origAppCfg) })
+	appCfg, err := s.ds.AppConfig(t.Context())
+	require.NoError(t, err)
+	appCfg.MDM.OnlyAllowAppleBusinessEnrollment = true
+	require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
+
+	// The DEP-assigned device has a row in host_dep_assignments for its serial (populated by
+	// the DEP sync above), so the full enroll flow — profile fetch, SCEP, Authenticate,
+	// TokenUpdate — must succeed end to end.
+	validDevice := mdmtest.NewTestMDMClientAppleDEPFromDevice(s.server.URL, depURLToken, depDevice.SerialNumber, depDevice.Model)
+	require.NoError(t, validDevice.Enroll())
+
+	// A device with a valid SCEP identity but no DEP assignment skips Fleet's
+	// enrollment-profile endpoint entirely (NewTestMDMClientAppleDirect never calls it), so
+	// SCEP enrollment succeeds and the device reaches the raw Authenticate checkin — which
+	// must reject it on its own.
+	rogueDevice := mdmtest.NewTestMDMClientAppleDirect(mdmtest.AppleEnrollInfo{
+		SCEPChallenge: s.scepChallenge,
+		SCEPURL:       s.server.URL + apple_mdm.SCEPPath,
+		MDMURL:        s.server.URL + apple_mdm.MDMPath,
+	}, "MacBookPro16,1")
+	err = rogueDevice.Enroll()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "authenticate:")
+	assert.ErrorContains(t, err, fmt.Sprintf("%d", http.StatusForbidden))
+
+	// Rejected at Authenticate, so no host record should have been created for it.
+	listHostsRes := listHostsResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
+	for _, h := range listHostsRes.Hosts {
+		assert.NotEqual(t, rogueDevice.UUID, h.UUID, "a host rejected at Authenticate must not be created")
+	}
+}
+
 func (s *integrationMDMTestSuite) TestGetDefaultDEPProfile() {
 	t := s.T()
 	s.enableABM(t.Name())

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3718,6 +3718,15 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 	_, err = s.ds.NewTeam(t.Context(), &fleet.Team{Name: "team", Secrets: []*fleet.EnrollSecret{{Secret: enrollSecret}}})
 	require.NoError(t, err)
 
+	// setup host so we can do device authenticated endpoints
+	host, err := s.ds.NewHost(t.Context(), &fleet.Host{TeamID: ptr.Uint(1)})
+	require.NoError(t, err)
+
+	// Mint a fresh device auth token
+	s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/device_url", host.ID), nil, http.StatusOK)
+	authToken, err := s.ds.GetDeviceAuthToken(t.Context(), host.ID)
+	require.NoError(t, err)
+
 	for _, isBlocked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("blocked=%v", isBlocked), func(t *testing.T) {
 			appCfg, err := s.ds.AppConfig(t.Context())
@@ -3766,6 +3775,9 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			assertAdminFacingResponse(t, resp, isBlocked)
 			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/manual", nil, getAdminStatusCode(isBlocked, http.StatusOK))
 			assertAdminFacingResponse(t, resp, isBlocked)
+
+			resp = s.DoRawNoAuth("GET", fmt.Sprintf("/api/latest/fleet/device/%s/mdm/apple/manual_enrollment_profile", authToken), nil, getUserStatusCode(isBlocked, http.StatusOK))
+			assertUserFacingResponse(t, resp, isBlocked)
 		})
 	}
 }

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3783,6 +3783,16 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			assertUserFacingResponse(t, resp, isBlocked)
 			resp = s.DoRawNoAuth("GET", "/mdm/apple/service_discovery/fake-token", nil, getUserStatusCode(isBlocked, http.StatusOK))
 			assertUserFacingResponse(t, resp, isBlocked)
+
+			// hit /enroll page and verify on the returned enroll page.
+			resp = s.DoRawNoAuth("GET", "/enroll", nil, http.StatusOK)
+			require.Equal(t, resp.Header.Get("Content-Type"), "text/html; charset=utf-8")
+			// assert it contains the content we expect
+			defer resp.Body.Close()
+			bodyBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			bodyString := string(bodyBytes)
+			assert.Contains(t, bodyString, fmt.Sprintf(`const IS_APPLE_MANUAL_ENROLLMENT_BLOCKED = "%t" == "true"`, isBlocked))
 		})
 	}
 }

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3666,13 +3666,12 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 		s.ds.SaveAppConfig(context.Background(), originalAppCfg)
 	})
 
-	getStatusCode := func(isBlocked bool) int {
+	getStatusCode := func(isBlocked bool, unblockedStatus int) int {
 		if isBlocked {
 			return http.StatusForbidden
 		}
 
-		// TODO: Should we alter this since some endpoints might return 204 or we might be okay with 400's
-		return http.StatusOK
+		return unblockedStatus
 	}
 
 	assertUserFacingResponse := func(t *testing.T, resp *http.Response, isBlocked bool) {
@@ -3689,7 +3688,7 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 <plist version="1.0">
 <dict>
 	<key>PRODUCT</key>
-	<string></string>
+	<string>iPhone</string>
 	<key>SERIAL</key>
 	<string>foo</string>
 	<key>UDID</key>
@@ -3717,17 +3716,36 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 
 			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.
 			// PKIOperation requires additional setup to verify, but it's under the same middleware.
-			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACaps")
+			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked, http.StatusOK), "operation", "GetCACaps")
 			assertUserFacingResponse(t, resp, isBlocked)
-			resp = s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACert")
+			resp = s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked, http.StatusOK), "operation", "GetCACert")
 			assertUserFacingResponse(t, resp, isBlocked)
 
-			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/ota", nil, getStatusCode(isBlocked), "enroll_secret", enrollSecret)
+			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/ota", nil, getStatusCode(isBlocked, http.StatusOK), "enroll_secret", enrollSecret)
 			assertUserFacingResponse(t, resp, isBlocked)
 
 			// Both requests return 403 forbidden here, but the following assert makes sure the blocked is the AB only blocked, the other forbidden is due to missing ceritficates,
 			// but it means we passed the blocked check.
-			resp = s.DoRaw("POST", "/api/latest/fleet/ota_enrollment", signedDeviceInfo, http.StatusForbidden, "enroll_secret", enrollSecret)
+			resp = s.DoRaw("POST", "/api/latest/fleet/ota_enrollment", signedDeviceInfo, getStatusCode(isBlocked, http.StatusForbidden), "enroll_secret", enrollSecret)
+			assertUserFacingResponse(t, resp, isBlocked)
+
+			// unblocked returns 401 with a redirect
+			apple_mdm.SetMachineInfoVerificationForTest(t, false)
+			resp = s.DoRawNoAuth("POST", "/api/mdm/apple/account_driven_enroll", signedDeviceInfo, getStatusCode(isBlocked, http.StatusUnauthorized))
+			assertUserFacingResponse(t, resp, isBlocked)
+			if !isBlocked {
+				assert.Contains(t, resp.Header.Get("Www-Authenticate"), `method="apple-as-web"`)
+			}
+			resp = s.DoRawNoAuth("POST", "/api/mdm/apple/account_driven_enroll/fake-token", signedDeviceInfo, getStatusCode(isBlocked, http.StatusUnauthorized))
+			assertUserFacingResponse(t, resp, isBlocked)
+			if !isBlocked {
+				assert.Contains(t, resp.Header.Get("Www-Authenticate"), `method="apple-as-web"`)
+			}
+
+			// WithAuth means we hit the to grab the profile, looking for an ADUE challenge, 404 on non-blocked is a good indicator we skipped the block.
+			resp = s.DoRaw("POST", "/api/mdm/apple/account_driven_enroll", signedDeviceInfo, getStatusCode(isBlocked, http.StatusNotFound))
+			assertUserFacingResponse(t, resp, isBlocked)
+			resp = s.DoRaw("POST", "/api/mdm/apple/account_driven_enroll/fake-token", signedDeviceInfo, getStatusCode(isBlocked, http.StatusNotFound))
 			assertUserFacingResponse(t, resp, isBlocked)
 		})
 	}

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -3727,6 +3728,14 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 	authToken, err := s.ds.GetDeviceAuthToken(t.Context(), host.ID)
 	require.NoError(t, err)
 
+	// setup automatic enrollment profile to get a token
+	depProfileToken := "fake-dep-token"
+	s.ds.NewMDMAppleEnrollmentProfile(t.Context(), fleet.MDMAppleEnrollmentProfilePayload{
+		Type:       fleet.MDMAppleEnrollmentTypeAutomatic,
+		DEPProfile: new(json.RawMessage(`{}`)),
+		Token:      depProfileToken,
+	})
+
 	for _, isBlocked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("blocked=%v", isBlocked), func(t *testing.T) {
 			appCfg, err := s.ds.AppConfig(t.Context())
@@ -3793,6 +3802,16 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			require.NoError(t, err)
 			bodyString := string(bodyBytes)
 			assert.Contains(t, bodyString, fmt.Sprintf(`const IS_APPLE_MANUAL_ENROLLMENT_BLOCKED = "%t" == "true"`, isBlocked))
+
+			encodedSigned := base64.StdEncoding.EncodeToString(signedDeviceInfo)
+			resp = s.DoRawWithHeaders("GET", "/api/mdm/apple/enroll", nil, getUserStatusCode(isBlocked, http.StatusOK), map[string]string{
+				"x-apple-aspen-deviceinfo": encodedSigned,
+			}, "token", depProfileToken)
+			assertUserFacingResponse(t, resp, isBlocked)
+			resp = s.DoRawWithHeaders("POST", "/api/mdm/apple/enroll", nil, getUserStatusCode(isBlocked, http.StatusOK), map[string]string{
+				"x-apple-aspen-deviceinfo": encodedSigned,
+			}, "token", depProfileToken)
+			assertUserFacingResponse(t, resp, isBlocked)
 		})
 	}
 }

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3689,7 +3689,7 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 
 			appCfg.MDM.AppleRequireHardwareAttestation = isBlocked
 			appCfg.MDM.OnlyAllowAppleBusinessEnrollment = isBlocked
-			require.Equal(t, isBlocked, appCfg.MDM.IsMDMSCEPBlocked())
+			require.Equal(t, isBlocked, appCfg.MDM.IsAppleMDMSCEPBlocked())
 			require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
 
 			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3656,3 +3656,48 @@ func (s *integrationMDMTestSuite) TestDEPSyncCursorPersistedAfterSuccessfulSync(
 		return nil
 	})
 }
+
+func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
+	t := s.T()
+
+	originalAppCfg, err := s.ds.AppConfig(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		s.ds.SaveAppConfig(context.Background(), originalAppCfg)
+	})
+
+	getStatusCode := func(isBlocked bool) int {
+		if isBlocked {
+			return http.StatusForbidden
+		}
+		return http.StatusOK
+	}
+
+	assertUserFacingResponse := func(resp *http.Response, isBlocked bool) {
+		assert.Equal(t, getStatusCode(isBlocked), resp.StatusCode)
+		if isBlocked {
+			errorMsg := extractServerErrorText(resp.Body)
+			expectedErr := fleet.ABOnlyEnrollmentForbiddenError{}
+			assert.Equal(t, expectedErr.Error(), errorMsg)
+		}
+	}
+
+	for _, isBlocked := range []bool{true, false} {
+		t.Run(fmt.Sprintf("blocked=%v", isBlocked), func(t *testing.T) {
+			appCfg, err := s.ds.AppConfig(t.Context())
+			require.NoError(t, err)
+
+			appCfg.MDM.AppleRequireHardwareAttestation = isBlocked
+			appCfg.MDM.OnlyAllowAppleBusinessEnrollment = isBlocked
+			require.Equal(t, isBlocked, appCfg.MDM.IsMDMSCEPBlocked())
+			require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
+
+			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.
+			// PKIOperation requires additional setup to verify, but it's under the same middleware.
+			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACaps")
+			assertUserFacingResponse(resp, isBlocked)
+			resp = s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACert")
+			assertUserFacingResponse(resp, isBlocked)
+		})
+	}
+}

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3778,6 +3778,11 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 
 			resp = s.DoRawNoAuth("GET", fmt.Sprintf("/api/latest/fleet/device/%s/mdm/apple/manual_enrollment_profile", authToken), nil, getUserStatusCode(isBlocked, http.StatusOK))
 			assertUserFacingResponse(t, resp, isBlocked)
+
+			resp = s.DoRawNoAuth("GET", "/mdm/apple/service_discovery", nil, getUserStatusCode(isBlocked, http.StatusOK))
+			assertUserFacingResponse(t, resp, isBlocked)
+			resp = s.DoRawNoAuth("GET", "/mdm/apple/service_discovery/fake-token", nil, getUserStatusCode(isBlocked, http.StatusOK))
+			assertUserFacingResponse(t, resp, isBlocked)
 		})
 	}
 }

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3670,15 +3670,20 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 		if isBlocked {
 			return http.StatusForbidden
 		}
+
+		// TODO: Should we alter this since some endpoints might return 204 or we might be okay with 400's
 		return http.StatusOK
 	}
 
-	assertUserFacingResponse := func(resp *http.Response, isBlocked bool) {
-		assert.Equal(t, getStatusCode(isBlocked), resp.StatusCode)
+	assertUserFacingResponse := func(t *testing.T, resp *http.Response, isBlocked bool) {
 		if isBlocked {
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 			errorMsg := extractServerErrorText(resp.Body)
 			expectedErr := fleet.ABOnlyEnrollmentForbiddenError{}
-			assert.Equal(t, expectedErr.Error(), errorMsg)
+			assert.Contains(t, errorMsg, expectedErr.Error())
+		} else {
+			// Just make sure we aren't seeing a 403.
+			assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
 		}
 	}
 
@@ -3692,12 +3697,17 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			require.Equal(t, isBlocked, appCfg.MDM.IsAppleMDMSCEPBlocked())
 			require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
 
+			enrollSecret := "team"
+
 			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.
 			// PKIOperation requires additional setup to verify, but it's under the same middleware.
 			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACaps")
-			assertUserFacingResponse(resp, isBlocked)
+			assertUserFacingResponse(t, resp, isBlocked)
 			resp = s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACert")
-			assertUserFacingResponse(resp, isBlocked)
+			assertUserFacingResponse(t, resp, isBlocked)
+
+			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/ota", nil, getStatusCode(isBlocked), "enroll_secret", enrollSecret)
+			assertUserFacingResponse(t, resp, isBlocked)
 		})
 	}
 }

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3787,11 +3787,11 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 
 	// setup team with enroll secret
 	enrollSecret := "team"
-	_, err = s.ds.NewTeam(t.Context(), &fleet.Team{Name: "team", Secrets: []*fleet.EnrollSecret{{Secret: enrollSecret}}})
+	team, err := s.ds.NewTeam(t.Context(), &fleet.Team{Name: "team", Secrets: []*fleet.EnrollSecret{{Secret: enrollSecret}}})
 	require.NoError(t, err)
 
 	// setup host so we can do device authenticated endpoints
-	host, err := s.ds.NewHost(t.Context(), &fleet.Host{TeamID: new(uint(1))})
+	host, err := s.ds.NewHost(t.Context(), &fleet.Host{TeamID: &team.ID})
 	require.NoError(t, err)
 
 	// Mint a fresh device auth token

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3676,16 +3676,34 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 	}
 
 	assertUserFacingResponse := func(t *testing.T, resp *http.Response, isBlocked bool) {
+		// Every request validates the status code, so no need to do it here.
 		if isBlocked {
-			assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 			errorMsg := extractServerErrorText(resp.Body)
 			expectedErr := fleet.ABOnlyEnrollmentForbiddenError{}
 			assert.Contains(t, errorMsg, expectedErr.Error())
-		} else {
-			// Just make sure we aren't seeing a 403.
-			assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
 		}
 	}
+
+	deviceInfo := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PRODUCT</key>
+	<string></string>
+	<key>SERIAL</key>
+	<string>foo</string>
+	<key>UDID</key>
+	<string></string>
+	<key>VERSION</key>
+	<string></string>
+</dict>
+</plist>`)
+	signedDeviceInfo, _, _ := s.getSignedOTAEnrollmentBody(t, deviceInfo)
+
+	// setup team with enroll secret
+	enrollSecret := "team"
+	_, err = s.ds.NewTeam(t.Context(), &fleet.Team{Name: "team", Secrets: []*fleet.EnrollSecret{{Secret: enrollSecret}}})
+	require.NoError(t, err)
 
 	for _, isBlocked := range []bool{true, false} {
 		t.Run(fmt.Sprintf("blocked=%v", isBlocked), func(t *testing.T) {
@@ -3697,8 +3715,6 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			require.Equal(t, isBlocked, appCfg.MDM.IsAppleMDMSCEPBlocked())
 			require.NoError(t, s.ds.SaveAppConfig(context.Background(), appCfg))
 
-			enrollSecret := "team"
-
 			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.
 			// PKIOperation requires additional setup to verify, but it's under the same middleware.
 			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked), "operation", "GetCACaps")
@@ -3707,6 +3723,11 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 			assertUserFacingResponse(t, resp, isBlocked)
 
 			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/ota", nil, getStatusCode(isBlocked), "enroll_secret", enrollSecret)
+			assertUserFacingResponse(t, resp, isBlocked)
+
+			// Both requests return 403 forbidden here, but the following assert makes sure the blocked is the AB only blocked, the other forbidden is due to missing ceritficates,
+			// but it means we passed the blocked check.
+			resp = s.DoRaw("POST", "/api/latest/fleet/ota_enrollment", signedDeviceInfo, http.StatusForbidden, "enroll_secret", enrollSecret)
 			assertUserFacingResponse(t, resp, isBlocked)
 		})
 	}

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3488,13 +3488,6 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	assert.True(t, hostResp.Host.MDMEnrollmentHardwareAttested)
 }
 
-// TestABOnlyEnrollmentBlocksAuthenticateForNonDEPHosts covers the AB-only enforcement in
-// MDMAppleCheckinAndCommandService.Authenticate directly, independent of the enrollment-profile
-// and SCEP layers that also enforce it. That matters because a device can reach the raw MDM
-// checkin endpoint without going through Fleet's profile-issuance endpoint at all — e.g. it
-// obtained a profile before AB-only was turned on, or via some other channel — so Authenticate
-// is the last line of defense and needs its own coverage rather than relying on the
-// profile-fetch block to catch every case.
 func (s *integrationMDMTestSuite) TestABOnlyEnrollmentBlocksAuthenticateForNonDEPHosts() {
 	t := s.T()
 	s.enableABM(t.Name())
@@ -3530,9 +3523,6 @@ func (s *integrationMDMTestSuite) TestABOnlyEnrollmentBlocksAuthenticateForNonDE
 	s.runDEPSchedule()
 	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
 
-	// Only OnlyAllowAppleBusinessEnrollment, not AppleRequireHardwareAttestation: SCEP
-	// blocking (IsAppleMDMSCEPBlocked) requires both, and we want SCEP to succeed here so
-	// the non-DEP device actually reaches Authenticate instead of being turned away earlier.
 	origAppCfg, err := s.ds.AppConfig(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() { s.ds.SaveAppConfig(context.Background(), origAppCfg) })

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3666,20 +3666,34 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 		s.ds.SaveAppConfig(context.Background(), originalAppCfg)
 	})
 
-	getStatusCode := func(isBlocked bool, unblockedStatus int) int {
+	getUserStatusCode := func(isBlocked bool, unblockedStatus int) int {
 		if isBlocked {
 			return http.StatusForbidden
 		}
 
 		return unblockedStatus
 	}
-
 	assertUserFacingResponse := func(t *testing.T, resp *http.Response, isBlocked bool) {
 		// Every request validates the status code, so no need to do it here.
 		if isBlocked {
 			errorMsg := extractServerErrorText(resp.Body)
 			expectedErr := fleet.ABOnlyEnrollmentForbiddenError{}
 			assert.Contains(t, errorMsg, expectedErr.Error())
+		}
+	}
+
+	getAdminStatusCode := func(isBlocked bool, unblockedStatus int) int {
+		if isBlocked {
+			return http.StatusBadRequest
+		}
+
+		return unblockedStatus
+	}
+	assertAdminFacingResponse := func(t *testing.T, resp *http.Response, isBlocked bool) {
+		// Every request validates the status code, so no need to do it here.
+		if isBlocked {
+			errorMsg := extractServerErrorText(resp.Body)
+			assert.Contains(t, errorMsg, fleet.AdminOnlyEnrollmentForbiddenErrMsg)
 		}
 	}
 
@@ -3716,37 +3730,42 @@ func (s *integrationMDMTestSuite) TestBlockedEndpointsForABOnlyACMEConfig() {
 
 			// we hit CA Caps and CA Cert to verify the middleware on all endpoints is blocking.
 			// PKIOperation requires additional setup to verify, but it's under the same middleware.
-			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked, http.StatusOK), "operation", "GetCACaps")
+			resp := s.DoRaw("GET", apple_mdm.SCEPPath, nil, getUserStatusCode(isBlocked, http.StatusOK), "operation", "GetCACaps")
 			assertUserFacingResponse(t, resp, isBlocked)
-			resp = s.DoRaw("GET", apple_mdm.SCEPPath, nil, getStatusCode(isBlocked, http.StatusOK), "operation", "GetCACert")
+			resp = s.DoRaw("GET", apple_mdm.SCEPPath, nil, getUserStatusCode(isBlocked, http.StatusOK), "operation", "GetCACert")
 			assertUserFacingResponse(t, resp, isBlocked)
 
-			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/ota", nil, getStatusCode(isBlocked, http.StatusOK), "enroll_secret", enrollSecret)
+			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/ota", nil, getUserStatusCode(isBlocked, http.StatusOK), "enroll_secret", enrollSecret)
 			assertUserFacingResponse(t, resp, isBlocked)
 
 			// Both requests return 403 forbidden here, but the following assert makes sure the blocked is the AB only blocked, the other forbidden is due to missing ceritficates,
 			// but it means we passed the blocked check.
-			resp = s.DoRaw("POST", "/api/latest/fleet/ota_enrollment", signedDeviceInfo, getStatusCode(isBlocked, http.StatusForbidden), "enroll_secret", enrollSecret)
+			resp = s.DoRaw("POST", "/api/latest/fleet/ota_enrollment", signedDeviceInfo, getUserStatusCode(isBlocked, http.StatusForbidden), "enroll_secret", enrollSecret)
 			assertUserFacingResponse(t, resp, isBlocked)
 
 			// unblocked returns 401 with a redirect
 			apple_mdm.SetMachineInfoVerificationForTest(t, false)
-			resp = s.DoRawNoAuth("POST", "/api/mdm/apple/account_driven_enroll", signedDeviceInfo, getStatusCode(isBlocked, http.StatusUnauthorized))
+			resp = s.DoRawNoAuth("POST", "/api/mdm/apple/account_driven_enroll", signedDeviceInfo, getUserStatusCode(isBlocked, http.StatusUnauthorized))
 			assertUserFacingResponse(t, resp, isBlocked)
 			if !isBlocked {
 				assert.Contains(t, resp.Header.Get("Www-Authenticate"), `method="apple-as-web"`)
 			}
-			resp = s.DoRawNoAuth("POST", "/api/mdm/apple/account_driven_enroll/fake-token", signedDeviceInfo, getStatusCode(isBlocked, http.StatusUnauthorized))
+			resp = s.DoRawNoAuth("POST", "/api/mdm/apple/account_driven_enroll/fake-token", signedDeviceInfo, getUserStatusCode(isBlocked, http.StatusUnauthorized))
 			assertUserFacingResponse(t, resp, isBlocked)
 			if !isBlocked {
 				assert.Contains(t, resp.Header.Get("Www-Authenticate"), `method="apple-as-web"`)
 			}
 
 			// WithAuth means we hit the to grab the profile, looking for an ADUE challenge, 404 on non-blocked is a good indicator we skipped the block.
-			resp = s.DoRaw("POST", "/api/mdm/apple/account_driven_enroll", signedDeviceInfo, getStatusCode(isBlocked, http.StatusNotFound))
+			resp = s.DoRaw("POST", "/api/mdm/apple/account_driven_enroll", signedDeviceInfo, getUserStatusCode(isBlocked, http.StatusNotFound))
 			assertUserFacingResponse(t, resp, isBlocked)
-			resp = s.DoRaw("POST", "/api/mdm/apple/account_driven_enroll/fake-token", signedDeviceInfo, getStatusCode(isBlocked, http.StatusNotFound))
+			resp = s.DoRaw("POST", "/api/mdm/apple/account_driven_enroll/fake-token", signedDeviceInfo, getUserStatusCode(isBlocked, http.StatusNotFound))
 			assertUserFacingResponse(t, resp, isBlocked)
+
+			resp = s.DoRaw("GET", "/api/latest/fleet/mdm/manual_enrollment_profile", nil, getAdminStatusCode(isBlocked, http.StatusOK))
+			assertAdminFacingResponse(t, resp, isBlocked)
+			resp = s.DoRaw("GET", "/api/latest/fleet/enrollment_profiles/manual", nil, getAdminStatusCode(isBlocked, http.StatusOK))
+			assertAdminFacingResponse(t, resp, isBlocked)
 		})
 	}
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -16893,6 +16893,21 @@ func (s *integrationMDMTestSuite) TestMachineInfoSignatureEnforcement() {
 	})
 }
 
+func (s *integrationMDMTestSuite) getSignedOTAEnrollmentBody(t *testing.T, reqBody []byte) ([]byte, *x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+
+	// Setup signed req body, but also verify we can sign it.
+	cert, key, err := apple_mdm.NewSCEPCACertKey()
+	require.NoError(t, err)
+	signedData, err := pkcs7.NewSignedData(reqBody)
+	require.NoError(t, err)
+	require.NoError(t, signedData.AddSigner(cert, key, pkcs7.SignerInfoConfig{}))
+	signedReqBody, err := signedData.Finish()
+	require.NoError(t, err)
+
+	return signedReqBody, cert, key
+}
+
 func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 	t := s.T()
 
@@ -16921,13 +16936,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 </plist>`)
 
 	// Setup signed req body, but also verify we can sign it.
-	cert, key, err := apple_mdm.NewSCEPCACertKey()
-	require.NoError(t, err)
-	signedData, err := pkcs7.NewSignedData(reqBody)
-	require.NoError(t, err)
-	require.NoError(t, signedData.AddSigner(cert, key, pkcs7.SignerInfoConfig{}))
-	signedReqBody, err := signedData.Finish()
-	require.NoError(t, err)
+	signedReqBody, cert, key := s.getSignedOTAEnrollmentBody(t, reqBody)
 
 	// ensure fleet profiles
 	s.awaitTriggerProfileSchedule(t)
@@ -17000,7 +17009,7 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 		})
 
 		t.Run("if serial is missing", func(t *testing.T) {
-			signedData, err = pkcs7.NewSignedData([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+			signedData, err := pkcs7.NewSignedData([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>

--- a/server/service/svctest/server.go
+++ b/server/service/svctest/server.go
@@ -198,6 +198,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 				"https://test-url.com",
 				cfg,
 				svc,
+				ds,
 			)
 			require.NoError(t, err)
 		}

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -621,6 +621,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 				"https://test-url.com",
 				cfg,
 				svc,
+				ds,
 			)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52062

The MDM Authenticate gate is a bit different from the ticket, but it was discovered via testing, that placing it at the top of `server/service/apple_mdm.go` does not work, since it only logs that due to the MultiService setup, and ours runs after nanoMDM leaving issues as logged only and not returned. So we wrap the entire multi service in a layer that runs before, meaning it also does not hit nanoMDM authenticate if the AB only gate is configured and the device does not have a DEP assignment. The rest of blocks is pretty straight forward.

`/enroll` block
<img width="524" height="172" alt="image" src="https://github.com/user-attachments/assets/c246b846-43de-4aa6-831b-0a8370dba533" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Apple Business-only enrollment controls for Apple device management.
  - Eligible Apple Business assignments are now required when this setting is enabled.
  - Device configuration responses indicate whether manual Apple enrollment is restricted.
  - Added clear access-denied messages for blocked enrollment attempts.

- **Bug Fixes**
  - Blocked unsupported manual, OTA, account-driven, SCEP, and service-discovery enrollment paths when Apple Business-only enrollment is active.
  - Enrollment pages now show an invalid or expired URL message when manual enrollment is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->