### PR TITLE
Show the default sort indicator on Hosts column

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tests.tsx
@@ -8,12 +8,12 @@ const mockRouter = createMockRouter();
 
 describe("TitleVersionsTable", () => {
   // Deliberately ordered so that the input order, host count order, and
-  // lexical and numeric version orderings are all different, and
-  // 1.2.10 vs 1.2.9 catches a lexical sort.
+  // lexical and numeric version orderings are all different. 1.2.10 vs 1.2.9
+  // catches a lexical version sort, and 10 vs 9 vs 2 a lexical host count one.
   const unsortedVersions = [
-    { id: 1, version: "1.2.9", vulnerabilities: [], hosts_count: 1 },
-    { id: 2, version: "1.2.2", vulnerabilities: [], hosts_count: 3 },
-    { id: 3, version: "1.2.10", vulnerabilities: [], hosts_count: 2 },
+    { id: 1, version: "1.2.9", vulnerabilities: [], hosts_count: 2 },
+    { id: 2, version: "1.2.2", vulnerabilities: [], hosts_count: 10 },
+    { id: 3, version: "1.2.10", vulnerabilities: [], hosts_count: 9 },
   ];
 
   const renderTable = (data = unsortedVersions) =>
@@ -38,6 +38,24 @@ describe("TitleVersionsTable", () => {
     renderTable();
 
     expect(renderedVersions()).toEqual(["1.2.2", "1.2.10", "1.2.9"]);
+  });
+
+  it("sorts by host count when the Hosts header is clicked", async () => {
+    const { user } = renderTable();
+    const hostsHeader = screen.getByRole("button", { name: "Hosts" });
+
+    // Hosts is the default sorted column, so the first click reverses it.
+    await user.click(hostsHeader);
+    expect(renderedVersions()).toEqual(["1.2.9", "1.2.10", "1.2.2"]);
+
+    await user.click(hostsHeader);
+    expect(renderedVersions()).toEqual(["1.2.2", "1.2.10", "1.2.9"]);
+
+    // Coming back from another sorted column re-sorts on host count, rather
+    // than flipping the direction of whichever column was already sorted.
+    await user.click(screen.getByRole("button", { name: "Version" }));
+    await user.click(hostsHeader);
+    expect(renderedVersions()).toEqual(["1.2.9", "1.2.10", "1.2.2"]);
   });
 
   it("sorts by version number when the Version header is clicked", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTableConfig.tsx
@@ -27,7 +27,7 @@ type IVersionCellProps = IStringCellProps<ISoftwareTitleVersion>;
 type IVulnCellProps = CellProps<ISoftwareTitleVersion, string[] | null>;
 type IHostCountCellProps = INumberCellProps<ISoftwareTitleVersion>;
 type IViewAllHostsLinkProps = CellProps<ISoftwareTitleVersion>;
-type IVersionHeaderProps = IHeaderProps<ISoftwareTitleVersion>;
+type ITableHeaderProps = IHeaderProps<ISoftwareTitleVersion>;
 
 const generateSoftwareTitleVersionsTableConfig = ({
   teamId,
@@ -36,10 +36,9 @@ const generateSoftwareTitleVersionsTableConfig = ({
   const tableHeaders = [
     {
       title: "Version",
-      Header: (cellProps: IVersionHeaderProps) => (
+      Header: (cellProps: ITableHeaderProps) => (
         <HeaderCell
           value="Version"
-          disableSortBy={false}
           isSortedDesc={cellProps.column.isSortedDesc}
         />
       ),
@@ -87,8 +86,13 @@ const generateSoftwareTitleVersionsTableConfig = ({
     },
     {
       title: "Hosts",
-      Header: "Hosts",
-      disableSortBy: true,
+      Header: (cellProps: ITableHeaderProps) => (
+        <HeaderCell
+          value="Hosts"
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      ),
+      disableSortBy: false,
       accessor: "hosts_count",
       Cell: (cellProps: IHostCountCellProps): JSX.Element => (
         <TextCell value={cellProps.cell.value} />


### PR DESCRIPTION
<img width="2032" height="1080" alt="Screenshot 2026-09-04 at 8 31 59 AM" src="https://github.com/user-attachments/assets/c86dd0d3-d7e4-4c5c-b83a-1788b928671f" />

Closes #52394

Added sorting indicators to the 'Hosts' column on on the Software title page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manuallying is needed

## Frontend

- [X] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sorting for the **Version** and **Hosts** columns in the software title versions table.
  - Column sorting supports toggling direction and re-sorting after selecting another column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->