### PR TITLE
Fix unsaved changes prompt on SSO settings when the form is back to its original state

### DIFF
--- a/changes/48386-sso-settings-form-dirty-state
+++ b/changes/48386-sso-settings-form-dirty-state
@@ -1,0 +1,2 @@
+- Fixed the unsaved changes prompt appearing when switching tabs on the SSO settings page after a field had been edited and then returned to its original value.
+- Updated the forms on the Authentication (SSO) settings page to follow Fleet's form validation patterns, so errors surface on the field being edited instead of on fields that haven't been filled in yet.

--- a/frontend/hooks/useFormValidation.ts
+++ b/frontend/hooks/useFormValidation.ts
@@ -93,9 +93,9 @@ interface IUseFormValidationReturn<TFormData> {
   isDirty: boolean;
 }
 
-const trimFormData = <TFormData>(
+export const trimFormData = <TFormData>(
   formData: TFormData,
-  skipTrim: readonly string[]
+  skipTrim: readonly string[] = []
 ): TFormData => {
   const trimmed = { ...formData } as Record<string, unknown>;
   Object.keys(trimmed).forEach((key) => {

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
@@ -1,14 +1,13 @@
-import React, { MutableRefObject } from "react";
+import React from "react";
 import { noop } from "lodash";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import { createMockConfig } from "__mocks__/configMock";
 import { createCustomRenderer } from "test/test-utils";
+import configAPI from "services/entities/config";
+import { IEndUserAuthentication } from "interfaces/config";
 
-import EndUserAuthSection, {
-  IEndUserAuthSectionProps,
-} from "./EndUserAuthSection";
-import { IFormDataIdp } from "./helpers";
+import EndUserAuthSection from "./EndUserAuthSection";
 
 jest.mock("components/ToastNotification", () => ({
   notify: {
@@ -19,116 +18,251 @@ jest.mock("components/ToastNotification", () => ({
   },
 }));
 
-const EMPTY_FORM_DATA: IFormDataIdp = {
+const EMPTY_END_USER_AUTH: IEndUserAuthentication = {
   idp_name: "",
   entity_id: "",
   metadata_url: "",
   metadata: "",
+  issuer_uri: "",
 };
 
-const FILLED_FORM_DATA: IFormDataIdp = {
+const CONFIGURED_END_USER_AUTH: IEndUserAuthentication = {
   idp_name: "Okta",
   entity_id: "https://fleet.example.com",
   metadata_url: "https://idp.example.com/metadata",
   metadata: "",
+  issuer_uri: "",
 };
 
-const createTestRenderer = () => {
-  return createCustomRenderer({
-    context: {
-      app: {
-        isPremiumTier: true,
-        config: createMockConfig(),
-      },
-    },
+const renderEndUserAuthSection = ({
+  endUserAuth = EMPTY_END_USER_AUTH,
+  onDirtyChange = noop,
+  isPremiumTier = true,
+}: {
+  endUserAuth?: IEndUserAuthentication;
+  onDirtyChange?: (hasUnsavedChanges: boolean) => void;
+  isPremiumTier?: boolean;
+} = {}) => {
+  // Deliberately left holding the empty default: the component must read the
+  // saved config from its prop, not from here.
+  const render = createCustomRenderer({
+    context: { app: { isPremiumTier, config: createMockConfig() } },
   });
-};
 
-const renderEndUserAuthSection = (
-  overrides?: Partial<IEndUserAuthSectionProps>
-) => {
-  const defaultProps: IEndUserAuthSectionProps = {
-    setDirty: jest.fn(),
-    formData: FILLED_FORM_DATA,
-    setFormData: jest.fn(),
-    originalFormData: {
-      current: FILLED_FORM_DATA,
-    } as MutableRefObject<IFormDataIdp>,
-    onSubmit: noop,
-    ...overrides,
-  };
-
-  const render = createTestRenderer();
-  return render(<EndUserAuthSection {...defaultProps} />);
+  return render(
+    <EndUserAuthSection
+      endUserAuth={endUserAuth}
+      onDirtyChange={onDirtyChange}
+      onSubmit={noop}
+    />
+  );
 };
 
 describe("EndUserAuthSection", () => {
-  it("enables Save when all fields are cleared but original data had values", () => {
-    renderEndUserAuthSection({
-      formData: EMPTY_FORM_DATA,
-      originalFormData: {
-        current: FILLED_FORM_DATA,
-      } as MutableRefObject<IFormDataIdp>,
-    });
+  const updateSpy = jest.spyOn(configAPI, "update");
 
-    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  beforeEach(() => {
+    updateSpy.mockClear();
+    updateSpy.mockResolvedValue(createMockConfig());
   });
 
-  it("disables Save when form starts empty and remains empty", () => {
-    renderEndUserAuthSection({
-      formData: EMPTY_FORM_DATA,
-      originalFormData: {
-        current: EMPTY_FORM_DATA,
-      } as MutableRefObject<IFormDataIdp>,
-    });
-
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  afterAll(() => {
+    updateSpy.mockRestore();
   });
 
-  it("enables Save when all required fields are filled with valid data", () => {
-    renderEndUserAuthSection({
-      formData: FILLED_FORM_DATA,
-      originalFormData: {
-        current: FILLED_FORM_DATA,
-      } as MutableRefObject<IFormDataIdp>,
-    });
+  it("shows the premium paywall on free tier", () => {
+    renderEndUserAuthSection({ isPremiumTier: false });
 
-    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
   });
 
-  it("disables Save when required fields are partially filled", () => {
-    renderEndUserAuthSection({
-      formData: {
-        idp_name: "Okta",
-        entity_id: "",
-        metadata_url: "",
-        metadata: "",
-      },
-      originalFormData: {
-        current: FILLED_FORM_DATA,
-      } as MutableRefObject<IFormDataIdp>,
-    });
+  it("seeds the fields from the config prop rather than AppContext", () => {
+    renderEndUserAuthSection({ endUserAuth: CONFIGURED_END_USER_AUTH });
 
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByLabelText("Identity provider name")).toHaveValue("Okta");
+    expect(screen.getByLabelText("Entity ID")).toHaveValue(
+      "https://fleet.example.com"
+    );
+    expect(screen.getByLabelText("Metadata URL")).toHaveValue(
+      "https://idp.example.com/metadata"
+    );
   });
 
-  it("clears form errors when user clears all fields", async () => {
-    const setFormData = jest.fn();
+  it("drops the errors already on screen as soon as the form is fully emptied", async () => {
     const { user } = renderEndUserAuthSection({
-      formData: FILLED_FORM_DATA,
-      setFormData,
-      originalFormData: {
-        current: FILLED_FORM_DATA,
-      } as MutableRefObject<IFormDataIdp>,
+      endUserAuth: CONFIGURED_END_USER_AUTH,
     });
 
-    // Clear the Identity provider name field
-    const idpNameInput = screen.getByLabelText("Identity provider name");
-    await user.clear(idpNameInput);
+    const idpName = screen.getByLabelText("Identity provider name");
+    const entityId = screen.getByLabelText("Entity ID");
+    const metadataUrl = screen.getByLabelText("Metadata URL");
 
-    // setFormData should have been called with idp_name cleared
-    expect(setFormData).toHaveBeenCalledWith(
-      expect.objectContaining({ idp_name: "" })
+    await user.clear(idpName);
+    await user.tab();
+    expect(
+      screen.getByText("Enter an identity provider name")
+    ).toBeInTheDocument();
+
+    await user.clear(entityId);
+    await user.clear(metadataUrl);
+
+    expect(screen.queryByText("Enter an identity provider name")).toBeNull();
+    expect(screen.queryByText("Enter an entity ID")).toBeNull();
+  });
+
+  it("keeps Save enabled on an empty form", () => {
+    renderEndUserAuthSection();
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("keeps Save enabled when required fields are only partially filled", async () => {
+    const { user } = renderEndUserAuthSection();
+
+    await user.type(screen.getByLabelText("Identity provider name"), "Okta");
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("does not light up untouched fields when moving out of one field", async () => {
+    const { user } = renderEndUserAuthSection();
+
+    await user.type(
+      screen.getByLabelText("Entity ID"),
+      "https://fleet.example.com"
+    );
+    await user.tab();
+
+    expect(screen.queryByText("Enter an identity provider name")).toBeNull();
+    expect(screen.queryByText("Enter metadata or a metadata URL")).toBeNull();
+  });
+
+  it("shows an error on the blurred field once its own value is invalid", async () => {
+    const { user } = renderEndUserAuthSection({
+      endUserAuth: CONFIGURED_END_USER_AUTH,
+    });
+
+    await user.clear(screen.getByLabelText("Identity provider name"));
+    await user.tab();
+
+    expect(
+      screen.getByText("Enter an identity provider name")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Enter an entity ID")).toBeNull();
+  });
+
+  it("clears a field's error when the field is focused again", async () => {
+    const { user } = renderEndUserAuthSection({
+      endUserAuth: CONFIGURED_END_USER_AUTH,
+    });
+
+    const idpName = screen.getByLabelText("Identity provider name");
+    await user.clear(idpName);
+    await user.tab();
+    expect(
+      screen.getByText("Enter an identity provider name")
+    ).toBeInTheDocument();
+
+    await user.click(idpName);
+
+    expect(screen.queryByText("Enter an identity provider name")).toBeNull();
+  });
+
+  it("reveals every error on submit and does not call the API", async () => {
+    const { user } = renderEndUserAuthSection();
+
+    await user.type(screen.getByLabelText("Identity provider name"), "Okta");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText("Enter an entity ID")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Enter metadata or a metadata URL").length
+    ).toBeGreaterThan(0);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports unsaved changes only while the form differs from what was saved", async () => {
+    const onDirtyChange = jest.fn();
+    const { user } = renderEndUserAuthSection({ onDirtyChange });
+
+    const idpName = screen.getByLabelText("Identity provider name");
+    await user.type(idpName, "Okta");
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    await user.clear(idpName);
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("stops reporting unsaved changes after a successful save", async () => {
+    const onDirtyChange = jest.fn();
+    const { user } = renderEndUserAuthSection({
+      endUserAuth: CONFIGURED_END_USER_AUTH,
+      onDirtyChange,
+    });
+
+    await user.type(
+      screen.getByLabelText("Identity provider name"),
+      " Renamed"
+    );
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it("submits trimmed values", async () => {
+    const { user } = renderEndUserAuthSection();
+
+    await user.type(
+      screen.getByLabelText("Identity provider name"),
+      "  Okta  "
+    );
+    await user.type(
+      screen.getByLabelText("Entity ID"),
+      "  https://fleet.example.com  "
+    );
+    await user.type(
+      screen.getByLabelText("Metadata URL"),
+      "  https://idp.example.com/metadata  "
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateSpy).toHaveBeenCalledWith({
+        mdm: {
+          end_user_authentication: {
+            idp_name: "Okta",
+            entity_id: "https://fleet.example.com",
+            metadata_url: "https://idp.example.com/metadata",
+            metadata: "",
+          },
+        },
+      })
+    );
+  });
+
+  it("saves an emptied form so the configuration can be cleared", async () => {
+    const { user } = renderEndUserAuthSection({
+      endUserAuth: CONFIGURED_END_USER_AUTH,
+    });
+
+    await user.clear(screen.getByLabelText("Identity provider name"));
+    await user.clear(screen.getByLabelText("Entity ID"));
+    await user.clear(screen.getByLabelText("Metadata URL"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(updateSpy).toHaveBeenCalledWith({
+        mdm: {
+          end_user_authentication: {
+            idp_name: "",
+            entity_id: "",
+            metadata_url: "",
+            metadata: "",
+          },
+        },
+      })
     );
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
@@ -38,15 +38,26 @@ const renderEndUserAuthSection = ({
   endUserAuth = EMPTY_END_USER_AUTH,
   onDirtyChange = noop,
   isPremiumTier = true,
+  gitOpsModeEnabled = false,
 }: {
   endUserAuth?: IEndUserAuthentication;
   onDirtyChange?: (hasUnsavedChanges: boolean) => void;
   isPremiumTier?: boolean;
+  gitOpsModeEnabled?: boolean;
 } = {}) => {
   // Deliberately left holding the empty default: the component must read the
   // saved config from its prop, not from here.
+  const config = createMockConfig();
   const render = createCustomRenderer({
-    context: { app: { isPremiumTier, config: createMockConfig() } },
+    context: {
+      app: {
+        isPremiumTier,
+        config: {
+          ...config,
+          gitops: { ...config.gitops, gitops_mode_enabled: gitOpsModeEnabled },
+        },
+      },
+    },
   });
 
   return render(
@@ -221,6 +232,48 @@ describe("EndUserAuthSection", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(false));
+  });
+
+  it("clears the paired metadata error once either field is filled", async () => {
+    const { user } = renderEndUserAuthSection();
+
+    await user.type(screen.getByLabelText("Identity provider name"), "Okta");
+    // Captured before submitting: the error text replaces the field's label.
+    const metadataUrl = screen.getByLabelText("Metadata URL");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(
+      screen.getAllByText("Enter metadata or a metadata URL")
+    ).toHaveLength(2);
+
+    await user.type(metadataUrl, "https://idp.example.com/metadata");
+
+    expect(screen.queryByText("Enter metadata or a metadata URL")).toBeNull();
+    // The errors the change didn't make irrelevant stay put.
+    expect(screen.getByText("Enter an entity ID")).toBeInTheDocument();
+  });
+
+  it("stops reporting unsaved changes when it unmounts", async () => {
+    const onDirtyChange = jest.fn();
+    const { user, unmount } = renderEndUserAuthSection({ onDirtyChange });
+
+    await user.type(screen.getByLabelText("Identity provider name"), "Okta");
+    expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+
+    unmount();
+
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("does not submit in GitOps mode", async () => {
+    const { user } = renderEndUserAuthSection({
+      endUserAuth: CONFIGURED_END_USER_AUTH,
+      gitOpsModeEnabled: true,
+    });
+
+    await user.type(screen.getByLabelText("Entity ID"), "{Enter}");
+
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 
   it("submits trimmed values", async () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
@@ -193,6 +193,18 @@ describe("EndUserAuthSection", () => {
     expect(onDirtyChange).toHaveBeenLastCalledWith(false);
   });
 
+  it("does not report unsaved changes for whitespace the submit would trim", async () => {
+    const onDirtyChange = jest.fn();
+    const { user } = renderEndUserAuthSection({
+      endUserAuth: CONFIGURED_END_USER_AUTH,
+      onDirtyChange,
+    });
+
+    await user.type(screen.getByLabelText("Identity provider name"), "   ");
+
+    expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("stops reporting unsaved changes after a successful save", async () => {
     const onDirtyChange = jest.fn();
     const { user } = renderEndUserAuthSection({

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -1,18 +1,15 @@
-import React, {
-  MutableRefObject,
-  useCallback,
-  useContext,
-  useState,
-} from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { AxiosResponse } from "axios";
+import { isEqual } from "lodash";
 
 import { expandErrorReasonRequired } from "interfaces/errors";
+import { IEndUserAuthentication } from "interfaces/config";
 import configAPI from "services/entities/config";
 import { AppContext } from "context/app";
+import useFormValidation from "hooks/useFormValidation";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button/Button";
-import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import CustomLink from "components/CustomLink";
@@ -20,28 +17,27 @@ import { notify } from "components/ToastNotification";
 
 import {
   IFormDataIdp,
-  IFormErrorsIdp,
   isEmptyFormData,
-  isMissingAnyRequiredField,
-  trimFormDataIdp,
-  validateFormDataIdp,
+  newFormDataIdp,
+  validateEndUserAuthForm,
 } from "./helpers";
 
 const baseClass = "end-user-auth-section";
 
 export interface IEndUserAuthSectionProps {
-  setDirty: (dirty: boolean) => void;
-  formData: IFormDataIdp;
-  setFormData: React.Dispatch<React.SetStateAction<IFormDataIdp>>;
-  originalFormData: MutableRefObject<IFormDataIdp>;
+  /**
+   * The saved config, from the page's own config query. AppContext holds a
+   * separate copy that the refetch after a save doesn't update, so seeding
+   * from there shows pre-save values once the card remounts.
+   */
+  endUserAuth?: IEndUserAuthentication;
+  onDirtyChange: (hasUnsavedChanges: boolean) => void;
   onSubmit: () => void;
 }
 
 const EndUserAuthSection = ({
-  setDirty,
-  formData,
-  setFormData,
-  originalFormData,
+  endUserAuth,
+  onDirtyChange,
   // Notify parent component of changes, since we're calling our own API
   // rather than using the common config update handler.
   onSubmit: announceChanges,
@@ -49,82 +45,62 @@ const EndUserAuthSection = ({
   const { config, isPremiumTier } = useContext(AppContext);
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
-  const [formErrors, setFormErrors] = useState<IFormErrorsIdp | null>(null);
+  const originalFormData = useRef(newFormDataIdp(endUserAuth));
 
-  const isFormCleared =
-    isEmptyFormData(formData) && !isEmptyFormData(originalFormData.current);
+  const {
+    formData,
+    setField,
+    reset,
+    getError,
+    clearFieldError,
+    validateField,
+    handleSubmit,
+    clearErrors,
+    isSubmitting,
+  } = useFormValidation<IFormDataIdp>({
+    initialFormData: originalFormData.current,
+    validate: validateEndUserAuthForm,
+  });
 
-  const enableSaveButton =
-    isFormCleared || (!isMissingAnyRequiredField(formData) && !formErrors);
+  const hasUnsavedChanges = !isEqual(formData, originalFormData.current);
 
-  const onInputChange = useCallback(
-    ({ name, value }: { name: keyof IFormDataIdp; value: string }) => {
-      const newData = { ...formData, [name]: value };
-      setFormData(newData);
-      setDirty(true);
+  const onFieldChange = (name: keyof IFormDataIdp, value: string) => {
+    setField(name, value);
+    // Emptying the last field is how the configuration gets cleared, and an
+    // empty form is valid, so every required-field error stops applying.
+    if (isEmptyFormData({ ...formData, [name]: value })) {
+      clearErrors();
+    }
+  };
 
-      const newErrors = validateFormDataIdp(newData);
-      if (!newErrors) {
-        // don't wait for onBlur to clear form errors if there are no new errors
-        setFormErrors(null);
-      } else if (formErrors?.[name] && !newErrors[name]) {
-        // don't wait for onBlur to update error on this field
-        setFormErrors(newErrors);
-      } else if (name === "metadata") {
-        // FIXME: See comment to InputField component regarding onBlur prop for textarea. For now,
-        // this check just always updates form errors whenever metadata field changes because
-        // onBlur doesn't currently work for textareas.
-        setFormErrors(newErrors);
-      }
-    },
-    [formData, setFormData, formErrors, setDirty]
-  );
+  useEffect(() => {
+    onDirtyChange(hasUnsavedChanges);
+  }, [hasUnsavedChanges, onDirtyChange]);
 
-  const onBlur = useCallback(() => {
-    const trimmed = trimFormDataIdp(formData);
-    setFormData(trimmed);
-    setFormErrors(validateFormDataIdp(trimmed));
-  }, [formData, setFormData]);
-
-  const onSubmit = useCallback(
-    async (e: React.FormEvent<SubmitEvent>) => {
-      e.preventDefault();
-      const trimmed = trimFormDataIdp(formData);
-      setFormData(trimmed);
-
-      const newErrors = validateFormDataIdp(trimmed);
-      if (newErrors) {
-        setFormErrors(newErrors);
+  const onValidSubmit = async (submitData: IFormDataIdp) => {
+    try {
+      await configAPI.update({
+        mdm: {
+          end_user_authentication: {
+            ...submitData,
+          },
+        },
+      });
+      notify.success("Successfully updated end user authentication.");
+      originalFormData.current = submitData;
+      reset(submitData);
+      announceChanges();
+    } catch (err) {
+      const ae = (typeof err === "object" ? err : {}) as AxiosResponse;
+      if (ae.status === 422) {
+        notify.error(`Couldn't update: ${expandErrorReasonRequired(err)}.`, {
+          response: err,
+        });
         return;
       }
-
-      try {
-        await configAPI.update({
-          mdm: {
-            end_user_authentication: {
-              ...trimmed,
-            },
-          },
-        });
-        notify.success("Successfully updated end user authentication.");
-        originalFormData.current = { ...formData };
-        setDirty(false);
-        // Notify parent component of changes, since we're calling our own API
-        // rather than using the common config update handler.
-        announceChanges();
-      } catch (err) {
-        const ae = (typeof err === "object" ? err : {}) as AxiosResponse;
-        if (ae.status === 422) {
-          notify.error(`Couldn't update: ${expandErrorReasonRequired(err)}.`, {
-            response: err,
-          });
-          return;
-        }
-        notify.error("Couldn't update. Please try again.", { response: err });
-      }
-    },
-    [formData, setFormData, setDirty]
-  );
+      notify.error("Couldn't update. Please try again.", { response: err });
+    }
+  };
 
   const renderContent = () => {
     if (!isPremiumTier) {
@@ -132,7 +108,7 @@ const EndUserAuthSection = ({
     }
 
     return (
-      <form>
+      <form onSubmit={handleSubmit(onValidSubmit)}>
         <p>
           After configuring, head to{" "}
           <strong>
@@ -152,22 +128,24 @@ const EndUserAuthSection = ({
         >
           <InputField
             label="Identity provider name"
-            onChange={onInputChange}
-            onBlur={onBlur}
             name="idp_name"
             value={formData.idp_name}
-            parseTarget
-            error={formErrors?.idp_name}
+            error={getError("idp_name")}
+            onChange={(value: string) => onFieldChange("idp_name", value)}
+            onFocus={() => clearFieldError("idp_name")}
+            onBlur={() => validateField("idp_name")}
+            disabled={isSubmitting}
             tooltip="A required human friendly name for the identity provider that will provide single sign-on authentication."
           />
           <InputField
             label="Entity ID"
-            onChange={onInputChange}
-            onBlur={onBlur}
             name="entity_id"
             value={formData.entity_id}
-            parseTarget
-            error={formErrors?.entity_id}
+            error={getError("entity_id")}
+            onChange={(value: string) => onFieldChange("entity_id", value)}
+            onFocus={() => clearFieldError("entity_id")}
+            onBlur={() => validateField("entity_id")}
+            disabled={isSubmitting}
             tooltip="The Entity ID is a required URI that you use to identify Fleet when configuring the identity provider. Okta calls this Audience Restriction."
           />
           <InputField
@@ -178,40 +156,38 @@ const EndUserAuthSection = ({
                 <b>Metadata URL</b> will be used.
               </>
             }
-            onChange={onInputChange}
-            onBlur={onBlur}
             name="metadata_url"
             value={formData.metadata_url}
-            parseTarget
-            error={formErrors?.metadata_url}
+            error={getError("metadata_url")}
+            onChange={(value: string) => onFieldChange("metadata_url", value)}
+            onFocus={() => clearFieldError("metadata_url")}
+            onBlur={() => validateField("metadata_url")}
+            disabled={isSubmitting}
             tooltip="Metadata URL provided by the identity provider."
           />
           <InputField
             label="Metadata"
             type="textarea"
-            onChange={onInputChange}
             name="metadata"
             value={formData.metadata}
-            parseTarget
-            error={formErrors?.metadata}
+            error={getError("metadata")}
+            onChange={(value: string) => onFieldChange("metadata", value)}
+            onFocus={() => clearFieldError("metadata")}
+            onBlur={() => validateField("metadata")}
+            disabled={isSubmitting}
             tooltip="Metadata XML provided by the identity provider."
           />
         </div>
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (
-            <TooltipWrapper
-              tipContent="Complete all required fields to save end user authentication."
-              disableTooltip={enableSaveButton || disableChildren}
-              underline={false}
+            <Button
+              type="submit"
+              disabled={isSubmitting || disableChildren}
+              isLoading={isSubmitting}
+              className="button-wrap"
             >
-              <Button
-                disabled={!enableSaveButton || disableChildren}
-                onClick={onSubmit}
-                className="button-wrap"
-              >
-                Save
-              </Button>
-            </TooltipWrapper>
+              Save
+            </Button>
           )}
         />
       </form>

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -6,7 +6,7 @@ import { expandErrorReasonRequired } from "interfaces/errors";
 import { IEndUserAuthentication } from "interfaces/config";
 import configAPI from "services/entities/config";
 import { AppContext } from "context/app";
-import useFormValidation from "hooks/useFormValidation";
+import useFormValidation, { trimFormData } from "hooks/useFormValidation";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button/Button";
@@ -62,7 +62,10 @@ const EndUserAuthSection = ({
     validate: validateEndUserAuthForm,
   });
 
-  const hasUnsavedChanges = !isEqual(formData, originalFormData.current);
+  const hasUnsavedChanges = !isEqual(
+    trimFormData(formData),
+    originalFormData.current
+  );
 
   const onFieldChange = (name: keyof IFormDataIdp, value: string) => {
     setField(name, value);

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -18,6 +18,7 @@ import { notify } from "components/ToastNotification";
 import {
   IFormDataIdp,
   isEmptyFormData,
+  METADATA_SIBLING,
   newFormDataIdp,
   validateEndUserAuthForm,
 } from "./helpers";
@@ -69,10 +70,21 @@ const EndUserAuthSection = ({
 
   const onFieldChange = (name: keyof IFormDataIdp, value: string) => {
     setField(name, value);
+
     // Emptying the last field is how the configuration gets cleared, and an
     // empty form is valid, so every required-field error stops applying.
     if (isEmptyFormData({ ...formData, [name]: value })) {
       clearErrors();
+      return;
+    }
+
+    // Filling either metadata field satisfies the shared requirement, but blur
+    // only revalidates the field that blurred, so the other keeps a stale copy
+    // of the message. An empty sibling can only be holding that shared error; a
+    // non-empty metadata URL may be holding a format error that still applies.
+    const sibling = METADATA_SIBLING[name];
+    if (value.trim() && sibling && !formData[sibling].trim()) {
+      clearFieldError(sibling);
     }
   };
 
@@ -80,7 +92,15 @@ const EndUserAuthSection = ({
     onDirtyChange(hasUnsavedChanges);
   }, [hasUnsavedChanges, onDirtyChange]);
 
+  useEffect(() => () => onDirtyChange(false), [onDirtyChange]);
+
   const onValidSubmit = async (submitData: IFormDataIdp) => {
+    // The fields and the button are disabled in GitOps mode.
+    // Prevent the form element itself from being submitted.
+    if (gitOpsModeEnabled) {
+      return;
+    }
+
     try {
       await configAPI.update({
         mdm: {
@@ -137,7 +157,7 @@ const EndUserAuthSection = ({
             onChange={(value: string) => onFieldChange("idp_name", value)}
             onFocus={() => clearFieldError("idp_name")}
             onBlur={() => validateField("idp_name")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="A required human friendly name for the identity provider that will provide single sign-on authentication."
           />
           <InputField
@@ -148,7 +168,7 @@ const EndUserAuthSection = ({
             onChange={(value: string) => onFieldChange("entity_id", value)}
             onFocus={() => clearFieldError("entity_id")}
             onBlur={() => validateField("entity_id")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="The Entity ID is a required URI that you use to identify Fleet when configuring the identity provider. Okta calls this Audience Restriction."
           />
           <InputField
@@ -165,7 +185,7 @@ const EndUserAuthSection = ({
             onChange={(value: string) => onFieldChange("metadata_url", value)}
             onFocus={() => clearFieldError("metadata_url")}
             onBlur={() => validateField("metadata_url")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="Metadata URL provided by the identity provider."
           />
           <InputField
@@ -177,7 +197,7 @@ const EndUserAuthSection = ({
             onChange={(value: string) => onFieldChange("metadata", value)}
             onFocus={() => clearFieldError("metadata")}
             onBlur={() => validateField("metadata")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="Metadata XML provided by the identity provider."
           />
         </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.tests.ts
@@ -1,9 +1,8 @@
 import { IEndUserAuthentication } from "interfaces/config";
 import {
   isEmptyFormData,
-  isMissingAnyRequiredField,
   newFormDataIdp,
-  validateFormDataIdp,
+  validateEndUserAuthForm,
 } from "./helpers";
 
 describe("IdPSection helpers", () => {
@@ -40,158 +39,127 @@ describe("IdPSection helpers", () => {
     });
   });
 
-  describe("isMissingAnyRequiredField", () => {
-    it("returns true if missing any required field", () => {
+  describe("validateEndUserAuthForm", () => {
+    it("returns no errors when all fields are valid", () => {
       expect(
-        isMissingAnyRequiredField({
+        validateEndUserAuthForm({
           entity_id: "entityId",
-          idp_name: "idpImageUrl",
+          idp_name: "idpName",
           metadata: "metadata",
-          metadata_url: "metadataUrl",
+          metadata_url: "https://metadataUrl.com",
         })
-      ).toBe(false); // all fields present
-
-      expect(
-        isMissingAnyRequiredField({
-          entity_id: "",
-          idp_name: "idpImageUrl",
-          metadata: "metadata",
-          metadata_url: "metadataUrl",
-        })
-      ).toBe(true); // entity_id is missing
-
-      expect(
-        isMissingAnyRequiredField({
-          entity_id: "entityId",
-          idp_name: "",
-          metadata: "metadata",
-          metadata_url: "metadataUrl",
-        })
-      ).toBe(true); // idp_name is missing
-
-      expect(
-        isMissingAnyRequiredField({
-          entity_id: "entityId",
-          idp_name: "idpImageUrl",
-          metadata: "",
-          metadata_url: "",
-        })
-      ).toBe(true); // metadata or metadata_url must be present
+      ).toEqual({});
     });
 
-    expect(
-      isMissingAnyRequiredField({
-        entity_id: "entityId",
-        idp_name: "idpImageUrl",
-        metadata: "",
-        metadata_url: "metadataUrl",
-      })
-    ).toBe(false); // metadata is not required if metadata_url is present
-
-    expect(
-      isMissingAnyRequiredField({
-        entity_id: "entityId",
-        idp_name: "idpImageUrl",
-        metadata: "metadata",
-        metadata_url: "",
-      })
-    ).toBe(false); // metadata_url is not required if metadata is present
-  });
-
-  describe("validateFormDataIdP", () => {
-    it("returns expected error messages", () => {
+    it("returns no errors when every field is empty, so the config can be cleared", () => {
       expect(
-        validateFormDataIdp({
-          entity_id: "entityId",
-          idp_name: "idpImageUrl",
-          metadata: "metadata",
-          metadata_url: "https://metadataUrl.com",
-        })
-      ).toEqual(null); // all fields valid
-
-      expect(
-        validateFormDataIdp({
+        validateEndUserAuthForm({
           entity_id: "",
           idp_name: "",
           metadata: "",
           metadata_url: "",
         })
-      ).toEqual(null); // all fields empty is valid (allows clearing settings)
+      ).toEqual({});
+    });
+
+    it("treats whitespace-only fields as empty", () => {
+      expect(
+        validateEndUserAuthForm({
+          entity_id: "  ",
+          idp_name: "   ",
+          metadata: " ",
+          metadata_url: "  ",
+        })
+      ).toEqual({});
 
       expect(
-        validateFormDataIdp({
+        validateEndUserAuthForm({
+          entity_id: "entityId",
+          idp_name: "   ",
+          metadata: "metadata",
+          metadata_url: "",
+        })
+      ).toEqual({ idp_name: "Enter an identity provider name" });
+    });
+
+    it("requires the identity provider name", () => {
+      expect(
+        validateEndUserAuthForm({
           entity_id: "entityId",
           idp_name: "",
           metadata: "metadata",
           metadata_url: "https://metadataUrl.com",
         })
-      ).toEqual({
-        idp_name: "Identity provider name must be present.",
-      });
+      ).toEqual({ idp_name: "Enter an identity provider name" });
+    });
 
+    it("requires the entity ID", () => {
       expect(
-        validateFormDataIdp({
+        validateEndUserAuthForm({
           entity_id: "",
-          idp_name: "idpImageUrl",
+          idp_name: "idpName",
           metadata: "metadata",
           metadata_url: "https://metadataUrl.com",
         })
-      ).toEqual({
-        entity_id: "Entity ID must be present.",
-      });
+      ).toEqual({ entity_id: "Enter an entity ID" });
+    });
 
+    it("requires either metadata or a metadata URL", () => {
       expect(
-        validateFormDataIdp({
+        validateEndUserAuthForm({
           entity_id: "entityId",
-          idp_name: "idpImageUrl",
+          idp_name: "idpName",
           metadata: "",
           metadata_url: "",
         })
       ).toEqual({
-        metadata: "Metadata or Metadata URL must be present.",
-        metadata_url: "Metadata or Metadata URL must be present.",
+        metadata: "Enter metadata or a metadata URL",
+        metadata_url: "Enter metadata or a metadata URL",
       });
+    });
+
+    it("accepts either metadata or a metadata URL on its own", () => {
+      expect(
+        validateEndUserAuthForm({
+          entity_id: "entityId",
+          idp_name: "idpName",
+          metadata: "metadata",
+          metadata_url: "",
+        })
+      ).toEqual({});
 
       expect(
-        validateFormDataIdp({
+        validateEndUserAuthForm({
           entity_id: "entityId",
-          idp_name: "idpImageUrl",
+          idp_name: "idpName",
+          metadata: "",
+          metadata_url: "https://metadataUrl.com",
+        })
+      ).toEqual({});
+    });
+
+    it("rejects a malformed metadata URL", () => {
+      expect(
+        validateEndUserAuthForm({
+          entity_id: "entityId",
+          idp_name: "idpName",
           metadata: "metadata",
           metadata_url: "metadataUrl",
         })
-      ).toEqual({
-        metadata_url: "Metadata URL is not a valid URL.",
-      });
+      ).toEqual({ metadata_url: "Enter a valid metadata URL" });
+    });
 
+    it("rejects a metadata URL without a supported protocol", () => {
       expect(
-        validateFormDataIdp({
+        validateEndUserAuthForm({
           entity_id: "entityId",
-          idp_name: "idpImageUrl",
+          idp_name: "idpName",
           metadata: "metadata",
           metadata_url: "metadataUrl.com",
         })
       ).toEqual({
-        metadata_url:
-          "Metadata URL must start with a supported protocol (https:// or http://).",
+        metadata_url: "Enter a metadata URL starting with https:// or http://",
       });
-
-      expect(
-        validateFormDataIdp({
-          entity_id: "entityId",
-          idp_name: "idpImageUrl",
-          metadata: "metadata",
-          metadata_url: "",
-        })
-      ).toEqual(null); // metadata is not required if metadata_url is present
-
-      expect(
-        validateFormDataIdp({
-          entity_id: "entityId",
-          idp_name: "idpImageUrl",
-          metadata: "",
-          metadata_url: "https://metadataUrl.com",
-        })
-      ).toEqual(null); // metadata is not required if metadata_url is present
     });
   });
 

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.ts
@@ -37,6 +37,17 @@ const trimFormDataIdp = (data: IFormDataIdp): IFormDataIdp => ({
   metadata: data.metadata.trim(),
 });
 
+/**
+ * Either field satisfies the metadata requirement, so they share one error
+ * message. Only `metadata_url` can also hold a URL-format error.
+ */
+export const METADATA_SIBLING: Partial<
+  Record<keyof IFormDataIdp, keyof IFormDataIdp>
+> = {
+  metadata: "metadata_url",
+  metadata_url: "metadata",
+};
+
 export const validateEndUserAuthForm = (
   formData: IFormDataIdp
 ): IFormErrors => {

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.ts
@@ -1,4 +1,5 @@
 import { IEndUserAuthentication } from "interfaces/config";
+import { IFormErrors } from "hooks/useFormValidation";
 
 import isURL from "validator/lib/isURL";
 
@@ -22,86 +23,56 @@ export const newFormDataIdp = (
 
 export const isEmptyFormData = (data: IFormDataIdp) => {
   return (
-    !data.idp_name && !data.entity_id && !data.metadata && !data.metadata_url
+    !data.idp_name.trim() &&
+    !data.entity_id.trim() &&
+    !data.metadata.trim() &&
+    !data.metadata_url.trim()
   );
 };
 
-export const isMissingAnyRequiredField = (data: IFormDataIdp) => {
-  return (
-    !data.idp_name || !data.entity_id || (!data.metadata && !data.metadata_url)
-  );
-};
-
-const errorIdpName = (data: IFormDataIdp) => {
-  if (!data.idp_name) {
-    return "Identity provider name must be present.";
-  }
-  return "";
-};
-
-const errorEntityId = (data: IFormDataIdp) => {
-  if (!data.entity_id) {
-    return "Entity ID must be present.";
-  }
-  return "";
-};
-
-const errorMetadataUrl = (data: IFormDataIdp) => {
-  switch (true) {
-    case !data.metadata && !data.metadata_url:
-      return "Metadata or Metadata URL must be present.";
-    case data.metadata_url && !isURL(data.metadata_url):
-      return "Metadata URL is not a valid URL.";
-    case data.metadata_url &&
-      !isURL(data.metadata_url, {
-        require_protocol: true,
-        protocols: ["http", "https"],
-      }):
-      return `Metadata URL must start with a supported protocol (https:// or http://).`;
-    default:
-      return "";
-  }
-};
-
-const errorMetadata = (data: IFormDataIdp) => {
-  if (!data.metadata && !data.metadata_url) {
-    return "Metadata or Metadata URL must be present.";
-  }
-  return "";
-};
-
-const validators = {
-  idp_name: errorIdpName,
-  entity_id: errorEntityId,
-  metadata_url: errorMetadataUrl,
-  metadata: errorMetadata,
-} as const;
-
-export const trimFormDataIdp = (data: IFormDataIdp): IFormDataIdp => ({
+const trimFormDataIdp = (data: IFormDataIdp): IFormDataIdp => ({
   idp_name: data.idp_name.trim(),
   entity_id: data.entity_id.trim(),
   metadata_url: data.metadata_url.trim(),
   metadata: data.metadata.trim(),
 });
 
-export type IFormErrorsIdp = Partial<Record<keyof IFormDataIdp, string>>;
+export const validateEndUserAuthForm = (
+  formData: IFormDataIdp
+): IFormErrors => {
+  const errors: IFormErrors = {};
+  const data = trimFormDataIdp(formData);
 
-export const validateFormDataIdp = (
-  data: IFormDataIdp
-): IFormErrorsIdp | null => {
-  let formErrors: IFormErrorsIdp | null = null;
+  // An entirely empty form is how an admin clears the configuration, so it is
+  // valid — required fields only apply once one of them has a value.
   if (isEmptyFormData(data)) {
-    return formErrors;
+    return errors;
   }
-  Object.entries(validators).forEach(([k, v]) => {
-    const err = v(data);
-    if (err) {
-      if (!formErrors) {
-        formErrors = { [k as keyof IFormDataIdp]: err };
-      } else {
-        formErrors[k as keyof IFormDataIdp] = err;
-      }
+
+  if (!data.idp_name) {
+    errors.idp_name = "Enter an identity provider name";
+  }
+
+  if (!data.entity_id) {
+    errors.entity_id = "Enter an entity ID";
+  }
+
+  if (!data.metadata && !data.metadata_url) {
+    errors.metadata = "Enter metadata or a metadata URL";
+    errors.metadata_url = "Enter metadata or a metadata URL";
+  } else if (data.metadata_url) {
+    if (!isURL(data.metadata_url)) {
+      errors.metadata_url = "Enter a valid metadata URL";
+    } else if (
+      !isURL(data.metadata_url, {
+        require_protocol: true,
+        protocols: ["http", "https"],
+      })
+    ) {
+      errors.metadata_url =
+        "Enter a metadata URL starting with https:// or http://";
     }
-  });
-  return formErrors;
+  }
+
+  return errors;
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tests.tsx
@@ -13,13 +13,18 @@ const createTestRenderer = () =>
     context: { app: { isPremiumTier: true } },
   });
 
-const renderSso = (subsection = "fleet-users") => {
+const renderSso = (subsection = "fleet-users", gitOpsModeEnabled = false) => {
   const router = ({ push: jest.fn() } as unknown) as InjectedRouter;
+  const config = createMockConfig();
+  const handleSubmit = jest.fn().mockResolvedValue(true);
   const render = createTestRenderer();
   const { user } = render(
     <Sso
-      appConfig={createMockConfig()}
-      handleSubmit={jest.fn().mockResolvedValue(true)}
+      appConfig={{
+        ...config,
+        gitops: { ...config.gitops, gitops_mode_enabled: gitOpsModeEnabled },
+      }}
+      handleSubmit={handleSubmit}
       isPremiumTier
       isUpdatingSettings={false}
       router={router}
@@ -27,7 +32,7 @@ const renderSso = (subsection = "fleet-users") => {
     />
   );
 
-  return { user, router };
+  return { user, router, handleSubmit };
 };
 
 const confirmSpy = jest.spyOn(window, "confirm");
@@ -74,6 +79,69 @@ describe("Sso - Fleet users", () => {
     await user.click(screen.getByText("End users"));
 
     expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears every error when SSO is turned back off", async () => {
+    const { user } = renderSso();
+
+    const enableSso = screen.getByRole("checkbox", { name: "enableSso" });
+    await user.click(enableSso);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(
+      screen.getByText("Enter an identity provider name")
+    ).toBeInTheDocument();
+
+    // The checkbox is what makes these fields required, so turning it off is
+    // this form's equivalent of the End users form emptying every field.
+    await user.click(enableSso);
+
+    expect(screen.queryByText("Enter an identity provider name")).toBeNull();
+    expect(screen.queryByText("Enter an entity ID")).toBeNull();
+    expect(screen.queryByText("Enter metadata or a metadata URL")).toBeNull();
+  });
+
+  it("clears the paired metadata error once either field is filled", async () => {
+    const { user } = renderSso();
+
+    await user.click(screen.getByRole("checkbox", { name: "enableSso" }));
+    // Captured before submitting: the error text replaces the field's label.
+    const metadata = screen.getByLabelText("Metadata");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(
+      screen.getAllByText("Enter metadata or a metadata URL")
+    ).toHaveLength(2);
+
+    await user.type(metadata, "<xml />");
+
+    expect(screen.queryByText("Enter metadata or a metadata URL")).toBeNull();
+    // The errors the change didn't make irrelevant stay put.
+    expect(
+      screen.getByText("Enter an identity provider name")
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a metadata URL format error when the other field is filled", async () => {
+    const { user } = renderSso();
+
+    await user.click(screen.getByRole("checkbox", { name: "enableSso" }));
+    const metadata = screen.getByLabelText("Metadata");
+    await user.type(screen.getByLabelText("Metadata URL"), "not a url");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.getByText("Enter a valid metadata URL")).toBeInTheDocument();
+
+    await user.type(metadata, "<xml />");
+
+    // Still applies: the URL is used over the metadata when both are set.
+    expect(screen.getByText("Enter a valid metadata URL")).toBeInTheDocument();
+  });
+
+  it("does not submit in GitOps mode", async () => {
+    const { user, handleSubmit } = renderSso("fleet-users", true);
+
+    await user.type(screen.getByLabelText("Entity ID"), "{Enter}");
+
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 
   it("does not prompt on tab switch when only whitespace was added", async () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tests.tsx
@@ -76,6 +76,13 @@ describe("Sso - Fleet users", () => {
     expect(confirmSpy).not.toHaveBeenCalled();
   });
 
+  it("does not prompt on tab switch when only whitespace was added", async () => {
+    const { user } = renderSso();
+    await user.type(screen.getByLabelText("Identity provider name"), "   ");
+    await user.click(screen.getByText("End users"));
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
   it("keeps save enabled and shows every error when submitting an invalid form", async () => {
     const handleSubmit = jest.fn().mockResolvedValue(true);
     const render = createTestRenderer();

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tests.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { noop } from "lodash";
+import { screen } from "@testing-library/react";
+import { InjectedRouter } from "react-router";
+
+import { createMockConfig } from "__mocks__/configMock";
+import { createCustomRenderer } from "test/test-utils";
+
+import Sso from "./Sso";
+
+const createTestRenderer = () =>
+  createCustomRenderer({
+    context: { app: { isPremiumTier: true } },
+  });
+
+const renderSso = (subsection = "fleet-users") => {
+  const router = ({ push: jest.fn() } as unknown) as InjectedRouter;
+  const render = createTestRenderer();
+  const { user } = render(
+    <Sso
+      appConfig={createMockConfig()}
+      handleSubmit={jest.fn().mockResolvedValue(true)}
+      isPremiumTier
+      isUpdatingSettings={false}
+      router={router}
+      subsection={subsection}
+    />
+  );
+
+  return { user, router };
+};
+
+const confirmSpy = jest.spyOn(window, "confirm");
+
+beforeEach(() => {
+  confirmSpy.mockClear();
+  confirmSpy.mockImplementation(() => true);
+});
+
+afterAll(() => {
+  confirmSpy.mockRestore();
+});
+
+describe("Sso - Fleet users", () => {
+  it("does not prompt on tab switch when a checkbox is toggled back to its original state", async () => {
+    const { user, router } = renderSso();
+
+    const enableSso = screen.getByRole("checkbox", { name: "enableSso" });
+    await user.click(enableSso);
+    await user.click(enableSso);
+
+    await user.click(screen.getByText("End users"));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalled();
+  });
+
+  it("prompts on tab switch when the form has unsaved changes", async () => {
+    const { user } = renderSso();
+
+    await user.click(screen.getByRole("checkbox", { name: "enableSso" }));
+    await user.click(screen.getByText("End users"));
+
+    expect(confirmSpy).toHaveBeenCalled();
+  });
+
+  it("does not prompt on tab switch when a text field is edited back to its original value", async () => {
+    const { user } = renderSso();
+
+    const idpName = screen.getByLabelText("Identity provider name");
+    await user.type(idpName, "Okta");
+    await user.clear(idpName);
+
+    await user.click(screen.getByText("End users"));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps save enabled and shows every error when submitting an invalid form", async () => {
+    const handleSubmit = jest.fn().mockResolvedValue(true);
+    const render = createTestRenderer();
+    const { user } = render(
+      <Sso
+        appConfig={createMockConfig()}
+        handleSubmit={handleSubmit}
+        isPremiumTier
+        isUpdatingSettings={false}
+        router={({ push: noop } as unknown) as InjectedRouter}
+        subsection="fleet-users"
+      />
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "enableSso" }));
+
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save).toBeEnabled();
+
+    await user.click(save);
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Enter an identity provider name")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Enter an entity ID")).toBeInTheDocument();
+    expect(save).toBeEnabled();
+  });
+});
+
+describe("Sso - End users", () => {
+  it("does not prompt on tab switch when a field is edited back to its original value", async () => {
+    const { user, router } = renderSso("end-users");
+
+    const idpName = screen.getByLabelText("Identity provider name");
+    await user.type(idpName, "Okta");
+    await user.clear(idpName);
+
+    await user.click(screen.getByText("Fleet users"));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(router.push).toHaveBeenCalled();
+  });
+
+  it("prompts on tab switch when the form has unsaved changes", async () => {
+    const { user } = renderSso("end-users");
+
+    await user.type(screen.getByLabelText("Identity provider name"), "Okta");
+    await user.click(screen.getByText("Fleet users"));
+
+    expect(confirmSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -18,7 +18,13 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { IAppConfigFormProps } from "../../../OrgSettingsPage/cards/constants";
 import EndUserAuthSection from "../IdentityProviders/components/EndUserAuthSection";
-import { ISsoFormData, newSsoFormData, validateSsoForm } from "./helpers";
+import {
+  ISsoFormData,
+  METADATA_SIBLING,
+  newSsoFormData,
+  SsoTextField,
+  validateSsoForm,
+} from "./helpers";
 
 export const AUTH_TARGETS_BY_INDEX = ["fleet-users", "end-users"];
 
@@ -62,7 +68,26 @@ const Sso = ({
 
   const originalFormData = useRef(formData);
 
+  const onFieldChange = (name: SsoTextField, value: string) => {
+    setField(name, value);
+
+    // Filling either metadata field satisfies the shared requirement, but blur
+    // only revalidates the field that blurred, so the other keeps a stale copy
+    // of the message. An empty sibling can only be holding that shared error; a
+    // non-empty metadata URL may be holding a format error that still applies.
+    const sibling = METADATA_SIBLING[name];
+    if (value.trim() && sibling && !formData[sibling].trim()) {
+      clearFieldError(sibling);
+    }
+  };
+
   const onValidSubmit = async (submitData: ISsoFormData) => {
+    // The fields and the button are disabled in GitOps mode, but the form
+    // element itself can still be submitted.
+    if (gitOpsModeEnabled) {
+      return;
+    }
+
     // Formatting of API not UI
     const formDataToSubmit = {
       sso_settings: {
@@ -105,9 +130,6 @@ const Sso = ({
       }
 
       reset(originalFormData.current);
-      // The End users panel unmounts on switch, discarding its own edits, but
-      // the flag it last reported stays behind.
-      setEndUserHasUnsavedChanges(false);
       const newSubsection = AUTH_TARGETS_BY_INDEX[index];
       router.push(
         newSubsection === "end-users"
@@ -131,7 +153,7 @@ const Sso = ({
             onChange={(value: boolean) => commitFields({ enableSso: value })}
             name="enableSso"
             value={enableSso}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
           >
             Enable single sign-on
           </Checkbox>
@@ -140,10 +162,10 @@ const Sso = ({
             name="idpName"
             value={idpName}
             error={getError("idpName")}
-            onChange={(value: string) => setField("idpName", value)}
+            onChange={(value: string) => onFieldChange("idpName", value)}
             onFocus={() => clearFieldError("idpName")}
             onBlur={() => validateField("idpName")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="A required human friendly name for the identity provider that will provide single sign-on authentication."
           />
           <InputField
@@ -152,10 +174,10 @@ const Sso = ({
             name="entityId"
             value={entityId}
             error={getError("entityId")}
-            onChange={(value: string) => setField("entityId", value)}
+            onChange={(value: string) => onFieldChange("entityId", value)}
             onFocus={() => clearFieldError("entityId")}
             onBlur={() => validateField("entityId")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="The Entity ID is a required URI that you use to identify Fleet when configuring the identity provider. Okta calls this Audience Restriction."
           />
           <InputField
@@ -163,10 +185,10 @@ const Sso = ({
             name="idpImageUrl"
             value={idpImageUrl}
             error={getError("idpImageUrl")}
-            onChange={(value: string) => setField("idpImageUrl", value)}
+            onChange={(value: string) => onFieldChange("idpImageUrl", value)}
             onFocus={() => clearFieldError("idpImageUrl")}
             onBlur={() => validateField("idpImageUrl")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip={`An optional link to an image such
             as a logo for the identity provider.`}
           />
@@ -176,10 +198,10 @@ const Sso = ({
             name="metadata"
             value={metadata}
             error={getError("metadata")}
-            onChange={(value: string) => setField("metadata", value)}
+            onChange={(value: string) => onFieldChange("metadata", value)}
             onFocus={() => clearFieldError("metadata")}
             onBlur={() => validateField("metadata")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="Metadata XML provided by the identity provider."
           />
           <InputField
@@ -193,10 +215,10 @@ const Sso = ({
             name="metadataUrl"
             value={metadataUrl}
             error={getError("metadataUrl")}
-            onChange={(value: string) => setField("metadataUrl", value)}
+            onChange={(value: string) => onFieldChange("metadataUrl", value)}
             onFocus={() => clearFieldError("metadataUrl")}
             onBlur={() => validateField("metadataUrl")}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
             tooltip="Metadata URL provided by the identity provider."
           />
           <Checkbox
@@ -205,7 +227,7 @@ const Sso = ({
             }
             name="enableSsoIdpLogin"
             value={enableSsoIdpLogin}
-            disabled={isSubmitting}
+            disabled={isSubmitting || gitOpsModeEnabled}
           >
             Allow SSO login initiated by identity provider
           </Checkbox>
@@ -216,7 +238,7 @@ const Sso = ({
               }
               name="enableJitProvisioning"
               value={enableJitProvisioning}
-              disabled={isSubmitting}
+              disabled={isSubmitting || gitOpsModeEnabled}
               helpText={
                 <>
                   <CustomLink

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import { isEqual } from "lodash";
 
-import useFormValidation from "hooks/useFormValidation";
+import useFormValidation, { trimFormData } from "hooks/useFormValidation";
 
 import SettingsSection from "pages/admin/components/SettingsSection";
 import PageDescription from "components/PageDescription";
@@ -91,7 +91,8 @@ const Sso = ({
   );
 
   const hasUnsavedChanges =
-    !isEqual(formData, originalFormData.current) || endUserHasUnsavedChanges;
+    !isEqual(trimFormData(formData), originalFormData.current) ||
+    endUserHasUnsavedChanges;
 
   const handleTabChange = useCallback(
     (index: number) => {

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef, useState } from "react";
+import { isEqual } from "lodash";
 
-import { IInputFieldParseTarget } from "interfaces/form_field";
+import useFormValidation from "hooks/useFormValidation";
 
 import SettingsSection from "pages/admin/components/SettingsSection";
 import PageDescription from "components/PageDescription";
@@ -8,7 +9,6 @@ import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
 import InputField from "components/forms/fields/InputField";
-import validUrl from "components/forms/validators/valid_url";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import TabText from "components/TabText";
 import TabNav from "components/TabNav";
@@ -18,71 +18,7 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { IAppConfigFormProps } from "../../../OrgSettingsPage/cards/constants";
 import EndUserAuthSection from "../IdentityProviders/components/EndUserAuthSection";
-import {
-  IFormDataIdp,
-  newFormDataIdp,
-} from "../IdentityProviders/components/EndUserAuthSection/helpers";
-
-interface ISsoFormData {
-  idpName: string;
-  enableSso: boolean;
-  entityId: string;
-  idpImageUrl: string;
-  metadata: string;
-  metadataUrl: string;
-  enableSsoIdpLogin: boolean;
-  enableJitProvisioning: boolean;
-}
-
-interface ISsoFormErrors {
-  idp_image_url?: string | null;
-  metadata?: string | null;
-  metadata_url?: string | null;
-  entity_id?: string | null;
-  idp_name?: string | null;
-}
-
-const validate = (formData: ISsoFormData) => {
-  const errors: ISsoFormErrors = {};
-
-  const {
-    enableSso,
-    idpImageUrl,
-    metadata,
-    metadataUrl,
-    entityId,
-    idpName,
-  } = formData;
-
-  if (enableSso) {
-    if (idpImageUrl && !validUrl({ url: idpImageUrl })) {
-      errors.idp_image_url = "IdP image URL is not a valid URL";
-    }
-
-    if (!metadata) {
-      if (!metadataUrl) {
-        errors.metadata_url =
-          "Metadata URL is required (if metadata is not present)";
-        errors.metadata =
-          "Metadata is required (if metadata URL is not present)";
-      } else if (
-        !validUrl({ url: metadataUrl, protocols: ["http", "https"] })
-      ) {
-        errors.metadata_url = "Metadata URL is not a valid URL";
-      }
-    }
-
-    if (!entityId) {
-      errors.entity_id = "Entity ID must be present";
-    }
-
-    if (!idpName) {
-      errors.idp_name = "Identity provider name must be present";
-    }
-  }
-
-  return errors;
-};
+import { ISsoFormData, newSsoFormData, validateSsoForm } from "./helpers";
 
 export const AUTH_TARGETS_BY_INDEX = ["fleet-users", "end-users"];
 
@@ -97,16 +33,20 @@ const Sso = ({
   const gitOpsModeEnabled = appConfig.gitops.gitops_mode_enabled;
   const selectedAuthTarget = subsection as string;
 
-  const [formData, setFormData] = useState<ISsoFormData>({
-    enableSso: appConfig.sso_settings?.enable_sso ?? false,
-    idpName: appConfig.sso_settings?.idp_name ?? "",
-    entityId: appConfig.sso_settings?.entity_id ?? "",
-    idpImageUrl: appConfig.sso_settings?.idp_image_url ?? "",
-    metadata: appConfig.sso_settings?.metadata ?? "",
-    metadataUrl: appConfig.sso_settings?.metadata_url ?? "",
-    enableSsoIdpLogin: appConfig.sso_settings?.enable_sso_idp_login ?? false,
-    enableJitProvisioning:
-      appConfig.sso_settings?.enable_jit_provisioning ?? false,
+  const {
+    formData,
+    setField,
+    commitFields,
+    reset,
+    getError,
+    clearFieldError,
+    validateField,
+    handleSubmit: onFormSubmit,
+    isSubmitting,
+  } = useFormValidation<ISsoFormData>({
+    initialFormData: newSsoFormData(appConfig),
+    validate: validateSsoForm,
+    isSubmitting: isUpdatingSettings,
   });
 
   const {
@@ -122,51 +62,18 @@ const Sso = ({
 
   const originalFormData = useRef(formData);
 
-  const [formErrors, setFormErrors] = useState<ISsoFormErrors>({});
-  const [formDirty, setFormDirty] = useState<boolean>(false);
-
-  const onInputChange = ({ name, value }: IInputFieldParseTarget) => {
-    const newFormData = { ...formData, [name]: value };
-    setFormData(newFormData);
-    const newErrs = validate(newFormData);
-    // only set errors that are updates of existing errors
-    // new errors are only set onBlur or submit
-    const errsToSet: Record<string, string> = {};
-    Object.keys(formErrors).forEach((k) => {
-      // @ts-ignore
-      if (newErrs[k]) {
-        // @ts-ignore
-        errsToSet[k] = newErrs[k];
-      }
-    });
-    setFormErrors(errsToSet);
-    setFormDirty(true);
-  };
-
-  const onInputBlur = () => {
-    setFormErrors(validate(formData));
-  };
-
-  const onFormSubmit = async (evt: React.MouseEvent<HTMLFormElement>) => {
-    evt.preventDefault();
-
-    const errs = validate(formData);
-    if (Object.keys(errs).length > 0) {
-      setFormErrors(errs);
-      return;
-    }
-
+  const onValidSubmit = async (submitData: ISsoFormData) => {
     // Formatting of API not UI
     const formDataToSubmit = {
       sso_settings: {
-        entity_id: entityId?.trim(),
-        idp_image_url: idpImageUrl?.trim(),
-        metadata: metadata?.trim(),
-        metadata_url: metadataUrl?.trim(),
-        idp_name: idpName?.trim(),
-        enable_sso: enableSso,
-        enable_sso_idp_login: enableSsoIdpLogin,
-        enable_jit_provisioning: enableJitProvisioning,
+        entity_id: submitData.entityId,
+        idp_image_url: submitData.idpImageUrl,
+        metadata: submitData.metadata,
+        metadata_url: submitData.metadataUrl,
+        idp_name: submitData.idpName,
+        enable_sso: submitData.enableSso,
+        enable_sso_idp_login: submitData.enableSsoIdpLogin,
+        enable_jit_provisioning: submitData.enableJitProvisioning,
         issuer_uri: appConfig.sso_settings?.issuer_uri ?? "",
         enable_jit_role_sync:
           appConfig.sso_settings?.enable_jit_role_sync ?? false,
@@ -174,29 +81,32 @@ const Sso = ({
     };
 
     if (await handleSubmit(formDataToSubmit)) {
-      setFormDirty(false);
-      originalFormData.current = { ...formData };
+      originalFormData.current = submitData;
+      reset(submitData);
     }
   };
 
-  const [endUserFormData, setEndUserFormData] = useState<IFormDataIdp>(
-    newFormDataIdp(appConfig?.mdm?.end_user_authentication)
+  const [endUserHasUnsavedChanges, setEndUserHasUnsavedChanges] = useState(
+    false
   );
-  const originalEndUserFormData = useRef(endUserFormData);
+
+  const hasUnsavedChanges =
+    !isEqual(formData, originalFormData.current) || endUserHasUnsavedChanges;
 
   const handleTabChange = useCallback(
     (index: number) => {
       if (
-        formDirty &&
+        hasUnsavedChanges &&
         // eslint-disable-next-line no-alert
         !confirm("Switch tabs?\n\nChanges you made will not be saved.")
       ) {
         return;
       }
 
-      setFormDirty(false);
-      setFormData(originalFormData.current);
-      setEndUserFormData(originalEndUserFormData.current);
+      reset(originalFormData.current);
+      // The End users panel unmounts on switch, discarding its own edits, but
+      // the flag it last reported stays behind.
+      setEndUserHasUnsavedChanges(false);
       const newSubsection = AUTH_TARGETS_BY_INDEX[index];
       router.push(
         newSubsection === "end-users"
@@ -204,12 +114,12 @@ const Sso = ({
           : PATHS.ADMIN_INTEGRATIONS_SSO_FLEET_USERS
       );
     },
-    [formDirty, router]
+    [hasUnsavedChanges, reset, router]
   );
 
   const renderFleetSsoTab = () => {
     return (
-      <form onSubmit={onFormSubmit} autoComplete="off">
+      <form onSubmit={onFormSubmit(onValidSubmit)} autoComplete="off">
         {/* "form" class applies global form styling to fields for free */}
         <div
           className={`form ${
@@ -217,55 +127,58 @@ const Sso = ({
           }`}
         >
           <Checkbox
-            onChange={onInputChange}
-            onBlur={onInputBlur}
+            onChange={(value: boolean) => commitFields({ enableSso: value })}
             name="enableSso"
             value={enableSso}
-            parseTarget
+            disabled={isSubmitting}
           >
             Enable single sign-on
           </Checkbox>
           <InputField
             label="Identity provider name"
-            onChange={onInputChange}
             name="idpName"
             value={idpName}
-            parseTarget
-            onBlur={onInputBlur}
-            error={formErrors.idp_name}
+            error={getError("idpName")}
+            onChange={(value: string) => setField("idpName", value)}
+            onFocus={() => clearFieldError("idpName")}
+            onBlur={() => validateField("idpName")}
+            disabled={isSubmitting}
             tooltip="A required human friendly name for the identity provider that will provide single sign-on authentication."
           />
           <InputField
             label="Entity ID"
             helpText="The URI you provide here must exactly match the Entity ID field used in the identity provider configuration."
-            onChange={onInputChange}
             name="entityId"
             value={entityId}
-            parseTarget
-            onBlur={onInputBlur}
-            error={formErrors.entity_id}
+            error={getError("entityId")}
+            onChange={(value: string) => setField("entityId", value)}
+            onFocus={() => clearFieldError("entityId")}
+            onBlur={() => validateField("entityId")}
+            disabled={isSubmitting}
             tooltip="The Entity ID is a required URI that you use to identify Fleet when configuring the identity provider. Okta calls this Audience Restriction."
           />
           <InputField
             label="IdP image URL"
-            onChange={onInputChange}
             name="idpImageUrl"
             value={idpImageUrl}
-            parseTarget
-            onBlur={onInputBlur}
-            error={formErrors.idp_image_url}
+            error={getError("idpImageUrl")}
+            onChange={(value: string) => setField("idpImageUrl", value)}
+            onFocus={() => clearFieldError("idpImageUrl")}
+            onBlur={() => validateField("idpImageUrl")}
+            disabled={isSubmitting}
             tooltip={`An optional link to an image such
             as a logo for the identity provider.`}
           />
           <InputField
             label="Metadata"
             type="textarea"
-            onChange={onInputChange}
             name="metadata"
             value={metadata}
-            parseTarget
-            onBlur={onInputBlur}
-            error={formErrors.metadata}
+            error={getError("metadata")}
+            onChange={(value: string) => setField("metadata", value)}
+            onFocus={() => clearFieldError("metadata")}
+            onBlur={() => validateField("metadata")}
+            disabled={isSubmitting}
             tooltip="Metadata XML provided by the identity provider."
           />
           <InputField
@@ -276,30 +189,33 @@ const Sso = ({
                 <b>Metadata URL</b> will be used.
               </>
             }
-            onChange={onInputChange}
             name="metadataUrl"
             value={metadataUrl}
-            parseTarget
-            onBlur={onInputBlur}
-            error={formErrors.metadata_url}
+            error={getError("metadataUrl")}
+            onChange={(value: string) => setField("metadataUrl", value)}
+            onFocus={() => clearFieldError("metadataUrl")}
+            onBlur={() => validateField("metadataUrl")}
+            disabled={isSubmitting}
             tooltip="Metadata URL provided by the identity provider."
           />
           <Checkbox
-            onChange={onInputChange}
-            onBlur={onInputBlur}
+            onChange={(value: boolean) =>
+              commitFields({ enableSsoIdpLogin: value })
+            }
             name="enableSsoIdpLogin"
             value={enableSsoIdpLogin}
-            parseTarget
+            disabled={isSubmitting}
           >
             Allow SSO login initiated by identity provider
           </Checkbox>
           {isPremiumTier && (
             <Checkbox
-              onChange={onInputChange}
-              onBlur={onInputBlur}
+              onChange={(value: boolean) =>
+                commitFields({ enableJitProvisioning: value })
+              }
               name="enableJitProvisioning"
               value={enableJitProvisioning}
-              parseTarget
+              disabled={isSubmitting}
               helpText={
                 <>
                   <CustomLink
@@ -319,9 +235,9 @@ const Sso = ({
           renderChildren={(disableChildren) => (
             <Button
               type="submit"
-              disabled={Object.keys(formErrors).length > 0 || disableChildren}
+              disabled={isSubmitting || disableChildren}
               className="button-wrap"
-              isLoading={isUpdatingSettings}
+              isLoading={isSubmitting}
             >
               Save
             </Button>
@@ -339,10 +255,8 @@ const Sso = ({
 
   const renderEndUserSsoTab = () => (
     <EndUserAuthSection
-      setDirty={setFormDirty}
-      formData={endUserFormData}
-      setFormData={setEndUserFormData}
-      originalFormData={originalEndUserFormData}
+      endUserAuth={appConfig.mdm?.end_user_authentication}
+      onDirtyChange={setEndUserHasUnsavedChanges}
       onSubmit={onSubmitEndUserSso}
     />
   );

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.tests.ts
@@ -86,7 +86,9 @@ describe("Sso helpers", () => {
           ...VALID_FORM_DATA,
           metadataUrl: "idp.example.com/metadata",
         })
-      ).toEqual({ metadataUrl: "Enter a valid metadata URL" });
+      ).toEqual({
+        metadataUrl: "Enter a metadata URL starting with https:// or http://",
+      });
     });
 
     it("validates the IdP image URL only when it has a value", () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.tests.ts
@@ -1,0 +1,139 @@
+import { createMockConfig } from "__mocks__/configMock";
+
+import { ISsoFormData, newSsoFormData, validateSsoForm } from "./helpers";
+
+const VALID_FORM_DATA: ISsoFormData = {
+  enableSso: true,
+  idpName: "Okta",
+  entityId: "https://fleet.example.com",
+  idpImageUrl: "",
+  metadata: "",
+  metadataUrl: "https://idp.example.com/metadata",
+  enableSsoIdpLogin: false,
+  enableJitProvisioning: false,
+};
+
+describe("Sso helpers", () => {
+  describe("validateSsoForm", () => {
+    it("returns no errors for a valid configuration", () => {
+      expect(validateSsoForm(VALID_FORM_DATA)).toEqual({});
+    });
+
+    it("skips every check while SSO is turned off", () => {
+      expect(
+        validateSsoForm({
+          ...VALID_FORM_DATA,
+          enableSso: false,
+          idpName: "",
+          entityId: "",
+          metadata: "",
+          metadataUrl: "",
+          idpImageUrl: "not a url",
+        })
+      ).toEqual({});
+    });
+
+    it("requires the identity provider name and entity ID", () => {
+      expect(
+        validateSsoForm({ ...VALID_FORM_DATA, idpName: "", entityId: "" })
+      ).toEqual({
+        idpName: "Enter an identity provider name",
+        entityId: "Enter an entity ID",
+      });
+    });
+
+    it("treats whitespace-only required fields as empty", () => {
+      expect(
+        validateSsoForm({ ...VALID_FORM_DATA, idpName: "   ", entityId: " " })
+      ).toEqual({
+        idpName: "Enter an identity provider name",
+        entityId: "Enter an entity ID",
+      });
+    });
+
+    it("requires either metadata or a metadata URL", () => {
+      expect(
+        validateSsoForm({ ...VALID_FORM_DATA, metadata: "", metadataUrl: "" })
+      ).toEqual({
+        metadata: "Enter metadata or a metadata URL",
+        metadataUrl: "Enter metadata or a metadata URL",
+      });
+    });
+
+    it("accepts metadata on its own", () => {
+      expect(
+        validateSsoForm({
+          ...VALID_FORM_DATA,
+          metadata: "<xml />",
+          metadataUrl: "",
+        })
+      ).toEqual({});
+    });
+
+    it("rejects an invalid metadata URL even when metadata is also present", () => {
+      expect(
+        validateSsoForm({
+          ...VALID_FORM_DATA,
+          metadata: "<xml />",
+          metadataUrl: "not a url",
+        })
+      ).toEqual({ metadataUrl: "Enter a valid metadata URL" });
+    });
+
+    it("rejects a metadata URL without a supported protocol", () => {
+      expect(
+        validateSsoForm({
+          ...VALID_FORM_DATA,
+          metadataUrl: "idp.example.com/metadata",
+        })
+      ).toEqual({ metadataUrl: "Enter a valid metadata URL" });
+    });
+
+    it("validates the IdP image URL only when it has a value", () => {
+      expect(validateSsoForm({ ...VALID_FORM_DATA, idpImageUrl: "" })).toEqual(
+        {}
+      );
+
+      expect(
+        validateSsoForm({ ...VALID_FORM_DATA, idpImageUrl: "not a url" })
+      ).toEqual({ idpImageUrl: "Enter a valid IdP image URL" });
+    });
+  });
+
+  describe("newSsoFormData", () => {
+    it("trims the saved values", () => {
+      const formData = newSsoFormData({
+        ...createMockConfig(),
+        sso_settings: {
+          enable_sso: true,
+          idp_name: "  Okta  ",
+          entity_id: "  https://fleet.example.com  ",
+          idp_image_url: "",
+          metadata: "",
+          metadata_url: "  https://idp.example.com/metadata  ",
+          issuer_uri: "",
+          enable_sso_idp_login: false,
+          enable_jit_provisioning: false,
+          enable_jit_role_sync: false,
+        },
+      });
+
+      expect(formData).toMatchObject({
+        enableSso: true,
+        idpName: "Okta",
+        entityId: "https://fleet.example.com",
+        metadataUrl: "https://idp.example.com/metadata",
+      });
+    });
+
+    it("falls back to empty strings when nothing is configured", () => {
+      expect(newSsoFormData(createMockConfig())).toMatchObject({
+        idpName: "",
+        entityId: "",
+        idpImageUrl: "",
+        metadata: "",
+        metadataUrl: "",
+      });
+    });
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.ts
@@ -1,5 +1,5 @@
 import { IConfig } from "interfaces/config";
-import { IFormErrors } from "hooks/useFormValidation";
+import { IFormErrors, trimFormData } from "hooks/useFormValidation";
 import validUrl from "components/forms/validators/valid_url";
 
 export interface ISsoFormData {
@@ -15,11 +15,11 @@ export interface ISsoFormData {
 
 export const newSsoFormData = (appConfig: IConfig): ISsoFormData => ({
   enableSso: appConfig.sso_settings?.enable_sso ?? false,
-  idpName: appConfig.sso_settings?.idp_name ?? "",
-  entityId: appConfig.sso_settings?.entity_id ?? "",
-  idpImageUrl: appConfig.sso_settings?.idp_image_url ?? "",
-  metadata: appConfig.sso_settings?.metadata ?? "",
-  metadataUrl: appConfig.sso_settings?.metadata_url ?? "",
+  idpName: appConfig.sso_settings?.idp_name?.trim() ?? "",
+  entityId: appConfig.sso_settings?.entity_id?.trim() ?? "",
+  idpImageUrl: appConfig.sso_settings?.idp_image_url?.trim() ?? "",
+  metadata: appConfig.sso_settings?.metadata?.trim() ?? "",
+  metadataUrl: appConfig.sso_settings?.metadata_url?.trim() ?? "",
   enableSsoIdpLogin: appConfig.sso_settings?.enable_sso_idp_login ?? false,
   enableJitProvisioning:
     appConfig.sso_settings?.enable_jit_provisioning ?? false,
@@ -28,6 +28,8 @@ export const newSsoFormData = (appConfig: IConfig): ISsoFormData => ({
 export const validateSsoForm = (formData: ISsoFormData): IFormErrors => {
   const errors: IFormErrors = {};
 
+  // Blur validates the raw values, so whitespace-only content has to read as
+  // empty here rather than only once the hook trims on submit.
   const {
     enableSso,
     idpImageUrl,
@@ -35,8 +37,10 @@ export const validateSsoForm = (formData: ISsoFormData): IFormErrors => {
     metadataUrl,
     entityId,
     idpName,
-  } = formData;
+  } = trimFormData(formData);
 
+  // Everything below only reaches the API when SSO is on, so an incomplete
+  // config the user is leaving turned off isn't an error.
   if (!enableSso) {
     return errors;
   }
@@ -45,13 +49,16 @@ export const validateSsoForm = (formData: ISsoFormData): IFormErrors => {
     errors.idpImageUrl = "Enter a valid IdP image URL";
   }
 
-  if (!metadata) {
-    if (!metadataUrl) {
-      errors.metadataUrl = "Enter metadata or a metadata URL";
-      errors.metadata = "Enter metadata or a metadata URL";
-    } else if (!validUrl({ url: metadataUrl, protocols: ["http", "https"] })) {
-      errors.metadataUrl = "Enter a valid metadata URL";
-    }
+  if (!metadata && !metadataUrl) {
+    errors.metadataUrl = "Enter metadata or a metadata URL";
+    errors.metadata = "Enter metadata or a metadata URL";
+  } else if (
+    // Checked whenever it has a value: when both are set the URL is the one
+    // that gets used, so an invalid one can't ride along on valid metadata.
+    metadataUrl &&
+    !validUrl({ url: metadataUrl, protocols: ["http", "https"] })
+  ) {
+    errors.metadataUrl = "Enter a valid metadata URL";
   }
 
   if (!entityId) {

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.ts
@@ -25,6 +25,22 @@ export const newSsoFormData = (appConfig: IConfig): ISsoFormData => ({
     appConfig.sso_settings?.enable_jit_provisioning ?? false,
 });
 
+export type SsoTextField =
+  | "idpName"
+  | "entityId"
+  | "idpImageUrl"
+  | "metadata"
+  | "metadataUrl";
+
+/**
+ * Either field satisfies the metadata requirement, so they share one error
+ * message. Only `metadataUrl` can also hold a URL-format error.
+ */
+export const METADATA_SIBLING: Partial<Record<SsoTextField, SsoTextField>> = {
+  metadata: "metadataUrl",
+  metadataUrl: "metadata",
+};
+
 export const validateSsoForm = (formData: ISsoFormData): IFormErrors => {
   const errors: IFormErrors = {};
 
@@ -52,13 +68,15 @@ export const validateSsoForm = (formData: ISsoFormData): IFormErrors => {
   if (!metadata && !metadataUrl) {
     errors.metadataUrl = "Enter metadata or a metadata URL";
     errors.metadata = "Enter metadata or a metadata URL";
-  } else if (
+  } else if (metadataUrl) {
     // Checked whenever it has a value: when both are set the URL is the one
     // that gets used, so an invalid one can't ride along on valid metadata.
-    metadataUrl &&
-    !validUrl({ url: metadataUrl, protocols: ["http", "https"] })
-  ) {
-    errors.metadataUrl = "Enter a valid metadata URL";
+    if (!validUrl({ url: metadataUrl })) {
+      errors.metadataUrl = "Enter a valid metadata URL";
+    } else if (!validUrl({ url: metadataUrl, protocols: ["http", "https"] })) {
+      errors.metadataUrl =
+        "Enter a metadata URL starting with https:// or http://";
+    }
   }
 
   if (!entityId) {

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/helpers.ts
@@ -1,0 +1,66 @@
+import { IConfig } from "interfaces/config";
+import { IFormErrors } from "hooks/useFormValidation";
+import validUrl from "components/forms/validators/valid_url";
+
+export interface ISsoFormData {
+  idpName: string;
+  enableSso: boolean;
+  entityId: string;
+  idpImageUrl: string;
+  metadata: string;
+  metadataUrl: string;
+  enableSsoIdpLogin: boolean;
+  enableJitProvisioning: boolean;
+}
+
+export const newSsoFormData = (appConfig: IConfig): ISsoFormData => ({
+  enableSso: appConfig.sso_settings?.enable_sso ?? false,
+  idpName: appConfig.sso_settings?.idp_name ?? "",
+  entityId: appConfig.sso_settings?.entity_id ?? "",
+  idpImageUrl: appConfig.sso_settings?.idp_image_url ?? "",
+  metadata: appConfig.sso_settings?.metadata ?? "",
+  metadataUrl: appConfig.sso_settings?.metadata_url ?? "",
+  enableSsoIdpLogin: appConfig.sso_settings?.enable_sso_idp_login ?? false,
+  enableJitProvisioning:
+    appConfig.sso_settings?.enable_jit_provisioning ?? false,
+});
+
+export const validateSsoForm = (formData: ISsoFormData): IFormErrors => {
+  const errors: IFormErrors = {};
+
+  const {
+    enableSso,
+    idpImageUrl,
+    metadata,
+    metadataUrl,
+    entityId,
+    idpName,
+  } = formData;
+
+  if (!enableSso) {
+    return errors;
+  }
+
+  if (idpImageUrl && !validUrl({ url: idpImageUrl })) {
+    errors.idpImageUrl = "Enter a valid IdP image URL";
+  }
+
+  if (!metadata) {
+    if (!metadataUrl) {
+      errors.metadataUrl = "Enter metadata or a metadata URL";
+      errors.metadata = "Enter metadata or a metadata URL";
+    } else if (!validUrl({ url: metadataUrl, protocols: ["http", "https"] })) {
+      errors.metadataUrl = "Enter a valid metadata URL";
+    }
+  }
+
+  if (!entityId) {
+    errors.entityId = "Enter an entity ID";
+  }
+
+  if (!idpName) {
+    errors.idpName = "Enter an identity provider name";
+  }
+
+  return errors;
+};


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48386. Also plugs in `useFormValidationHook` into both `Fleet users` and `End users` forms.

On Settings > Integrations > Authentication (SSO), checking and then unchecking "Enable single sign-on" left the form marked as having unsaved changes, so switching tabs prompted "Changes you made will not be saved". This PR fixes that.

I've also decided to plug in the validation hook into both the Fleet users and End users form in this same PR since they're tightly coupled.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/0efeb633-dac6-4500-ab7c-29f9382a01f2



## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SSO settings no longer show unsaved-change prompts when edits are restored, contain only whitespace, or are cleared.
  - Validation errors now appear beside the relevant fields.
  - Metadata URLs require supported protocols, and required fields are validated consistently.
  - Related metadata errors clear when either valid metadata field is filled.

- **Improvements**
  - SSO forms now support field-level validation and clearing saved configuration.
  - Submitted values are trimmed, and invalid data cannot be saved.
  - SSO settings are read-only while GitOps mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->