### PR TITLE
disable resize on both text areas in MDM Command details modal

### DIFF
--- a/changes/52407-remove-resize-from-mdm-command-details-modal
+++ b/changes/52407-remove-resize-from-mdm-command-details-modal
@@ -1,0 +1,1 @@
+- Fixed an issue where a text area resize icon was present, when it shouldn't be.

--- a/frontend/components/forms/fields/InputField/InputField.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tsx
@@ -57,6 +57,8 @@ export interface IInputFieldProps {
   min?: string | number;
   /** Only effective on input type number */
   max?: string | number;
+  /** Only effective on textarea elements */
+  disableResize?: boolean;
 }
 
 const InputField = ({
@@ -84,6 +86,7 @@ const InputField = ({
   helpText = "",
   enableShowSecret = false,
   enableCopy = false,
+  disableResize = false,
   ignore1password = true,
   step,
   min,
@@ -190,6 +193,10 @@ const InputField = ({
       { "copy-enabled": enableCopy }
     );
 
+    const textAreaInputClasses = classnames(inputClasses, {
+      [`${baseClass}__textarea--resize-disabled`]: disableResize,
+    });
+
     return (
       <FormField
         {...formFieldProps}
@@ -203,7 +210,7 @@ const InputField = ({
             onChange={onInputChange}
             onBlur={onBlur}
             onFocus={onFocus}
-            className={inputClasses}
+            className={textAreaInputClasses}
             disabled={readOnly || disabled}
             placeholder={placeholder}
             ref={(r) => {

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -50,6 +50,10 @@
     min-width: 100%;
     max-width: 100%;
     display: block;
+
+    &--resize-disabled {
+      resize: none;
+    }
   }
 
   &__label {

--- a/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tsx
+++ b/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tsx
@@ -200,6 +200,7 @@ export const ModalContent = ({
           value={result.payload}
           readOnly
           enableCopy
+          disableResize
         />
       )}
       {!!result.result && (
@@ -213,6 +214,7 @@ export const ModalContent = ({
           value={result.result}
           readOnly
           enableCopy
+          disableResize
         />
       )}
     </div>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52407 

Before:
<img width="820" height="771" alt="Screenshot 2026-09-07 at 17 00 16" src="https://github.com/user-attachments/assets/9cba3967-d8cd-4188-8182-b2a9ff6787ef" />

After:
<img width="825" height="772" alt="Screenshot 2026-09-07 at 17 00 36" src="https://github.com/user-attachments/assets/7dbe6a9c-78b5-44e2-a476-7beb8b6e0667" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unintended resize control from text areas in the MDM command details modal.
  * Prevented manual resizing of the request payload and host response fields for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->