### PR TITLE
fix(ee/ca): allow GitOps apply without private key when no CA changes exist (#52545)

### DIFF
--- a/changes/52545-gitops-ca-no-private-key
+++ b/changes/52545-gitops-ca-no-private-key
@@ -1,0 +1,1 @@
+- Fixed an issue where GitOps apply failed when no server private key was configured even if no Certificate Authority changes were requested.

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -494,10 +494,6 @@ func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incomi
 		return fleet.NewInvalidArgumentError("gitops", "certificate_authorities: batch apply is intended only for use with gitops")
 	}
 
-	if len(svc.config.Server.PrivateKey) == 0 {
-		return &fleet.BadRequestError{Message: "Server private key must be configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key"}
-	}
-
 	ops, err := svc.getCertificateAuthoritiesBatchOperations(ctx, incoming)
 	if err != nil {
 		return err
@@ -510,6 +506,15 @@ func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incomi
 
 	if opts.SkipDeletes {
 		ops.Delete = nil
+	}
+
+	if len(ops.Add) == 0 && len(ops.Delete) == 0 && len(ops.Update) == 0 {
+		svc.logger.DebugContext(ctx, "batch apply certificate authorities: no certificate authority changes to apply")
+		return nil
+	}
+
+	if len(svc.config.Server.PrivateKey) == 0 {
+		return &fleet.BadRequestError{Message: "Server private key must be configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key"}
 	}
 
 	if opts.DryRun {

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -494,6 +494,17 @@ func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incomi
 		return fleet.NewInvalidArgumentError("gitops", "certificate_authorities: batch apply is intended only for use with gitops")
 	}
 
+	hasIncomingCAs := len(incoming.DigiCert) > 0 ||
+		len(incoming.EST) > 0 ||
+		len(incoming.Hydrant) > 0 ||
+		incoming.NDESSCEP != nil ||
+		len(incoming.CustomScepProxy) > 0 ||
+		len(incoming.Smallstep) > 0
+
+	if hasIncomingCAs && len(svc.config.Server.PrivateKey) == 0 {
+		return &fleet.BadRequestError{Message: "Server private key must be configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key"}
+	}
+
 	ops, err := svc.getCertificateAuthoritiesBatchOperations(ctx, incoming)
 	if err != nil {
 		return err

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -240,8 +240,11 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		require.Nil(t, createdCA)
 	})
 
-	t.Run("Batch apply errors when no private key is configured", func(t *testing.T) {
+	t.Run("Batch apply succeeds when no private key is configured and no CA changes exist", func(t *testing.T) {
 		ds := new(mock.Store)
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
 		authorizer, err := authz.NewAuthorizer()
 		require.NoError(t, err)
 		svc := &Service{
@@ -253,6 +256,37 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
 
 		err = svc.BatchApplyCertificateAuthorities(ctx, fleet.GroupedCertificateAuthorities{}, fleet.BatchApplyCertificateAuthoritiesOpts{ViaGitOps: true})
+		require.NoError(t, err)
+	})
+
+	t.Run("Batch apply errors when no private key is configured and CA changes exist", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+		authorizer, err := authz.NewAuthorizer()
+		require.NoError(t, err)
+		svc := &Service{
+			logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+			ds:     ds,
+			authz:  authorizer,
+		}
+		svc.config.Server.PrivateKey = ""
+		ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+		err = svc.BatchApplyCertificateAuthorities(ctx, fleet.GroupedCertificateAuthorities{
+			DigiCert: []fleet.DigiCertCA{
+				{
+					Name:                          "DigiCert1",
+					URL:                           digicertURL,
+					APIToken:                      "token",
+					ProfileID:                     "profile",
+					CertificateCommonName:         "cn",
+					CertificateUserPrincipalNames: []string{"upn"},
+					CertificateSeatID:             "seat",
+				},
+			},
+		}, fleet.BatchApplyCertificateAuthoritiesOpts{ViaGitOps: true})
 		require.EqualError(t, err, "Server private key must be configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key")
 	})
 


### PR DESCRIPTION
**Related issue:** Resolves #52545

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Summary of Changes

In `ee/server/service/certificate_authorities.go`:
- `BatchApplyCertificateAuthorities` previously checked `len(svc.config.Server.PrivateKey) == 0` immediately before computing operations (`svc.getCertificateAuthoritiesBatchOperations`).
- When customers ran GitOps apply on instances without a configured server private key, GitOps applies failed with `"applying certificate authorities: Bad request: Server private key must be configured"` even when the configuration contained no Certificate Authority changes or when the incoming CA section was empty.
- Defer the `Server.PrivateKey` validation check until after batch operations are calculated and verified to contain non-empty additions, deletions, or updates.
- If no CA operations need to be performed (or `ops == nil`), the method logs debug and returns `nil` cleanly without requiring `FLEET_SERVER_PRIVATE_KEY`.
- Updated unit tests in `ee/server/service/certificate_authorities_test.go` to verify that batch apply succeeds when no private key is configured and no CA changes exist, and still strictly errors when actual CA operations are attempted without a private key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitOps certificate authority apply requests with no changes now succeed even when no server private key is configured.
  * Requests that add, update, or remove certificate authorities continue to require a configured server private key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->