### PR TITLE
Stop serving a dead archived disk encryption key for Linux hosts

### DIFF
--- a/changes/46535-linux-stale-archived-key
+++ b/changes/46535-linux-stale-archived-key
@@ -1,0 +1,1 @@
+- Fixed Fleet offering a Linux host's previous disk encryption key after detecting that the escrowed LUKS key slot was removed. `GET /api/v1/fleet/hosts/:id/encryption_key` no longer falls back to the archived key for Linux hosts, and the host details page only offers the key while disk encryption is "Verified".

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -244,7 +244,11 @@ describe("Host Actions Dropdown", () => {
   });
 
   describe("Show disk encryption key action", () => {
-    it("hides the show disk encryption key action for macOS device when key is stored but device is not connected to Fleet MDM", async () => {
+    type DropdownProps = Partial<
+      React.ComponentProps<typeof HostActionsDropdown>
+    >;
+
+    const openActions = async (props: DropdownProps) => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -261,170 +265,92 @@ describe("Host Actions Dropdown", () => {
           onSelect={noop}
           hostStatus="online"
           hostMdmEnrollmentStatus={null}
-          doesStoreEncryptionKey
           hostMdmDeviceStatus="unlocked"
           hostScriptsEnabled
-          isConnectedToFleetMdm={false}
-          hostPlatform="darwin"
+          {...props}
         />
       );
 
       await user.click(screen.getByText("Actions"));
+    };
 
-      expect(
-        screen.queryByText("Show disk encryption key")
-      ).not.toBeInTheDocument();
-    });
-
-    it("hides the show disk encryption key action for iOS device", async () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isGlobalAdmin: true,
-            isPremiumTier: true,
-            currentUser: createMockUser(),
-          },
+    const cases: { name: string; props: DropdownProps; shown: boolean }[] = [
+      {
+        name:
+          "hides the action for a macOS device when the key is stored but the device is not connected to Fleet MDM",
+        props: {
+          isEncryptionKeyAvailable: true,
+          isConnectedToFleetMdm: false,
+          hostPlatform: "darwin",
         },
-      });
-
-      const { user } = render(
-        <HostActionsDropdown
-          hostTeamId={null}
-          onSelect={noop}
-          hostStatus="online"
-          hostMdmEnrollmentStatus={null}
-          doesStoreEncryptionKey
-          hostMdmDeviceStatus="unlocked"
-          hostScriptsEnabled
-          isConnectedToFleetMdm
-          hostPlatform="ios"
-        />
-      );
-
-      await user.click(screen.getByText("Actions"));
-
-      expect(
-        screen.queryByText("Show disk encryption key")
-      ).not.toBeInTheDocument();
-    });
-
-    it("hides the show disk encryption key action for Android device", async () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isPremiumTier: true,
-            isGlobalAdmin: true,
-            currentUser: createMockUser(),
-          },
+        shown: false,
+      },
+      {
+        name: "hides the action for an iOS device",
+        props: {
+          isEncryptionKeyAvailable: true,
+          isConnectedToFleetMdm: true,
+          hostPlatform: "ios",
         },
-      });
-
-      const { user } = render(
-        <HostActionsDropdown
-          hostTeamId={null}
-          onSelect={noop}
-          hostStatus="online"
-          hostMdmEnrollmentStatus={null}
-          doesStoreEncryptionKey
-          hostMdmDeviceStatus="unlocked"
-          hostScriptsEnabled
-          isConnectedToFleetMdm
-          hostPlatform="android"
-        />
-      );
-
-      await user.click(screen.getByText("Actions"));
-
-      expect(
-        screen.queryByText("Show disk encryption key")
-      ).not.toBeInTheDocument();
-    });
-
-    it("includes the show disk encryption key action when key is stored and macOS device is connected to Fleet MDM", async () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isGlobalAdmin: true,
-            isPremiumTier: true,
-            currentUser: createMockUser(),
-          },
+        shown: false,
+      },
+      {
+        name: "hides the action for an Android device",
+        props: {
+          isEncryptionKeyAvailable: true,
+          isConnectedToFleetMdm: true,
+          hostPlatform: "android",
         },
-      });
-
-      const { user } = render(
-        <HostActionsDropdown
-          hostTeamId={null}
-          onSelect={noop}
-          hostStatus="online"
-          hostMdmEnrollmentStatus={null}
-          doesStoreEncryptionKey
-          hostMdmDeviceStatus="unlocked"
-          hostScriptsEnabled
-          isConnectedToFleetMdm
-        />
-      );
-
-      await user.click(screen.getByText("Actions"));
-
-      expect(screen.getByText("Show disk encryption key")).toBeInTheDocument();
-    });
-
-    it("includes the show disk encryption key action when key is stored for Linux device", async () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isGlobalAdmin: true,
-            isPremiumTier: true,
-            currentUser: createMockUser(),
-          },
+        shown: false,
+      },
+      {
+        name:
+          "includes the action when the key is stored and the macOS device is connected to Fleet MDM",
+        props: {
+          isEncryptionKeyAvailable: true,
+          isConnectedToFleetMdm: true,
+          hostPlatform: "darwin",
         },
-      });
-
-      const { user } = render(
-        <HostActionsDropdown
-          hostTeamId={null}
-          onSelect={noop}
-          hostStatus="online"
-          hostMdmEnrollmentStatus={null}
-          doesStoreEncryptionKey
-          hostMdmDeviceStatus="unlocked"
-          hostScriptsEnabled
-          hostPlatform="debian"
-        />
-      );
-
-      await user.click(screen.getByText("Actions"));
-
-      expect(screen.getByText("Show disk encryption key")).toBeInTheDocument();
-    });
-
-    it("includes the show disk encryption key action when key is stored for Windows device", async () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isGlobalAdmin: true,
-            isPremiumTier: true,
-            currentUser: createMockUser(),
-          },
+        shown: true,
+      },
+      {
+        name: "includes the action when the key is stored for a Linux device",
+        props: { isEncryptionKeyAvailable: true, hostPlatform: "debian" },
+        shown: true,
+      },
+      {
+        name:
+          "includes the action when only an archived key exists for a macOS device connected to Fleet MDM",
+        props: {
+          isEncryptionKeyArchived: true,
+          isConnectedToFleetMdm: true,
+          hostPlatform: "darwin",
         },
-      });
+        shown: true,
+      },
+      {
+        // Fleet never serves a Linux host's archived key, so the menu must not offer it.
+        name:
+          "hides the action when only an archived key exists for a Linux device",
+        props: { isEncryptionKeyArchived: true, hostPlatform: "ubuntu" },
+        shown: false,
+      },
+      {
+        name: "includes the action when the key is stored for a Windows device",
+        props: { isEncryptionKeyAvailable: true, hostPlatform: "windows" },
+        shown: true,
+      },
+    ];
 
