### PR TITLE
Docs: clarify that SCIM deprovisioning deletes the Fleet user

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -485,7 +485,7 @@ This activity contains the following fields:
 
 ## deleted_user
 
-Generated when a user is deleted.
+Generated when a user is deleted. An admin can delete the user, or SCIM can deprovision one that was deleted or deactivated in the IdP. For a SCIM deprovisioning, Fleet is the author of the activity rather than a Fleet user.
 
 This activity contains the following fields:
 - "user_id": Unique ID of the deleted user in Fleet.

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -295,6 +295,12 @@ If the user is later reactivated in the IdP, Fleet will automatically recreate t
 
 No manual intervention is required. This applies only to SSO-authenticated users. API-only and password-authenticated users are not affected.
 
+Fleet deletes the account instead of marking it inactive. Fleet has no deactivated user state, so a deprovisioned user no longer appears in **Settings > Users** or in the response from the [list users](https://fleetdm.com/docs/rest-api/rest-api#list-users) endpoint.
+
+Fleet records each deprovisioning as a `deleted_user` activity in the [audit log](https://fleetdm.com/docs/using-fleet/audit-logs). Fleet is the author of this activity, not the admin who configured SCIM.
+
+Using a compliance tool that reviews access by reading Fleet's user list? Treat a user's absence from the list as deprovisioning. The audit log has the record of when it happened.
+
 
 ## Email two-factor authentication (2FA)
 


### PR DESCRIPTION
Fleet has no deactivated user state. SCIM deactivation and deletion both hard-delete the Fleet user, so a deprovisioned user disappears from the users list rather than appearing as deactivated. The deprovisioning record is the deleted_user activity, whose author is Fleet.

Documents existing behavior. Resolves #45371.
