### PR TITLE
APNS push when call directly and not via transaction for VPP and IPA activate next

### DIFF
--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -1903,19 +1903,24 @@ WHERE
 		return ctxerr.Wrap(ctx, err, "insert nano queue")
 	}
 
-	// best-effort APNs push notification to the host, not critical because we
-	// have a cron job that will retry for hosts with pending MDM commands.
-	wrapped, ok := tx.(common_mysql.WrappedExtContext)
-	if ds.pusher == nil || !ok {
+	if ds.pusher == nil {
 		return nil
 	}
-	// we wrap the APNs Push here, as activate next upcoming is called from many sites
-	// and it's racy to ping before we have committed the transaction.
-	wrapped.AddOnCommitHook(func() {
+
+	switch v := tx.(type) {
+	case common_mysql.WrappedExtContext:
+		v.AddOnCommitHook(func() {
+			if _, err := ds.pusher.Push(ctx, []string{hostData.UUID}); err != nil {
+				ds.logger.ErrorContext(ctx, "failed to send push notification", "err", err, "hostID", hostID, "hostUUID", hostData.UUID)
+			}
+		})
+	case *sqlx.DB:
+		// We are not in a transaction but rather just auto-commit mode, fire the push immediately.
 		if _, err := ds.pusher.Push(ctx, []string{hostData.UUID}); err != nil {
 			ds.logger.ErrorContext(ctx, "failed to send push notification", "err", err, "hostID", hostID, "hostUUID", hostData.UUID)
 		}
-	})
+	}
+
 	return nil
 }
 

