### PR TITLE
unblock app.managed configuration

### DIFF
--- a/changes/51070-unblock-app-managed-ddm
+++ b/changes/51070-unblock-app-managed-ddm
@@ -1,0 +1,1 @@
+- Fixed an issue where com.apple.configuration.app.managed became blocked while it previously was not.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1051,7 +1051,7 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 		return NewInvalidArgumentError(r.Type, "Declaration profile can't include status subscription type. To get host's vitals, please use queries and policies.")
 	}
 
-	if r.Type == "com.apple.configuration.app.managed" || r.Type == "com.apple.configuration.package" {
+	if r.Type == "com.apple.configuration.package" {
 		return NewInvalidArgumentError(r.Type, "Declaration profile can't include software management types. To manage software, please use the Software tab.")
 	}
 

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -264,13 +264,12 @@ func TestMDMAppleRawDeclarationValidateUserProvided(t *testing.T) {
 			errContains: "Declaration profile can't include status subscription type.",
 		},
 		{
-			name:        "managed app configuration not allowed",
-			declType:    "com.apple.configuration.app.managed",
-			wantErr:     true,
-			errContains: "Declaration profile can't include software management types. To manage software, please use the Software tab.",
+			name:     "managed app configuration allowed",
+			declType: "com.apple.configuration.app.managed",
+			wantErr:  false,
 		},
 		{
-			name:        "managed app configuration not allowed",
+			name:        "package configuration not allowed",
 			declType:    "com.apple.configuration.package",
 			wantErr:     true,
 			errContains: "Declaration profile can't include software management types. To manage software, please use the Software tab.",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51070 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Apple MDM app-managed configuration declarations are no longer incorrectly blocked.
  - Package configuration declarations remain restricted as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->