### PR TITLE
Wrap setup experience advanced options in a card

### DIFF
--- a/changes/52474-wrap-setup-experience-advanced-options
+++ b/changes/52474-wrap-setup-experience-advanced-options
@@ -1,0 +1,1 @@
+- Wrapped the "Advanced options" sections on the Setup experience > Bootstrap package and Setup assistant pages in a card with the Save button on the right, matching the pattern used elsewhere in the Controls section.

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/BootstrapAdvancedOptions.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/BootstrapAdvancedOptions.tsx
@@ -8,6 +8,7 @@ import RevealButton from "components/buttons/RevealButton";
 import Checkbox from "components/forms/fields/Checkbox";
 import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+import Card from "components/Card";
 
 const baseClass = "bootstrap-advanced-options";
 
@@ -67,7 +68,11 @@ const BootstrapAdvancedOptions = ({
         <form onSubmit={onSubmit}>
           <GitOpsModeTooltipWrapper
             renderChildren={(gitopsDisable) => (
-              <div className={`${baseClass}__advanced-options-controls`}>
+              <Card
+                className={`${baseClass}__settings-card`}
+                color="white"
+                borderRadiusSize="large"
+              >
                 <Checkbox
                   value={selectManualAgentInstall}
                   onChange={onChange}
@@ -80,20 +85,14 @@ const BootstrapAdvancedOptions = ({
                     Install Fleet&apos;s agent (fleetd) manually
                   </TooltipWrapper>
                 </Checkbox>
-                {/* The wrapper div is needed to keep the button from stretching full width
-                 * of the flex container */}
-                <div>
-                  <Button
-                    disabled={
-                      gitopsDisable || disableInstallManually || isSaving
-                    }
-                    type="submit"
-                    isLoading={isSaving}
-                  >
-                    Save
-                  </Button>
-                </div>
-              </div>
+                <Button
+                  disabled={gitopsDisable || disableInstallManually || isSaving}
+                  type="submit"
+                  isLoading={isSaving}
+                >
+                  Save
+                </Button>
+              </Card>
             )}
           />
         </form>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/_styles.scss
@@ -9,9 +9,18 @@
     align-self: flex-start;
   }
 
-  &__advanced-options-controls {
+  &__settings-card {
+    box-sizing: border-box;
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     gap: $pad-large;
+
+    // .form-field is styled globally at width: 100%, which forces the
+    // checkbox to consume the whole row, leaving no room for Save.
+    .form-field {
+      width: auto;
+    }
   }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/AdvancedOptionsForm/AdvancedOptionsForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/AdvancedOptionsForm/AdvancedOptionsForm.tsx
@@ -7,6 +7,7 @@ import Checkbox from "components/forms/fields/Checkbox";
 import Button from "components/buttons/Button";
 import { notify } from "components/ToastNotification";
 import RevealButton from "components/buttons/RevealButton";
+import Card from "components/Card";
 
 const baseClass = "advanced-options-form";
 
@@ -58,15 +59,21 @@ const AdvancedOptionsForm = ({
       />
       {showAdvancedOptions && (
         <form onSubmit={handleSubmit}>
-          <Checkbox
-            value={releaseDevice}
-            onChange={() => setReleaseDevice(!releaseDevice)}
+          <Card
+            className={`${baseClass}__settings-card`}
+            color="white"
+            borderRadiusSize="large"
           >
-            <TooltipWrapper tipContent={tooltip}>
-              Release device manually
-            </TooltipWrapper>
-          </Checkbox>
-          <Button type="submit">Save</Button>
+            <Checkbox
+              value={releaseDevice}
+              onChange={() => setReleaseDevice(!releaseDevice)}
+            >
+              <TooltipWrapper tipContent={tooltip}>
+                Release device manually
+              </TooltipWrapper>
+            </Checkbox>
+            <Button type="submit">Save</Button>
+          </Card>
         </form>
       )}
     </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/AdvancedOptionsForm/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/AdvancedOptionsForm/_styles.scss
@@ -9,4 +9,19 @@
     // the reveal button isn't wider than it needs to be.
     align-self: flex-start;
   }
+
+  &__settings-card {
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: $pad-large;
+
+    // .form-field is styled globally at width: 100%, which forces the
+    // checkbox to consume the whole row, leaving no room for Save.
+    .form-field {
+      width: auto;
+    }
+  }
 }


### PR DESCRIPTION
Before, the Save buttons under Advanced options looked off, as if they're meant to save the whole section. Wrapping them in a card to make it more clear that the Save button is only meant for the Advanced options.

**Related issue:** Part of the resolution for #52474

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] QA'd all new/changed functionality manually


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

---

Before:

<img width="2986" height="1700" alt="Screenshot 2026-09-07 at 12-51-25 Controls Fleet" src="https://github.com/user-attachments/assets/43e8feb3-667c-45c5-af51-4e5977dae156" />
<img width="2986" height="1700" alt="Screenshot 2026-09-07 at 12-51-19 Controls Fleet" src="https://github.com/user-attachments/assets/da912510-6e13-4bab-b5e0-5d40a727ec7e" />

After:

<img width="2986" height="1700" alt="Screenshot 2026-09-07 at 12-43-18 Controls Fleet" src="https://github.com/user-attachments/assets/648a71c9-2234-4a09-bb13-91c809d4c382" />
<img width="2986" height="1700" alt="Screenshot 2026-09-07 at 12-43-28 Controls Fleet" src="https://github.com/user-attachments/assets/9699ed1e-a6bd-4a70-8e6e-f3efc91dcf4d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Advanced options sections on the Setup experience pages to use a card layout.
  * Positioned the Save button to the right, matching the Controls section design.
  * Improved responsive spacing and alignment for the checkbox and Save button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->