### PR TITLE
Add AI assistance disclosure line to the PR template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,6 +52,7 @@ Go and API conventions (ctxerr error wrapping, error types, request/response str
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. When creating a PR (e.g. `gh pr create`), use that file as the body and fill it in — do not open a PR with an empty or freeform description. A CI check (`check-pr-template`) fails PRs whose description is missing the template.
+- Fill in the `**AI assistance:**` line at the top of the template with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not). Never delete that line.
 
 ## Development commands
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,7 +52,7 @@ Go and API conventions (ctxerr error wrapping, error types, request/response str
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. When creating a PR (e.g. `gh pr create`), use that file as the body and fill it in — do not open a PR with an empty or freeform description. A CI check (`check-pr-template`) fails PRs whose description is missing the template.
-- Under the `## AI` section of the template, add an `**AI:** <tool> (<model ID>)` line with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
+- Add a `## AI` section to the PR description, between the Testing and Frontend sections, containing an `**AI:** <tool> (<model ID>)` line with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
 
 ## Development commands
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,7 +52,7 @@ Go and API conventions (ctxerr error wrapping, error types, request/response str
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. When creating a PR (e.g. `gh pr create`), use that file as the body and fill it in — do not open a PR with an empty or freeform description. A CI check (`check-pr-template`) fails PRs whose description is missing the template.
-- Add an `**AI assistance:** <tool> (<model ID>)` line as the first line of the PR description, with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
+- Under the `## AI` section of the template, add an `**AI:** <tool> (<model ID>)` line with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
 
 ## Development commands
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,7 +52,7 @@ Go and API conventions (ctxerr error wrapping, error types, request/response str
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. When creating a PR (e.g. `gh pr create`), use that file as the body and fill it in — do not open a PR with an empty or freeform description. A CI check (`check-pr-template`) fails PRs whose description is missing the template.
-- Fill in the `**AI assistance:**` line at the top of the template with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not). Never delete that line.
+- Add an `**AI assistance:** <tool> (<model ID>)` line as the first line of the PR description, with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
 
 ## Development commands
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,16 @@
+<!--
+  AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
+  filling in this template, you MUST keep and complete the "AI assistance"
+  line below. Do not delete it and do not leave the placeholders.
+
+  - Tool: the harness or product you are running in (e.g. "Claude Code").
+  - Model: the exact model ID your environment reports (e.g.
+    "claude-fable-5-1"). If your environment does not tell you the model ID,
+    write "unknown" rather than guessing.
+  - Keep the line format exactly as-is so it is easy to search for.
+-->
+**AI assistance:** <tool> (<model ID>)
+
 <!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
 **Related issue:** Resolves #
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,11 +24,12 @@ For unreleased bug fixes in a release candidate, one of:
 - [ ] Confirmed that the fix is not expected to adversely impact load test results
 - [ ] Alerted the release DRI if additional load testing is needed
 
-## AI
-
 <!--
   AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
-  filling in this template, you MUST add the following line under this heading:
+  filling in this template, you MUST add the following section here, between
+  "Testing" and "Frontend":
+
+    ## AI
 
     **AI:** <tool> (<model ID>)
 
@@ -36,7 +37,7 @@ For unreleased bug fixes in a release candidate, one of:
   - Model: the exact model ID your environment reports (e.g.
     "claude-fable-5-1"). If your environment does not tell you the model ID,
     write "unknown" rather than guessing.
-  - Keep the line format exactly as-is so it is easy to search for.
+  - Keep the format exactly as-is so it is easy to search for.
 -->
 
 ## Frontend

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,20 +24,19 @@ For unreleased bug fixes in a release candidate, one of:
 - [ ] Confirmed that the fix is not expected to adversely impact load test results
 - [ ] Alerted the release DRI if additional load testing is needed
 
+## AI
+
 <!--
   AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
-  filling in this template, you MUST add the following line as the first line
-  of the PR description, above "Related issue":
+  filling in this template, you MUST add the following line under this heading:
 
-    **AI assistance:** <tool> (<model ID>)
+    **AI:** <tool> (<model ID>)
 
   - Tool: the harness or product you are running in (e.g. "Claude Code").
   - Model: the exact model ID your environment reports (e.g.
     "claude-fable-5-1"). If your environment does not tell you the model ID,
     write "unknown" rather than guessing.
   - Keep the line format exactly as-is so it is easy to search for.
-
-  Humans filling in this template by hand can ignore this comment.
 -->
 
 ## Frontend

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,18 @@
 <!--
   AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
-  filling in this template, you MUST keep and complete the "AI assistance"
-  line below. Do not delete it and do not leave the placeholders.
+  filling in this template, you MUST add the following line as the first line
+  of the PR description, above "Related issue":
+
+    **AI assistance:** <tool> (<model ID>)
 
   - Tool: the harness or product you are running in (e.g. "Claude Code").
   - Model: the exact model ID your environment reports (e.g.
     "claude-fable-5-1"). If your environment does not tell you the model ID,
     write "unknown" rather than guessing.
   - Keep the line format exactly as-is so it is easy to search for.
--->
-**AI assistance:** <tool> (<model ID>)
 
+  Humans filling in this template by hand can ignore this comment.
+-->
 <!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
 **Related issue:** Resolves #
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,3 @@
-<!--
-  AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
-  filling in this template, you MUST add the following line as the first line
-  of the PR description, above "Related issue":
-
-    **AI assistance:** <tool> (<model ID>)
-
-  - Tool: the harness or product you are running in (e.g. "Claude Code").
-  - Model: the exact model ID your environment reports (e.g.
-    "claude-fable-5-1"). If your environment does not tell you the model ID,
-    write "unknown" rather than guessing.
-  - Keep the line format exactly as-is so it is easy to search for.
-
-  Humans filling in this template by hand can ignore this comment.
--->
 <!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
 **Related issue:** Resolves #
 
@@ -38,6 +23,22 @@ For unreleased bug fixes in a release candidate, one of:
 
 - [ ] Confirmed that the fix is not expected to adversely impact load test results
 - [ ] Alerted the release DRI if additional load testing is needed
+
+<!--
+  AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
+  filling in this template, you MUST add the following line as the first line
+  of the PR description, above "Related issue":
+
+    **AI assistance:** <tool> (<model ID>)
+
+  - Tool: the harness or product you are running in (e.g. "Claude Code").
+  - Model: the exact model ID your environment reports (e.g.
+    "claude-fable-5-1"). If your environment does not tell you the model ID,
+    write "unknown" rather than guessing.
+  - Keep the line format exactly as-is so it is easy to search for.
+
+  Humans filling in this template by hand can ignore this comment.
+-->
 
 ## Frontend
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository. Claude Code users: see `.claude/CLAUDE.md` for the full project guide; the rules below apply to every agent.
+
+## Opening a pull request
+
+- The PR description MUST start from `.github/pull_request_template.md`. Use that file as the body and fill it in. Do not open a PR with an empty or freeform description.
+- Fill in the `**AI assistance:**` line at the top of the template with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not). Never delete that line.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,4 @@ Instructions for AI coding agents working in this repository. Claude Code users:
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. Use that file as the body and fill it in. Do not open a PR with an empty or freeform description.
-- Under the `## AI` section of the template, add an `**AI:** <tool> (<model ID>)` line with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
+- Add a `## AI` section to the PR description, between the Testing and Frontend sections, containing an `**AI:** <tool> (<model ID>)` line with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,4 @@ Instructions for AI coding agents working in this repository. Claude Code users:
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. Use that file as the body and fill it in. Do not open a PR with an empty or freeform description.
-- Fill in the `**AI assistance:**` line at the top of the template with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not). Never delete that line.
+- Add an `**AI assistance:** <tool> (<model ID>)` line as the first line of the PR description, with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,4 +5,4 @@ Instructions for AI coding agents working in this repository. Claude Code users:
 ## Opening a pull request
 
 - The PR description MUST start from `.github/pull_request_template.md`. Use that file as the body and fill it in. Do not open a PR with an empty or freeform description.
-- Add an `**AI assistance:** <tool> (<model ID>)` line as the first line of the PR description, with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).
+- Under the `## AI` section of the template, add an `**AI:** <tool> (<model ID>)` line with the tool you are running in and the exact model ID your environment reports (write `unknown` if it does not).


### PR DESCRIPTION
**AI assistance:** Claude Code (claude-fable-5-1)

**Related issue:** N/A

Many PRs at Fleet are now opened by AI coding agents. This adds a cooperative disclosure mechanism so reviewers can see which tool and model produced a PR.

- Adds a hidden HTML comment at the top of `.github/pull_request_template.md` addressed to AI agents, plus a visible `**AI assistance:** <tool> (<model ID>)` line for them to fill in. Agents are told to write `unknown` rather than guess a model ID they can't see.
- Adds a matching instruction to `.claude/CLAUDE.md`.
- Adds `AGENTS.md`, which Codex, Cursor, and Copilot read, so non-Claude agents also get the PR template rule.

No CI enforcement; this relies on agents following the instruction.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually
