### PR TITLE
Show tooltip for truncated labels in hosts filter dropdown

### DIFF
--- a/changes/50799-label-filter-truncated-tooltip
+++ b/changes/50799-label-filter-truncated-tooltip
@@ -1,0 +1,1 @@
+* Added a tooltip showing the full label name when labels are truncated in the "Filter by platform or label" dropdown on the Hosts page.

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tests.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { renderWithSetup } from "test/test-utils";
+import { createMockLabel } from "__mocks__/labelsMock";
+import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
+
+import LabelFilterSelect from "./LabelFilterSelect";
+
+jest.mock("hooks/useCheckTruncatedElement", () => ({
+  useCheckTruncatedElement: jest.fn(),
+}));
+
+const mockedUseCheckTruncatedElement = useCheckTruncatedElement as jest.Mock;
+
+const LONG_LABEL_NAME =
+  "A very long custom label name that will not fit inside the dropdown";
+
+const defaultProps = {
+  labels: [
+    createMockLabel({
+      id: 42,
+      label_type: "regular",
+      name: LONG_LABEL_NAME,
+      display_text: LONG_LABEL_NAME,
+    }),
+  ],
+  selectedLabel: null,
+  canAddNewLabels: true,
+  onChange: jest.fn(),
+  onAddLabel: jest.fn(),
+};
+
+const openMenu = async (user: ReturnType<typeof renderWithSetup>["user"]) => {
+  await user.click(screen.getByText("Filter by platform or label"));
+};
+
+describe("LabelFilterSelect", () => {
+  beforeEach(() => {
+    mockedUseCheckTruncatedElement.mockReturnValue(false);
+  });
+
+  it("shows a tooltip with the full name when a label option is truncated", async () => {
+    mockedUseCheckTruncatedElement.mockReturnValue(true);
+    const { user } = renderWithSetup(<LabelFilterSelect {...defaultProps} />);
+
+    await openMenu(user);
+    await user.hover(screen.getByText(LONG_LABEL_NAME));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      LONG_LABEL_NAME
+    );
+  });
+
+  it("does not show a tooltip when a label option is not truncated", async () => {
+    const { user } = renderWithSetup(<LabelFilterSelect {...defaultProps} />);
+
+    await openMenu(user);
+    await user.hover(screen.getByText(LONG_LABEL_NAME));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -16,6 +16,7 @@ import {
 } from "utilities/constants";
 import Icon from "components/Icon";
 import Spinner from "components/Spinner";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 
 import CustomLabelGroupHeading from "../CustomLabelGroupHeading";
 import { createDropdownOptions, IEmptyOption, IGroupOption } from "./helpers";
@@ -67,7 +68,11 @@ const formatOptionLabel = (data: ILabel | IEmptyOption) => {
           className="option-icon"
         />
       )}
-      <span>{displayText}</span>
+      <TooltipTruncatedText
+        className="option-label__text"
+        value={displayText}
+        fixedPositionStrategy
+      />
     </div>
   );
 };

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -130,10 +130,8 @@
     &--is-selected {
       background-color: transparent;
 
-      .option-label {
-        span {
-          font-weight: $bold;
-        }
+      .option-label__text {
+        font-weight: $bold;
       }
     }
 
@@ -162,18 +160,25 @@
   .option-label {
     display: flex;
     align-items: center;
-
-    span {
-      font-size: $x-small;
-      font-weight: $regular;
-      color: $core-fleet-black;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+    min-width: 0;
 
     .option-icon {
+      flex-shrink: 0;
       margin-right: $pad-small;
+    }
+  }
+
+  .option-label__text {
+    min-width: 0;
+    font-size: $x-small;
+    font-weight: $regular;
+    color: $core-fleet-black;
+
+    // TooltipWrapper has `cursor: default` on its element, which sits
+    // below the pointer the option row and the closed control set on hover.
+    // Inherit so the text defers to whichever surface it is rendered in.
+    .component__tooltip-wrapper__element {
+      cursor: inherit;
     }
   }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50799

Long label names are truncated in the "Filter by platform or label" dropdown with no tooltip, so labels that differ only past the truncation point can't be told apart.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<img width="311" height="616" alt="Screenshot 2026-09-04 at 2 10 35 PM" src="https://github.com/user-attachments/assets/d4eca5e5-416f-486e-986a-b3d46af2a5d7" />


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooltips showing the full label name when labels are truncated in the Hosts page’s platform or label filter dropdown.

- **Bug Fixes**
  - Improved label option layout and text handling so long labels display correctly while preserving selection styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->