### PR TITLE
Fix policy description and resolution newlines being collapsed

### DIFF
--- a/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/details/PolicyDetailsPage/_styles.scss
@@ -34,6 +34,12 @@
     gap: $pad-medium;
   }
 
+  &__policy-description {
+    p {
+      white-space: pre-wrap;
+    }
+  }
+
   &__policy-name {
     font-size: $large;
     display: flex;
@@ -82,10 +88,6 @@
       margin-right: $pad-xsmall;
       flex-shrink: 0;
     }
-  }
-
-  &__resolve dd {
-    white-space: normal;
   }
 
   &__details {


### PR DESCRIPTION
<img width="1546" height="660" alt="Screenshot 2026-09-04 at 8 58 09 AM" src="https://github.com/user-attachments/assets/908e049c-ac40-48e3-8249-f8c4420164ea" />

Policy descriptions rendered through PageDescription had no white-space rule, and a stale `white-space: normal` override on the Resolve DataSet cancelled the pre-wrap that its `multiline` modifier already provides.

# Checklist for submitter

## Testing

- [X] QA'd all new/changed functionality manually

## Frontend

- [X] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Policy descriptions now preserve intentional whitespace and line breaks when displayed.
  - Updated description formatting for a more accurate presentation of policy content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->