--- a/server/datastore/mysql/in_house_apps_test.go
+++ b/server/datastore/mysql/in_house_apps_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	nanomdm_mysql "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/storage/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
@@ -27,6 +28,7 @@ func TestInHouseApps(t *testing.T) {
 		name string
 		fn   func(t *testing.T, ds *Datastore)
 	}{
+		{"InHouseAppInstallPushesViaDirectActivation", testInHouseAppInstallPushesViaDirectActivation},
 		{"TestInHouseAppsCrud", testInHouseAppsCrud},
 		{"MultipleTeams", testInHouseAppsMultipleTeams},
 		{"BatchSetInHouseInstallers", testBatchSetInHouseInstallers},
@@ -164,7 +166,8 @@ func testInHouseAppsCrud(t *testing.T, ds *Datastore) {
 				LabelID:   label.ID,
 				LabelName: label.Name,
 			},
-		}}
+		},
+	}
 	cfg := []byte(`<dict><key>k</key><string>v1</string></dict>`)
 	updatePayload := fleet.UpdateSoftwareInstallerPayload{
 		TeamID:          &team.ID,
@@ -392,7 +395,6 @@ func testInHouseAppsMultipleTeams(t *testing.T, ds *Datastore) {
 	err = sqlx.GetContext(ctx, ds.reader(ctx), &count, `SELECT COUNT(id) FROM software_titles`)
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
-
 }
 
 func testInHouseAppsCategories(t *testing.T, ds *Datastore) {
@@ -1859,7 +1861,6 @@ func testInHouseAppsCancelledOnUnenroll(t *testing.T, ds *Datastore) {
 	summary, err = ds.GetSummaryHostInHouseAppInstalls(ctx, ptr.Uint(0), inHouseAppID)
 	require.NoError(t, err)
 	require.Equal(t, fleet.VPPAppStatusSummary{Installed: 0, Pending: 0, Failed: 1}, *summary)
-
 }
 
 // setupTestInHouseApp inserts both iOS and iPadOS rows for the given filename
@@ -2246,4 +2247,52 @@ func testInHouseAppManifestURLUsesAppleServerURL(t *testing.T, ds *Datastore) {
 	// split-hostname deployment does not expose to them.
 	require.Contains(t, rawCmd, deviceURL+"/api/latest/fleet/software/titles/")
 	require.NotContains(t, rawCmd, adminURL)
+}
+
+func testInHouseAppInstallPushesViaDirectActivation(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host := test.NewHost(t, ds, "ipa-direct-activation-host", "ipa-direct-1", "ipa-direct-1-key", "ipa-direct-1-uuid", time.Now())
+	nanoEnroll(t, ds, host, false)
+
+	user := test.NewUser(t, ds, "Direct Activation", "direct-activation@example.com", true)
+
+	payload := fleet.UploadSoftwareInstallerPayload{
+		UserID:           user.ID,
+		Title:            "direct-activation-app",
+		Filename:         "direct-activation.ipa",
+		BundleIdentifier: "com.direct.activation",
+		StorageID:        "direct-activation-storage",
+		Platform:         "ios",
+		Extension:        "ipa",
+		Version:          "1.0.0",
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+	}
+	installerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &payload)
+	require.NoError(t, err)
+
+	var pushedIDs []string
+	ds.WithPusher(pusherFunc(func(ctx context.Context, ids []string) (map[string]*push.Response, error) {
+		pushedIDs = append(pushedIDs, ids...)
+		return okPusherFunc(ctx, ids)
+	}))
+	t.Cleanup(func() { ds.WithPusher(nil) })
+
+	cmd1 := createInHouseAppInstallRequest(t, ds, host.ID, installerID, titleID, user)
+	// cmd2 stays queued behind cmd1, which is still activated.
+	cmd2 := createInHouseAppInstallRequest(t, ds, host.ID, installerID, titleID, user)
+
+	// cmd1's insert already pushed once; isolate the push triggered by activating cmd2.
+	pushedIDs = nil
+
+	// Mirrors production: the activity ACL adapter calls this directly against
+	// ds.writer(ctx) once cmd1 completes, with no surrounding transaction.
+	require.NoError(t, ds.ActivateNextUpcomingActivityForHost(ctx, host.ID, cmd1))
+
+	require.Equal(t, []string{host.UUID}, pushedIDs, "no APNs push when activation runs outside a transaction")
+
+	var cmd2Rows int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &cmd2Rows, "SELECT COUNT(*) FROM nano_commands WHERE command_uuid = ?", cmd2)
+	})
 }

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -3319,19 +3319,24 @@ ORDER BY
 		return ctxerr.Wrap(ctx, err, "insert nano queue")
 	}
 
