### PR TITLE
Android Custom Commands: Removing sensitive fields from raw_result

### DIFF
--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -204,6 +204,8 @@ func (svc *Service) handlePubSubCommand(ctx context.Context, token string, rawDa
 
 	newStatus, errCode, errMsg := androidOperationTerminalState(&op)
 
+	redactOperationSensitiveFields(&op)
+
 	// Store the raw Operation JSON so custom command results can be retrieved via the API.
 	var rawResult *string
 	if resultJSON, err := json.Marshal(op); err == nil {

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/androidmanagement/v1"
+	"google.golang.org/api/googleapi"
 )
 
 // sha256 of "TestBrand:test-serial". Will need to be updated if our test enrollment message changes
@@ -2695,6 +2696,39 @@ func TestPubSubCommand(t *testing.T) {
 		require.NotNil(t, capturedRawResult, "raw_result should be stored on status update")
 		require.Contains(t, *capturedRawResult, stored.OperationName, "raw_result should contain the operation name")
 		require.Contains(t, *capturedRawResult, `"done":true`, "raw_result should contain done:true")
+	})
+
+	t.Run("newPassword is redacted from raw_result metadata", func(t *testing.T) {
+		svc, mockDS := newSvc(t)
+
+		stored := &android.MDMAndroidCommand{
+			CommandUUID:   "cmd-uuid-redact",
+			HostUUID:      "host-uuid",
+			OperationName: "enterprises/E/devices/D/operations/redact-1",
+			CommandType:   string(android.MDMAndroidCommandTypeResetPassword),
+			Status:        string(android.MDMAndroidCommandStatusPending),
+		}
+		mockDS.GetMDMAndroidCommandByOperationNameFunc = func(ctx context.Context, opName string) (*android.MDMAndroidCommand, error) {
+			return stored, nil
+		}
+		var capturedRawResult *string
+		mockDS.UpdateMDMAndroidCommandStatusFunc = func(ctx context.Context, commandUUID, status string, errorCode, errorMessage, rawResult *string) error {
+			capturedRawResult = rawResult
+			return nil
+		}
+
+		op := androidmanagement.Operation{
+			Name: stored.OperationName,
+			Done: true,
+			Metadata: googleapi.RawMessage(`{"@type":"type.googleapis.com/google.android.devicemanagement.v1.Command","type":"RESET_PASSWORD","newPassword":"s3cret!","userName":"enterprises/E/users/U"}`),
+		}
+		msg := makeMessage(t, op)
+		require.NoError(t, svc.ProcessPubSubPush(t.Context(), validToken, msg))
+
+		require.NotNil(t, capturedRawResult)
+		require.NotContains(t, *capturedRawResult, "s3cret!", "newPassword value must not appear in raw_result")
+		require.NotContains(t, *capturedRawResult, "newPassword", "newPassword key must not appear in raw_result")
+		require.Contains(t, *capturedRawResult, "RESET_PASSWORD", "other metadata fields should be preserved")
 	})
 
 	t.Run("pending -> error on op.Error set", func(t *testing.T) {

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -2718,8 +2718,8 @@ func TestPubSubCommand(t *testing.T) {
 		}
 
 		op := androidmanagement.Operation{
-			Name: stored.OperationName,
-			Done: true,
+			Name:     stored.OperationName,
+			Done:     true,
 			Metadata: googleapi.RawMessage(`{"@type":"type.googleapis.com/google.android.devicemanagement.v1.Command","type":"RESET_PASSWORD","newPassword":"s3cret!","userName":"enterprises/E/users/U"}`),
 		}
 		msg := makeMessage(t, op)

--- a/server/mdm/android/service/reconcile_commands.go
+++ b/server/mdm/android/service/reconcile_commands.go
@@ -158,6 +158,7 @@ func reconcileAndroidCommands(ctx context.Context, ds fleet.Datastore, client an
 
 		default:
 			status, errCode, errMsg := androidOperationTerminalState(op)
+			redactOperationSensitiveFields(op)
 			var rawResult *string
 			if resultJSON, err := json.Marshal(op); err == nil {
 				s := string(resultJSON)

--- a/server/mdm/android/service/reconcile_commands_test.go
+++ b/server/mdm/android/service/reconcile_commands_test.go
@@ -117,6 +117,31 @@ func TestReconcileAndroidCommands(t *testing.T) {
 		}
 	})
 
+	t.Run("newPassword is redacted from raw_result metadata", func(t *testing.T) {
+		cmd := pendingCommandForReconcile("cmd-redact", string(android.MDMAndroidCommandTypeResetPassword), 48*time.Hour)
+		mockDS, client, logger := newReconcileFixture(t, cmd)
+		client.EnterprisesDevicesOperationsGetFunc = func(ctx context.Context, operationName string) (*androidmanagement.Operation, error) {
+			return &androidmanagement.Operation{
+				Name: operationName,
+				Done: true,
+				Metadata: []byte(`{"@type":"type.googleapis.com/google.android.devicemanagement.v1.Command","type":"RESET_PASSWORD","newPassword":"s3cret!","userName":"enterprises/E/users/U"}`),
+			}, nil
+		}
+		var gotRawResult *string
+		mockDS.UpdateMDMAndroidCommandStatusFunc = func(ctx context.Context, commandUUID, status string, errorCode, errorMessage, rawResult *string) error {
+			gotRawResult = rawResult
+			return nil
+		}
+
+		require.NoError(t, reconcileAndroidCommands(t.Context(), &mockDS.DataStore, client, logger, noopNewActivity, reconcileNow, reconcileTestCallInterval))
+
+		require.True(t, mockDS.UpdateMDMAndroidCommandStatusFuncInvoked)
+		require.NotNil(t, gotRawResult)
+		require.NotContains(t, *gotRawResult, "s3cret!", "newPassword value must not appear in raw_result")
+		require.NotContains(t, *gotRawResult, "newPassword", "newPassword key must not appear in raw_result")
+		require.Contains(t, *gotRawResult, "RESET_PASSWORD", "other metadata fields should be preserved")
+	})
+
 	t.Run("operation still running is left pending", func(t *testing.T) {
 		cmd := pendingCommandForReconcile("cmd-running", string(android.MDMAndroidCommandTypeWipe), 48*time.Hour)
 		mockDS, client, logger := newReconcileFixture(t, cmd)

--- a/server/mdm/android/service/reconcile_commands_test.go
+++ b/server/mdm/android/service/reconcile_commands_test.go
@@ -122,8 +122,8 @@ func TestReconcileAndroidCommands(t *testing.T) {
 		mockDS, client, logger := newReconcileFixture(t, cmd)
 		client.EnterprisesDevicesOperationsGetFunc = func(ctx context.Context, operationName string) (*androidmanagement.Operation, error) {
 			return &androidmanagement.Operation{
-				Name: operationName,
-				Done: true,
+				Name:     operationName,
+				Done:     true,
 				Metadata: []byte(`{"@type":"type.googleapis.com/google.android.devicemanagement.v1.Command","type":"RESET_PASSWORD","newPassword":"s3cret!","userName":"enterprises/E/users/U"}`),
 			}, nil
 		}

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	_ "embed"
@@ -973,6 +974,9 @@ func redactOperationSensitiveFields(op *androidmanagement.Operation) {
 	}
 	var m map[string]any
 	if err := json.Unmarshal(op.Metadata, &m); err != nil {
+		if bytes.Contains(op.Metadata, []byte(`"newPassword"`)) {
+			op.Metadata = nil
+		}
 		return
 	}
 	if _, ok := m["newPassword"]; ok {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	_ "embed"
@@ -11,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -966,6 +966,8 @@ func marshalRawCommand(cmd *androidmanagement.Command) sql.Null[string] {
 	return sql.Null[string]{V: string(b), Valid: true}
 }
 
+var sensitiveMetadataKeyRe = regexp.MustCompile(`"(?:\\u[0-9a-fA-F]{4}|n)ewPassword"\s*:\s*"[^"]*"\s*,?\s*`)
+
 // redactOperationSensitiveFields strips sensitive fields (e.g. newPassword) from
 // the AMAPI Operation metadata before the Operation is persisted as raw_result.
 func redactOperationSensitiveFields(op *androidmanagement.Operation) {
@@ -974,9 +976,7 @@ func redactOperationSensitiveFields(op *androidmanagement.Operation) {
 	}
 	var m map[string]any
 	if err := json.Unmarshal(op.Metadata, &m); err != nil {
-		if bytes.Contains(op.Metadata, []byte(`"newPassword"`)) {
-			op.Metadata = nil
-		}
+		op.Metadata = sensitiveMetadataKeyRe.ReplaceAll(op.Metadata, nil)
 		return
 	}
 	if _, ok := m["newPassword"]; ok {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -965,6 +965,24 @@ func marshalRawCommand(cmd *androidmanagement.Command) sql.Null[string] {
 	return sql.Null[string]{V: string(b), Valid: true}
 }
 
+// redactOperationSensitiveFields strips sensitive fields (e.g. newPassword) from
+// the AMAPI Operation metadata before the Operation is persisted as raw_result.
+func redactOperationSensitiveFields(op *androidmanagement.Operation) {
+	if len(op.Metadata) == 0 {
+		return
+	}
+	var m map[string]any
+	if err := json.Unmarshal(op.Metadata, &m); err != nil {
+		return
+	}
+	if _, ok := m["newPassword"]; ok {
+		delete(m, "newPassword")
+		if b, err := json.Marshal(m); err == nil {
+			op.Metadata = b
+		}
+	}
+}
+
 // resolveAndroidCommandTarget centralizes the host/enterprise/secret lookup shared by all three command-issuing methods
 // (Lock, Wipe, ClearPasscode). Returns the host (for host_mdm_actions writes and audit fields) and the AMAPI deviceName
 // ready to pass to IssueCommand. Authorization is applied here so the per-command methods stay thin.


### PR DESCRIPTION
# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [x] Alerted the release DRI if additional load testing is needed


```
 $ curl -X POST https://localhost:8080/api/latest/fleet/commands/run   -H "Authorization: Bearer /Ddu4UJaXKva1EfLa5UdM3Ho0pnSfbF57G7U1TT3rtraVIj6xuIQMutPwQCvgQFYV0qfuUCbiX/IBnrjnNz7yg=="   -H "Content-Type: application/json"   -k   -d '{
    "command": "'$(echo -n '{"type":"RESET_PASSWORD","newPassword":"1234"}' | base64)'",
    "host_uuids": ["0a22e1b251b7fe7441b9381f5a78531d259aa933a9f5e081512e95dbcefed37b"]
  }'
{
  "command_uuid": "bea5f3dd-3e1d-4a0a-9ad1-5aaa4d064a7d",
  "request_type": "RESET_PASSWORD",
  "platform": "android"
}
```

```
> SELECT command_uuid, command_type, status, raw_command, raw_result  FROM mdm_android_commands  WHERE command_uuid = 'bea5f3dd-3e1d-4a0a-9ad1-5aaa4d064a7d'\G
*************************** 1. row ***************************
command_uuid: bea5f3dd-3e1d-4a0a-9ad1-5aaa4d064a7d
command_type: RESET_PASSWORD
      status: acknowledged
 raw_command: {"duration":"315360000s","type":"RESET_PASSWORD"}
  raw_result: {"done":true,"metadata":{"@type":"type.googleapis.com/google.android.devicemanagement.v1.Command","createTime":"2026-09-04T21:17:50.970Z","duration":"315360000s","type":"RESET_PASSWORD","userName":"enterprises/LC03k6enk8/users/100440021117198030193"},"name":"enterprises/LC03k6enk8/devices/3d3ba6758a67c88b/operations/1788556670970","response":{"@type":"type.googleapis.com/google.android.devicemanagement.v1.IssueCommandResponse"}}
1 row in set (0.00 sec)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive Android reset-password values and metadata keys are removed from stored command results.
  * Other operation metadata remains available for troubleshooting and status tracking.
  * Sensitive values remain protected when command metadata is malformed or cannot be parsed.

* **Bug Fixes**
  * Redaction is applied consistently to newly completed commands and commands finalized during reconciliation.
  * Prevents sensitive data from being retained in persisted command results across completion workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->