### PR TITLE
Controls > OS settings > Configuration profiles: Copy change

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
@@ -163,7 +163,9 @@ describe("AssetsTab", () => {
     render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
 
     expect(
-      screen.getByText(/Manage assets that provide data or credentials/i)
+      screen.getByText(
+        /Add assets \(data or credentials\) to use them in many Apple declaration \(DDM\) profiles/i
+      )
     ).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: /Add asset$/i })

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -137,7 +137,7 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
           header="No assets"
           info={
             canAddAsset
-              ? "Add an asset to make it available for reference in Apple DDM declarations."
+              ? "Add assets (data or credentials) to use them in many Apple declaration (DDM) profiles. Apple only."
               : "No assets have been added."
           }
           primaryButton={
@@ -180,7 +180,7 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
       <div className={`${baseClass}__tab-header`}>
         <PageDescription
           variant="right-panel"
-          content="Manage assets that provide data or credentials referenced by DDM declarations."
+          content="Add assets (data or credentials) to use them in many Apple declaration (DDM) profiles. Apple only."
         />
         {showAddAssetButton && (
           <GitOpsModeTooltipWrapper


### PR DESCRIPTION
Context: https://fleetdm.slack.com/archives/C02A8BRABB5/p1788804073139729?thread_ts=1788749928.253329&cid=C02A8BRABB5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Assets page description and empty-state guidance to clarify that assets include data or credentials and can be used across Apple DDM profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->