### PR TITLE
Fixing Microsoft Graph unreleased security concerns.

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -94,7 +94,7 @@ type generateGitopsClient interface {
 	GetSetupExperienceScript(teamID uint) (*fleet.Script, error)
 	GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error)
 	GetCertificateAuthoritiesSpec(includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error)
-	GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredential, error)
+	GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredentialMetadata, error)
 	GetCertificateTemplates(teamID string) ([]*fleet.CertificateTemplateResponseSummary, error)
 	ListFleetMaintainedApps(teamID uint) ([]fleet.MaintainedApp, error)
 	GetFleetMaintainedApp(id uint) (*fleet.MaintainedApp, error)
@@ -865,7 +865,7 @@ func (cmd *GenerateGitopsCommand) generateOrgSettings() (orgSettings map[string]
 	}
 	orgSettings["certificate_authorities"] = certificateAuthorities // TODO(hca): Ask Scott about jsonFieldName usage
 
-	var graphCreds []*fleet.MicrosoftGraphCredential
+	var graphCreds []*fleet.MicrosoftGraphCredentialMetadata
 	if cmd.AppConfig.License.IsPremium() {
 		graphCreds, err = cmd.Client.GetMicrosoftGraphCredentials()
 		if err != nil {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -919,19 +919,18 @@ func (MockClient) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetu
 	return nil, fmt.Errorf("unexpected team ID: %d", teamID)
 }
 
-func (MockClient) GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredential, error) {
+func (MockClient) GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 	return nil, nil
 }
 
-// graphCredClient returns one stored credential, as the endpoint does once one is configured. The secret comes back
-// masked from the API, so generate-gitops must not emit it.
+// graphCredClient returns one stored credential, as the endpoint does once one is configured. A read carries no
+// secret, so generate-gitops has none to emit and must write a placeholder instead.
 type graphCredClient struct{ MockClient }
 
-func (graphCredClient) GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredential, error) {
-	return []*fleet.MicrosoftGraphCredential{{
-		TenantID:     "5b1fc5b6-9502-4cf9-90cf-d0b656eaf7a4",
-		ClientID:     "122349c0-2458-448d-a9ae-f40b81a63213",
-		ClientSecret: fleet.MaskedPassword,
+func (graphCredClient) GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
+	return []*fleet.MicrosoftGraphCredentialMetadata{{
+		TenantID: "5b1fc5b6-9502-4cf9-90cf-d0b656eaf7a4",
+		ClientID: "122349c0-2458-448d-a9ae-f40b81a63213",
 	}}, nil
 }
 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -9389,12 +9389,10 @@ func TestGitOpsMicrosoftGraphCredentials(t *testing.T) {
 	}
 	// Deletions are computed from the metadata read (which decrypts nothing), so both reads must be backed by the same
 	// store or a removed key looks like "nothing was configured".
-	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
-		out := make([]*fleet.MicrosoftGraphCredential, 0, len(stored))
+	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
+		out := make([]*fleet.MicrosoftGraphCredentialMetadata, 0, len(stored))
 		for _, c := range stored {
-			meta := *c
-			meta.ClientSecret = ""
-			out = append(out, &meta)
+			out = append(out, &c.MicrosoftGraphCredentialMetadata)
 		}
 		return out, nil
 	}

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -103,7 +103,7 @@ func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.GetWindowsEnrollmentDefaultFleetFunc = func(ctx context.Context) (*uint, string, error) {
 		return nil, "", nil
 	}
-	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 		return nil, nil
 	}
 	ds.NewGlobalPolicyFunc = func(ctx context.Context, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
@@ -640,7 +640,7 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 	ds.ListMicrosoftGraphCredentialsFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
 		return nil, nil
 	}
-	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 		return nil, nil
 	}
 	ds.UpdateMicrosoftGraphCredentialInvalidAggregateFunc = func(ctx context.Context) error { return nil }

--- a/cmd/fleetctl/fleetctl/testing_utils_test.go
+++ b/cmd/fleetctl/fleetctl/testing_utils_test.go
@@ -273,7 +273,7 @@ func setupEmptyGitOpsMocks(ds *mock.Store) {
 	ds.ListMicrosoftGraphCredentialsFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
 		return nil, nil
 	}
