### PR TITLE
Add allenhouchins as maintainer for pkg/patch_policy

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -203,7 +203,6 @@ module.exports.custom = {
 
     // 💝 Fleet-maintained apps
     'ee/maintained-apps/inputs': 'allenhouchins',
-    'pkg/patch_policy': 'allenhouchins',//« Patch policy query generation shared by FMA tooling
   },
 
   // FUTURE: Support DRIs for confidential and other repos (except see other note above about a consolidated way to do it, to reduce these 4-6 config keys into one)

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -203,7 +203,7 @@ module.exports.custom = {
 
     // 💝 Fleet-maintained apps
     'ee/maintained-apps/inputs': 'allenhouchins',
-    'pkg/patch_policy': 'allenhouchins',//« Patch policy query generation shared by FMA tooling and the Fleet server
+    'pkg/patch_policy': 'allenhouchins',//« Patch policy query generation shared by FMA tooling
   },
 
   // FUTURE: Support DRIs for confidential and other repos (except see other note above about a consolidated way to do it, to reduce these 4-6 config keys into one)

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -203,6 +203,7 @@ module.exports.custom = {
 
     // 💝 Fleet-maintained apps
     'ee/maintained-apps/inputs': 'allenhouchins',
+    'pkg/patch_policy': 'allenhouchins',//« Patch policy query generation shared by FMA tooling and the Fleet server
   },
 
   // FUTURE: Support DRIs for confidential and other repos (except see other note above about a consolidated way to do it, to reduce these 4-6 config keys into one)
@@ -271,6 +272,7 @@ module.exports.custom = {
     // FMA and icons
     'frontend/pages/SoftwarePage/components/icons': 'allenhouchins',
     'ee/maintained-apps': 'allenhouchins',
+    'pkg/patch_policy': 'allenhouchins',
     'website/assets/images': 'allenhouchins',
 
     // Other brandfronts


### PR DESCRIPTION
Requesting this access since the vast majority of Windows Fleet-maintained apps require custom patch policies.

**Related issue:** N/A

## Summary

Adds `pkg/patch_policy` to `githubRepoMaintainersByPath` in `website/config/custom.js` with `allenhouchins` as maintainer.

`pkg/patch_policy` holds the patch policy query generation shared by the Fleet-maintained apps (FMA) tooling and the Fleet server. It is maintained alongside `ee/maintained-apps`, which already lists the same maintainer, so PRs that only touch this package should auto-approve and be unfreezable the same way FMA changes are.

## Reviewer notes

- Only the maintainers map is changed. The DRI map (`githubRepoDRIByPath`) is left alone since it only controls review requests, not auto-approval.
- Nothing in `CODEOWNERS` currently covers `pkg/`, so this adds no conflicting reviewer requirement.
- Config-only change to the website's repo-automation settings. No runtime code, tests, migrations, or user-visible behavior changes.
- Verified the file still loads with `node -e "require('./website/config/custom.js')"`.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository path-based approval settings for changes under `pkg/patch_policy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->