### PR TITLE
Website: update labels on search bars on docs and article pages

### DIFF
--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -84,7 +84,7 @@ parasails.registerComponent('docsNavAndSearch', {
         policies: 'Search policies',
         tables: 'Search data tables',
         controls: 'Search controls'
-      }
+      };
       if(!searchIndexesThatExist.includes(this.searchFilter)){
         throw new Error(`Invalid 'searchFilter' value provided to <docs-nav-and-search> component. Please change the searchFilter value to one of: ${searchIndexesThatExist.join(', ')}`);
       }

--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -75,13 +75,23 @@ parasails.registerComponent('docsNavAndSearch', {
   mounted: async function() {
     let filterForSearch = {};
     if(this.searchFilter){
-      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'handbook', 'controls'];
+      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'controls'];
+      let buttonTextBySearchFilter = {
+        docs: 'Search the docs',
+        software: 'Search software',
+        queries: 'Search reports',
+        vitals: 'Search vitals',
+        policies: 'Search policies',
+        tables: 'Search data tables',
+        controls: 'Search controls'
+      }
       if(!searchIndexesThatExist.includes(this.searchFilter)){
         throw new Error(`Invalid 'searchFilter' value provided to <docs-nav-and-search> component. Please change the searchFilter value to one of: ${searchIndexesThatExist.join(', ')}`);
       }
       filterForSearch = {
         'facetFilters': [`section:${this.searchFilter}`]
       };
+      this.searchBoxLabel = buttonTextBySearchFilter[this.searchFilter];
     }
     if(this.algoliaPublicKey) {
       docsearch({
@@ -89,9 +99,15 @@ parasails.registerComponent('docsNavAndSearch', {
         apiKey: this.algoliaPublicKey,
         indexName: 'fleetdm',
         container: '#docsearch-query',
-        placeholder: 'Search',
+        placeholder: this.searchBoxLabel,
         debug: false,
         searchParameters: filterForSearch,
+        translations: {
+          button: {
+            buttonText: this.searchBoxLabel,
+            buttonAriaLabel: this.searchBoxLabel,
+          },
+        },
       });
     }
   },

--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -77,11 +77,17 @@ parasails.registerPage('articles', {
           apiKey: this.algoliaPublicKey,
           indexName: 'fleetdm',
           container: '#docsearch-query',
-          placeholder: 'Search',
+          placeholder: 'Search articles',
           debug: false,
           clickAnalytics: true,
           searchParameters: {
             facetFilters: ['section:articles']
+          },
+          translations: {
+            button: {
+              buttonText: 'Search articles',
+              buttonAriaLabel: 'Search articles',
+            },
           },
         });
       }

--- a/website/assets/js/pages/articles/basic-article.page.js
+++ b/website/assets/js/pages/articles/basic-article.page.js
@@ -103,11 +103,17 @@ parasails.registerPage('basic-article', {
         apiKey: this.algoliaPublicKey,
         indexName: 'fleetdm',
         container: '#docsearch-query',
-        placeholder: 'Search',
+        placeholder: 'Search articles',
         debug: false,
         clickAnalytics: true,
         searchParameters: {
           facetFilters: ['section:articles']
+        },
+        translations: {
+          button: {
+            buttonText: 'Search articles',
+            buttonAriaLabel: 'Search articles',
+          },
         },
       });
       // For mobile search
@@ -116,11 +122,17 @@ parasails.registerPage('basic-article', {
         apiKey: this.algoliaPublicKey,
         indexName: 'fleetdm',
         container: '#mobile-docsearch',
-        placeholder: 'Search',
+        placeholder: 'Search articles',
         debug: false,
         clickAnalytics: true,
         searchParameters: {
           facetFilters: ['section:articles']
+        },
+        translations: {
+          button: {
+            buttonText: 'Search articles',
+            buttonAriaLabel: 'Search articles',
+          },
         },
       });
     }

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -19,7 +19,7 @@
             </div>
             <div class="form-control border-0 ">
             <input class="docsearch-input pr-1"
-              placeholder="Search" aria-label="Search the handbook"
+              placeholder="Search" aria-label="Search"
               />
             </div>
           </div>


### PR DESCRIPTION
Related to: #52383

Changes:
- Updated the docs-nav-and-search component to set a label on the search bar on documentation pages.
- Updated the search bar on article pages to say "Search articles"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated search placeholders and accessible labels to clearly identify when users are searching articles.
  * Improved consistency between search field text and search button labels across desktop and mobile views.

* **User Interface**
  * Updated handbook search wording to use the simpler “Search” label.
  * Search controls now display context-appropriate text based on the selected search area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->