### PR TITLE
Docs: Note mobile online/offline heuristic on Get hosts summary

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3851,6 +3851,8 @@ If `mdm_id`, `mdm_name` or `mdm_enrollment_status` is specified, then Windows Se
 
 Returns the count of all hosts organized by status. `online_count` includes all hosts currently enrolled in Fleet. `offline_count` includes all hosts that haven't checked into Fleet recently. `mia_count` includes all hosts that haven't been seen by Fleet in more than 30 days. `new_count` includes the hosts that have been enrolled to Fleet in the last 24 hours.
 
+For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is based on the most recent MDM check-in (`nano_enrollments.last_seen_at` for Apple; `detail_updated_at` for Android) within a 1-hour window, instead of the osquery check-in interval used by other platforms.
+
 `GET /api/v1/fleet/host_summary`
 
 #### Parameters

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3851,7 +3851,7 @@ If `mdm_id`, `mdm_name` or `mdm_enrollment_status` is specified, then Windows Se
 
 Returns the count of all hosts organized by status. `online_count` includes all hosts currently enrolled in Fleet. `offline_count` includes all hosts that haven't checked into Fleet recently. `mia_count` includes all hosts that haven't been seen by Fleet in more than 30 days. `new_count` includes the hosts that have been enrolled to Fleet in the last 24 hours.
 
-For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is based on the most recent MDM check-in (`nano_enrollments.last_seen_at` for Apple; `detail_updated_at` for Android) within a 1-hour window, instead of the osquery check-in interval used by other platforms.
+For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is derived from the freshest MDM activity signal — the most recent of `host_seen_times.seen_time`, `nano_enrollments.last_seen_at` (Apple, active enrollments only), or `detail_updated_at` — within a ~1-hour window, instead of the per-host osquery check-in interval used by other platforms.
 
 `GET /api/v1/fleet/host_summary`
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3851,7 +3851,7 @@ If `mdm_id`, `mdm_name` or `mdm_enrollment_status` is specified, then Windows Se
 
 Returns the count of all hosts organized by status. `online_count` includes all hosts currently enrolled in Fleet. `offline_count` includes all hosts that haven't checked into Fleet recently. `mia_count` includes all hosts that haven't been seen by Fleet in more than 30 days. `new_count` includes the hosts that have been enrolled to Fleet in the last 24 hours.
 
-For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is derived from the freshest MDM activity signal — the most recent of `host_seen_times.seen_time`, `nano_enrollments.last_seen_at` (Apple, active enrollments only), or `detail_updated_at` — within a ~1-hour window, instead of the per-host osquery check-in interval used by other platforms.
+For iOS, iPadOS, and Android hosts, which don't run osquery, `online`/`offline` is derived from the most recent of `nano_enrollments.last_seen_at` (Apple, active enrollments only) or `host_seen_times.seen_time`, falling back to `detail_updated_at` when neither is present — within a ~1-hour window, instead of the per-host osquery check-in interval used by other platforms.
 
 `GET /api/v1/fleet/host_summary`
 


### PR DESCRIPTION
## Issue
Closes #52571 (sub-issue of parent story #50155)

## Description
- Adds a single paragraph under **Get hosts summary** in `docs/REST API/rest-api.md` explaining that iOS/iPadOS/Android hosts derive `online`/`offline` from the most recent MDM check-in — `nano_enrollments.last_seen_at` for Apple; `detail_updated_at` for Android — within a 1-hour window, instead of the osquery check-in interval used by other platforms.
- Docs-only slice of parent story #50155. The behavior itself ships in sibling PRs #52518 (backend heuristic) and #52483 (frontend modal). This PR just documents the contract.
- Targets `docs-v4.93.0` so the note ships with the 4.93 reference-docs cut.

## Screenrecording
- Not applicable — docs-only.



## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
- No code paths touched; nothing to automate. QA renders the docs from `docs-v4.93.0` after merge and confirms the paragraph appears under **Get hosts summary**.