### PR TITLE
Fix custom host vital height on host details

### DIFF
--- a/changes/51096-custom-host-vital-height
+++ b/changes/51096-custom-host-vital-height
@@ -1,0 +1,1 @@
+* Fixed custom host vitals rendering taller than other host vitals on the host details page.

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -123,6 +123,11 @@
     display: inline-flex;
     align-items: center;
     gap: $pad-xsmall;
+
+    // Cancel the pencil icon's vertical padding to keep the custom vital aligned with the rest of the grid.
+    .button {
+      margin-block: -$pad-xsmall;
+    }
   }
 
   .text-muted {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51096

The pencil button in a custom host vital's label is taller than the label's line box, which stretched the row and left custom vitals misaligned against every other vital on the host details page.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

#### Before

"Custom vital" and "zzzvital" misaligned

<img width="864" height="440" alt="Screenshot 2026-09-04 at 1 39 12 PM" src="https://github.com/user-attachments/assets/f7963c3d-26c2-4eb7-9b14-371d26ae1de9" />


#### After

"Custom vital" and "zzzvital" now aligned

<img width="857" height="414" alt="Screenshot 2026-09-04 at 1 40 36 PM" src="https://github.com/user-attachments/assets/7ff0b7f4-3b22-44bb-960c-8cc34681d6f4" />


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed custom vitals on the host details page appearing taller than other vitals.
  - Improved alignment of the edit icon and custom vital titles within the vitals grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->