-	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 		return nil, nil
 	}
 	ds.UpdateMicrosoftGraphCredentialInvalidAggregateFunc = func(ctx context.Context) error { return nil }

--- a/ee/server/service/microsoft_graph_credentials.go
+++ b/ee/server/service/microsoft_graph_credentials.go
@@ -18,8 +18,8 @@ const maxMicrosoftGraphCredentials = 1
 
 // ListMicrosoftGraphCredentials returns the stored credentials with their per-tenant sync status. Client secrets are
 // never decrypted on this path.
-func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.MicrosoftGraphCredential{}, fleet.ActionRead); err != nil {
 		return nil, err
 	}
 
@@ -36,7 +36,7 @@ func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet
 // sync. Unchanged credentials are skipped entirely: re-applying an identical GitOps config makes no network call,
 // performs no write, and emits no activity.
 func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, incoming []fleet.MicrosoftGraphCredential, dryRun bool) error {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.Authorize(ctx, &fleet.MicrosoftGraphCredential{}, fleet.ActionWrite); err != nil {
 		return err
 	}
 

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -1470,6 +1470,16 @@ allow {
 }
 
 ##
+# Microsoft Graph credentials
+##
+# Global admins and gitops can read and write Microsoft Graph credentials.
+allow {
+  object.type == "microsoft_graph_credential"
+  subject.global_role == [admin, gitops][_]
+  action == [read, write][_]
+}
+
+##
 # Certificate Authorities
 ##
 # Global admins and gitops can configure, read, list, and read secrets of certificate authorities.

--- a/server/datastore/mysql/microsoft_autopilot.go
+++ b/server/datastore/mysql/microsoft_autopilot.go
@@ -63,14 +63,14 @@ ORDER BY tenant_id`
 }
 
 // ListMicrosoftGraphCredentialMetadata returns the stored credentials without their client secrets.
-func (ds *Datastore) ListMicrosoftGraphCredentialMetadata(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+func (ds *Datastore) ListMicrosoftGraphCredentialMetadata(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 	const stmt = `
 SELECT tenant_id, client_id, credential_invalid, last_synced_at, last_sync_error
 FROM mdm_microsoft_graph_credentials
 ORDER BY tenant_id`
 
 	// Non-nil so the endpoint serializes an empty list as [] rather than null.
-	creds := make([]*fleet.MicrosoftGraphCredential, 0)
+	creds := make([]*fleet.MicrosoftGraphCredentialMetadata, 0)
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &creds, stmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
 	}

--- a/server/datastore/mysql/microsoft_autopilot_test.go
+++ b/server/datastore/mysql/microsoft_autopilot_test.go
@@ -250,7 +250,6 @@ func testGraphCredentialMetadataOmitsSecret(t *testing.T, ds *Datastore) {
 	require.Len(t, meta, 1)
 	assert.Equal(t, testTenantA, meta[0].TenantID)
 	assert.Equal(t, "client-"+testTenantA, meta[0].ClientID)
-	assert.Empty(t, meta[0].ClientSecret, "the metadata read must not carry the secret")
 	// The fields the UI needs, including the banner flag, still come through.
 	assert.True(t, meta[0].CredentialInvalid)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2597,7 +2597,7 @@ type Datastore interface {
 
 	// ListMicrosoftGraphCredentialMetadata returns the stored credentials without their client secrets, decrypting
 	// nothing.
-	ListMicrosoftGraphCredentialMetadata(ctx context.Context) ([]*MicrosoftGraphCredential, error)
+	ListMicrosoftGraphCredentialMetadata(ctx context.Context) ([]*MicrosoftGraphCredentialMetadata, error)
 
 	// ReplaceMicrosoftGraphCredentials reconciles the stored credentials.
 	ReplaceMicrosoftGraphCredentials(ctx context.Context, upsert []*MicrosoftGraphCredential, deleteTenantIDs []string) error

--- a/server/fleet/microsoft_graph.go
+++ b/server/fleet/microsoft_graph.go
@@ -19,12 +19,11 @@ func IsValidEntraGUID(s string) bool {
 	return entraGUIDRegex.MatchString(s)
 }
 
-// MicrosoftGraphCredential is the Entra app-registration credential Fleet authenticates with when calling Microsoft Graph.
-type MicrosoftGraphCredential struct {
+// MicrosoftGraphCredentialMetadata is a stored credential without its client secret. This is what the read endpoint
+// serializes, so it must never gain a secret field.
+type MicrosoftGraphCredentialMetadata struct {
 	TenantID string `json:"tenant_id" db:"tenant_id"`
 	ClientID string `json:"client_id" db:"client_id"`
-	// ClientSecret is write-only. Omitting it on a write means "keep the stored secret".
-	ClientSecret string `json:"client_secret,omitempty" db:"-"`
 
 	// CredentialInvalid is set by the sync when the credential fails to authenticate or is denied, and cleared on the
 	// next successful sync.
@@ -32,6 +31,19 @@ type MicrosoftGraphCredential struct {
 	// LastSyncedAt and LastSyncError report the outcome of the most recent sync for this tenant.
 	LastSyncedAt  *time.Time `json:"last_synced_at" db:"last_synced_at"`
 	LastSyncError *string    `json:"last_sync_error" db:"last_sync_error"`
+}
+
+// MicrosoftGraphCredential is the Entra app-registration credential Fleet authenticates with when calling Microsoft
+// Graph: the metadata plus the secret.
+type MicrosoftGraphCredential struct {
+	MicrosoftGraphCredentialMetadata
+
+	// ClientSecret is write-only. Omitting it on a write means "keep the stored secret".
+	ClientSecret string `json:"client_secret,omitempty" db:"-"`
+}
+
+func (c MicrosoftGraphCredential) AuthzType() string {
+	return "microsoft_graph_credential"
 }
 
 // Configured reports whether the credential carries everything needed to mint a token.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1709,8 +1709,8 @@ type Service interface {
 	//////////////////////////////////////////////////////////////////////////////
 	// Microsoft Graph
 
-	// ListMicrosoftGraphCredentials returns the stored Microsoft Graph credentials with their per-tenant sync status. Client secrets are masked.
-	ListMicrosoftGraphCredentials(ctx context.Context) ([]*MicrosoftGraphCredential, error)
+	// ListMicrosoftGraphCredentials returns the stored Microsoft Graph credentials with their per-tenant sync status.
+	ListMicrosoftGraphCredentials(ctx context.Context) ([]*MicrosoftGraphCredentialMetadata, error)
 	// ApplyMicrosoftGraphCredentials declaratively reconciles the stored Microsoft Graph credentials to the supplied
 	// list, verifying any new or changed credential against Graph before storing it. A tenant absent from the list is deleted.
 	ApplyMicrosoftGraphCredentials(ctx context.Context, creds []MicrosoftGraphCredential, dryRun bool) error

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1516,7 +1516,7 @@ type GetHostMDMProfileInstallStatusFunc func(ctx context.Context, hostUUID strin
 
 type ListMicrosoftGraphCredentialsFunc func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error)
 
-type ListMicrosoftGraphCredentialMetadataFunc func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error)
+type ListMicrosoftGraphCredentialMetadataFunc func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error)
 
 type ReplaceMicrosoftGraphCredentialsFunc func(ctx context.Context, upsert []*fleet.MicrosoftGraphCredential, deleteTenantIDs []string) error
 
@@ -11160,7 +11160,7 @@ func (s *DataStore) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet
 	return s.ListMicrosoftGraphCredentialsFunc(ctx)
 }
 
-func (s *DataStore) ListMicrosoftGraphCredentialMetadata(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+func (s *DataStore) ListMicrosoftGraphCredentialMetadata(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 	s.mu.Lock()
 	s.ListMicrosoftGraphCredentialMetadataFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -1009,7 +1009,7 @@ type BatchSetAppleDDMAssetsFunc func(ctx context.Context, teamID *uint, teamName
 
 type ReleaseABDevicesFunc func(ctx context.Context, hostIDs []uint) ([]*fleet.ABReleaseDeviceResponse, error)
 
-type ListMicrosoftGraphCredentialsFunc func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error)
+type ListMicrosoftGraphCredentialsFunc func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error)
 
 type ApplyMicrosoftGraphCredentialsFunc func(ctx context.Context, creds []fleet.MicrosoftGraphCredential, dryRun bool) error
 
@@ -5973,7 +5973,7 @@ func (s *Service) ReleaseABDevices(ctx context.Context, hostIDs []uint) ([]*flee
 	return s.ReleaseABDevicesFunc(ctx, hostIDs)
 }
 
-func (s *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+func (s *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 	s.mu.Lock()
 	s.ListMicrosoftGraphCredentialsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/client_microsoft_graph_credentials.go
+++ b/server/service/client_microsoft_graph_credentials.go
@@ -9,8 +9,8 @@ func (c *Client) ApplyMicrosoftGraphCredentials(creds []fleet.MicrosoftGraphCred
 	return c.authenticatedRequest(req, "PUT", "/api/latest/fleet/microsoft_graph_credentials", &responseBody)
 }
 
-// GetMicrosoftGraphCredentials returns the stored credentials with their per-tenant sync status. Client secrets come back masked.
-func (c *Client) GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredential, error) {
+// GetMicrosoftGraphCredentials returns the stored credentials with their per-tenant sync status.
+func (c *Client) GetMicrosoftGraphCredentials() ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 	var responseBody listMicrosoftGraphCredentialsResponse
 	err := c.authenticatedRequest(nil, "GET", "/api/latest/fleet/microsoft_graph_credentials", &responseBody)
 	return responseBody.MicrosoftGraphCredentials, err

--- a/server/service/microsoft_graph_credentials.go
+++ b/server/service/microsoft_graph_credentials.go
@@ -11,8 +11,8 @@ import (
 /////////////////////////////////////////////////////////////////////////////////
 
 type listMicrosoftGraphCredentialsResponse struct {
-	MicrosoftGraphCredentials []*fleet.MicrosoftGraphCredential `json:"microsoft_graph_credentials"`
-	Err                       error                             `json:"error,omitempty"`
+	MicrosoftGraphCredentials []*fleet.MicrosoftGraphCredentialMetadata `json:"microsoft_graph_credentials"`
+	Err                       error                                     `json:"error,omitempty"`
 }
 
 func (r listMicrosoftGraphCredentialsResponse) Error() error { return r.Err }
@@ -25,7 +25,7 @@ func listMicrosoftGraphCredentialsEndpoint(ctx context.Context, _ any, svc fleet
 	return listMicrosoftGraphCredentialsResponse{MicrosoftGraphCredentials: creds}, nil
 }
 
-func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 	// skipauth: No authorization check needed due to implementation returning only license error.
 	svc.authz.SkipAuthorization(ctx)
 	return nil, fleet.ErrMissingLicense

--- a/server/service/microsoft_graph_credentials_test.go
+++ b/server/service/microsoft_graph_credentials_test.go
@@ -397,8 +397,8 @@ func TestMicrosoftGraphCredentialsAuth(t *testing.T) {
 		{"global gitops", &fleet.User{GlobalRole: new(fleet.RoleGitOps)}, false},
 		{"global maintainer", &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}, true},
 		{"global observer", &fleet.User{GlobalRole: new(fleet.RoleObserver)}, true},
-		{"team admin", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}}, true},
-		{"team observer", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}}, true},
+		{"team admin", &fleet.User{Teams: []fleet.UserTeam{{ID: 1, Role: fleet.RoleAdmin}}}, true},
+		{"team observer", &fleet.User{Teams: []fleet.UserTeam{{ID: 1, Role: fleet.RoleObserver}}}, true},
 		{"no user", nil, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/service/microsoft_graph_credentials_test.go
+++ b/server/service/microsoft_graph_credentials_test.go
@@ -117,12 +117,10 @@ func setupGraphCredsTest(t *testing.T, tier string, privateKey string, verifyErr
 		}
 		return out, nil
 	}
-	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
-		out := make([]*fleet.MicrosoftGraphCredential, 0, len(env.stored))
+	ds.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
+		out := make([]*fleet.MicrosoftGraphCredentialMetadata, 0, len(env.stored))
 		for _, c := range env.stored {
-			meta := *c
-			meta.ClientSecret = "" // the metadata read never decrypts
-			out = append(out, &meta)
+			out = append(out, &c.MicrosoftGraphCredentialMetadata)
 		}
 		return out, nil
 	}
@@ -375,47 +373,45 @@ func TestListMicrosoftGraphCredentials(t *testing.T) {
 	require.Len(t, creds, 1)
 	assert.Equal(t, graphTenantA, creds[0].TenantID)
 	assert.Equal(t, graphClientA, creds[0].ClientID)
-	assert.Empty(t, creds[0].ClientSecret, "the secret is write-only and must never be returned, not even as a mask")
+	// No assertion that the secret is absent: the returned type has no field to carry one.
 	// Per-tenant status is the whole reason this endpoint exists; it is no longer on the app config.
 	assert.True(t, creds[0].CredentialInvalid)
 
 	assert.True(t, env.ds.ListMicrosoftGraphCredentialMetadataFuncInvoked,
 		"the read must go through the metadata query")
 	assert.False(t, env.ds.ListMicrosoftGraphCredentialsFuncInvoked,
-		"the read must not decrypt secrets it is about to mask")
+		"the read must not decrypt secrets it has no way to return")
 }
 
 func TestMicrosoftGraphCredentialsAuth(t *testing.T) {
 	t.Parallel()
 	env := setupGraphCredsTest(t, fleet.TierPremium, "test-private-key", nil)
 
+	// Reading a credential is held to the same roles as writing one, so a single expectation covers both calls.
 	for _, tc := range []struct {
-		name            string
-		user            *fleet.User
-		shouldFailWrite bool
-		shouldFailRead  bool
+		name       string
+		user       *fleet.User
+		shouldFail bool
 	}{
-		{"global admin", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, false, false},
-		{"global gitops", &fleet.User{GlobalRole: new(fleet.RoleGitOps)}, false, false},
-		{"global maintainer", &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}, true, false},
-		{"global observer", &fleet.User{GlobalRole: new(fleet.RoleObserver)}, true, false},
-		{"team admin", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}}, true, false},
-		{"team observer", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}}, true, false},
-		// Every authenticated role may read the config, so an anonymous caller is the only case that distinguishes
-		// "read is authorized" from "read skips authorization entirely".
-		{"no user", nil, true, true},
+		{"global admin", &fleet.User{GlobalRole: new(fleet.RoleAdmin)}, false},
+		{"global gitops", &fleet.User{GlobalRole: new(fleet.RoleGitOps)}, false},
+		{"global maintainer", &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}, true},
+		{"global observer", &fleet.User{GlobalRole: new(fleet.RoleObserver)}, true},
+		{"team admin", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}}, true},
+		{"team observer", &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}}, true},
+		{"no user", nil, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := viewer.NewContext(env.ctx, viewer.Viewer{User: tc.user})
 
 			_, err := env.svc.ListMicrosoftGraphCredentials(ctx)
-			checkAuthErr(t, tc.shouldFailRead, err)
+			checkAuthErr(t, tc.shouldFail, err)
 
 			// A dry run exercises the authorization check without depending on the datastore mocks.
 			err = env.svc.ApplyMicrosoftGraphCredentials(ctx, []fleet.MicrosoftGraphCredential{
 				{TenantID: graphTenantA, ClientID: graphClientA, ClientSecret: "secret-a"},
 			}, true)
-			checkAuthErr(t, tc.shouldFailWrite, err)
+			checkAuthErr(t, tc.shouldFail, err)
 		})
 	}
 }

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -122,7 +122,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 			}
 		}
 		if mockDS.ListMicrosoftGraphCredentialMetadataFunc == nil {
-			mockDS.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+			mockDS.ListMicrosoftGraphCredentialMetadataFunc = func(ctx context.Context) ([]*fleet.MicrosoftGraphCredentialMetadata, error) {
 				return nil, nil
 			}
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/security/issues/44

Unreleased bug:
- Increased authz requirement to admin/gitops for Microsoft Graph
- Created a separate type for Microsoft Graph without a secret, so it is impossible to leak the secret.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Microsoft Graph credential listings now return non-secret metadata only; client secrets are no longer exposed in read responses.
  * Client secrets remain write-only when credentials are configured.

* **Access Control**
  * Added dedicated permissions for reading and updating Microsoft Graph credentials.
  * Global administrators and GitOps roles can manage these credentials.

* **GitOps**
  * GitOps credential generation now handles metadata-only responses and preserves secure secret handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->