### PR TITLE
Fix hanging period in Android refetch tooltip

### DIFF
--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -176,10 +176,9 @@ export const ANDROID_NO_REFETCH_TOOLTIP_MESSAGE = (
     automatically when they change. If changes aren&apos;t appearing,{" "}
     <CustomLink
       url={`${LEARN_MORE_ABOUT_BASE_LINK}/android-manual-sync`}
-      text="learn how to sync manually"
+      text="learn how to sync manually."
       newTab
       variant="tooltip-link"
     />
-    .
   </>
 );


### PR DESCRIPTION
# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

---

Before:

<img width="287" height="140" alt="Screenshot 2026-09-04 at 07 19 08" src="https://github.com/user-attachments/assets/8e2b3bf4-e6c4-499a-bc70-b72002b7a191" />

After:

<img width="272" height="136" alt="Screenshot 2026-09-04 at 07 20 42" src="https://github.com/user-attachments/assets/65e76b3b-a9f0-4e10-a562-219ad0bc5d72" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Android manual-sync tooltip punctuation so the period appears within the linked text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->