### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/amie/darwin.json
+++ b/ee/maintained-apps/outputs/amie/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "260831.0.0",
+      "version": "260903.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app' AND version_compare(bundle_short_version, '260831.0.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app' AND version_compare(bundle_short_version, '260903.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'so.amie.electron-app' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/amieso/electron-releases/releases/download/v260831.0.0/Amie-260831.0.0-arm64-mac.zip",
+      "installer_url": "https://github.com/amieso/electron-releases/releases/download/v260903.0.0/Amie-260903.0.0-arm64-mac.zip",
       "install_script_ref": "be47fa85",
       "uninstall_script_ref": "44125419",
-      "sha256": "024f3b4ab668585c772e94668183d1de8f84904ed6901b2a1026af65a1433372",
+      "sha256": "973952b3b6c5752ff97543096a3cc4bf8a2a7a483636d3675e8edaf47fe58b1b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/antigravity/darwin.json
+++ b/ee/maintained-apps/outputs/antigravity/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.12.0",
+      "version": "2.12.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.12.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.12.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.google.antigravity' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.12.0-5051501534642176/darwin-arm/Antigravity.dmg",
+      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.12.2-6298742303883264/darwin-arm/Antigravity.dmg",
       "install_script_ref": "b60a046d",
       "uninstall_script_ref": "5e1a08b9",
-      "sha256": "cd1cca7ce2a64f6df0c3bcc13e54bf80644440f5dc8df22a8b21ddd22ef1c415",
+      "sha256": "9f22b1f7a444d3c0c99483528963381f45e287237e3ba18bedc8bf47935b3d18",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/aws-sam-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-sam-cli/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.166.0",
+      "version": "1.166.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.166.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.166.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'aws sam command line interface.exe');"
       },
-      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.166.0/AWS_SAM_CLI_64_PY3.msi",
+      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.166.1/AWS_SAM_CLI_64_PY3.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "a3074b39",
-      "sha256": "be19604c6a883e249acf4041b834157375563e0b5df18866c11f29e0a64cb344",
+      "sha256": "4bf6752fe33871eeafce666c2048c376dd474fa1db87fe5da7b95e73f2f24c6c",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.771",
+      "version": "6.773",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.771') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.773') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.hegenberg.BetterTouchTool' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.771-2026090202.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.773-2026090402.zip",
       "install_script_ref": "17a00450",
       "uninstall_script_ref": "aef4d4fc",
-      "sha256": "735197abc73e506538bea7af4d9ba8a62e188bd03c3285c11612c46f5f1c9a3b",
+      "sha256": "d8fe32b90a3c3cdfc67b6295c02250cae64343ec558e6073d4f6bad269de3054",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.901.22334",
+      "version": "26.901.31953",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.901.22334') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.901.31953') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.openai.chat' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.901.22334.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.901.31953.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "b2e671d34269789fd1747072018295f48f486cfac2cf0c6b6a8e15fc218b06f0",
+      "sha256": "81cb140ab2586663ac439035e79d137be48e474ec4f5be75e209d258feb15bd3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cherry-studio/darwin.json
+++ b/ee/maintained-apps/outputs/cherry-studio/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.kangfenmao.CherryStudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.kangfenmao.CherryStudio' AND version_compare(bundle_short_version, '2.0.11') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.kangfenmao.CherryStudio' AND version_compare(bundle_short_version, '2.0.12') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.kangfenmao.CherryStudio' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.11/Cherry-Studio-2.0.11-mac-arm64.dmg",
+      "installer_url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.12/Cherry-Studio-2.0.12-mac-arm64.dmg",
       "install_script_ref": "31529318",
       "uninstall_script_ref": "4e2b7fe0",
-      "sha256": "5117ae19d1228ad9ecab4b051963864740c4e8886a5537966603b9d2640188c0",
+      "sha256": "d1cfadb5bd4087b2ae64b922d791fab538b3de40f448e8c3a47dce2c1fc38da8",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.46388.0",
+      "version": "1.46388.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.46388.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.46388.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.anthropic.claudefordesktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.46388.0/Claude-88d4ea2fdadb149723ebab39764c160d03d9ee82.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.46388.1/Claude-2dfd5f2c40e82ccf388f5dc1d3f1ce93a3671b03.zip",
       "install_script_ref": "98321e4d",
       "uninstall_script_ref": "421baa98",
-      "sha256": "b813afc8a067dd29d24ce04dd0a78d4c3189dc892fa05ecbfc4aedee9d91ebee",
+      "sha256": "894de7f1b18941af9459c07d1dc344e8b503ee38e839617ae1e09013a1132514",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.9.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.mozilla.nightly' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-03-09-07-39-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-03-21-57-30-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "f693ee5b548ab74b4ee5ed6f5093ea559f45618d32c3b780276c5217f402fcba",
+      "sha256": "28032cce1686cb7119df5c4d6a68c81e0e261f69ad4c3ea6ffe4ca22d0e4fd8c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/markedit/darwin.json
+++ b/ee/maintained-apps/outputs/markedit/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.34.0",
+      "version": "1.35.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.cyan.markedit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.cyan.markedit' AND version_compare(bundle_short_version, '1.34.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.cyan.markedit' AND version_compare(bundle_short_version, '1.35.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'app.cyan.markedit' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/MarkEdit-app/MarkEdit/releases/download/v1.34.0/MarkEdit-1.34.0.dmg",
+      "installer_url": "https://github.com/MarkEdit-app/MarkEdit/releases/download/v1.35.0/MarkEdit-1.35.0.dmg",
       "install_script_ref": "d9059f8f",
       "uninstall_script_ref": "be802818",
