### PR TITLE
Link Arch Linux and Omarchy to arch-linux-management page

### DIFF
--- a/website/views/pages/linux-management.ejs
+++ b/website/views/pages/linux-management.ejs
@@ -35,8 +35,8 @@
                   <div purpose="checklist">
                     <p>Red Hat Enterprise Linux (RHEL) 7+</p>
                     <p>openSUSE 15.6+</p>
-                    <p>Arch Linux</p>
-                    <p>Omarchy</p>
+                    <p><a href="/arch-linux-management">Arch Linux</a></p>
+                    <p><a href="/arch-linux-management">Omarchy</a></p>
                   </div>
                 </div>
                 <div>


### PR DESCRIPTION
**Related issue:** N/A

Links "Arch Linux" and "Omarchy" in the linux-management page's "Built for Linux" checklist to `/arch-linux-management`.

## Testing

- [x] QA'd manually

## Frontend

- [ ] Screenshot attached (before/after)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the Linux distribution checklist so the Arch Linux and Omarchy entries link to the Arch Linux management page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->