-      const { user } = render(
-        <HostActionsDropdown
-          hostTeamId={null}
-          onSelect={noop}
-          hostStatus="online"
-          hostMdmEnrollmentStatus={null}
-          doesStoreEncryptionKey
-          hostMdmDeviceStatus="unlocked"
-          hostScriptsEnabled
-          hostPlatform="windows"
-        />
-      );
+    it.each(cases)("$name", async ({ props, shown }) => {
+      await openActions(props);
 
-      await user.click(screen.getByText("Actions"));
-
-      expect(screen.getByText("Show disk encryption key")).toBeInTheDocument();
+      const action = screen.queryByText("Show disk encryption key");
+      if (shown) {
+        expect(action).toBeInTheDocument();
+      } else {
+        expect(action).not.toBeInTheDocument();
+      }
     });
   });
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
@@ -17,7 +17,8 @@ interface IHostActionsDropdownProps {
   /** This represents the mdm managed host device status (e.g. unlocked, locked,
    * unlocking, locking, ...etc) */
   hostMdmDeviceStatus: HostMdmDeviceStatusUIState;
-  doesStoreEncryptionKey?: boolean;
+  isEncryptionKeyAvailable?: boolean;
+  isEncryptionKeyArchived?: boolean;
   isConnectedToFleetMdm?: boolean;
   hostPlatform?: string;
   hostCpuType?: string;
@@ -46,7 +47,8 @@ const HostActionsDropdown = ({
   hostStatus,
   hostMdmEnrollmentStatus,
   hostMdmDeviceStatus,
-  doesStoreEncryptionKey,
+  isEncryptionKeyAvailable,
+  isEncryptionKeyArchived,
   isConnectedToFleetMdm,
   isDEPAssignedToFleet = false,
   hostPlatform = "",
@@ -111,7 +113,8 @@ const HostActionsDropdown = ({
       globalConfig?.mdm?.apple_bm_enabled_and_configured ?? false,
     isWindowsMdmEnabledAndConfigured,
     isAndroidMdmEnabledAndConfigured,
-    doesStoreEncryptionKey: doesStoreEncryptionKey ?? false,
+    isEncryptionKeyAvailable: isEncryptionKeyAvailable ?? false,
+    isEncryptionKeyArchived: isEncryptionKeyArchived ?? false,
     hostMdmDeviceStatus,
     hostScriptsEnabled,
     scriptsGloballyDisabled:

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -113,7 +113,8 @@ interface IHostActionConfigOptions {
   isAppleBusinessEnabledAndConfigured: boolean;
   isWindowsMdmEnabledAndConfigured: boolean;
   isAndroidMdmEnabledAndConfigured: boolean;
-  doesStoreEncryptionKey: boolean;
+  isEncryptionKeyAvailable: boolean;
+  isEncryptionKeyArchived: boolean;
   hostMdmDeviceStatus: HostMdmDeviceStatusUIState;
   hostScriptsEnabled: boolean | null;
   scriptsGloballyDisabled: boolean | undefined;
@@ -348,7 +349,8 @@ const canShowDiskEncryption = (config: IHostActionConfigOptions) => {
   const {
     isPremiumTier,
     isConnectedToFleetMdm,
-    doesStoreEncryptionKey,
+    isEncryptionKeyAvailable,
+    isEncryptionKeyArchived,
     hostPlatform,
   } = config;
   if (!isPremiumTier) {
@@ -361,7 +363,12 @@ const canShowDiskEncryption = (config: IHostActionConfigOptions) => {
   if (isAppleDevice(hostPlatform) && !isConnectedToFleetMdm) {
     return false;
   }
-  return doesStoreEncryptionKey;
+  // Fleet never serves a Linux host's archived key: the current key is only
+  // removed once its LUKS slot is proven gone, so the archived one is dead.
+  if (isLinuxLike(hostPlatform)) {
+    return isEncryptionKeyAvailable;
+  }
+  return isEncryptionKeyAvailable || isEncryptionKeyArchived;
 };
 
 const canShowRecoveryLockPassword = (config: IHostActionConfigOptions) => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1136,10 +1136,8 @@ const HostDetailsPage = ({
         hostStatus={host.status}
         hostMdmDeviceStatus={hostMdmDeviceStatus}
         hostMdmEnrollmentStatus={host.mdm.enrollment_status}
-        doesStoreEncryptionKey={
-          host.mdm.encryption_key_available ||
-          !!host.mdm.encryption_key_archived
-        }
+        isEncryptionKeyAvailable={host.mdm.encryption_key_available}
+        isEncryptionKeyArchived={!!host.mdm.encryption_key_archived}
         isConnectedToFleetMdm={host.mdm?.connected_to_fleet}
         isDEPAssignedToFleet={host.dep_assigned_to_fleet}
         hostScriptsEnabled={host.scripts_enabled}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -4032,9 +4032,16 @@ func (svc *Service) getHostDiskEncryptionKey(ctx context.Context, host *fleet.Ho
 	if err != nil && !fleet.IsNotFound(err) {
 		return nil, ctxerr.Wrap(ctx, err, "getting host encryption key")
 	}
-	archivedKey, err := svc.ds.GetHostArchivedDiskEncryptionKey(ctx, host)
-	if err != nil && !fleet.IsNotFound(err) {
-		return nil, ctxerr.Wrap(ctx, err, "getting host archived disk encryption key")
+	// The archived fallback exists for macOS, where re-enrollment clears the
+	// current row while the archived FileVault key is still valid. On Linux the
+	// current row is authoritative: it only goes missing once the verify query
+	// proved the key slot is gone, so the archived key is known to be dead.
+	var archivedKey *fleet.HostArchivedDiskEncryptionKey
+	if !host.IsLUKSSupported() {
+		archivedKey, err = svc.ds.GetHostArchivedDiskEncryptionKey(ctx, host)
+		if err != nil && !fleet.IsNotFound(err) {
+			return nil, ctxerr.Wrap(ctx, err, "getting host archived disk encryption key")
+		}
 	}
 	if key == nil && archivedKey == nil {
 		return nil, ctxerr.Wrap(ctx, newNotFoundError(), "host encryption key is not set")

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1059,6 +1059,7 @@ func TestHostDetailsOSSettings(t *testing.T) {
 			}
 		})
 	}
+
 }
 
 // Fragile test: This test is fragile because of the large reliance on Datastore mocks. Consider refactoring test/logic or removing the test. It may be slowing us down more than helping us.
@@ -4356,12 +4357,15 @@ func TestHostEncryptionKey(t *testing.T) {
 		passphrase := "this_is_a_passphrase"
 		base64EncryptedKey, err := mdm.EncryptAndEncode(passphrase, symmetricKey)
 		require.NoError(t, err)
+		base64ArchivedKey, err := mdm.EncryptAndEncode("previous_passphrase", symmetricKey)
+		require.NoError(t, err)
 
 		ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
 			return host, nil
 		}
+		// A decryptable archived key is always present: Linux must never fall back to it.
 		ds.GetHostArchivedDiskEncryptionKeyFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostArchivedDiskEncryptionKey, error) {
-			return &fleet.HostArchivedDiskEncryptionKey{}, nil
+			return &fleet.HostArchivedDiskEncryptionKey{Base64Encrypted: base64ArchivedKey}, nil
 		}
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { // needed for new activity
 			return &fleet.AppConfig{}, nil
@@ -4375,15 +4379,25 @@ func TestHostEncryptionKey(t *testing.T) {
 		require.Error(t, err, "private key is unavailable")
 		require.Nil(t, key)
 
-		// error when key is not set
+		// not found when the verify query deleted the key
 		ds.GetHostDiskEncryptionKeyFunc = func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
-			return &fleet.HostDiskEncryptionKey{}, nil
+			return nil, newNotFoundError()
 		}
 		fleetCfg.Server.PrivateKey = symmetricKey
 		svc, ctx = newTestServiceWithConfig(t, ds, fleetCfg, nil, nil)
 		ctx = test.UserContext(ctx, test.UserAdmin)
 		key, err = svc.HostEncryptionKey(ctx, 1)
-		require.Error(t, err, "host encryption key is not set")
+		require.True(t, fleet.IsNotFound(err), "expected not found, got: %v", err)
+		require.Nil(t, key)
+
+		// not found when a new escrow is queued but the key hasn't arrived yet
+		ds.GetHostDiskEncryptionKeyFunc = func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
+			return &fleet.HostDiskEncryptionKey{}, nil
+		}
+		svc, ctx = newTestServiceWithConfig(t, ds, fleetCfg, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+		key, err = svc.HostEncryptionKey(ctx, 1)
+		require.True(t, fleet.IsNotFound(err), "expected not found, got: %v", err)
 		require.Nil(t, key)
 
 		// error when key is not set


### PR DESCRIPTION
https://github.com/user-attachments/assets/04a14cd1-d76d-4eb5-94e1-78876e7796b3

Relates to #46535

Fleet fell back to the archived key when a Linux host's current key was missing or empty. That fallback is only valid for macOS re-enrollment; on Linux the row is removed once the slot is proven gone, so the archived key is dead.

`GET /hosts/:id/encryption_key` now skips the archived key entirely for Linux hosts. The host actions menu receives the available and archived flags separately and, for Linux, offers "Show disk encryption key" only when a verified current key exists.

Also fixed a data race:

The luks_verify check reads its two inputs at different times. The key slots come from a snapshot captured when osquery runs the query, while the stored key is read later, when the results are ingested. A mismatch was taken as proof the key slot was gone.
    
So a key escrowed between those two moments was deleted by a report that could not have seen it. The end user entered their passphrase, fleetd added the slot and escrowed successfully, and Fleet then discarded the key and returned the host to "Action required". The slot stayed on disk holding a passphrase Fleet no longer had, and fleetd never removed it because its own request had succeeded. Repeating this consumes slots until escrow fails outright.
    
Skip the deletion when the stored key was written within the last five minutes, since a report captured before it cannot judge it. The window only has to exceed how long a batch sits between running the query and submitting its results. A slot that really is gone is caught on the next run.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

## Frontend

- [X] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Linux hosts no longer display or return a previously archived disk-encryption key after the active key has been removed.
  - The disk-encryption key action is now available on Linux only when a current key is verified.
  - macOS and other supported platforms continue to support archived-key access where applicable.
  - Hosts without an available key now correctly report that no key was found, including while a newly escrowed key is pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->