-      "sha256": "e38962edcca263e31d947987212f25ecc25d85af7f848dcb0cc31587d0332b76",
+      "sha256": "15c4930969b411de98c3397094d3815b40463781dd01161581f26f54d6108e7e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.5.20",
+      "version": "1.5.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.20') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.21') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'best.swift.Notepad' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.20/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.21/Notepad.zip",
       "install_script_ref": "7bdbf044",
       "uninstall_script_ref": "abe56690",
-      "sha256": "3faa7b3b6480bfb4ce348d069003b30a1a6d498ceea77e4fe3828a778459d8fd",
+      "sha256": "3089a4cb93c07835fad2e5c59208ee748160c70314841ad55989309067554125",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/windows.json
+++ b/ee/maintained-apps/outputs/ocenaudio/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.20.5",
+      "version": "3.21.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team' AND version_compare(version, '3.20.5') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team' AND version_compare(version, '3.21.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'ocenaudio.exe');"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_windows64.exe",
       "install_script_ref": "ebf8794b",
       "uninstall_script_ref": "7264fb50",
-      "sha256": "c11b53cab88c03aa8e163438109e51436d1c52ed0242072656bfeaff7f549023",
+      "sha256": "bd4f859297f53b4736fcb560a7746330269c1e07ccead0377d3e49546a470f31",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.26.4",
+      "version": "12.26.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.26.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.26.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.postmanlabs.mac' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.26.4/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.26.5/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "727f8e9d",
-      "sha256": "fae609665aa3011467ae59df7bd6016bb4bc6d051a3fe1d20f189e5673d14931",
+      "sha256": "c4a57c725b04729ceb14c5b9cf7408cfe85d9fb48129a0c8f1dc6d4552a7e11c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/darwin.json
+++ b/ee/maintained-apps/outputs/prisma-browser/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.8.4.76",
+      "version": "152.8.5.83",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '152.8.4.76') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '152.8.5.83') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.talon-sec.Work' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-152.8.4.76-48109319.pkg",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-152.8.5.83-2b4ba508.pkg",
       "install_script_ref": "827875fd",
       "uninstall_script_ref": "ff947f47",
-      "sha256": "2bd92b08e2da32ad1157bc210a29f131b6bede2c78800147f33620cfe035179f",
+      "sha256": "93a82c7ade5c5dd972306f2c3ac7f72b7d8bf396c5e3bb497c63f21588b6589d",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/windows.json
+++ b/ee/maintained-apps/outputs/prisma-browser/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.8.4.76",
+      "version": "152.8.5.83",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '152.8.4.76') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '152.8.5.83') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'prisma browser.exe');"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_152_8_4_76-152.8.4.76-39b8f6c4.msi",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_152_8_5_83-152.8.5.83-4c48f0a4.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "84194ed8",
-      "sha256": "4368d1d49ba708ff3b5a017f8cdd5c860b37efb2bb3cc758ce9db065310f5686",
+      "sha256": "6721c076a9211734d044ced038b3f1cc3fd7e3621d57529b10bbc7eb41e2643f",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/tableplus/windows.json
+++ b/ee/maintained-apps/outputs/tableplus/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.10.1",
+      "version": "26.10.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'TablePlus%' AND publisher = 'TablePlus, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'TablePlus%' AND publisher = 'TablePlus, Inc' AND version_compare(version, '26.10.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'TablePlus%' AND publisher = 'TablePlus, Inc' AND version_compare(version, '26.10.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'tableplus.exe');"
       },
-      "installer_url": "https://files.tableplus.com/windows/26.10.1/TablePlusSetup.exe",
+      "installer_url": "https://files.tableplus.com/windows/26.10.2/TablePlusSetup.exe",
       "install_script_ref": "052dc935",
       "uninstall_script_ref": "8bfcecd6",
-      "sha256": "0f6793dd5b3e34ca25fa7416a1942ddab8376d9df9eece8913f906362e98f0c0",
+      "sha256": "733531702933da6251c8685d03e9184e4b9a5046d4b12455fc57ba43f30c2582",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated maintained app packages and version detection for Amie, Antigravity, AWS SAM CLI, BetterTouchTool, ChatGPT, Cherry Studio, Claude, MarkEdit, Notepad, ocenaudio, Postman, Prisma Access Browser, and TablePlus.
  - Updated Firefox Nightly macOS package metadata to a newer build.
  - Refreshed installer download links and checksums to match the latest releases across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->