### PR TITLE
Docs: Document skipped_install on host software responses (#52297)

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5417,6 +5417,8 @@ Currently, `hash_sha256`, `executable_sha256`, and `executable_path` are only su
 
 `software_package.has_uninstall_script` is `true` when the installer has a non-empty uninstall script configured. It's omitted for VPP and in-house apps. For `.tgz` and script-only (`.ps1`/`.sh`/`.py`) packages the uninstall script is optional, so this field is what tells clients whether uninstall is actually available.
 
+`skipped_install` is `true` when the last install was a patch-when-closed skip (the target app was open). `status` is `failed_install` in that case; the field distinguishes a deferred install from a real failure. Omitted otherwise.
+
 #### Example
 
 `GET /api/v1/fleet/hosts/123/software`
@@ -5509,6 +5511,8 @@ On Windows hosts, `last_opened_at` is supported for software from the `programs`
 Currently, `hash_sha256`, `executable_sha256`, and `executable_path` are only supported for macOS software from the `apps` source. `hash_sha256` is the [`cdhash_sha256`](https://fleetdm.com/tables/codesign).
 
 `software_package.has_uninstall_script` is `true` when the installer has a non-empty uninstall script configured. It's omitted for VPP and in-house apps. For `.tgz` and script-only (`.ps1`/`.sh`/`.py`) packages the uninstall script is optional, so this field is what tells clients whether uninstall is actually available.
+
+`skipped_install` is `true` when the last install was a patch-when-closed skip (the target app was open). `status` is `failed_install` in that case; the field distinguishes a deferred install from a real failure. Omitted otherwise.
 
 #### Example
 


### PR DESCRIPTION
## Issue
Companion docs PR for #52297. Feature PR: #52567.

## Description
- Adds a short note on both `GET /hosts/:id/software` and `GET /device/:token/software` explaining the new `skipped_install` boolean. The field is `true` when the last install was a patch-when-closed skip (target app was open); `status` is `failed_install` in that case, and clients can key on the boolean to distinguish a deferred install from a real failure.
- Docs-only, no code changes.

## Screenrecording



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually