### PR TITLE
Fix gitops wiping all VPP and ABM token assignments when config references a fleet created in the same run

### DIFF
--- a/changes/51687-gitops-vpp-abm-assignment-wipe
+++ b/changes/51687-gitops-vpp-abm-assignment-wipe
@@ -1,0 +1,1 @@
+- Fixed `fleetctl gitops` temporarily clearing all Volume Purchasing Program and Apple Business Manager token/fleet assignments when the configuration referenced a fleet created in the same run; a run that failed mid-apply left the assignments permanently removed.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -144,7 +145,7 @@ func gitopsCommand() *cli.Command {
 			var originalVPPConfig []any
 			var teamNames []string
 			var teamDryRunAssumptions *fleet.TeamSpecsDryRunAssumptions
-			var abmTeams, vppTeams, missingVPPTeams []string
+			var abmTeams, missingABMTeams, vppTeams, missingVPPTeams []string
 			var hasMissingABMTeam, usesLegacyABMConfig bool
 			var windowsEnrollmentDefaultFleet string
 			var windowsEnrollmentFleetMissing bool
@@ -525,10 +526,11 @@ func gitopsCommand() *cli.Command {
 				// grab some information to help us determine allowed/restricted actions and
 				// when to perform the associations.
 				if isGlobalConfig && totalFilenames > 1 && !(totalFilenames == 2 && noTeamPresent) && appConfig.License.IsPremium() {
-					abmTeams, hasMissingABMTeam, usesLegacyABMConfig, err = checkABMTeamAssignments(config, fleetClient)
+					abmTeams, missingABMTeams, usesLegacyABMConfig, err = checkABMTeamAssignments(config, fleetClient)
 					if err != nil {
 						return err
 					}
+					hasMissingABMTeam = len(missingABMTeams) > 0
 
 					vppTeams, missingVPPTeams, err = checkVPPTeamAssignments(config, fleetClient)
 					if err != nil {
@@ -544,12 +546,16 @@ func gitopsCommand() *cli.Command {
 								if appleBM, ok := mdmMap["apple_business"]; ok {
 									if bmSettings, ok := appleBM.([]any); ok {
 										originalABMConfig = bmSettings
+										// Some referenced fleets are only created later in this run, and the server
+										// rejects a config naming unknown fleets. Holding the key back entirely is
+										// not an option either: an absent key is normalized to an empty list (see
+										// DoGitOps), which the server takes as "clear every token's default fleets".
+										// So apply the config with only the missing fleet references blanked, keeping
+										// all existing assignments; the original config is applied after teams are
+										// processed.
+										mdmMap["apple_business"] = abmConfigWithoutMissingFleets(bmSettings, missingABMTeams)
 									}
 								}
-
-								// If team is not found, we need to remove the AppleBMDefaultTeam from
-								// the global config, and then apply it after teams are processed
-								mdmMap["apple_business"] = nil
 								mdmMap["apple_bm_default_team"] = ""
 							}
 						}
@@ -561,12 +567,13 @@ func gitopsCommand() *cli.Command {
 								if vpp, ok := mdmMap["volume_purchasing_program"]; ok {
 									if vppSettings, ok := vpp.([]any); ok {
 										originalVPPConfig = vppSettings
+										// Same idea as apple_business above: an absent key is normalized to an
+										// empty list, which wipes every token's fleet assignments. Apply the config
+										// with only the missing fleets filtered out, keeping assignments to existing
+										// fleets; the original config is applied after teams are processed.
+										mdmMap["volume_purchasing_program"] = vppConfigWithoutMissingFleets(vppSettings, missingVPPTeams)
 									}
 								}
-
-								// If a team is not found, we need to remove the VPP config from
-								// the global config and then apply it after teams are processed
-								mdmMap["volume_purchasing_program"] = nil
 							}
 						}
 					}
@@ -591,10 +598,11 @@ func gitopsCommand() *cli.Command {
 				}
 
 				// Teams need a VPP token before VPP apps can be applied. When some VPP
-				// teams don't exist yet, the VPP config is temporarily removed from the
-				// global config, which clears all VPP token assignments. To avoid
-				// "No available VPP Token" errors, we defer app_store_apps for every
-				// team in the VPP config and re-apply them after tokens are reassigned.
+				// teams don't exist yet, the interim config applied above filters them
+				// out, so their token assignment only lands with the end-of-run re-apply.
+				// To avoid "No available VPP Token" errors in the meantime, defer
+				// app_store_apps for every team in the VPP config and re-apply them
+				// after tokens are reassigned.
 				if !isGlobalConfig && len(missingVPPTeams) > 0 && len(config.Software.AppStoreApps) > 0 {
 					if slices.Contains(vppTeams, *config.TeamName) {
 						missingVPPTeamsWithApps = append(missingVPPTeamsWithApps, missingVPPTeamWithApps{
@@ -1162,7 +1170,7 @@ func extractControlsForNoTeam(flFilenames cli.StringSlice, appConfig *fleet.Enri
 // 3. Performs validations according to the spec for both the new and the
 // deprecated key used for this setting.
 func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
-	abmTeams []string, missingTeam bool, usesLegacyConfig bool, err error,
+	abmTeams []string, missingTeams []string, usesLegacyConfig bool, err error,
 ) {
 	if mdm, ok := config.OrgSettings["mdm"]; ok {
 		if mdmMap, ok := mdm.(map[string]any); ok {
@@ -1173,25 +1181,25 @@ func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
 			appleBM, hasNewConfig := mdmMap["apple_business"]
 
 			if hasLegacyConfig && hasNewConfig {
-				return nil, false, false, errors.New(fleet.AppleABMDefaultTeamDeprecatedMessage)
+				return nil, nil, false, errors.New(fleet.AppleABMDefaultTeamDeprecatedMessage)
 			}
 
 			abmToks, err := fleetClient.CountABMTokens()
 			if err != nil {
-				return nil, false, false, err
+				return nil, nil, false, err
 			}
 
 			if hasLegacyConfig && abmToks > 1 {
-				return nil, false, false, errors.New(fleet.AppleABMDefaultTeamDeprecatedMessage)
+				return nil, nil, false, errors.New(fleet.AppleABMDefaultTeamDeprecatedMessage)
 			}
 
 			if !hasLegacyConfig && !hasNewConfig {
-				return nil, false, false, nil
+				return nil, nil, false, nil
 			}
 
 			teams, err := fleetClient.ListTeams("")
 			if err != nil {
-				return nil, false, false, err
+				return nil, nil, false, err
 			}
 			teamNames := map[string]struct{}{}
 			for _, tm := range teams {
@@ -1205,7 +1213,7 @@ func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
 					abmTeams = append(abmTeams, appleBMDefaultTeam)
 					usesLegacyConfig = true
 					if _, ok = teamNames[appleBMDefaultTeam]; !ok {
-						missingTeam = true
+						missingTeams = append(missingTeams, appleBMDefaultTeam)
 					}
 				}
 			}
@@ -1214,13 +1222,13 @@ func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
 				if settingMap, ok := appleBM.([]any); ok {
 					for _, item := range settingMap {
 						if cfg, ok := item.(map[string]any); ok {
-							for _, teamConfigKey := range []string{"macos_fleet", "ios_fleet", "ipados_fleet"} {
+							for _, teamConfigKey := range []string{"macos_fleet", "ios_fleet", "ipados_fleet", "byod_fleet"} {
 								if team, ok := cfg[teamConfigKey].(string); ok && team != "" {
 									// normalize for Unicode support
 									team = norm.NFC.String(team)
 									abmTeams = append(abmTeams, team)
 									if _, ok := teamNames[team]; !ok {
-										missingTeam = true
+										missingTeams = append(missingTeams, team)
 									}
 								}
 							}
@@ -1231,7 +1239,70 @@ func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
 		}
 	}
 
-	return abmTeams, missingTeam, usesLegacyConfig, nil
+	return abmTeams, missingTeams, usesLegacyConfig, nil
+}
+
+// abmConfigWithoutMissingFleets returns a copy of the apple_business config with
+// references to not-yet-created fleets blanked out, so the initial apply keeps every
+// other token/fleet default intact.
+func abmConfigWithoutMissingFleets(bmSettings []any, missingTeams []string) []any {
+	missing := make(map[string]struct{}, len(missingTeams))
+	for _, name := range missingTeams {
+		missing[name] = struct{}{}
+	}
+	interim := make([]any, 0, len(bmSettings))
+	for _, item := range bmSettings {
+		cfg, ok := item.(map[string]any)
+		if !ok {
+			interim = append(interim, item)
+			continue
+		}
+		cp := make(map[string]any, len(cfg))
+		maps.Copy(cp, cfg)
+		for _, teamConfigKey := range []string{"macos_fleet", "ios_fleet", "ipados_fleet", "byod_fleet"} {
+			if team, ok := cp[teamConfigKey].(string); ok {
+				if _, isMissing := missing[norm.NFC.String(team)]; isMissing {
+					cp[teamConfigKey] = ""
+				}
+			}
+		}
+		interim = append(interim, cp)
+	}
+	return interim
+}
+
+// vppConfigWithoutMissingFleets returns a copy of the volume_purchasing_program
+// config with not-yet-created fleets filtered out of each token's fleet list, so the
+// initial apply keeps every assignment to an existing fleet intact.
+func vppConfigWithoutMissingFleets(vppSettings []any, missingTeams []string) []any {
+	missing := make(map[string]struct{}, len(missingTeams))
+	for _, name := range missingTeams {
+		missing[name] = struct{}{}
+	}
+	interim := make([]any, 0, len(vppSettings))
+	for _, item := range vppSettings {
+		cfg, ok := item.(map[string]any)
+		if !ok {
+			interim = append(interim, item)
+			continue
+		}
+		cp := make(map[string]any, len(cfg))
+		maps.Copy(cp, cfg)
+		if fleets, ok := cp["fleets"].([]any); ok {
+			kept := make([]any, 0, len(fleets))
+			for _, f := range fleets {
+				if name, ok := f.(string); ok {
+					if _, isMissing := missing[norm.NFC.String(name)]; isMissing {
+						continue
+					}
+				}
+				kept = append(kept, f)
+			}
+			cp["fleets"] = kept
+		}
+		interim = append(interim, cp)
+	}
+	return interim
 }
 
 // knownTeamNamesForTokenAssignment returns the set of team names that count as

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -1212,7 +1212,10 @@ func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
 					appleBMDefaultTeam = norm.NFC.String(appleBMDefaultTeam)
 					abmTeams = append(abmTeams, appleBMDefaultTeam)
 					usesLegacyConfig = true
-					if _, ok = teamNames[appleBMDefaultTeam]; !ok {
+					// Reserved names ("No team"/"Unassigned"/...) are never returned by
+					// ListTeams but aren't teams to be created either, so don't treat them
+					// as missing.
+					if _, ok = teamNames[appleBMDefaultTeam]; !ok && appleBMDefaultTeam != "" && !fleet.IsReservedTeamName(appleBMDefaultTeam) {
 						missingTeams = append(missingTeams, appleBMDefaultTeam)
 					}
 				}
@@ -1227,7 +1230,7 @@ func checkABMTeamAssignments(config *spec.GitOps, fleetClient *service.Client) (
 									// normalize for Unicode support
 									team = norm.NFC.String(team)
 									abmTeams = append(abmTeams, team)
-									if _, ok := teamNames[team]; !ok {
+									if _, ok := teamNames[team]; !ok && !fleet.IsReservedTeamName(team) {
 										missingTeams = append(missingTeams, team)
 									}
 								}

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -1122,9 +1122,9 @@ func TestGitOpsABMMissingTeamKeepsExistingAssignments(t *testing.T) {
 	// token's macOS default fleet is already the existing team before the run.
 	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
 		return []*fleet.ABMToken{{
-			ID:                  1,
-			OrganizationName:    "Fleet ABM",
-			MacOSDefaultTeamID:  new(existingTeam.ID),
+			ID:                 1,
+			OrganizationName:   "Fleet ABM",
+			MacOSDefaultTeamID: new(existingTeam.ID),
 		}}, nil
 	}
 	type abmSave struct {

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -937,6 +937,270 @@ software:
 	assert.Contains(t, buf.String(), fmt.Sprintf(fleetctl.ReapplyingTeamForVPPAppsMsg, newTeamName))
 }
 
+// TestGitOpsVPPMissingTeamKeepsExistingAssignments covers issue #51687: when the VPP
+// config references a team that doesn't exist yet, the interim config applied before
+// teams are created must keep every assignment to an existing team. Previously the
+// whole VPP section was held back, which the server received as an empty list and
+// answered by clearing ALL token/team assignments — a run that failed before the
+// end-of-run re-apply (e.g. on an unrelated error) left them wiped permanently.
+func TestGitOpsVPPMissingTeamKeepsExistingAssignments(t *testing.T) {
+	testing_utils.StartAndServeVPPServer(t)
+	ds, _, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
+	renewDate := time.Now().Add(24 * time.Hour)
+	token, err := test.CreateVPPTokenEncoded(renewDate, "fleet", "ca")
+	require.NoError(t, err)
+
+	existingTeamName := "Existing Team"
+	newTeamName := "New Team"
+
+	existingTeam := &fleet.Team{ID: 42, Name: existingTeamName}
+	savedTeams[existingTeamName] = &existingTeam
+
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+	ds.GetVPPAppsFunc = func(ctx context.Context, teamID *uint) ([]fleet.VPPAppResponse, error) {
+		return []fleet.VPPAppResponse{}, nil
+	}
+	ds.GetABMTokenCountFunc = func(ctx context.Context) (int, error) {
+		return 0, nil
+	}
+	ds.GetCertificateTemplatesByTeamIDFunc = func(ctx context.Context, teamID uint, options fleet.ListOptions) ([]*fleet.CertificateTemplateResponseSummary, *fleet.PaginationMetadata, error) {
+		return []*fleet.CertificateTemplateResponseSummary{}, &fleet.PaginationMetadata{}, nil
+	}
+	ds.ListCertificateAuthoritiesFunc = func(ctx context.Context) ([]*fleet.CertificateAuthoritySummary, error) {
+		return nil, nil
+	}
+
+	// The token is already assigned to the existing team before the run.
+	vppToken := &fleet.VPPTokenDB{
+		ID:          1,
+		OrgName:     "Fleet",
+		Location:    "Earth",
+		RenewDate:   renewDate,
+		Token:       string(token),
+		Teams:       []fleet.TeamTuple{{ID: existingTeam.ID, Name: existingTeamName}},
+		CountryCode: "us",
+	}
+	tokensByTeams := map[uint]*fleet.VPPTokenDB{existingTeam.ID: vppToken}
+	var updateCalls [][]uint
+	ds.UpdateVPPTokenTeamsFunc = func(ctx context.Context, id uint, teams []uint) (*fleet.VPPTokenDB, error) {
+		updateCalls = append(updateCalls, teams)
+		for _, teamID := range teams {
+			tokensByTeams[teamID] = vppToken
+		}
+		return vppToken, nil
+	}
+	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
+		return []*fleet.VPPTokenDB{vppToken}, nil
+	}
+	ds.GetVPPTokenByTeamIDFunc = func(ctx context.Context, teamID *uint) (*fleet.VPPTokenDB, error) {
+		if teamID == nil {
+			return vppToken, nil
+		}
+		token, ok := tokensByTeams[*teamID]
+		if !ok {
+			return nil, sql.ErrNoRows
+		}
+		return token, nil
+	}
+	ds.GetSoftwareCategoryNameToIDMapFunc = func(ctx context.Context, teamID uint, names []string) (map[string]uint, error) {
+		return map[string]uint{}, nil
+	}
+	ds.InsertOrReplaceMDMConfigAssetFunc = func(ctx context.Context, asset fleet.MDMConfigAsset) error {
+		return nil
+	}
+	ds.HardDeleteMDMConfigAssetFunc = func(ctx context.Context, assetName fleet.MDMAssetName) error {
+		return nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
+
+	globalCfg := fmt.Sprintf(`
+policies:
+queries:
+agent_options:
+controls:
+org_settings:
+  mdm:
+    volume_purchasing_program:
+      - location: Earth
+        teams:
+          - %q
+          - %q
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Fleet
+  secrets:
+    - secret: "FLEET_GLOBAL_ENROLL_SECRET"
+`, existingTeamName, newTeamName)
+
+	teamCfg := func(name string) string {
+		return fmt.Sprintf(`
+name: %q
+team_settings:
+  secrets:
+    - secret: "%s-secret"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+policies:
+queries:
+software:
+`, name, name)
+	}
+
+	tmpDir := t.TempDir()
+	globalFile := filepath.Join(tmpDir, "default.yml")
+	require.NoError(t, os.WriteFile(globalFile, []byte(globalCfg), 0o644))
+	existingTeamFile := filepath.Join(tmpDir, "existing-team.yml")
+	require.NoError(t, os.WriteFile(existingTeamFile, []byte(teamCfg(existingTeamName)), 0o644))
+	newTeamFile := filepath.Join(tmpDir, "new-team.yml")
+	require.NoError(t, os.WriteFile(newTeamFile, []byte(teamCfg(newTeamName)), 0o644))
+
+	_, err = fleetctltest.RunAppNoChecks([]string{
+		"gitops", "-f", globalFile, "-f", existingTeamFile, "-f", newTeamFile,
+	})
+	require.NoError(t, err)
+
+	// The existing team's assignment must be present in every write; a write without
+	// it means the run had a window (or a permanent state, if interrupted) with the
+	// assignment lost.
+	require.True(t, ds.UpdateVPPTokenTeamsFuncInvoked)
+	for i, call := range updateCalls {
+		assert.Contains(t, call, existingTeam.ID,
+			"UpdateVPPTokenTeams call %d dropped the existing team's assignment", i)
+	}
+}
+
+// TestGitOpsABMMissingTeamKeepsExistingAssignments is the apple_business analog of
+// TestGitOpsVPPMissingTeamKeepsExistingAssignments (issue #51687): when an ABM entry
+// references a team that doesn't exist yet, the interim config must keep every
+// default-fleet assignment that points at an existing team. Previously the section was
+// held back, reached the server as an empty list, and cleared every token's defaults.
+func TestGitOpsABMMissingTeamKeepsExistingAssignments(t *testing.T) {
+	ds, _, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	existingTeamName := "Existing Team"
+	newTeamName := "New Team"
+
+	existingTeam := &fleet.Team{ID: 42, Name: existingTeamName}
+	savedTeams[existingTeamName] = &existingTeam
+
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+	ds.GetVPPAppsFunc = func(ctx context.Context, teamID *uint) ([]fleet.VPPAppResponse, error) {
+		return []fleet.VPPAppResponse{}, nil
+	}
+	ds.GetCertificateTemplatesByTeamIDFunc = func(ctx context.Context, teamID uint, options fleet.ListOptions) ([]*fleet.CertificateTemplateResponseSummary, *fleet.PaginationMetadata, error) {
+		return []*fleet.CertificateTemplateResponseSummary{}, &fleet.PaginationMetadata{}, nil
+	}
+	ds.ListCertificateAuthoritiesFunc = func(ctx context.Context) ([]*fleet.CertificateAuthoritySummary, error) {
+		return nil, nil
+	}
+	ds.InsertOrReplaceMDMConfigAssetFunc = func(ctx context.Context, asset fleet.MDMConfigAsset) error {
+		return nil
+	}
+	ds.HardDeleteMDMConfigAssetFunc = func(ctx context.Context, assetName fleet.MDMAssetName) error {
+		return nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
+	ds.GetABMTokenCountFunc = func(ctx context.Context) (int, error) {
+		return 1, nil
+	}
+	// Fresh copy per call: validateABMAssignments mutates the returned tokens. The
+	// token's macOS default fleet is already the existing team before the run.
+	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
+		return []*fleet.ABMToken{{
+			ID:                  1,
+			OrganizationName:    "Fleet ABM",
+			MacOSDefaultTeamID:  new(existingTeam.ID),
+		}}, nil
+	}
+	type abmSave struct {
+		org   string
+		macos *uint
+	}
+	var saveCalls []abmSave
+	ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error {
+		saveCalls = append(saveCalls, abmSave{org: tok.OrganizationName, macos: tok.MacOSDefaultTeamID})
+		return nil
+	}
+
+	globalCfg := fmt.Sprintf(`
+policies:
+queries:
+agent_options:
+controls:
+org_settings:
+  mdm:
+    apple_business:
+      - organization_name: Fleet ABM
+        macos_fleet: %q
+        ios_fleet: %q
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Fleet
+  secrets:
+    - secret: "FLEET_GLOBAL_ENROLL_SECRET"
+`, existingTeamName, newTeamName)
+
+	teamCfg := func(name string) string {
+		return fmt.Sprintf(`
+name: %q
+team_settings:
+  secrets:
+    - secret: "%s-secret"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+policies:
+queries:
+software:
+`, name, name)
+	}
+
+	tmpDir := t.TempDir()
+	globalFile := filepath.Join(tmpDir, "default.yml")
+	require.NoError(t, os.WriteFile(globalFile, []byte(globalCfg), 0o644))
+	existingTeamFile := filepath.Join(tmpDir, "existing-team.yml")
+	require.NoError(t, os.WriteFile(existingTeamFile, []byte(teamCfg(existingTeamName)), 0o644))
+	newTeamFile := filepath.Join(tmpDir, "new-team.yml")
+	require.NoError(t, os.WriteFile(newTeamFile, []byte(teamCfg(newTeamName)), 0o644))
+
+	_, err := fleetctltest.RunAppNoChecks([]string{
+		"gitops", "-f", globalFile, "-f", existingTeamFile, "-f", newTeamFile,
+	})
+	require.NoError(t, err)
+
+	// The token's macOS default (an existing team) must survive every save; a save
+	// with it nil means the run had a window — or a permanent state, if interrupted —
+	// with the assignment lost.
+	require.True(t, ds.SaveABMTokenFuncInvoked)
+	require.NotEmpty(t, saveCalls)
+	for i, call := range saveCalls {
+		if assert.NotNil(t, call.macos, "SaveABMToken call %d (org %s) dropped the existing macOS default fleet", i, call.org) {
+			assert.Equal(t, existingTeam.ID, *call.macos, "SaveABMToken call %d (org %s) changed the existing macOS default fleet", i, call.org)
+		}
+	}
+}
+
 // TestGitOpsNewTeamVPPSharedWithUnsuppliedExistingTeam covers issue #44444: adding
 // a NEW team that shares a VPP token with an EXISTING team must succeed even when
 // the existing team's config file is NOT supplied in the same run. Detecting a

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -1118,25 +1118,40 @@ func TestGitOpsABMMissingTeamKeepsExistingAssignments(t *testing.T) {
 	ds.GetABMTokenCountFunc = func(ctx context.Context) (int, error) {
 		return 1, nil
 	}
-	// Fresh copy per call: validateABMAssignments mutates the returned tokens. The
-	// token's macOS default fleet is already the existing team before the run.
+	// Fresh copies per call: validateABMAssignments mutates the returned tokens. Token 1
+	// ("Fleet ABM") already points every platform default at the existing team before the
+	// run; token 2 is the newly added one whose default fleet is created in this run.
 	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
-		return []*fleet.ABMToken{{
-			ID:                 1,
-			OrganizationName:   "Fleet ABM",
-			MacOSDefaultTeamID: new(existingTeam.ID),
-		}}, nil
+		return []*fleet.ABMToken{
+			{
+				ID:                  1,
+				OrganizationName:    "Fleet ABM",
+				MacOSDefaultTeamID:  new(existingTeam.ID),
+				IOSDefaultTeamID:    new(existingTeam.ID),
+				IPadOSDefaultTeamID: new(existingTeam.ID),
+				BYODDefaultTeamID:   new(existingTeam.ID),
+			},
+			{ID: 2, OrganizationName: "Other ABM"},
+		}, nil
 	}
 	type abmSave struct {
-		org   string
-		macos *uint
+		org                      string
+		macos, ios, ipados, byod *uint
 	}
 	var saveCalls []abmSave
 	ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error {
-		saveCalls = append(saveCalls, abmSave{org: tok.OrganizationName, macos: tok.MacOSDefaultTeamID})
+		saveCalls = append(saveCalls, abmSave{
+			org:    tok.OrganizationName,
+			macos:  tok.MacOSDefaultTeamID,
+			ios:    tok.IOSDefaultTeamID,
+			ipados: tok.IPadOSDefaultTeamID,
+			byod:   tok.BYODDefaultTeamID,
+		})
 		return nil
 	}
 
+	// Fleet ABM keeps the existing team on every platform; Other ABM points at the
+	// not-yet-created team, which is what triggers the interim strip/filter path.
 	globalCfg := fmt.Sprintf(`
 policies:
 queries:
@@ -1148,13 +1163,17 @@ org_settings:
       - organization_name: Fleet ABM
         macos_fleet: %q
         ios_fleet: %q
+        ipados_fleet: %q
+        byod_fleet: %q
+      - organization_name: Other ABM
+        macos_fleet: %q
   server_settings:
     server_url: https://example.com
   org_info:
     org_name: Fleet
   secrets:
     - secret: "FLEET_GLOBAL_ENROLL_SECRET"
-`, existingTeamName, newTeamName)
+`, existingTeamName, existingTeamName, existingTeamName, existingTeamName, newTeamName)
 
 	teamCfg := func(name string) string {
 		return fmt.Sprintf(`
@@ -1189,16 +1208,26 @@ software:
 	})
 	require.NoError(t, err)
 
-	// The token's macOS default (an existing team) must survive every save; a save
-	// with it nil means the run had a window — or a permanent state, if interrupted —
-	// with the assignment lost.
+	// Fleet ABM's defaults (all the existing team) must survive every save; a save with
+	// any of them nil means the run had a window — or a permanent state, if interrupted —
+	// with that platform's assignment lost.
 	require.True(t, ds.SaveABMTokenFuncInvoked)
-	require.NotEmpty(t, saveCalls)
+	var fleetABMSaves int
 	for i, call := range saveCalls {
-		if assert.NotNil(t, call.macos, "SaveABMToken call %d (org %s) dropped the existing macOS default fleet", i, call.org) {
-			assert.Equal(t, existingTeam.ID, *call.macos, "SaveABMToken call %d (org %s) changed the existing macOS default fleet", i, call.org)
+		if call.org != "Fleet ABM" {
+			continue
+		}
+		fleetABMSaves++
+		for _, d := range []struct {
+			name string
+			id   *uint
+		}{{"macOS", call.macos}, {"iOS", call.ios}, {"iPadOS", call.ipados}, {"BYOD", call.byod}} {
+			if assert.NotNil(t, d.id, "SaveABMToken call %d dropped Fleet ABM's %s default fleet", i, d.name) {
+				assert.Equal(t, existingTeam.ID, *d.id, "SaveABMToken call %d changed Fleet ABM's %s default fleet", i, d.name)
+			}
 		}
 	}
+	require.NotZero(t, fleetABMSaves, "expected at least one SaveABMToken call for Fleet ABM")
 }
 
 // TestGitOpsNewTeamVPPSharedWithUnsuppliedExistingTeam covers issue #44444: adding


### PR DESCRIPTION
**Related issue:** Resolves #51687

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Details

- When a GitOps run's `volume_purchasing_program` or `apple_business` config referenced a fleet created later in the same run, the section was held back from the first config apply. The server received it as an empty list and cleared every token's fleet assignments — and a run failing before the end-of-run re-apply left them permanently removed.
- The client now applies a filtered interim config instead: missing fleets are dropped from VPP entries and missing `*_fleet` references are blanked on ABM entries, so assignments to existing fleets always survive. The original config is still applied in full at the end of the run.
- `byod_fleet` is now included when detecting missing fleets (previously unchecked, so a config referencing a new BYOD fleet failed the run).

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Regression tests assert no assignment write ever drops an existing fleet (verified failing before the fix). Manually verified against a live server: a run interrupted mid-apply now leaves VPP/ABM assignments intact, and a completed run converges to the declared state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitOps configurations that reference fleets created later in the same run.
  * Preserved existing Volume Purchasing Program and Apple Business Manager token and fleet assignments during interim updates.
  * Prevented interrupted GitOps runs from permanently clearing token and fleet assignments.
  * Improved handling of BYOD assignments and reserved fleet names.
  * Ensured assignments to existing fleets remain intact even when other referenced fleets have not yet been created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->