### PR TITLE
fix(mdm): prevent windows client certificate lifetime truncation (#52601)

### DIFF
--- a/changes/52601-windows-mdm-client-cert-validity
+++ b/changes/52601-windows-mdm-client-cert-validity
@@ -1,0 +1,1 @@
+- Fixed Windows MDM client certificate backdating where NotBefore was backdated by the 180-day renewal period, properly setting validity to 365 days from issuance with a 10-minute clock-skew allowance and aligning WstepCertRenewalPeriodInDays to 180 days.

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -232,8 +232,8 @@ const (
 	// Supported Enroll Type Full
 	ReqSecTokenEnrollTypeFull = "Full"
 
-	// Provisioning Doc Certificate Renewal Period (365 days)
-	WstepCertRenewalPeriodInDays = "365"
+	// Provisioning Doc Certificate Renewal Period in Days (180 days, matching PolicyCertRenewalPeriodInSecs)
+	WstepCertRenewalPeriodInDays = "180"
 
 	// Provisioning Doc Server supports ROBO auto certificate renewal
 	// TODO: Add renewal support

--- a/server/mdm/microsoft/wstep.go
+++ b/server/mdm/microsoft/wstep.go
@@ -481,13 +481,15 @@ func azureDataFromClaims(ctx context.Context, claims jwt.MapClaims) (AzureData, 
 }
 
 func populateClientCert(sn *big.Int, subject string, issuerCert *x509.Certificate, csr *x509.CertificateRequest) (*x509.Certificate, error) {
-	certRenewalPeriodInSecsInt, err := strconv.Atoi(syncml.PolicyCertRenewalPeriodInSecs)
+	certValidityPeriodInSecsInt, err := strconv.Atoi(syncml.PolicyCertValidityPeriodInSecs)
 	if err != nil {
-		return nil, fmt.Errorf("invalid renewal time: %w", err)
+		return nil, fmt.Errorf("invalid validity time: %w", err)
 	}
 
-	notBeforeDuration := time.Now().Add(time.Duration(certRenewalPeriodInSecsInt) * -time.Second)
-	yearDuration := 365 * 24 * time.Hour
+	// Minor clock-skew allowance of 10 minutes to accommodate client clock variations
+	now := time.Now()
+	notBefore := now.Add(-10 * time.Minute)
+	notAfter := now.Add(time.Duration(certValidityPeriodInSecsInt) * time.Second)
 
 	certSubject := pkix.Name{
 		OrganizationalUnit: []string{syncml.DocProvisioningAppProviderID},
@@ -508,8 +510,8 @@ func populateClientCert(sn *big.Int, subject string, issuerCert *x509.Certificat
 		EmailAddresses:     csr.EmailAddresses,
 		DNSNames:           csr.DNSNames,
 		URIs:               csr.URIs,
-		NotBefore:          notBeforeDuration,
-		NotAfter:           notBeforeDuration.Add(yearDuration),
+		NotBefore:          notBefore,
+		NotAfter:           notAfter,
 		SerialNumber:       sn,
 		KeyUsage:           x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 

--- a/server/mdm/microsoft/wstep.go
+++ b/server/mdm/microsoft/wstep.go
@@ -480,6 +480,8 @@ func azureDataFromClaims(ctx context.Context, claims jwt.MapClaims) (AzureData, 
 	}, nil
 }
 
+// populateClientCert constructs an x509 client certificate template for Windows MDM enrollment,
+// configuring the certificate validity period derived from MDM policy settings.
 func populateClientCert(sn *big.Int, subject string, issuerCert *x509.Certificate, csr *x509.CertificateRequest) (*x509.Certificate, error) {
 	certValidityPeriodInSecsInt, err := strconv.Atoi(syncml.PolicyCertValidityPeriodInSecs)
 	if err != nil {

--- a/server/mdm/microsoft/wstep_test.go
+++ b/server/mdm/microsoft/wstep_test.go
@@ -408,7 +408,7 @@ func TestPopulateClientCertValidityAndNotBefore(t *testing.T) {
 		"NotAfter should match PolicyCertValidityPeriodInSecs from now, got %v", cert.NotAfter)
 
 	// The effective remaining validity from issuance time must closely track PolicyCertValidityPeriodInSecs
-	validityFromNow := cert.NotAfter.Sub(time.Now())
+	validityFromNow := time.Until(cert.NotAfter)
 	require.Greater(t, validityFromNow, expectedValidity-24*time.Hour, "validity must match policy period, not halved by renewal backdating")
 
 	// Verify WstepCertRenewalPeriodInDays matches PolicyCertRenewalPeriodInSecs converted to days
@@ -417,4 +417,3 @@ func TestPopulateClientCertValidityAndNotBefore(t *testing.T) {
 	expectedRenewalDays := fmt.Sprintf("%d", renewalSecs/(24*60*60))
 	require.Equal(t, expectedRenewalDays, syncml.WstepCertRenewalPeriodInDays)
 }
-

--- a/server/mdm/microsoft/wstep_test.go
+++ b/server/mdm/microsoft/wstep_test.go
@@ -6,7 +6,9 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -395,17 +397,24 @@ func TestPopulateClientCertValidityAndNotBefore(t *testing.T) {
 	require.True(t, cert.NotBefore.After(expectedNotBeforeMin) && cert.NotBefore.Before(expectedNotBeforeMax),
 		"NotBefore should be ~10m in the past (clock-skew), got %v", cert.NotBefore)
 
-	// NotAfter should be derived from syncml.PolicyCertValidityPeriodInSecs (~365 days from now)
-	expectedNotAfterMin := beforeCall.Add(365*24*time.Hour - 5*time.Second)
-	expectedNotAfterMax := afterCall.Add(365*24*time.Hour + 5*time.Second)
+	// NotAfter should be derived from syncml.PolicyCertValidityPeriodInSecs
+	validitySecs, err := strconv.ParseInt(syncml.PolicyCertValidityPeriodInSecs, 10, 64)
+	require.NoError(t, err)
+	expectedValidity := time.Duration(validitySecs) * time.Second
+
+	expectedNotAfterMin := beforeCall.Add(expectedValidity - 5*time.Second)
+	expectedNotAfterMax := afterCall.Add(expectedValidity + 5*time.Second)
 	require.True(t, cert.NotAfter.After(expectedNotAfterMin) && cert.NotAfter.Before(expectedNotAfterMax),
-		"NotAfter should be ~365 days in the future, got %v", cert.NotAfter)
+		"NotAfter should match PolicyCertValidityPeriodInSecs from now, got %v", cert.NotAfter)
 
-	// The effective remaining validity from issuance time must be approximately 365 days (not halved to 185 days)
+	// The effective remaining validity from issuance time must closely track PolicyCertValidityPeriodInSecs
 	validityFromNow := cert.NotAfter.Sub(time.Now())
-	require.Greater(t, validityFromNow, 360*24*time.Hour, "validity must be ~365 days, not halved by 180d renewal backdating")
+	require.Greater(t, validityFromNow, expectedValidity-24*time.Hour, "validity must match policy period, not halved by renewal backdating")
 
-	// Verify WstepCertRenewalPeriodInDays matches PolicyCertRenewalPeriodInSecs (180 days)
-	require.Equal(t, "180", syncml.WstepCertRenewalPeriodInDays)
+	// Verify WstepCertRenewalPeriodInDays matches PolicyCertRenewalPeriodInSecs converted to days
+	renewalSecs, err := strconv.ParseInt(syncml.PolicyCertRenewalPeriodInSecs, 10, 64)
+	require.NoError(t, err)
+	expectedRenewalDays := fmt.Sprintf("%d", renewalSecs/(24*60*60))
+	require.Equal(t, expectedRenewalDays, syncml.WstepCertRenewalPeriodInDays)
 }
 

--- a/server/mdm/microsoft/wstep_test.go
+++ b/server/mdm/microsoft/wstep_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/cryptoutil"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
@@ -371,3 +372,40 @@ func TestAzureDataFromClaims(t *testing.T) {
 		require.Equal(t, "user@example.com", data.UPN)
 	})
 }
+
+func TestPopulateClientCertValidityAndNotBefore(t *testing.T) {
+	issuerCert, err := cryptoutil.DecodePEMCertificate(testCert)
+	require.NoError(t, err)
+
+	sn := big.NewInt(12345)
+	subject := "test-device-uuid"
+	csr := &x509.CertificateRequest{
+		Version: 1,
+	}
+
+	beforeCall := time.Now()
+	cert, err := populateClientCert(sn, subject, issuerCert, csr)
+	afterCall := time.Now()
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+
+	// NotBefore should be within 10m clock-skew allowance, not backdated by 180 days (#52601)
+	expectedNotBeforeMin := beforeCall.Add(-10*time.Minute - 5*time.Second)
+	expectedNotBeforeMax := afterCall.Add(-10*time.Minute + 5*time.Second)
+	require.True(t, cert.NotBefore.After(expectedNotBeforeMin) && cert.NotBefore.Before(expectedNotBeforeMax),
+		"NotBefore should be ~10m in the past (clock-skew), got %v", cert.NotBefore)
+
+	// NotAfter should be derived from syncml.PolicyCertValidityPeriodInSecs (~365 days from now)
+	expectedNotAfterMin := beforeCall.Add(365*24*time.Hour - 5*time.Second)
+	expectedNotAfterMax := afterCall.Add(365*24*time.Hour + 5*time.Second)
+	require.True(t, cert.NotAfter.After(expectedNotAfterMin) && cert.NotAfter.Before(expectedNotAfterMax),
+		"NotAfter should be ~365 days in the future, got %v", cert.NotAfter)
+
+	// The effective remaining validity from issuance time must be approximately 365 days (not halved to 185 days)
+	validityFromNow := cert.NotAfter.Sub(time.Now())
+	require.Greater(t, validityFromNow, 360*24*time.Hour, "validity must be ~365 days, not halved by 180d renewal backdating")
+
+	// Verify WstepCertRenewalPeriodInDays matches PolicyCertRenewalPeriodInSecs (180 days)
+	require.Equal(t, "180", syncml.WstepCertRenewalPeriodInDays)
+}
+


### PR DESCRIPTION
**Related issue:** Resolves #52601

### Summary of Changes

This PR resolves issue #52601 by fixing the Windows MDM client certificate backdating calculation in `populateClientCert` and aligning the renewal period constants:

1. **Eliminate 180-day backdating truncation (`server/mdm/microsoft/wstep.go`)**:
   - `populateClientCert` previously computed `NotBefore` by subtracting `PolicyCertRenewalPeriodInSecs` (180 days) from `time.Now()`, and added a hardcoded 365-day duration to get `NotAfter`, leaving the newly-issued certificate with only ~185 days of remaining validity and immediately opening the Windows renewal window at enrollment.
   - Fixed by deriving `NotBefore` from issuance time with a 10-minute clock-skew allowance (`now.Add(-10 * time.Minute)`), matching the SCEP / token PKI pattern used across Fleet.
   - Derived `NotAfter` directly from `syncml.PolicyCertValidityPeriodInSecs` (`now.Add(validityPeriod)`), ensuring the issued certificate validity stays strictly synchronized with the policy advertised in `GetPolicies`.

2. **Align renewal period constant (`server/mdm/microsoft/syncml/syncml.go`)**:
   - Updated `WstepCertRenewalPeriodInDays` from `"365"` to `"180"` to match `PolicyCertRenewalPeriodInSecs = "15552000"` (180 days).

3. **Automated Unit Tests (`server/mdm/microsoft/wstep_test.go`)**:
   - Added `TestPopulateClientCertValidityAndNotBefore` verifying that `NotBefore` reflects current issuance time with the 10m leeway, `NotAfter` provides the full 365-day validity window without truncation, and `WstepCertRenewalPeriodInDays` agrees with `PolicyCertRenewalPeriodInSecs`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`: `changes/52601-windows-mdm-client-cert-validity`
- [x] Input data is properly validated
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing
- [x] Added/updated automated tests (`TestPopulateClientCertValidityAndNotBefore` in `server/mdm/microsoft/wstep_test.go`)
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Windows MDM client certificate validity dates.
  - Certificates now use a one-year validity period from issuance, with a 10-minute allowance for device clock differences.
  - Aligned certificate renewal timing to a 180-day period.
  - Improved certificate timing to reduce validity issues caused by device clock differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->