### PR TITLE
Fix phantom Fleet Desktop update for Raspberry Pi Imager

### DIFF
--- a/changes/52647-raspberry-pi-imager-version-v-prefix
+++ b/changes/52647-raspberry-pi-imager-version-v-prefix
@@ -1,0 +1,1 @@
+- Fixed Fleet Desktop showing a phantom "Update" button for the Raspberry Pi Imager Fleet-maintained app by aligning its catalog version with the "v" prefix macOS reports in `bundle_short_version`.

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
@@ -45,6 +45,7 @@ var Funcs = map[string][]func(*maintained_apps.FMAManifestApp) (*maintained_apps
 	"onedrive/darwin":               {OneDriveVersionShortener},
 	"pd/darwin":                     {PdVersionTransformer},
 	"smallstepagent/darwin":         {SmallstepAgentVersionTransformer},
+	"raspberry-pi-imager/darwin":    {RaspberryPiImagerVersionTransformer},
 	"sonos/darwin":                  {SonosVersionTransformer},
 	"harmony-sase/darwin":           {HarmonySASEVersionShortener},
 	"visual-studio-code/darwin":     {VSCodeUniversalInstaller},

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener.go
@@ -120,3 +120,19 @@ func SmallstepAgentVersionTransformer(app *maintained_apps.FMAManifestApp) (*mai
 	app.Version = "v" + app.Version
 	return app, nil
 }
+
+// RaspberryPiImagerVersionTransformer prepends "v" to match what macOS reports as
+// bundle_short_version for Raspberry Pi Imager (e.g. "2.0.11.1" → "v2.0.11.1"; the
+// app's CFBundleShortVersionString carries the upstream GitHub release tag's "v"
+// prefix). Without this, Fleet Desktop's own "update available" check treats the
+// "v" prefix as making the installed version older, showing a phantom update.
+func RaspberryPiImagerVersionTransformer(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
+	if app.Version == "" {
+		return app, errors.New("empty version for Raspberry Pi Imager")
+	}
+	if strings.HasPrefix(app.Version, "v") {
+		return app, nil
+	}
+	app.Version = "v" + app.Version
+	return app, nil
+}

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener_test.go
@@ -116,6 +116,32 @@ func TestSmallstepAgentVersionTransformer(t *testing.T) {
 	}
 }
 
+func TestRaspberryPiImagerVersionTransformer(t *testing.T) {
+	tcs := []struct {
+		name     string
+		version  string
+		expected string
+		wantErr  bool
+	}{
+		{name: "empty version", version: "", wantErr: true},
+		{name: "numeric version", version: "2.0.11.1", expected: "v2.0.11.1"},
+		{name: "already prefixed", version: "v2.0.11.1", expected: "v2.0.11.1"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &maintained_apps.FMAManifestApp{Version: tc.version, Slug: "raspberry-pi-imager"}
+			result, err := RaspberryPiImagerVersionTransformer(app)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result.Version)
+		})
+	}
+}
+
 func TestMySQLWorkbenchVersionTransformer(t *testing.T) {
 	tcs := []struct {
 		name     string

--- a/ee/maintained-apps/outputs/raspberry-pi-imager/darwin.json
+++ b/ee/maintained-apps/outputs/raspberry-pi-imager/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.0.11.1",
+      "version": "v2.0.11.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raspberrypi.rpi-imager';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raspberrypi.rpi-imager' AND version_compare(bundle_short_version, '2.0.11.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raspberrypi.rpi-imager' AND version_compare(bundle_short_version, 'v2.0.11.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.raspberrypi.rpi-imager' AND a.bundle_executable != '');"
       },
       "installer_url": "https://github.com/raspberrypi/rpi-imager/releases/download/v2.0.11.1/rpi-imager-v2.0.11.1.dmg",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52647

## Summary

Fleet Desktop's "My device" page showed a phantom "Update" button for the Raspberry Pi Imager Fleet-maintained app, even when the host already had the latest version installed.

Root cause: Raspberry Pi Imager's macOS build sets `CFBundleShortVersionString` to the upstream GitHub release tag verbatim, including its leading "v" (e.g. `v2.0.11.1`), while the FMA catalog tracked the plain version (`2.0.11.1`). The auto-generated patch policy's `version_compare()` SQL tolerated this mismatch and correctly passed, but Fleet Desktop's own "is an update available" check does not tolerate the prefix, so it disagreed and nagged for an update that doesn't exist.

## Fix

Added a per-app version transformer for `raspberry-pi-imager/darwin`, mirroring the existing `SmallstepAgentVersionTransformer` (Smallstep Agent has the same "v"-in-tag quirk): it prepends "v" to the ingested Homebrew version so the catalog version matches what macOS actually reports. Regenerated the app's output manifest via the documented `go run cmd/maintained-apps/main.go --slug="raspberry-pi-imager/darwin" --debug` workflow — the catalog version is now `v2.0.11.1`, matching the host exactly, so both the patch policy and Fleet Desktop's comparison agree.

This only fixes Raspberry Pi Imager specifically; future upstream releases will continue to be handled automatically since the transformer runs on every re-ingestion.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a phantom “Update” button for the Raspberry Pi Imager app in Fleet Desktop.
  - Raspberry Pi Imager versions on macOS now match the `v`-prefixed format reported by the operating system.
  - Updated the maintained app definition to recognize version `v2.0.11.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->