### PR TITLE
Managed bookmark: "🦢 Drafting" board => "🦢📨🎉 Product design intake & outtake"

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -567,7 +567,7 @@
                         </dict>
                         <dict>
                             <key>name</key>
-                            <string>🦢 Drafting board (:product)</string>
+                            <string>🦢📨🎉 Product design intake & outtake</string>
                             <key>url</key>
                             <string>https://github.com/orgs/fleetdm/projects/67</string>
                         </dict>

--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -567,7 +567,7 @@
                         </dict>
                         <dict>
                             <key>name</key>
-                            <string>🦢📨🎉 Product design intake & outtake</string>
+                            <string>🦢📨🎉 Product design intake &amp; outtake</string>
                             <key>url</key>
                             <string>https://github.com/orgs/fleetdm/projects/67</string>
                         </dict>


### PR DESCRIPTION
Context: https://github.com/fleetdm/fleet/pull/51867


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Renamed the Product Design bookmark in the managed Google Chrome bookmarks to “🦢📨🎉 Product design intake & outtake.”
  - The bookmark continues to link to the same GitHub project board, so the destination remains unchanged.
  - This updated label provides clearer guidance when accessing the Product Design intake and outtake workflow from managed Chrome bookmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->