### PR TITLE
Website: remove duplicate route

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1426,7 +1426,6 @@ module.exports.routes = {
   'GET /learn-more-about/windows-default-fleet': '/guides/windows-mdm-setup#set-a-default-fleet-for-new-hosts',
   'GET /learn-more-about/device-and-user-scope': '/guides/custom-os-settings#device-and-user-scope',
   'GET /learn-more-about/idp-account-sync': '/guides/deploying-apple-account-provisioning-with-fleet',
-  'GET /learn-more-about/android-encryption-status': 'https://developers.google.com/android/management/reference/rest/v1/enterprises.devices#EncryptionStatus',
   'GET /learn-more-about/security-posture': 'https://developers.google.com/android/management/reference/rest/v1/enterprises.devices#DevicePosture',
   'GET /learn-more-about/software-update-status': 'https://developers.google.com/android/management/reference/rest/v1/enterprises.devices#SystemUpdateInfo',
   'GET /learn-more-about/ddm-activations': '/guides/custom-os-settings#apple-declarations-ddm',


### PR DESCRIPTION
Changes:
- removed a duplicate route that is preventing the website from deploying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the outdated Android encryption status redirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->