### PR TITLE
vulnerabilities: strip epoch prefixes from Linux package versions for CPE generation

### DIFF
--- a/changes/strip-linux-package-epochs-cpe
+++ b/changes/strip-linux-package-epochs-cpe
@@ -1,0 +1,1 @@
+- Fixed false-positive vulnerabilities on Linux hosts for packages whose version includes an epoch prefix (e.g. `2:4.24.6-1`). The epoch is now stripped before CPE generation, so the upstream version is matched against the NVD instead of a corrupted one.

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -318,6 +318,7 @@ var (
 	macOSMSTeamsVersion  = regexp.MustCompile(`(\d).00.(\d)(\d+)`)
 	citrixName           = regexp.MustCompile(`Citrix Workspace [0-9]+`)
 	minioAltDate         = regexp.MustCompile(`^\d{14}$`)
+	linuxPackageEpoch    = regexp.MustCompile(`^[0-9]+:`) // epoch prefix of Linux package versions, e.g. "2:" in "2:4.24.6-1"
 	softwareTransformers = []struct {
 		matches func(*fleet.Software) bool
 		mutate  func(context.Context, *fleet.Software, *slog.Logger)
@@ -603,6 +604,23 @@ var (
 				default:
 					s.Version = parts[0] + "." + parts[1]
 				}
+			},
+		},
+		{
+			// Linux package managers (pacman, dpkg, rpm) prefix the version with an epoch (e.g. "2:4.24.6-1") when
+			// upstream changes its versioning scheme, so the package manager still considers the new version newer.
+			// The epoch is not part of the upstream version and never appears in NVD CPEs. If left in place,
+			// sanitizeVersion replaces the colon with a dot ("2.4.24.6-1"), which corrupts the major version and
+			// causes false-positive CVEs (e.g. Samba 4.24.6 being matched against Samba 2.x vulnerabilities).
+			matches: func(s *fleet.Software) bool {
+				switch s.Source {
+				case "pacman_packages", "deb_packages", "rpm_packages":
+					return linuxPackageEpoch.MatchString(s.Version)
+				}
+				return false
+			},
+			mutate: func(ctx context.Context, s *fleet.Software, logger *slog.Logger) {
+				s.Version = linuxPackageEpoch.ReplaceAllString(s.Version, "")
 			},
 		},
 	}

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -2678,6 +2678,97 @@ func TestMutateSoftware(t *testing.T) {
 				Source:  "programs",
 			},
 		},
