### PR TITLE
Fix jwkset goroutine leak

### DIFF
--- a/changes/windows-entra-jwks-cache
+++ b/changes/windows-entra-jwks-cache
@@ -1,0 +1,1 @@
+- Fixed Windows automatic enrollment (Microsoft Entra ID) re-downloading Microsoft's JWT signing keys and leaking a background refresh goroutine. The keys are now fetched once and refreshed hourly.

--- a/server/mdm/microsoft/wstep.go
+++ b/server/mdm/microsoft/wstep.go
@@ -352,7 +352,7 @@ func (m *manager) GetAzureAuthTokenClaims(ctx context.Context, tokenStr string) 
 	}
 
 	if len(tokenStr) == 0 {
-		return AzureData{}, ctxerr.New(ctx, "invalid STS token")
+		return AzureData{}, ctxerr.New(ctx, "empty Azure JWT token")
 	}
 
 	// Decode base64 token

--- a/server/mdm/microsoft/wstep.go
+++ b/server/mdm/microsoft/wstep.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/MicahParks/jwkset"
@@ -55,6 +56,9 @@ type CertManager interface {
 
 	// GetEUATokenClaims validates the given EUA token and returns the parsed claims.
 	GetEUATokenClaims(token string) (*EUATokenClaims, error)
+
+	// GetAzureAuthTokenClaims validates the given Azure AD token and returns its Fleet-relevant claims.
+	GetAzureAuthTokenClaims(ctx context.Context, token string) (AzureData, error)
 
 	// TODO: implement other methods as needed:
 	// - verify certificate-device association
@@ -107,6 +111,9 @@ type manager struct {
 	// maxSerialNumber holds the maximum serial number. The maximum value a serial number can have
 	// is 2^160. However, this could be limited further if required.
 	maxSerialNumber *big.Int
+
+	// azureJWKS lazily creates the shared JWK Set client used to verify Azure AD tokens.
+	azureJWKS func() (jwkset.Storage, error)
 }
 
 // NewCertManager returns a new CertManager instance.
@@ -131,6 +138,7 @@ func newManager(store CertStore, certPEM []byte, privKeyPEM []byte) (*manager, e
 		identityPrivateKey:  key,
 		identityFingerprint: fp,
 		maxSerialNumber:     new(big.Int).Lsh(big.NewInt(1), 128), // 2^12,
+		azureJWKS:           sync.OnceValues(newAzureJWKSClient),
 	}, nil
 }
 