-	// best-effort APNs push notification to the host, not critical because we
-	// have a cron job that will retry for hosts with pending MDM commands.
-	wrapped, ok := tx.(platform_mysql.WrappedExtContext)
-	if ds.pusher == nil || !ok {
+	if ds.pusher == nil {
 		return nil
 	}
-	// we wrap the APNs Push here, as activate next upcoming is called from many sites
-	// and it's racy to ping before we have committed the transaction.
-	wrapped.AddOnCommitHook(func() {
+	switch v := tx.(type) {
+	case platform_mysql.WrappedExtContext:
+		// we wrap the APNs Push here, as activate next upcoming is called from many sites
+		// and it's racy to ping before we have committed the transaction.
+		v.AddOnCommitHook(func() {
+			if _, err := ds.pusher.Push(ctx, []string{hostData.UUID}); err != nil {
+				ds.logger.ErrorContext(ctx, "failed to send push notification", "err", err, "hostID", hostID, "hostUUID", hostData.UUID)
+			}
+		})
+	case *sqlx.DB:
+		// We are not in a transaction but rather just auto-commit mode, fire the push immediately.
 		if _, err := ds.pusher.Push(ctx, []string{hostData.UUID}); err != nil {
 			ds.logger.ErrorContext(ctx, "failed to send push notification", "err", err, "hostID", hostID, "hostUUID", hostData.UUID)
 		}
-	})
+	}
 	return nil
 }
 

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -28,6 +28,7 @@ func TestVPP(t *testing.T) {
 		name string
 		fn   func(t *testing.T, ds *Datastore)
 	}{
+		{"VPPInstallPushesViaDirectActivation", testVPPInstallPushesViaDirectActivation},
 		{"SetTeamVPPApps", testSetTeamVPPApps},
 		{"SetTeamVPPAppsWithLabels", testSetTeamVPPAppsWithLabels},
 		{"VPPAppMetadata", testVPPAppMetadata},
@@ -3507,6 +3508,51 @@ func testVPPInstallPushesAfterCommit(t *testing.T, ds *Datastore) {
 	require.Equal(t, []string{host.UUID}, pushedIDs, "no APNs push for the activated VPP install")
 	require.Equal(t, 1, cmdRows, "push fired before the nano_commands row was committed")
 	require.Equal(t, 1, queueRows, "push fired before the nano_enrollment_queue row was committed")
+}
+
+func testVPPInstallPushesViaDirectActivation(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	test.CreateInsertGlobalVPPToken(t, ds)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "direct-activation-host",
+		UUID:           uuid.NewString(),
+		Platform:       string(fleet.IOSPlatform),
+		HardwareSerial: uuid.NewString(),
+	})
+	require.NoError(t, err)
+	nanoEnroll(t, ds, host, false)
+
+	const adamID = "direct_activation"
+	setupTestVPPApp(t, ds, adamID, fleet.IOSPlatform)
+	appID := fleet.VPPAppID{AdamID: adamID, Platform: fleet.IOSPlatform}
+
+	var pushedIDs []string
+	ds.WithPusher(pusherFunc(func(ctx context.Context, ids []string) (map[string]*push.Response, error) {
+		pushedIDs = append(pushedIDs, ids...)
+		return okPusherFunc(ctx, ids)
+	}))
+	t.Cleanup(func() { ds.WithPusher(nil) })
+
+	const cmd1, cmd2 = "direct-activation-cmd-1", "direct-activation-cmd-2"
+	require.NoError(t, ds.InsertHostVPPSoftwareInstall(ctx, host.ID, appID, cmd1, "evt-1", fleet.HostSoftwareInstallOptions{}))
+	// cmd2 stays queued behind cmd1, which is still activated.
+	require.NoError(t, ds.InsertHostVPPSoftwareInstall(ctx, host.ID, appID, cmd2, "evt-2", fleet.HostSoftwareInstallOptions{}))
+
+	// cmd1's insert already pushed once; isolate the push triggered by activating cmd2.
+	pushedIDs = nil
+
+	// Mirrors production: the activity ACL adapter calls this directly against
+	// ds.writer(ctx) once cmd1 completes, with no surrounding transaction.
+	require.NoError(t, ds.ActivateNextUpcomingActivityForHost(ctx, host.ID, cmd1))
+
+	require.Equal(t, []string{host.UUID}, pushedIDs, "no APNs push when activation runs outside a transaction")
+
+	var cmd2Rows int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &cmd2Rows, "SELECT COUNT(*) FROM nano_commands WHERE command_uuid = ?", cmd2)
+	})
+	require.Equal(t, 1, cmd2Rows)
 }
 
 // testVPPInstallQueueRowNotBackdated ensures we don't backdate VPP installs into the nano commands table.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves a finding by QA, with the new approach of moving away from 30-60 second cron and rather a daily sweep, it's super important all devices/actions sends a ping, rather than relying on the APNS pusher job.
https://github.com/fleetdm/fleet/issues/50682#issuecomment-5543227568

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. No.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Push notifications are now sent when app installations are activated directly, outside a database transaction.
  - Queued app installation commands continue processing correctly after direct activation.
  - Applies to both in-house and VPP app installations.
  - In-house app manifests are now fetched from the Apple device-facing server URL.
  - Transaction-based activation continues to send notifications after the transaction completes.

- **Tests**
  - Added coverage for push notifications, manifest URLs, and queued command handling during direct activation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->