### PR TITLE
Fix misaligned status icon in policy results table

### DIFF
--- a/changes/49964-policy-results-status-alignment
+++ b/changes/49964-policy-results-status-alignment
@@ -1,0 +1,1 @@
+* Fixed the vertically misaligned pass/fail status icon in the policy results table when running a live policy query.

--- a/frontend/pages/policies/edit/components/PolicyResultsTable/PolicyResultsTableConfig.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResultsTable/PolicyResultsTableConfig.tsx
@@ -6,7 +6,7 @@ import { memoize } from "lodash";
 
 import { ColumnInstance } from "react-table";
 
-import Icon from "components/Icon/Icon";
+import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 
@@ -66,21 +66,12 @@ const generateTableHeaders = (): IDataColumn[] => {
       disableSortBy: false,
       sortType: "hasLength",
       accessor: "query_results",
-      Cell: (cellProps: ICellProps): JSX.Element => (
-        <>
-          {cellProps.cell.value.length ? (
-            <>
-              <Icon name="success" />
-              <span className="status-header-text">Pass</span>
-            </>
-          ) : (
-            <>
-              <Icon name="error" />
-              <span className="status-header-text">Fail</span>
-            </>
-          )}
-        </>
-      ),
+      Cell: (cellProps: ICellProps): JSX.Element =>
+        cellProps.cell.value.length ? (
+          <StatusIndicatorWithIcon status="success" value="Pass" />
+        ) : (
+          <StatusIndicatorWithIcon status="error" value="Fail" />
+        ),
     },
   ];
   return tableHeaders;

--- a/frontend/pages/policies/edit/components/PolicyResultsTable/_styles.scss
+++ b/frontend/pages/policies/edit/components/PolicyResultsTable/_styles.scss
@@ -41,11 +41,6 @@
         padding-right: 4px;
       }
     }
-    .query_results__cell {
-      .status-header-text {
-        margin-left: 10px;
-      }
-    }
   }
 
   &__empty-table {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49964

The pass/fail icon in the policy results table sits on the text baseline instead of being centered against its label, so the status reads as visibly misaligned after a live policy run.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually

#### Before

<img width="1120" height="514" alt="Screenshot 2026-09-04 at 2 40 38 PM" src="https://github.com/user-attachments/assets/5ee3c0e5-5dfe-45c1-ad0e-2dfb3e296e80" />

#### After

<img width="996" height="472" alt="Screenshot 2026-09-04 at 2 46 58 PM" src="https://github.com/user-attachments/assets/2f278af4-ae79-435c-b402-b9323065f9a7" />


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed vertical alignment of Pass/Fail status indicators in the policy results table during live policy queries.
  - Updated status displays for a more consistent appearance across policy results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->