@@ -338,7 +346,11 @@ func (m *manager) GetSTSAuthTokenUPNClaim(tokenStr string) (string, error) {
 
 // GetAzureAuthTokenClaims validates the given Azure AD token and returns
 // UPN, TenantID, UniqueName, DeviceID
-func GetAzureAuthTokenClaims(ctx context.Context, tokenStr string) (AzureData, error) {
+func (m *manager) GetAzureAuthTokenClaims(ctx context.Context, tokenStr string) (AzureData, error) {
+	if m == nil {
+		return AzureData{}, ctxerr.New(ctx, "windows mdm identity keypair was not configured")
+	}
+
 	if len(tokenStr) == 0 {
 		return AzureData{}, ctxerr.New(ctx, "invalid STS token")
 	}
@@ -355,19 +367,11 @@ func GetAzureAuthTokenClaims(ctx context.Context, tokenStr string) (AzureData, e
 		return AzureData{}, ctxerr.New(ctx, "invalid Azure JWT format")
 	}
 
-	// Parse JWT token
-	jwksURI := "https://login.microsoftonline.com/common/discovery/v2.0/keys"
-	var token *jwt.Token
-	FLEET_DEV_AZURE_JWT_JWKS_URI := dev_mode.Env("FLEET_DEV_AZURE_JWT_JWKS_URI")
-	if FLEET_DEV_AZURE_JWT_JWKS_URI != "" {
-		jwksURI = FLEET_DEV_AZURE_JWT_JWKS_URI
-	}
-
-	keys, err := jwkset.NewDefaultHTTPClient([]string{jwksURI})
+	keys, err := m.azureJWKS()
 	if err != nil {
 		return AzureData{}, ctxerr.Wrap(ctx, err, "failed to retrieve Azure JWT signing keys")
 	}
-	token, err = jwt.Parse(string(tokenBytes), func(token *jwt.Token) (any, error) {
+	token, err := jwt.Parse(string(tokenBytes), func(token *jwt.Token) (any, error) {
 		tokenAlg, ok := token.Header["alg"]
 		if !ok {
 			return nil, errors.New("Azure JWT missing alg header")
@@ -406,6 +410,21 @@ func GetAzureAuthTokenClaims(ctx context.Context, tokenStr string) (AzureData, e
 	}
 
 	return azureDataFromClaims(ctx, token.Claims.(jwt.MapClaims))
+}
+
+// newAzureJWKSClient is wrapped in sync.OnceValues so the client, and its hourly background
+// refresh goroutine, are created once per manager instead of on every token validation.
+func newAzureJWKSClient() (jwkset.Storage, error) {
+	jwksURI := "https://login.microsoftonline.com/common/discovery/v2.0/keys"
+	if devURI := dev_mode.Env("FLEET_DEV_AZURE_JWT_JWKS_URI"); devURI != "" {
+		jwksURI = devURI
+	}
+
+	jwksetClient, err := jwkset.NewDefaultHTTPClient([]string{jwksURI})
+	if err != nil {
+		return nil, fmt.Errorf("create Azure JWKS client: %w", err)
+	}
+	return jwksetClient, nil
 }
 
 // azureDataFromClaims extracts and validates the Fleet-relevant claims from an already signature-verified Azure AD JWT.

--- a/server/mdm/microsoft/wstep_test.go
+++ b/server/mdm/microsoft/wstep_test.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"crypto/sha1" //nolint:gosec
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/MicahParks/jwkset"
 	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/cryptoutil"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
@@ -369,5 +375,95 @@ func TestAzureDataFromClaims(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, data.UniqueName)
 		require.Equal(t, "user@example.com", data.UPN)
+	})
+}
+
+func TestGetAzureAuthTokenClaims(t *testing.T) {
+	ctx := t.Context()
+	const tid = "6d8769e6-0f8b-418d-b385-1a53968781c9"
+	const kid = "test-kid"
+
+	newTestManager := func(t *testing.T) *manager {
+		var store CertStore
+		m, err := newManager(store, testCert, testKey)
+		require.NoError(t, err)
+		return m
+	}
+	m := newTestManager(t)
+
+	// Serve the manager's identity key as a JWK Set and count fetches.
+	jwk, err := jwkset.NewJWKFromKey(m.identityPrivateKey, jwkset.JWKOptions{
+		Metadata: jwkset.JWKMetadataOptions{KID: kid},
+	})
+	require.NoError(t, err)
+	jwks := jwkset.NewMemoryStorage()
+	require.NoError(t, jwks.KeyWrite(ctx, jwk))
+	jwksJSON, err := jwks.JSONPublic(ctx)
+	require.NoError(t, err)
+
+	var fetches atomic.Int32
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetches.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksJSON)
+	}))
+	t.Cleanup(jwksServer.Close)
+	dev_mode.SetOverride("FLEET_DEV_AZURE_JWT_JWKS_URI", jwksServer.URL, t)
+
+	signedToken := func(kid string) string {
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+			"upn": "user@example.com",
+			"tid": tid,
+			"iss": "https://sts.windows.net/" + tid + "/",
+			"aud": "https://fleet.example.com",
+			"scp": "mdm_delegation",
+			"exp": time.Now().Add(10 * time.Minute).Unix(),
+		})
+		token.Header["kid"] = kid
+		signed, err := token.SignedString(m.identityPrivateKey)
+		require.NoError(t, err)
+		return base64.StdEncoding.EncodeToString([]byte(signed))
+	}
+
+	t.Run("rejects empty token", func(t *testing.T) {
+		_, err := m.GetAzureAuthTokenClaims(ctx, "")
+		require.ErrorContains(t, err, "invalid STS token")
+	})
+
+	t.Run("rejects nil manager", func(t *testing.T) {
+		var nilManager *manager
+		_, err := nilManager.GetAzureAuthTokenClaims(ctx, signedToken(kid))
+		require.ErrorContains(t, err, "not configured")
+	})
+
+	t.Run("validates tokens and fetches the JWK Set once", func(t *testing.T) {
+		m := newTestManager(t)
+		before := fetches.Load()
+		for range 3 {
+			data, err := m.GetAzureAuthTokenClaims(ctx, signedToken(kid))
+			require.NoError(t, err)
+			require.Equal(t, "user@example.com", data.UPN)
+			require.Equal(t, tid, data.TenantID)
+			require.Equal(t, []string{"https://fleet.example.com"}, data.Audience)
+		}
+		require.Equal(t, before+1, fetches.Load())
+	})
+
+	t.Run("rejects token signed by unknown key", func(t *testing.T) {
+		m := newTestManager(t)
+		before := fetches.Load()
+		_, err := m.GetAzureAuthTokenClaims(ctx, signedToken("unknown-kid"))
+		require.ErrorIs(t, err, jwkset.ErrKeyNotFound)
+		// The initial fetch plus one refresh triggered by the unknown key ID.
+		require.Equal(t, before+2, fetches.Load())
+	})
+
+	t.Run("rejects tampered token", func(t *testing.T) {
+		tok := signedToken(kid)
+		raw, err := base64.StdEncoding.DecodeString(tok)
+		require.NoError(t, err)
+		tampered := base64.StdEncoding.EncodeToString(append(raw, 'x'))
+		_, err = m.GetAzureAuthTokenClaims(ctx, tampered)
+		require.Error(t, err)
 	})
 }

