### PR TITLE
Keep unreported Android app installs pending instead of failing them

### DIFF
--- a/changes/52617-android-setup-app-marked-failed.md
+++ b/changes/52617-android-setup-app-marked-failed.md
@@ -1,0 +1,1 @@
+- Fixed Android App Store apps installed during the setup experience being marked "Failed" even though they installed successfully. An app that a device status report mentions in neither its application reports nor its non-compliance reports now stays pending for a later report instead of failing immediately.

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -1731,13 +1731,9 @@ func (svc *Service) verifyDeviceSoftware(ctx context.Context, host *fleet.Host, 
 			continue
 		}
 
-		// no non-compliance report, but also not reported as installed, give it another
-		// chance later if the applied version == requested version? For now, marking as
-		// failed, we don't know how long it might take for the device to receive another
-		// policy, it may never happen.
-		markVerified[packageName] = false
-		svc.logger.ErrorContext(ctx, "Software failed to install without non-compliance report", "host_uuid", hostUUID, "package_name", packageName,
-			"installation_failure_reason", "unknown - no non-compliance report received")
+		// Absent from both reports is not a failure: a real one arrives as a non-compliance
+		// report, so wait for a later message as the in-progress case above does.
+		svc.logger.DebugContext(ctx, "Software not reported as installed or failed yet, will remain pending", "host_uuid", hostUUID, "package_name", packageName)
 	}
 
 	var toVerifyUUIDs, toFailUUIDs []string

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -2562,6 +2562,55 @@ func TestStatusReportAppInstallVerification(t *testing.T) {
 		require.True(t, mockDS.BulkSetVPPInstallsAsFailedFuncInvoked)
 	})
 