+		{
+			name: "pacman package with epoch (samba)",
+			s: &fleet.Software{
+				Name:    "samba",
+				Version: "2:4.24.6-1",
+				Source:  "pacman_packages",
+			},
+			sanitized: &fleet.Software{
+				Name:    "samba",
+				Version: "4.24.6-1",
+				Source:  "pacman_packages",
+			},
+		},
+		{
+			name: "pacman package with multi-digit epoch",
+			s: &fleet.Software{
+				Name:    "docker",
+				Version: "10:29.7.2-1",
+				Source:  "pacman_packages",
+			},
+			sanitized: &fleet.Software{
+				Name:    "docker",
+				Version: "29.7.2-1",
+				Source:  "pacman_packages",
+			},
+		},
+		{
+			name: "pacman package without epoch (not transformed)",
+			s: &fleet.Software{
+				Name:    "curl",
+				Version: "8.21.0-1",
+				Source:  "pacman_packages",
+			},
+			sanitized: &fleet.Software{
+				Name:    "curl",
+				Version: "8.21.0-1",
+				Source:  "pacman_packages",
+			},
+		},
+		{
+			name: "deb package with epoch",
+			s: &fleet.Software{
+				Name:    "samba",
+				Version: "2:4.17.12+dfsg-0ubuntu1",
+				Source:  "deb_packages",
+			},
+			sanitized: &fleet.Software{
+				Name:    "samba",
+				Version: "4.17.12+dfsg-0ubuntu1",
+				Source:  "deb_packages",
+			},
+		},
+		{
+			name: "rpm package with epoch",
+			s: &fleet.Software{
+				Name:    "docker-ce",
+				Version: "1:24.0.7-1.el9",
+				Source:  "rpm_packages",
+			},
+			sanitized: &fleet.Software{
+				Name:    "docker-ce",
+				Version: "24.0.7-1.el9",
+				Source:  "rpm_packages",
+			},
+		},
+		{
+			name: "epoch-like version from non-package source (not transformed)",
+			s: &fleet.Software{
+				Name:    "Some App",
+				Version: "2:4.24.6",
+				Source:  "programs",
+			},
+			sanitized: &fleet.Software{
+				Name:    "Some App",
+				Version: "2:4.24.6",
+				Source:  "programs",
+			},
+		},
+		{
+			name: "pacman package with colon not at start (not transformed)",
+			s: &fleet.Software{
+				Name:    "foo",
+				Version: "4.24.6:1",
+				Source:  "pacman_packages",
+			},
+			sanitized: &fleet.Software{
+				Name:    "foo",
+				Version: "4.24.6:1",
+				Source:  "pacman_packages",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NotPanics(t, func() { mutateSoftware(t.Context(), tc.s, slog.New(slog.DiscardHandler)) })


### PR DESCRIPTION
**Related issue:** Resolves #52645

## Summary

Linux package managers (pacman, dpkg, rpm) add an epoch prefix to a package version, for example `2:4.24.6-1`. The epoch is not part of the upstream version. NVD CPEs do not contain it.

`sanitizeVersion` replaces the colon with a dot. `2:4.24.6-1` becomes `2.4.24.6-1`. The CPE then has major version 2. The NVD matcher compares it against Samba 2.x ranges. On one Arch Linux host this produced 39 CVEs for Samba, 75 for ffmpeg, 17 for wpa_supplicant, 10 for flatpak and 8 for docker.

This PR adds one entry to `softwareTransformers` in `server/vulnerabilities/nvd/cpe.go`. The entry removes a leading `^[0-9]+:` before CPE matching for `pacman_packages`, `deb_packages` and `rpm_packages`. The transformer changes only the in-memory copy used for CPE matching. The version shown in the UI does not change.

`deb_packages` and `rpm_packages` normally use OVAL, not NVD. The Ubuntu kernel iterator still sends `deb_packages` to `CPEFromSoftware`, and Debian and RPM epochs have the same syntax. The transformer includes them for that reason.

## Results on the affected host (Fleet 4.91.0 with the patched binary)

| Package | Raw version | CPE version before | CPE version after | CVEs before | CVEs after |
|---|---|---|---|---|---|
| samba | `2:4.24.6-1` | `2.4.24.6-1` | `4.24.6-1` | 39 | 1 (CVE-2026-2340) |
| docker | `1:29.7.2-1` | `1.29.7.2-1` | `29.7.2-1` | 8 | 0 |
| flatpak | `1:1.18.1-1` | `1.1.18.1-1` | `1.18.1-1` | 10 | 0 |
| wpa_supplicant | `2:2.12-1` | `2.2.12-1` | `2.12-1` | 17 | 0 |
| ffmpeg | `2:9.0.1-1` | `2.9.0.1-1` | `9.0.1-1` | 75 | 2 |

This PR was prepared with Claude Code on behalf of @jellespijker. Jelle reviewed every line before it was opened.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated. The regex is anchored at the start of the string and applies only to three package sources.

## Testing

- [x] Added/updated automated tests. `TestMutateSoftware` has new cases for pacman, deb and rpm versions with and without an epoch, and negative cases for other sources and for a colon that is not at the start.
- [x] QA'd all new/changed functionality manually on an Arch Linux host. See the table above.

```
go test -tags fts5 ./server/vulnerabilities/nvd/...
```
All packages pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved vulnerability matching for Linux packages by correctly handling versions with numeric epoch prefixes.
  - Reduced false-positive matches against NVD entries for Pacman, Debian, and RPM packages.
  - Preserved existing behavior for packages without epoch prefixes and for versions from other sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->