--- a/server/mdm/microsoft/wstep_test.go
+++ b/server/mdm/microsoft/wstep_test.go
@@ -427,7 +427,7 @@ func TestGetAzureAuthTokenClaims(t *testing.T) {
 
 	t.Run("rejects empty token", func(t *testing.T) {
 		_, err := m.GetAzureAuthTokenClaims(ctx, "")
-		require.ErrorContains(t, err, "invalid STS token")
+		require.ErrorContains(t, err, "empty Azure JWT token")
 	})
 
 	t.Run("rejects nil manager", func(t *testing.T) {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1028,6 +1028,10 @@ func (svc *Service) authBinarySecurityToken(ctx context.Context, authToken *flee
 
 	// Validating the Binary Security Token Type used on Automatic Enrollments
 	if authToken.IsAzureJWTToken() {
+		if svc.wstepCertManager == nil {
+			return "", "", 0, ctxerr.New(ctx, "windows mdm identity keypair was not configured")
+		}
+
 		appConfig, err := svc.ds.AppConfig(ctx)
 		if err != nil {
 			return "", "", 0, ctxerr.Wrap(ctx, err, "retrieving app config for auth token validation")
@@ -1044,7 +1048,7 @@ func (svc *Service) authBinarySecurityToken(ctx context.Context, authToken *flee
 		}
 
 		// Validate the JWT Auth token by retreving its claims
-		tokenData, err := microsoft_mdm.GetAzureAuthTokenClaims(ctx, authToken.Content)
+		tokenData, err := svc.wstepCertManager.GetAzureAuthTokenClaims(ctx, authToken.Content)
 		if err != nil {
 			return "", "", 0, fmt.Errorf("binary security token claim failed: %v", err)
 		}


### PR DESCRIPTION
**Related issue:** Resolves #53085

`GetAzureAuthTokenClaims` created a new `jwkset` HTTP client on every call. Each client downloads Microsoft's JWKS and starts a refresh goroutine. This was a goroutine leak.

The number of leaked goroutines is equal to the number of Entra ID token signature verifications. An enrollment requires 2 token verifications. One from `GetMDMWindowsPolicyResponse` and another from `GetMDMWindowsEnrollResponse`. If the server has handled 1000 enrollments since startup, that's 2000 goroutines leaked, 2000 requests per hour or about 1 request every 2s to the same JWK Set endpoint.

The client is now created once per `CertManager` with `sync.OnceValues`: keys are fetched on first use, refreshed hourly (with other default behaviors).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually (@getvictor )

I did not do a full test with a Windows machine and Entra ID. I am lacking an Entra ID tenant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved Windows automatic enrollment with Microsoft Entra ID by preventing repeated downloads of JWT signing keys.
- Added hourly key refresh behavior to keep authentication validation current.
- Eliminated a background refresh issue that could cause resource leaks.
- Improved handling of missing Windows MDM certificate manager configuration with a clearer error.
- Improved Azure authentication token validation, including clearer handling of empty and invalid tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->