+	t.Run("pending app not reported at all stays pending until a later report", func(t *testing.T) {
+		t.Cleanup(func() {
+			mockDS.ListHostMDMAndroidVPPAppsPendingInstallWithVersionFuncInvoked = false
+			mockDS.BulkSetVPPInstallsAsVerifiedFuncInvoked = false
+			mockDS.BulkSetVPPInstallsAsFailedFuncInvoked = false
+		})
+
+		pendingApp := &fleet.HostAndroidVPPSoftwareInstall{
+			AdamID:            "com.example.app",
+			CommandUUID:       "a",
+			AssociatedEventID: "2",
+		}
+		mockDS.ListHostMDMAndroidVPPAppsPendingInstallWithVersionFunc = func(ctx context.Context, hostUUID string, version int64) ([]*fleet.HostAndroidVPPSoftwareInstall, error) {
+			appVersion, _ := strconv.Atoi(pendingApp.AssociatedEventID)
+			if int64(appVersion) <= version {
+				return []*fleet.HostAndroidVPPSoftwareInstall{pendingApp}, nil
+			}
+			return nil, nil
+		}
+
+		var wantVerified []string
+		mockDS.BulkSetVPPInstallsAsVerifiedFunc = func(ctx context.Context, hostID uint, cmdUUIDs []string) error {
+			require.Equal(t, wantVerified, cmdUUIDs)
+			return nil
+		}
+		mockDS.BulkSetVPPInstallsAsFailedFunc = func(ctx context.Context, hostID uint, cmdUUIDs []string) error {
+			require.Empty(t, cmdUUIDs)
+			return nil
+		}
+
+		// The device applied the policy but says nothing about the app, neither an
+		// application report nor a non-compliance report.
+		policyVersion := new(2)
+		statusReport := createStatusAppReportMessage(t, androidDevice.UUID, "test", createAndroidDeviceId("test"), policyVersion, nil, nil)
+		err := svc.ProcessPubSubPush(context.Background(), "value", &statusReport)
+		require.NoError(t, err)
+		require.True(t, mockDS.ListHostMDMAndroidVPPAppsPendingInstallWithVersionFuncInvoked)
+		require.True(t, mockDS.BulkSetVPPInstallsAsFailedFuncInvoked)
+
+		// A later report saying the app is installed must still be able to verify it.
+		wantVerified = []string{pendingApp.CommandUUID}
+		statusReport = createStatusAppReportMessage(t, androidDevice.UUID, "test", createAndroidDeviceId("test"), policyVersion, []*androidmanagement.ApplicationReport{
+			{PackageName: pendingApp.AdamID, State: "INSTALLED"},
+		}, nil)
+		err = svc.ProcessPubSubPush(context.Background(), "value", &statusReport)
+		require.NoError(t, err)
+		require.True(t, mockDS.BulkSetVPPInstallsAsVerifiedFuncInvoked)
+	})
+
 	t.Run("multiple apps in various states", func(t *testing.T) {
 		t.Cleanup(func() {
 			mockDS.ListHostMDMAndroidVPPAppsPendingInstallWithVersionFuncInvoked = false
@@ -2613,7 +2662,6 @@ func TestStatusReportAppInstallVerification(t *testing.T) {
 		commandsToStatus := map[string]fleet.SoftwareInstallerStatus{
 			"a": fleet.SoftwareInstalled,
 			"b": fleet.SoftwareInstalled,
-			"c": fleet.SoftwareInstallFailed,
 			"d": fleet.SoftwareInstallFailed,
 		}
 		mockDS.BulkSetVPPInstallsAsVerifiedFunc = func(ctx context.Context, hostID uint, cmdUUIDs []string) error {
@@ -2621,7 +2669,7 @@ func TestStatusReportAppInstallVerification(t *testing.T) {
 			return nil
 		}
 		mockDS.BulkSetVPPInstallsAsFailedFunc = func(ctx context.Context, hostID uint, cmdUUIDs []string) error {
-			require.ElementsMatch(t, []string{"c", "d"}, cmdUUIDs)
+			require.ElementsMatch(t, []string{"d"}, cmdUUIDs)
 			return nil
 		}
 		mockDS.GetPastActivityDataForAndroidVPPAppInstallFunc = func(ctx context.Context, cmdUUID string, status fleet.SoftwareInstallerStatus) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error) {
@@ -2632,7 +2680,7 @@ func TestStatusReportAppInstallVerification(t *testing.T) {
 		}
 
 		policyVersion := new(2)
-		// app1 and app2 verified, app3 not reported at all so failed, app4 failed with compliance report
+		// app1 and app2 verified, app3 not reported at all so still pending, app4 failed with compliance report
 		enrollmentMessage := createStatusAppReportMessage(t, androidDevice.UUID, "test", createAndroidDeviceId("test"), policyVersion, []*androidmanagement.ApplicationReport{
 			{PackageName: pendingApps[0].AdamID, State: "INSTALLED"},
 			{PackageName: pendingApps[1].AdamID, State: "INSTALLED"},


### PR DESCRIPTION
**Related issue:** Resolves #52617

Apps installed during the Android setup experience could show as "Failed" in Fleet while the device had them installed and running.

`verifyDeviceSoftware` marks a pending app failed when the device's status report mentions it in neither `ApplicationReports` nor `NonComplianceDetails`. But absence isn't a failure signal: AMAPI reports a real failure as a non-compliance detail, and an app that is still settling is simply left out of both lists. The guess is also unrecoverable, because `verification_failed_at` takes the row out of `ListHostMDMAndroidVPPAppsPendingInstallWithVersion`, so the later report that says `INSTALLED` never gets a chance to correct it.

The fix leaves those apps out of both the verified and the failed set, so they stay pending for a later report. That's the same thing the `PENDING`/`IN_PROGRESS` branch a few lines up already does, and the loop below already skips apps missing from `markVerified` ("ignore those not in markVerified, as they will enter a final state in a future pub-sub message"). The production change is one removed assignment and a log line dropped from error to debug.

### Trade-off

An install that fails silently — no non-compliance report, ever — now stays pending instead of being failed. I went with option (a) from the issue because the two errors aren't equal: a stuck Pending is still correctable by the next report, while a wrong Failed is terminal and contradicts what the user sees on the device. Android app installs don't go through `upcoming_activities`, so a pending row doesn't hold up anything else on the host.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

`TestStatusReportAppInstallVerification` gains a case where the device applies the policy and says nothing at all about a pending app: it must stay pending, and a later `INSTALLED` report must still verify it. The existing `multiple apps in various states` case encoded the bug as expected behaviour ("app3 not reported at all so failed"), so its expectation moves from failed to pending.

Both were checked by reverting the fix: the new case then fails on `Should be empty, but was [a]` and the updated case on the failed-set contents, while the other six cases pass either way. `go test ./server/mdm/android/... -race` is green.

### Manual QA

Ran a local Fleet server with Android MDM enabled and a fake enrolled Android host, and pushed AMAPI status reports at the Pub/Sub endpoint. Same database and same build flags for both columns — the only difference is `pubsub.go`.

| Device status report | Before | After |
|---|---|---|
| App missing from both reports | `failed_install` | `pending_install` |
| …then a later report says `INSTALLED` | `failed_install` | `installed` |
| Non-compliance report (a real failure) | `failed_install` | `failed_install` |
| Non-compliance `PENDING` / `IN_PROGRESS` | `pending_install` | `pending_install` |

Row 1 is the reported bug, row 2 shows it was unrecoverable, and rows 3 and 4 confirm genuine failures and in-progress installs are unaffected. Statuses are from `GET /api/latest/fleet/hosts/:id/software`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android app installations missing from a status report now remain pending instead of being incorrectly marked as failed.
  * Installations later reported as successful can now be verified correctly.
  * Explicitly reported installation failures continue to be marked as failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->