### PR TITLE
Document the Android-only host vitals in the REST API reference

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4625,6 +4625,206 @@ Returns the information of the specified host.
 }
 ```
 
+#### Example (Android)
+`GET /api/v1/fleet/hosts/121`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "host": {
+    "created_at": "2021-08-19T02:02:22Z",
+    "updated_at": "2021-08-19T21:14:58Z",
+    "id": 1,
+    "detail_updated_at": "2021-08-19T21:07:53Z",
+    "last_restarted_at": "0001-01-01T00:00:00Z",
+    "software_updated_at": "2020-11-05T05:09:44Z",
+    "label_updated_at": "2021-08-19T21:07:53Z",
+    "policy_updated_at": "2023-06-26T18:33:15Z",
+    "last_enrolled_at": "2021-08-19T02:02:22Z",
+    "last_mdm_checked_in_at": "2023-02-26T22:33:12Z",
+    "last_mdm_enrolled_at": "2023-02-26T22:33:12Z",
+    "mdm_enrollment_hardware_attested": false,
+    "seen_time": "2021-08-19T21:14:58Z",
+    "refetch_requested": false,
+    "hostname": "Anna's Google Pixel 9",
+    "uuid": "309a4b7d-0000-0000-8e7f-26ae0815ede8",
+    "platform": "android",
+    "osquery_version": "",
+    "orbit_version": null,
+    "fleet_desktop_version": null,
+    "scripts_enabled": null,
+    "os_version": "Android 16 (2026-05-01)",
+    "build": "",
+    "platform_like": "",
+    "code_name": "",
+    "uptime": 0,
+    "memory": 8589934592,
+    "cpu_type": "",
+    "cpu_subtype": "",
+    "cpu_brand": "",
+    "cpu_physical_cores": 0,
+    "cpu_logical_cores": 0,
+    "hardware_vendor": "google",
+    "hardware_model": "Google Pixel 9",
+    "hardware_version": "",
+    "hardware_serial": "3B241102E5",
+    "computer_name": "Anna's Google Pixel 9",
+    "timezone": null,
+    "display_name": "Anna's Google Pixel 9",
+    "public_ip": "",
+    "primary_ip": "",
+    "primary_mac": "",
+    "distributed_interval": 0,
+    "config_tls_refresh": 0,
+    "logger_tls_period": 0,
+    "team_id": null,
+    "fleet_id": null,
+    "pack_stats": null,
+    "team_name": null,
+    "fleet_name": null,
+    "gigs_disk_space_available": 92.4,
+    "percent_disk_space_available": 72,
+    "gigs_total_disk_space": 128,
+    "adb_enabled": false,
+    "api_level": 36,
+    "bootloader_version": "caiman-1.0-13984080",
+    "device_kernel_version": "6.1.124-android16-11-g8b6a1e0f4f9a-ab13984080",
+    "encryption_type": "ACTIVE",
+    "imei": "351756051523999",
+    "manufacturer": "Google",
+    "passcode_protected": true,
+    "play_protect_enabled": true,
+    "security_posture": "AT_RISK",
+    "security_posture_details": [
+      {
+        "security_risk": "UNKNOWN_OS",
+        "advice": [
+          "This device is running an unrecognized version of Android. Install a certified build from the device manufacturer."
+        ]
+      }
+    ],
+    "security_update_version": "2026-05-01",
+    "system_update_status": "UP_TO_DATE",
+    "telephony_infos": [
+      {
+        "phone_number": "+1-123-456-7890",
+        "carrier_name": "Verizon",
+        "iccid": "89014103211118510720",
+        "activation_state": "ACTIVATED",
+        "config_mode": "ADMIN_CONFIGURED"
+      }
+    ],
+    "status": "online",
+    "display_text": "Anna's Google Pixel 9",
+    "issues": {
+      "failing_policies_count": 0,
+      "critical_vulnerabilities_count": 0, // Available in Fleet Premium
+      "total_issues_count": 0
+    },
+    "geolocation": {
+      "country_iso": "US",
+      "city_name": "New York",
+      "geometry": {
+        "type": "point",
+        "coordinates": [40.6799, -74.0028]
+      }
+    },
+    "end_users": [
+      {
+        "idp_info_updated_at": "2025-03-20T02:02:17Z",
+        "idp_id": "f26f8649-1e25-42c5-be71-1b1e6de56d3d",
+        "idp_username": "anna@example.com",
+        "idp_full_name": "Anna Chao",
+        "idp_department": "Product",
+        "idp_groups": [
+          "Product",
+          "Designers"
+        ],
+        "other_emails": []
+      }
+    ],
+    "labels": [
+      {
+        "created_at": "2021-08-19T02:02:17Z",
+        "updated_at": "2021-08-19T02:02:17Z",
+        "id": 6,
+        "name": "All Hosts",
+        "description": "All hosts which have enrolled in Fleet",
+        "query": "SELECT 1;",
+        "platform": "",
+        "label_type": "builtin",
+        "label_membership_type": "dynamic"
+      },
+      {
+        "created_at": "2021-08-19T02:02:17Z",
+        "updated_at": "2021-08-19T02:02:17Z",
+        "id": 14,
+        "name": "Android",
+        "description": "All Android hosts",
+        "query": "",
+        "platform": "android",
+        "label_type": "builtin",
+        "label_membership_type": "manual"
+      }
+    ],
+    "packs": [],
+    "policies": [],
+    "software": [
+      {
+        "id": 411,
+        "name": "Gmail",
+        "version": "2026.05.04.123456789",
+        "source": "android_apps",
+        "application_id": "com.google.android.gm",
+        "generated_cpe": "",
+        "vulnerabilities": null,
+        "installed_paths": []
+      },
+      {
+        "id": 412,
+        "name": "Slack",
+        "version": "26.05.10.0",
+        "source": "android_apps",
+        "application_id": "com.Slack",
+        "generated_cpe": "",
+        "vulnerabilities": null,
+        "installed_paths": []
+      }
+    ],
+    "mdm": {
+      "encryption_key_available": false,
+      "enrollment_status": "On (automatic)",
+      "is_personal_enrollment": false,
+      "name": "Fleet",
+      "connected_to_fleet": true,
+      "server_url": "https://acme.com",
+      "device_status": "unlocked",
+      "pending_action": "",
+      "os_settings": {
+        "disk_encryption": {
+          "status": null,
+          "detail": ""
+        }
+      },
+      "profiles": [
+        {
+          "profile_uuid": "g954ec5ea-a334-4825-87b3-937e7e381f24",
+          "name": "Android Wi-Fi Profile",
+          "status": "verified",
+          "operation_type": "install",
+          "scope": null,
+          "managed_local_account": null,
+          "detail": ""
+        }
+      ]
+    }
+  }
+}
+```
+
 `mdm.os_settings.host_name` reports the host name template enforcement status for a macOS, iOS, or iPadOS host. Its `status` is one of `pending`, `verifying`, `verified`, or `failed`, and `detail` carries the error message when the status is `failed`. The object is omitted entirely for hosts that aren't enforced (no template set on the host's fleet or on "Unassigned", non-MDM hosts, and personal (BYOD) enrollments).
 
 `mdm.bootstrap_token_escrowed` indicates whether Fleet has escrowed a [bootstrap token](https://support.apple.com/guide/deployment/use-secure-and-bootstrap-tokens-dep24dbdcf9e/web) for the macOS host. The bootstrap token authorizes certain MDM operations, such as remote wipe and installing OS updates, without requiring a user with a secure token to be logged in. This field is only present for macOS hosts.
@@ -4641,6 +4841,11 @@ Returns the information of the specified host.
 > - These iOS/iPadOS vitals are collected via Apple's [`DeviceInformation`](https://developer.apple.com/documentation/devicemanagement/deviceinformationcommand/command-data.dictionary/queries-data.dictionary) MDM command. A property the device doesn't report is omitted from the response rather than returned as `null`. The exception is `mdm_options`, which is returned as an empty object when the device reports it with nothing set.
 > - `cellular_technology` is one of `None`, `GSM`, `CDMA`, or `GSM and CDMA`. This will be `unknown` if Apple adds a value in the future that Fleet doesn't recognize.
 > - `device_properties_attestation` is an array of base64-encoded DER certificates forming a chain, leaf first. The chain is anchored to Apple's Enterprise Attestation Root CA, which is not itself included in the array.
+> - Currently, the following are supported only for Android: `adb_enabled`, `api_level`, `bootloader_version`, `device_kernel_version`, `encryption_type`, `imei`, `manufacturer`, `meid`, `passcode_protected`, `play_protect_enabled`, `security_posture`, `security_posture_details`, `security_update_version`, `system_update_status`, and `telephony_infos`.
+> - These Android vitals are collected from the status reports Fleet receives from the [Android Management API](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices) (AMAPI). A vital the device doesn't report is omitted from the response rather than returned as `null`, and a whole group of them is missing unless the policy applied to the host turns on the matching status reporting setting: `deviceSettings` for `adb_enabled`, `encryption_type`, `passcode_protected`, and `play_protect_enabled`, and `securityPosture` for `security_posture` and `security_posture_details`.
+> - `telephony_infos`, `imei`, and `meid` are only returned for company-owned (fully managed) hosts, never for personal (BYOD) enrollments. `telephony_infos` holds one entry per SIM card, so a dual-SIM host reports more than one, and its `activation_state` and `config_mode` describe eSIMs on Android 15 and above only. A host reports either `imei` or `meid` depending on its radio, never both.
+> - `encryption_type`, `security_posture`, `system_update_status`, `security_posture_details[].security_risk`, `telephony_infos[].activation_state`, and `telephony_infos[].config_mode` carry AMAPI's raw enum values, such as `ACTIVE`, `AT_RISK`, `UP_TO_DATE`, `UNKNOWN_OS`, `ACTIVATED`, and `ADMIN_CONFIGURED`. AMAPI's "no data" sentinels (`*_UNSPECIFIED` and `UPDATE_STATUS_UNKNOWN`) are omitted from the response instead of being returned.
+> - `security_update_version` is the host's Android security patch level. It's also folded into `os_version`, for example `Android 16 (2026-05-01)`.
 
 > Note:
 > - `orbit_version: null` means this agent is not a fleetd agent
@@ -5170,6 +5375,206 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
 }
 ```
 
+#### Example (Android)
+`GET /api/v1/fleet/hosts/identifier/392547dc-0000-0000-a87a-d701ff75bc65`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "host": {
+    "created_at": "2021-08-19T02:02:22Z",
+    "updated_at": "2021-08-19T21:14:58Z",
+    "id": 1,
+    "detail_updated_at": "2021-08-19T21:07:53Z",
+    "last_restarted_at": "0001-01-01T00:00:00Z",
+    "software_updated_at": "2020-11-05T05:09:44Z",
+    "label_updated_at": "2021-08-19T21:07:53Z",
+    "policy_updated_at": "2023-06-26T18:33:15Z",
+    "last_enrolled_at": "2021-08-19T02:02:22Z",
+    "last_mdm_checked_in_at": "2023-02-26T22:33:12Z",
+    "last_mdm_enrolled_at": "2023-02-26T22:33:12Z",
+    "mdm_enrollment_hardware_attested": false,
+    "seen_time": "2021-08-19T21:14:58Z",
+    "refetch_requested": false,
+    "hostname": "Anna's Google Pixel 9",
+    "uuid": "309a4b7d-0000-0000-8e7f-26ae0815ede8",
+    "platform": "android",
+    "osquery_version": "",
+    "orbit_version": null,
+    "fleet_desktop_version": null,
+    "scripts_enabled": null,
+    "os_version": "Android 16 (2026-05-01)",
+    "build": "",
+    "platform_like": "",
+    "code_name": "",
+    "uptime": 0,
+    "memory": 8589934592,
+    "cpu_type": "",
+    "cpu_subtype": "",
+    "cpu_brand": "",
+    "cpu_physical_cores": 0,
+    "cpu_logical_cores": 0,
+    "hardware_vendor": "google",
+    "hardware_model": "Google Pixel 9",
+    "hardware_version": "",
+    "hardware_serial": "3B241102E5",
+    "computer_name": "Anna's Google Pixel 9",
+    "timezone": null,
+    "display_name": "Anna's Google Pixel 9",
+    "public_ip": "",
+    "primary_ip": "",
+    "primary_mac": "",
+    "distributed_interval": 0,
+    "config_tls_refresh": 0,
+    "logger_tls_period": 0,
+    "team_id": null,
+    "fleet_id": null,
+    "pack_stats": null,
+    "team_name": null,
+    "fleet_name": null,
+    "gigs_disk_space_available": 92.4,
+    "percent_disk_space_available": 72,
+    "gigs_total_disk_space": 128,
+    "adb_enabled": false,
+    "api_level": 36,
+    "bootloader_version": "caiman-1.0-13984080",
+    "device_kernel_version": "6.1.124-android16-11-g8b6a1e0f4f9a-ab13984080",
+    "encryption_type": "ACTIVE",
+    "imei": "351756051523999",
+    "manufacturer": "Google",
+    "passcode_protected": true,
+    "play_protect_enabled": true,
+    "security_posture": "AT_RISK",
+    "security_posture_details": [
+      {
+        "security_risk": "UNKNOWN_OS",
+        "advice": [
+          "This device is running an unrecognized version of Android. Install a certified build from the device manufacturer."
+        ]
+      }
+    ],
+    "security_update_version": "2026-05-01",
+    "system_update_status": "UP_TO_DATE",
+    "telephony_infos": [
+      {
+        "phone_number": "+1-123-456-7890",
+        "carrier_name": "Verizon",
+        "iccid": "89014103211118510720",
+        "activation_state": "ACTIVATED",
+        "config_mode": "ADMIN_CONFIGURED"
+      }
+    ],
+    "status": "online",
+    "display_text": "Anna's Google Pixel 9",
+    "issues": {
+      "failing_policies_count": 0,
+      "critical_vulnerabilities_count": 0, // Available in Fleet Premium
+      "total_issues_count": 0
+    },
+    "geolocation": {
+      "country_iso": "US",
+      "city_name": "New York",
+      "geometry": {
+        "type": "point",
+        "coordinates": [40.6799, -74.0028]
+      }
+    },
+    "end_users": [
+      {
+        "idp_info_updated_at": "2025-03-20T02:02:17Z",
+        "idp_id": "f26f8649-1e25-42c5-be71-1b1e6de56d3d",
+        "idp_username": "anna@example.com",
+        "idp_full_name": "Anna Chao",
+        "idp_department": "Product",
+        "idp_groups": [
+          "Product",
+          "Designers"
+        ],
+        "other_emails": []
+      }
+    ],
+    "labels": [
+      {
+        "created_at": "2021-08-19T02:02:17Z",
+        "updated_at": "2021-08-19T02:02:17Z",
+        "id": 6,
+        "name": "All Hosts",
+        "description": "All hosts which have enrolled in Fleet",
+        "query": "SELECT 1;",
+        "platform": "",
+        "label_type": "builtin",
+        "label_membership_type": "dynamic"
+      },
+      {
+        "created_at": "2021-08-19T02:02:17Z",
+        "updated_at": "2021-08-19T02:02:17Z",
+        "id": 14,
+        "name": "Android",
+        "description": "All Android hosts",
+        "query": "",
+        "platform": "android",
+        "label_type": "builtin",
+        "label_membership_type": "manual"
+      }
+    ],
+    "packs": [],
+    "policies": [],
+    "software": [
+      {
+        "id": 411,
+        "name": "Gmail",
+        "version": "2026.05.04.123456789",
+        "source": "android_apps",
+        "application_id": "com.google.android.gm",
+        "generated_cpe": "",
+        "vulnerabilities": null,
+        "installed_paths": []
+      },
+      {
+        "id": 412,
+        "name": "Slack",
+        "version": "26.05.10.0",
+        "source": "android_apps",
+        "application_id": "com.Slack",
+        "generated_cpe": "",
+        "vulnerabilities": null,
+        "installed_paths": []
+      }
+    ],
+    "mdm": {
+      "encryption_key_available": false,
+      "enrollment_status": "On (automatic)",
+      "is_personal_enrollment": false,
+      "name": "Fleet",
+      "connected_to_fleet": true,
+      "server_url": "https://acme.com",
+      "device_status": "unlocked",
+      "pending_action": "",
+      "os_settings": {
+        "disk_encryption": {
+          "status": null,
+          "detail": ""
+        }
+      },
+      "profiles": [
+        {
+          "profile_uuid": "g954ec5ea-a334-4825-87b3-937e7e381f24",
+          "name": "Android Wi-Fi Profile",
+          "status": "verified",
+          "operation_type": "install",
+          "scope": null,
+          "managed_local_account": null,
+          "detail": ""
+        }
+      ]
+    }
+  }
+}
+```
+
 > Note: the response above assumes a [GeoIP database is configured](https://fleetdm.com/docs/deploying/configuration#geoip), otherwise the `geolocation` object won't be included.
 
 > Note: `installed_paths` may be blank depending on installer package. For example, on Linux, RPM-installed packages do not provide installed path information.
@@ -5180,6 +5585,11 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
 > - These iOS/iPadOS vitals are collected via Apple's [`DeviceInformation`](https://developer.apple.com/documentation/devicemanagement/deviceinformationcommand/command-data.dictionary/queries-data.dictionary) MDM command. A property the device doesn't report is omitted from the response rather than returned as `null`. The exception is `mdm_options`, which is returned as an empty object when the device reports it with nothing set.
 > - `cellular_technology` is one of `None`, `GSM`, `CDMA`, or `GSM and CDMA`. This will be `unknown` if Apple adds a value in the future that Fleet doesn't recognize.
 > - `device_properties_attestation` is an array of base64-encoded DER certificates forming a chain, leaf first. The chain is anchored to Apple's Enterprise Attestation Root CA, which is not itself included in the array.
+> - Currently, the following are supported only for Android: `adb_enabled`, `api_level`, `bootloader_version`, `device_kernel_version`, `encryption_type`, `imei`, `manufacturer`, `meid`, `passcode_protected`, `play_protect_enabled`, `security_posture`, `security_posture_details`, `security_update_version`, `system_update_status`, and `telephony_infos`.
+> - These Android vitals are collected from the status reports Fleet receives from the [Android Management API](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices) (AMAPI). A vital the device doesn't report is omitted from the response rather than returned as `null`, and a whole group of them is missing unless the policy applied to the host turns on the matching status reporting setting: `deviceSettings` for `adb_enabled`, `encryption_type`, `passcode_protected`, and `play_protect_enabled`, and `securityPosture` for `security_posture` and `security_posture_details`.
+> - `telephony_infos`, `imei`, and `meid` are only returned for company-owned (fully managed) hosts, never for personal (BYOD) enrollments. `telephony_infos` holds one entry per SIM card, so a dual-SIM host reports more than one, and its `activation_state` and `config_mode` describe eSIMs on Android 15 and above only. A host reports either `imei` or `meid` depending on its radio, never both.
+> - `encryption_type`, `security_posture`, `system_update_status`, `security_posture_details[].security_risk`, `telephony_infos[].activation_state`, and `telephony_infos[].config_mode` carry AMAPI's raw enum values, such as `ACTIVE`, `AT_RISK`, `UP_TO_DATE`, `UNKNOWN_OS`, `ACTIVATED`, and `ADMIN_CONFIGURED`. AMAPI's "no data" sentinels (`*_UNSPECIFIED` and `UPDATE_STATUS_UNKNOWN`) are omitted from the response instead of being returned.
+> - `security_update_version` is the host's Android security patch level. It's also folded into `os_version`, for example `Android 16 (2026-05-01)`.
 
 
 ### Get host by Fleet Desktop token
@@ -5416,6 +5826,10 @@ X-Client-Cert-Serial: <fleet_identity_scep_cert_serial>
 `browser` and `extension_for` fields are included when set and when empty. `extension_for` will show the browser or Visual Studio Code fork associated with the extension, allowing for differentiation between e.g. an extension installed on Visual Studio Code and one installed on Cursor. `browser` is deprecated, and only shows this information for browser plugins.
 
 > `global_config.mdm.enabled_and_configured` only represents Apple MDM, and will return false if Apple MDM is not configured even if other platforms have MDM enabled and configured.
+
+> Note:
+> - For an Android host, the response also includes the Android-only vitals documented under ["Get host"](#get-host): `adb_enabled`, `api_level`, `bootloader_version`, `device_kernel_version`, `encryption_type`, `imei`, `manufacturer`, `meid`, `passcode_protected`, `play_protect_enabled`, `security_posture`, `security_posture_details`, `security_update_version`, `system_update_status`, and `telephony_infos`. They're omitted for hosts on every other platform, as is any individual vital the device hasn't reported.
+> - `telephony_infos`, `imei`, and `meid` are only returned for company-owned (fully managed) hosts, never for personal (BYOD) enrollments.
 
 ### Delete host
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4649,7 +4649,7 @@ Returns the information of the specified host.
     "mdm_enrollment_hardware_attested": false,
     "seen_time": "2021-08-19T21:14:58Z",
     "refetch_requested": false,
-    "hostname": "Anna's Google Pixel 9",
+    "hostname": "Anna Chao's Google Pixel 9",
     "uuid": "309a4b7d-0000-0000-8e7f-26ae0815ede8",
     "platform": "android",
     "osquery_version": "",
@@ -4657,12 +4657,14 @@ Returns the information of the specified host.
     "fleet_desktop_version": null,
     "scripts_enabled": null,
     "os_version": "Android 16 (2026-05-01)",
+    "os_update_minimum_version": null,
+    "os_update_deadline": null,
     "build": "",
     "platform_like": "",
     "code_name": "",
     "uptime": 0,
     "memory": 8589934592,
-    "cpu_type": "",
+    "cpu_type": "caiman",
     "cpu_subtype": "",
     "cpu_brand": "",
     "cpu_physical_cores": 0,
@@ -4671,9 +4673,9 @@ Returns the information of the specified host.
     "hardware_model": "Google Pixel 9",
     "hardware_version": "",
     "hardware_serial": "3B241102E5",
-    "computer_name": "Anna's Google Pixel 9",
+    "computer_name": "Anna Chao's Google Pixel 9",
     "timezone": null,
-    "display_name": "Anna's Google Pixel 9",
+    "display_name": "Anna Chao's Google Pixel 9",
     "public_ip": "",
     "primary_ip": "",
     "primary_mac": "",
@@ -4710,7 +4712,7 @@ Returns the information of the specified host.
     "system_update_status": "UP_TO_DATE",
     "telephony_infos": [
       {
-        "phone_number": "+1-123-456-7890",
+        "phone_number": "+15551234567",
         "carrier_name": "Verizon",
         "iccid": "89014103211118510720",
         "activation_state": "ACTIVATED",
@@ -4718,20 +4720,13 @@ Returns the information of the specified host.
       }
     ],
     "status": "online",
-    "display_text": "Anna's Google Pixel 9",
+    "display_text": "Anna Chao's Google Pixel 9",
     "issues": {
       "failing_policies_count": 0,
       "critical_vulnerabilities_count": 0, // Available in Fleet Premium
       "total_issues_count": 0
     },
-    "geolocation": {
-      "country_iso": "US",
-      "city_name": "New York",
-      "geometry": {
-        "type": "point",
-        "coordinates": [40.6799, -74.0028]
-      }
-    },
+    "batteries": [],
     "end_users": [
       {
         "idp_info_updated_at": "2025-03-20T02:02:17Z",
@@ -4842,8 +4837,9 @@ Returns the information of the specified host.
 > - `cellular_technology` is one of `None`, `GSM`, `CDMA`, or `GSM and CDMA`. This will be `unknown` if Apple adds a value in the future that Fleet doesn't recognize.
 > - `device_properties_attestation` is an array of base64-encoded DER certificates forming a chain, leaf first. The chain is anchored to Apple's Enterprise Attestation Root CA, which is not itself included in the array.
 > - Currently, the following are supported only for Android: `adb_enabled`, `api_level`, `bootloader_version`, `device_kernel_version`, `encryption_type`, `imei`, `manufacturer`, `meid`, `passcode_protected`, `play_protect_enabled`, `security_posture`, `security_posture_details`, `security_update_version`, `system_update_status`, and `telephony_infos`.
-> - These Android vitals are collected from the status reports Fleet receives from the [Android Management API](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices) (AMAPI). A vital the device doesn't report is omitted from the response rather than returned as `null`, and a whole group of them is missing unless the policy applied to the host turns on the matching status reporting setting: `deviceSettings` for `adb_enabled`, `encryption_type`, `passcode_protected`, and `play_protect_enabled`, and `securityPosture` for `security_posture` and `security_posture_details`.
-> - `telephony_infos`, `imei`, and `meid` are only returned for company-owned (fully managed) hosts, never for personal (BYOD) enrollments. `telephony_infos` holds one entry per SIM card, so a dual-SIM host reports more than one, and its `activation_state` and `config_mode` describe eSIMs on Android 15 and above only. A host reports either `imei` or `meid` depending on its radio, never both.
+> - These Android vitals are collected from the status reports Fleet receives from the [Android Management API](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices) (AMAPI). A vital the device doesn't report is omitted from the response rather than returned as `null`. A host that hasn't sent a status report yet returns none of them, and a device whose Android version doesn't report a given vital omits just that one.
+> - `telephony_infos`, `imei`, and `meid` are never returned for a personal (BYOD) enrollment. AMAPI only reports them for fully managed devices in the first place, and Fleet gates the response on its own enrollment record so they stay hidden after a BYOD host unenrolls. `telephony_infos` holds one entry per SIM card, so a dual-SIM host reports more than one, and it requires Android 6 or above. Its `activation_state` and `config_mode` describe eSIMs on Android 15 and above only. A host reports either `imei` or `meid` depending on its radio, never both.
+> - `security_posture_details[].advice` holds AMAPI's default, non-localized admin-facing message for each risk. Fleet has no device locale to select a localized variant with, so the localized messages aren't returned.
 > - `encryption_type`, `security_posture`, `system_update_status`, `security_posture_details[].security_risk`, `telephony_infos[].activation_state`, and `telephony_infos[].config_mode` carry AMAPI's raw enum values, such as `ACTIVE`, `AT_RISK`, `UP_TO_DATE`, `UNKNOWN_OS`, `ACTIVATED`, and `ADMIN_CONFIGURED`. AMAPI's "no data" sentinels (`*_UNSPECIFIED` and `UPDATE_STATUS_UNKNOWN`) are omitted from the response instead of being returned.
 > - `security_update_version` is the host's Android security patch level. It's also folded into `os_version`, for example `Android 16 (2026-05-01)`.
 
@@ -5399,20 +5395,22 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
     "mdm_enrollment_hardware_attested": false,
     "seen_time": "2021-08-19T21:14:58Z",
     "refetch_requested": false,
-    "hostname": "Anna's Google Pixel 9",
-    "uuid": "309a4b7d-0000-0000-8e7f-26ae0815ede8",
+    "hostname": "Anna Chao's Google Pixel 9",
+    "uuid": "392547dc-0000-0000-a87a-d701ff75bc65",
     "platform": "android",
     "osquery_version": "",
     "orbit_version": null,
     "fleet_desktop_version": null,
     "scripts_enabled": null,
     "os_version": "Android 16 (2026-05-01)",
+    "os_update_minimum_version": null,
+    "os_update_deadline": null,
     "build": "",
     "platform_like": "",
     "code_name": "",
     "uptime": 0,
     "memory": 8589934592,
-    "cpu_type": "",
+    "cpu_type": "caiman",
     "cpu_subtype": "",
     "cpu_brand": "",
     "cpu_physical_cores": 0,
@@ -5421,9 +5419,9 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
     "hardware_model": "Google Pixel 9",
     "hardware_version": "",
     "hardware_serial": "3B241102E5",
-    "computer_name": "Anna's Google Pixel 9",
+    "computer_name": "Anna Chao's Google Pixel 9",
     "timezone": null,
-    "display_name": "Anna's Google Pixel 9",
+    "display_name": "Anna Chao's Google Pixel 9",
     "public_ip": "",
     "primary_ip": "",
     "primary_mac": "",
@@ -5460,7 +5458,7 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
     "system_update_status": "UP_TO_DATE",
     "telephony_infos": [
       {
-        "phone_number": "+1-123-456-7890",
+        "phone_number": "+15551234567",
         "carrier_name": "Verizon",
         "iccid": "89014103211118510720",
         "activation_state": "ACTIVATED",
@@ -5468,20 +5466,13 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
       }
     ],
     "status": "online",
-    "display_text": "Anna's Google Pixel 9",
+    "display_text": "Anna Chao's Google Pixel 9",
     "issues": {
       "failing_policies_count": 0,
       "critical_vulnerabilities_count": 0, // Available in Fleet Premium
       "total_issues_count": 0
     },
-    "geolocation": {
-      "country_iso": "US",
-      "city_name": "New York",
-      "geometry": {
-        "type": "point",
-        "coordinates": [40.6799, -74.0028]
-      }
-    },
+    "batteries": [],
     "end_users": [
       {
         "idp_info_updated_at": "2025-03-20T02:02:17Z",
@@ -5581,13 +5572,15 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
 
 `browser` and `extension_for` fields are included when set and when empty. `extension_for` will show the browser or Visual Studio Code fork associated with the extension, allowing for differentiation between e.g. an extension installed on Visual Studio Code and one installed on Cursor. `browser` is deprecated, and only shows this information for browser plugins.
 
-> Note: Currently, the following are supported only for iOS/iPadOS: `accessibility_settings`, `app_analytics_enabled`, `awaiting_configuration`, `battery_level`, `bluetooth_mac`, `cellular_technology`, `data_roaming_enabled`, `device_properties_attestation`, `diagnostic_submission_enabled`, `eas_device_identifier`, `is_cloud_backup_enabled`, `is_device_locator_service_enabled`, `is_do_not_disturb_in_effect`, `is_mdm_lost_mode_enabled`, `is_network_tethered`, `itunes_store_account_hash`, `itunes_store_account_is_active`, `last_cloud_backup_date`, `mdm_options`, `model_number`, `modem_firmware_version`, `organization_info`, `personal_hotspot_enabled`, `push_token`, `service_subscriptions`, `supplemental_build_version`, `supplemental_os_version_extra`, `udid`, and `wifi_mac`.
+> Note:
+> - Currently, the following are supported only for iOS/iPadOS: `accessibility_settings`, `app_analytics_enabled`, `awaiting_configuration`, `battery_level`, `bluetooth_mac`, `cellular_technology`, `data_roaming_enabled`, `device_properties_attestation`, `diagnostic_submission_enabled`, `eas_device_identifier`, `is_cloud_backup_enabled`, `is_device_locator_service_enabled`, `is_do_not_disturb_in_effect`, `is_mdm_lost_mode_enabled`, `is_network_tethered`, `itunes_store_account_hash`, `itunes_store_account_is_active`, `last_cloud_backup_date`, `mdm_options`, `model_number`, `modem_firmware_version`, `organization_info`, `personal_hotspot_enabled`, `push_token`, `service_subscriptions`, `supplemental_build_version`, `supplemental_os_version_extra`, `udid`, and `wifi_mac`.
 > - These iOS/iPadOS vitals are collected via Apple's [`DeviceInformation`](https://developer.apple.com/documentation/devicemanagement/deviceinformationcommand/command-data.dictionary/queries-data.dictionary) MDM command. A property the device doesn't report is omitted from the response rather than returned as `null`. The exception is `mdm_options`, which is returned as an empty object when the device reports it with nothing set.
 > - `cellular_technology` is one of `None`, `GSM`, `CDMA`, or `GSM and CDMA`. This will be `unknown` if Apple adds a value in the future that Fleet doesn't recognize.
 > - `device_properties_attestation` is an array of base64-encoded DER certificates forming a chain, leaf first. The chain is anchored to Apple's Enterprise Attestation Root CA, which is not itself included in the array.
 > - Currently, the following are supported only for Android: `adb_enabled`, `api_level`, `bootloader_version`, `device_kernel_version`, `encryption_type`, `imei`, `manufacturer`, `meid`, `passcode_protected`, `play_protect_enabled`, `security_posture`, `security_posture_details`, `security_update_version`, `system_update_status`, and `telephony_infos`.
-> - These Android vitals are collected from the status reports Fleet receives from the [Android Management API](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices) (AMAPI). A vital the device doesn't report is omitted from the response rather than returned as `null`, and a whole group of them is missing unless the policy applied to the host turns on the matching status reporting setting: `deviceSettings` for `adb_enabled`, `encryption_type`, `passcode_protected`, and `play_protect_enabled`, and `securityPosture` for `security_posture` and `security_posture_details`.
-> - `telephony_infos`, `imei`, and `meid` are only returned for company-owned (fully managed) hosts, never for personal (BYOD) enrollments. `telephony_infos` holds one entry per SIM card, so a dual-SIM host reports more than one, and its `activation_state` and `config_mode` describe eSIMs on Android 15 and above only. A host reports either `imei` or `meid` depending on its radio, never both.
+> - These Android vitals are collected from the status reports Fleet receives from the [Android Management API](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices) (AMAPI). A vital the device doesn't report is omitted from the response rather than returned as `null`. A host that hasn't sent a status report yet returns none of them, and a device whose Android version doesn't report a given vital omits just that one.
+> - `telephony_infos`, `imei`, and `meid` are never returned for a personal (BYOD) enrollment. AMAPI only reports them for fully managed devices in the first place, and Fleet gates the response on its own enrollment record so they stay hidden after a BYOD host unenrolls. `telephony_infos` holds one entry per SIM card, so a dual-SIM host reports more than one, and it requires Android 6 or above. Its `activation_state` and `config_mode` describe eSIMs on Android 15 and above only. A host reports either `imei` or `meid` depending on its radio, never both.
+> - `security_posture_details[].advice` holds AMAPI's default, non-localized admin-facing message for each risk. Fleet has no device locale to select a localized variant with, so the localized messages aren't returned.
 > - `encryption_type`, `security_posture`, `system_update_status`, `security_posture_details[].security_risk`, `telephony_infos[].activation_state`, and `telephony_infos[].config_mode` carry AMAPI's raw enum values, such as `ACTIVE`, `AT_RISK`, `UP_TO_DATE`, `UNKNOWN_OS`, `ACTIVATED`, and `ADMIN_CONFIGURED`. AMAPI's "no data" sentinels (`*_UNSPECIFIED` and `UPDATE_STATUS_UNKNOWN`) are omitted from the response instead of being returned.
 > - `security_update_version` is the host's Android security patch level. It's also folded into `os_version`, for example `Android 16 (2026-05-01)`.
 
@@ -5827,9 +5820,7 @@ X-Client-Cert-Serial: <fleet_identity_scep_cert_serial>
 
 > `global_config.mdm.enabled_and_configured` only represents Apple MDM, and will return false if Apple MDM is not configured even if other platforms have MDM enabled and configured.
 
-> Note:
-> - For an Android host, the response also includes the Android-only vitals documented under ["Get host"](#get-host): `adb_enabled`, `api_level`, `bootloader_version`, `device_kernel_version`, `encryption_type`, `imei`, `manufacturer`, `meid`, `passcode_protected`, `play_protect_enabled`, `security_posture`, `security_posture_details`, `security_update_version`, `system_update_status`, and `telephony_infos`. They're omitted for hosts on every other platform, as is any individual vital the device hasn't reported.
-> - `telephony_infos`, `imei`, and `meid` are only returned for company-owned (fully managed) hosts, never for personal (BYOD) enrollments.
+> Note: Android hosts can't be reached through this endpoint. They don't run Fleet Desktop, so they never get a token, and certificate authentication is limited to iOS and iPadOS. To read an Android host's vitals, use ["Get host"](#get-host) or ["Get host by identifier"](#get-host-by-identifier).
 
 ### Delete host
 


### PR DESCRIPTION
**Related issue:** Resolves #51205

Documents the Android host vitals that #51202 already flattens into the single-host API responses. Documentation only — no code changes.

- `GET /api/v1/fleet/hosts/:id` and `GET /api/v1/fleet/hosts/identifier/:identifier` each get an `#### Example (Android)` response alongside the existing macOS and iOS/iPadOS ones, plus note bullets covering all 15 Android-only fields.
- `GET /api/v1/fleet/device/:token` gets a note saying Android hosts can't reach it. The story asked for the vitals to be documented there too, but they can't appear: `HostDeviceURL` rejects `android` outright, Android hosts never get a Fleet Desktop token, and certificate auth is iOS/iPadOS-only. Saying so seemed better than documenting a response nobody can get.

`meid` is described in the notes but deliberately absent from the example — a device reports `imei` or `meid` depending on its radio, never both.

Everything documented was checked against the merged implementation with a script: every field name matches a `json:` tag on `HostMDMAndroidDeviceVitals` / `MDMAndroidTelephonyInfo` / `MDMAndroidPostureDetail`, every key in the example maps to a real tag somewhere in `server/fleet` or `server/service`, the cited AMAPI enum values all exist in the vendored client, and the two example blocks differ only in the `uuid` each endpoint is looked up by.

One pre-existing line changed: the "Get host by identifier" note's lead sentence became a bare `> Note:` followed by a bullet, matching the equivalent block under "Get host". Without that, the appended Android bullets read as though they were also "supported only for iOS/iPadOS".

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

  N/A — documentation only, no user-visible product change.

## Testing

- [x] QA'd all new/changed functionality manually

Verified locally:

- Both Android example blocks parse as JSON (after stripping the file's pre-existing `// Available in Fleet Premium` inline comment) and differ only in `uuid`.
- All 15 `json:` tags on `HostMDMAndroidDeviceVitals` appear in each note's field list — exact set match, no extras or omissions. `telephony_infos[]` and `security_posture_details[]` keys match their structs exactly.
- Diffed the Android example's key set against the iOS/iPadOS one: the only fields absent are `additional`, `disk_encryption_enabled`, `geolocation`, `maintenance_window`, and `users`, all `omitempty` and genuinely absent for an Android host.
- Repo-wide `[here]` / `[click here]` anchor check passes; the new AMAPI link returns 200; both internal anchors (`#get-host`, `#get-host-by-identifier`) exist.

To review against a real device: enroll a fully managed Android host and confirm `GET /api/v1/fleet/hosts/:id` returns the vitals as documented, then confirm a BYOD host returns no `telephony_infos`, `imei`, or `meid`.
