### PR TITLE
Fix JIT provisioning activity copy to use passive voice

### DIFF
--- a/changes/46741-jit-activity-copy
+++ b/changes/46741-jit-activity-copy
@@ -1,0 +1,1 @@
+- Fixed activity feed copy for role changes made via just-in-time (JIT) provisioning to use passive voice (e.g., "user@example.com was removed from the Engineering fleet via just-in-time (JIT) provisioning") instead of showing the user as both actor and subject.

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -76,7 +76,7 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "save user")
 		}
-		if err := fleet.LogRoleChangeActivities(ctx, svc, user, oldGlobalRole, oldTeamsRoles, user); err != nil {
+		if err := fleet.LogRoleChangeActivities(ctx, svc, user, oldGlobalRole, oldTeamsRoles, user, true); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "log activities for role change")
 		}
 		return user, nil

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -118,7 +118,7 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		globalRole = ptr.String(fleet.RoleObserver)
 	}
 
-	user, err = svc.Service.NewUser(ctx, fleet.UserPayload{
+	user, err = svc.Service.NewUser(fleet.ContextWithJIT(ctx), fleet.UserPayload{
 		Name:       &displayName,
 		Email:      ptr.String(auth.UserID()),
 		SSOEnabled: ptr.Bool(true),

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -121,7 +121,7 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 	user, err = svc.Service.NewUser(ctx, fleet.UserPayload{
 		Name:           &displayName,
 		Email:          ptr.String(auth.UserID()),
-		SSOEnabled:     ptr.Bool(true),
+		SSOEnabled:     new(true),
 		GlobalRole:     globalRole,
 		Teams:          &teamRoles,
 		JITProvisioned: true,

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -118,12 +118,13 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		globalRole = ptr.String(fleet.RoleObserver)
 	}
 
-	user, err = svc.Service.NewUser(fleet.ContextWithJIT(ctx), fleet.UserPayload{
-		Name:       &displayName,
-		Email:      ptr.String(auth.UserID()),
-		SSOEnabled: ptr.Bool(true),
-		GlobalRole: globalRole,
-		Teams:      &teamRoles,
+	user, err = svc.Service.NewUser(ctx, fleet.UserPayload{
+		Name:           &displayName,
+		Email:          ptr.String(auth.UserID()),
+		SSOEnabled:     ptr.Bool(true),
+		GlobalRole:     globalRole,
+		Teams:          &teamRoles,
+		JITProvisioned: true,
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "creating new SSO user")

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -386,6 +386,7 @@ export interface IActivityDetails {
   failure_reason?: string;
   user_email?: string;
   user_id?: number;
+  jit?: boolean;
   webhook_url?: string;
   // Policy automation outcomes (failed_automation_*/ran_automation_* activities).
   status_code?: number;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -470,6 +470,24 @@ describe("Activity Feed", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders passive voice without JIT suffix when actor_id === user_id but no jit flag (invite flow)", () => {
+    const activity = createMockActivity({
+      actor_id: 5,
+      type: ActivityType.UserChangedGlobalRole,
+      details: {
+        user_id: 5,
+        user_email: "invited@example.com",
+        role: "admin",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(screen.getByText("invited@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/was assigned the/)).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.queryByText(/via just-in-time/)).toBeNull();
+  });
+
   it("correctly renders a changed_user_global_role type activity when changing an existing user's global role, premium", () => {
     const activity = createMockActivity({
       actor_id: 1,
@@ -563,6 +581,26 @@ describe("Activity Feed", () => {
     expect(screen.queryByText("Ally Admin")).toBeNull();
     const forAllTeams = screen.queryByText("for all fleets.");
     expect(forAllTeams).toBeNull();
+  });
+
+  it("renders passive voice without JIT suffix for changed_user_team_role when actor_id === user_id (invite flow)", () => {
+    const activity = createMockActivity({
+      actor_id: 5,
+      type: ActivityType.UserChangedTeamRole,
+      details: {
+        user_id: 5,
+        user_email: "invited@example.com",
+        role: "observer",
+        team_name: "Test Team",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(screen.getByText("invited@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/was assigned the/)).toBeInTheDocument();
+    expect(screen.getByText("observer")).toBeInTheDocument();
+    expect(screen.getByText("Test Team")).toBeInTheDocument();
+    expect(screen.queryByText(/via just-in-time/)).toBeNull();
   });
 
   it("correctly renders a changed_user_team_role type activity when changing an existing user's team role", () => {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -452,22 +452,22 @@ describe("Activity Feed", () => {
 
   it("correctly renders a changed_user_global_role type activity for a premium SSO user created by JIT provisioning", () => {
     const activity = createMockActivity({
-      actor_id: 3,
       type: ActivityType.UserChangedGlobalRole,
       details: {
-        user_id: 3,
         user_email: "jit@sso.com",
         role: "observer",
+        jit: true,
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
 
-    //  If actor_id is the same as user_id:
-    // "<user_email> was assigned the <role> for all fleets."
+    // "<user_email> was assigned the <role> role for all fleets via just-in-time (JIT) provisioning."
     expect(screen.getByText("jit@sso.com")).toBeInTheDocument();
     expect(screen.getByText(/was assigned the/)).toBeInTheDocument();
     expect(screen.getByText("observer")).toBeInTheDocument();
-    expect(screen.getByText(/role for all fleets./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/via just-in-time \(JIT\) provisioning\./)
+    ).toBeInTheDocument();
   });
 
   it("correctly renders a changed_user_global_role type activity when changing an existing user's global role, premium", () => {
@@ -540,26 +540,25 @@ describe("Activity Feed", () => {
 
   it("correctly renders a changed_user_team_role type activity when a new SSO team user is created via JIT provisioning", () => {
     const activity = createMockActivity({
-      actor_id: 1,
       actor_full_name: "Ally Admin",
       type: ActivityType.UserChangedTeamRole,
       details: {
-        user_id: 1,
         user_email: "jit@sso.com",
         role: "maintainer",
         team_name: "Test Team",
+        jit: true,
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
 
-    // If actor_id is the same as user_id:
-    // "<user_email> was assigned the <role> role for the <team_name> fleet."
+    // "<user_email> was assigned the <role> role for the <team_name> fleet via just-in-time (JIT) provisioning."
     expect(screen.getByText("jit@sso.com")).toBeInTheDocument();
     expect(screen.getByText(/was assigned the/)).toBeInTheDocument();
     expect(screen.getByText("maintainer")).toBeInTheDocument();
-    expect(screen.getByText(/role for the/)).toBeInTheDocument();
     expect(screen.getByText(/Test Team/)).toBeInTheDocument();
-    expect(screen.getByText(/fleet\./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/via just-in-time \(JIT\) provisioning\./)
+    ).toBeInTheDocument();
 
     expect(screen.queryByText("Ally Admin")).toBeNull();
     const forAllTeams = screen.queryByText("for all fleets.");
@@ -610,6 +609,28 @@ describe("Activity Feed", () => {
     expect(screen.getByText("Test Team")).toBeInTheDocument();
   });
 
+  it("renders a deleted_user_team_role via JIT provisioning", () => {
+    const activity = createMockActivity({
+      actor_full_name: "Jit User",
+      type: ActivityType.UserDeletedTeamRole,
+      details: {
+        user_email: "jit@sso.com",
+        team_name: "Test Team",
+        jit: true,
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    // "<user_email> was removed from the <team_name> fleet via just-in-time (JIT) provisioning."
+    expect(screen.getByText("jit@sso.com")).toBeInTheDocument();
+    expect(screen.getByText(/was removed from the/)).toBeInTheDocument();
+    expect(screen.getByText("Test Team")).toBeInTheDocument();
+    expect(
+      screen.getByText(/via just-in-time \(JIT\) provisioning\./)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Jit User")).toBeNull();
+  });
+
   it("renders a deleted_user_global_role type activity globally for premium users", () => {
     const activity = createMockActivity({
       type: ActivityType.UserDeletedGlobalRole,
@@ -637,6 +658,28 @@ describe("Activity Feed", () => {
     expect(screen.getByText("maintainer")).toBeInTheDocument();
     const forAllTeams = screen.queryByText("for all fleets.");
     expect(forAllTeams).toBeNull();
+  });
+
+  it("renders a deleted_user_global_role via JIT provisioning for premium users", () => {
+    const activity = createMockActivity({
+      actor_full_name: "Jit User",
+      type: ActivityType.UserDeletedGlobalRole,
+      details: {
+        user_email: "jit@sso.com",
+        role: "maintainer",
+        jit: true,
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    // "<user_email> was removed as <role> for all fleets via just-in-time (JIT) provisioning."
+    expect(screen.getByText("jit@sso.com")).toBeInTheDocument();
+    expect(screen.getByText(/was removed as/)).toBeInTheDocument();
+    expect(screen.getByText("maintainer")).toBeInTheDocument();
+    expect(
+      screen.getByText(/via just-in-time \(JIT\) provisioning\./)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Jit User")).toBeNull();
   });
 
   it("renders an 'edited_disk_encryption_settings' type activity for a fleet", () => {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -330,7 +330,11 @@ const TAGGED_TEMPLATES = {
   userChangedGlobalRole: (activity: IActivity, isPremiumTier: boolean) => {
     const { user_email, role, jit } = activity.details || {};
 
-    if (jit) {
+    if (
+      jit ||
+      (activity.actor_id != null &&
+        activity.actor_id === activity.details?.user_id)
+    ) {
       return (
         <>
           was assigned the <b>{role}</b> role
@@ -349,7 +353,11 @@ const TAGGED_TEMPLATES = {
   userDeletedGlobalRole: (activity: IActivity, isPremiumTier: boolean) => {
     const { user_email, role, jit } = activity.details || {};
 
-    if (jit) {
+    if (
+      jit ||
+      (activity.actor_id != null &&
+        activity.actor_id === activity.details?.user_id)
+    ) {
       return (
         <>
           was removed as <b>{role}</b>
@@ -368,7 +376,11 @@ const TAGGED_TEMPLATES = {
   userChangedTeamRole: (activity: IActivity) => {
     const { user_email, role, team_name, jit } = activity.details || {};
 
-    if (jit) {
+    if (
+      jit ||
+      (activity.actor_id != null &&
+        activity.actor_id === activity.details?.user_id)
+    ) {
       return (
         <>
           was assigned the <b>{role}</b> role for the <b>{team_name}</b> fleet
@@ -386,7 +398,11 @@ const TAGGED_TEMPLATES = {
   userDeletedTeamRole: (activity: IActivity) => {
     const { user_email, team_name, jit } = activity.details || {};
 
-    if (jit) {
+    if (
+      jit ||
+      (activity.actor_id != null &&
+        activity.actor_id === activity.details?.user_id)
+    ) {
       return (
         <>
           was removed from the <b>{team_name}</b> fleet via just-in-time (JIT)
@@ -2953,7 +2969,9 @@ const GlobalActivityItem = ({
       case ActivityType.UserDeletedGlobalRole:
       case ActivityType.UserChangedTeamRole:
       case ActivityType.UserDeletedTeamRole:
-        return activity.details?.jit ? (
+        return activity.details?.jit ||
+          (activity.actor_id != null &&
+            activity.actor_id === activity.details?.user_id) ? (
           <b>{activity.details?.user_email} </b>
         ) : (
           DEFAULT_ACTOR_DISPLAY

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -328,60 +328,75 @@ const TAGGED_TEMPLATES = {
     );
   },
   userChangedGlobalRole: (activity: IActivity, isPremiumTier: boolean) => {
-    const { actor_id } = activity;
-    const { user_id, user_email, role } = activity.details || {};
+    const { user_email, role, jit } = activity.details || {};
 
-    if (actor_id === user_id) {
-      // this is the case when SSO user is crated via JIT provisioning
-      // should only be possible for premium tier, but check anyway
+    if (jit) {
       return (
         <>
           was assigned the <b>{role}</b> role
-          {isPremiumTier && " for all fleets"}.
+          {isPremiumTier && " for all fleets"} via just-in-time (JIT)
+          provisioning.
         </>
       );
     }
     return (
       <>
-        changed <b>{user_email}</b> to <b>{activity.details?.role}</b>
+        changed <b>{user_email}</b> to <b>{role}</b>
         {isPremiumTier && " for all fleets"}.
       </>
     );
   },
   userDeletedGlobalRole: (activity: IActivity, isPremiumTier: boolean) => {
+    const { user_email, role, jit } = activity.details || {};
+
+    if (jit) {
+      return (
+        <>
+          was removed as <b>{role}</b>
+          {isPremiumTier && " for all fleets"} via just-in-time (JIT)
+          provisioning.
+        </>
+      );
+    }
     return (
       <>
-        removed <b>{activity.details?.user_email}</b> as{" "}
-        <b>{activity.details?.role}</b>
+        removed <b>{user_email}</b> as <b>{role}</b>
         {isPremiumTier && " for all fleets"}.
       </>
     );
   },
   userChangedTeamRole: (activity: IActivity) => {
-    const { actor_id } = activity;
-    const { user_id, user_email, role, team_name } = activity.details || {};
+    const { user_email, role, team_name, jit } = activity.details || {};
 
-    const varText =
-      actor_id === user_id ? (
+    if (jit) {
+      return (
         <>
-          was assigned the <b>{role}</b> role
-        </>
-      ) : (
-        <>
-          changed <b>{user_email}</b> to <b>{role}</b>
+          was assigned the <b>{role}</b> role for the <b>{team_name}</b> fleet
+          via just-in-time (JIT) provisioning.
         </>
       );
+    }
     return (
       <>
-        {varText} for the <b>{team_name}</b> fleet.
+        changed <b>{user_email}</b> to <b>{role}</b> for the <b>{team_name}</b>{" "}
+        fleet.
       </>
     );
   },
   userDeletedTeamRole: (activity: IActivity) => {
+    const { user_email, team_name, jit } = activity.details || {};
+
+    if (jit) {
+      return (
+        <>
+          was removed from the <b>{team_name}</b> fleet via just-in-time (JIT)
+          provisioning.
+        </>
+      );
+    }
     return (
       <>
-        removed <b>{activity.details?.user_email}</b> from the{" "}
-        <b>{activity.details?.team_name}</b> fleet.
+        removed <b>{user_email}</b> from the <b>{team_name}</b> fleet.
       </>
     );
   },
@@ -2935,8 +2950,10 @@ const GlobalActivityItem = ({
 
     switch (activity.type) {
       case ActivityType.UserChangedGlobalRole:
+      case ActivityType.UserDeletedGlobalRole:
       case ActivityType.UserChangedTeamRole:
-        return activity.actor_id === activity.details?.user_id ? (
+      case ActivityType.UserDeletedTeamRole:
+        return activity.details?.jit ? (
           <b>{activity.details?.user_email} </b>
         ) : (
           DEFAULT_ACTOR_DISPLAY

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -161,6 +161,11 @@ const getMacOSSetupAssistantMessage = (
   );
 };
 
+const isSelfActorRoleActivity = (activity: IActivity): boolean =>
+  !!activity.details?.jit ||
+  (activity.actor_id != null &&
+    activity.actor_id === activity.details?.user_id);
+
 const TAGGED_TEMPLATES = {
   liveQueryActivityTemplate: (activity: IActivity) => {
     const { targets_count: count, query_name: queryName, stats } =
@@ -330,16 +335,12 @@ const TAGGED_TEMPLATES = {
   userChangedGlobalRole: (activity: IActivity, isPremiumTier: boolean) => {
     const { user_email, role, jit } = activity.details || {};
 
-    if (
-      jit ||
-      (activity.actor_id != null &&
-        activity.actor_id === activity.details?.user_id)
-    ) {
+    if (isSelfActorRoleActivity(activity)) {
       return (
         <>
           was assigned the <b>{role}</b> role
-          {isPremiumTier && " for all fleets"} via just-in-time (JIT)
-          provisioning.
+          {isPremiumTier && " for all fleets"}
+          {jit && " via just-in-time (JIT) provisioning"}.
         </>
       );
     }
@@ -353,16 +354,12 @@ const TAGGED_TEMPLATES = {
   userDeletedGlobalRole: (activity: IActivity, isPremiumTier: boolean) => {
     const { user_email, role, jit } = activity.details || {};
 
-    if (
-      jit ||
-      (activity.actor_id != null &&
-        activity.actor_id === activity.details?.user_id)
-    ) {
+    if (isSelfActorRoleActivity(activity)) {
       return (
         <>
           was removed as <b>{role}</b>
-          {isPremiumTier && " for all fleets"} via just-in-time (JIT)
-          provisioning.
+          {isPremiumTier && " for all fleets"}
+          {jit && " via just-in-time (JIT) provisioning"}.
         </>
       );
     }
@@ -376,15 +373,11 @@ const TAGGED_TEMPLATES = {
   userChangedTeamRole: (activity: IActivity) => {
     const { user_email, role, team_name, jit } = activity.details || {};
 
-    if (
-      jit ||
-      (activity.actor_id != null &&
-        activity.actor_id === activity.details?.user_id)
-    ) {
+    if (isSelfActorRoleActivity(activity)) {
       return (
         <>
           was assigned the <b>{role}</b> role for the <b>{team_name}</b> fleet
-          via just-in-time (JIT) provisioning.
+          {jit && " via just-in-time (JIT) provisioning"}.
         </>
       );
     }
@@ -398,15 +391,11 @@ const TAGGED_TEMPLATES = {
   userDeletedTeamRole: (activity: IActivity) => {
     const { user_email, team_name, jit } = activity.details || {};
 
-    if (
-      jit ||
-      (activity.actor_id != null &&
-        activity.actor_id === activity.details?.user_id)
-    ) {
+    if (isSelfActorRoleActivity(activity)) {
       return (
         <>
-          was removed from the <b>{team_name}</b> fleet via just-in-time (JIT)
-          provisioning.
+          was removed from the <b>{team_name}</b> fleet
+          {jit && " via just-in-time (JIT) provisioning"}.
         </>
       );
     }
@@ -2969,9 +2958,7 @@ const GlobalActivityItem = ({
       case ActivityType.UserDeletedGlobalRole:
       case ActivityType.UserChangedTeamRole:
       case ActivityType.UserDeletedTeamRole:
-        return activity.details?.jit ||
-          (activity.actor_id != null &&
-            activity.actor_id === activity.details?.user_id) ? (
+        return isSelfActorRoleActivity(activity) ? (
           <b>{activity.details?.user_email} </b>
         ) : (
           DEFAULT_ACTOR_DISPLAY

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -408,6 +408,7 @@ type ActivityTypeChangedUserGlobalRole struct {
 	UserName  string `json:"user_name"`
 	UserEmail string `json:"user_email"`
 	Role      string `json:"role"`
+	JIT       bool   `json:"jit,omitempty"`
 }
 
 func (a ActivityTypeChangedUserGlobalRole) ActivityName() string {
@@ -419,6 +420,7 @@ type ActivityTypeDeletedUserGlobalRole struct {
 	UserName  string `json:"user_name"`
 	UserEmail string `json:"user_email"`
 	OldRole   string `json:"role"`
+	JIT       bool   `json:"jit,omitempty"`
 }
 
 func (a ActivityTypeDeletedUserGlobalRole) ActivityName() string {
@@ -432,6 +434,7 @@ type ActivityTypeChangedUserTeamRole struct {
 	Role      string `json:"role"`
 	TeamID    uint   `json:"team_id" renameto:"fleet_id"`
 	TeamName  string `json:"team_name" renameto:"fleet_name"`
+	JIT       bool   `json:"jit,omitempty"`
 }
 
 func (a ActivityTypeChangedUserTeamRole) ActivityName() string {
@@ -445,6 +448,7 @@ type ActivityTypeDeletedUserTeamRole struct {
 	Role      string `json:"role"`
 	TeamID    uint   `json:"team_id" renameto:"fleet_id"`
 	TeamName  string `json:"team_name" renameto:"fleet_name"`
+	JIT       bool   `json:"jit,omitempty"`
 }
 
 func (a ActivityTypeDeletedUserTeamRole) ActivityName() string {
@@ -1444,8 +1448,9 @@ func (a ActivityTypeDeletedOrgLogo) ActivityName() string {
 }
 
 // LogRoleChangeActivities logs activities for each role change, globally and one for each change in teams.
+// If jit is true, the activities are marked as originating from JIT (just-in-time) SSO provisioning.
 func LogRoleChangeActivities(
-	ctx context.Context, svc Service, adminUser *User, oldGlobalRole *string, oldTeamRoles []UserTeam, user *User,
+	ctx context.Context, svc Service, adminUser *User, oldGlobalRole *string, oldTeamRoles []UserTeam, user *User, jit bool,
 ) error {
 	if user.GlobalRole != nil && (oldGlobalRole == nil || *oldGlobalRole != *user.GlobalRole) {
 		if err := svc.NewActivity(
@@ -1456,6 +1461,7 @@ func LogRoleChangeActivities(
 				UserName:  user.Name,
 				UserEmail: user.Email,
 				Role:      *user.GlobalRole,
+				JIT:       jit,
 			},
 		); err != nil {
 			return err
@@ -1470,6 +1476,7 @@ func LogRoleChangeActivities(
 				UserName:  user.Name,
 				UserEmail: user.Email,
 				OldRole:   *oldGlobalRole,
+				JIT:       jit,
 			},
 		); err != nil {
 			return err
@@ -1497,6 +1504,7 @@ func LogRoleChangeActivities(
 				Role:      t.Role,
 				TeamID:    t.ID,
 				TeamName:  t.Name,
+				JIT:       jit,
 			},
 		); err != nil {
 			return err
@@ -1516,6 +1524,7 @@ func LogRoleChangeActivities(
 				Role:      o.Role,
 				TeamID:    o.ID,
 				TeamName:  o.Name,
+				JIT:       jit,
 			},
 		); err != nil {
 			return err

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -1,7 +1,6 @@
 package fleet
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,19 +11,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server"
 	"golang.org/x/crypto/bcrypt"
 )
-
-type ctxKeyJIT struct{}
-
-// ContextWithJIT marks the context as originating from JIT SSO provisioning.
-func ContextWithJIT(ctx context.Context) context.Context {
-	return context.WithValue(ctx, ctxKeyJIT{}, true)
-}
-
-// IsJITContext returns true if the context was marked as JIT provisioning.
-func IsJITContext(ctx context.Context) bool {
-	v, _ := ctx.Value(ctxKeyJIT{}).(bool)
-	return v
-}
 
 // ErrLastGlobalAdmin is returned when an operation would remove the last global admin.
 var ErrLastGlobalAdmin = errors.New("cannot remove the last global admin")
@@ -325,6 +311,7 @@ type UserPayload struct {
 	NewPassword              *string       `json:"new_password,omitempty"`
 	Settings                 *UserSettings `json:"settings,omitempty"`
 	InviteID                 *uint         `json:"-"`
+	JITProvisioned           bool          `json:"-"`
 
 	// If this is an API-only user, then this can be used to specify which
 	// API endpoints the user has access to

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,19 @@ import (
 	"github.com/fleetdm/fleet/v4/server"
 	"golang.org/x/crypto/bcrypt"
 )
+
+type ctxKeyJIT struct{}
+
+// ContextWithJIT marks the context as originating from JIT SSO provisioning.
+func ContextWithJIT(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxKeyJIT{}, true)
+}
+
+// IsJITContext returns true if the context was marked as JIT provisioning.
+func IsJITContext(ctx context.Context) bool {
+	v, _ := ctx.Value(ctxKeyJIT{}).(bool)
+	return v
+}
 
 // ErrLastGlobalAdmin is returned when an operation would remove the last global admin.
 var ErrLastGlobalAdmin = errors.New("cannot remove the last global admin")

--- a/server/service/activities_test.go
+++ b/server/service/activities_test.go
@@ -104,6 +104,58 @@ func Test_logRoleChangeActivities(t *testing.T) {
 	}
 }
 
+func Test_logRoleChangeActivitiesJIT(t *testing.T) {
+	ds := new(mock.Store)
+	opts := &TestServerOpts{}
+	svc, ctx := newTestService(t, ds, nil, nil, opts)
+
+	type activityRecord struct {
+		name string
+		jit  bool
+	}
+	var recorded []activityRecord
+	opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+		var isJIT bool
+		switch a := activity.(type) {
+		case fleet.ActivityTypeChangedUserGlobalRole:
+			isJIT = a.JIT
+		case fleet.ActivityTypeDeletedUserGlobalRole:
+			isJIT = a.JIT
+		case fleet.ActivityTypeChangedUserTeamRole:
+			isJIT = a.JIT
+		case fleet.ActivityTypeDeletedUserTeamRole:
+			isJIT = a.JIT
+		}
+		recorded = append(recorded, activityRecord{name: activity.ActivityName(), jit: isJIT})
+		return nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+
+	user := &fleet.User{
+		ID:         1,
+		GlobalRole: ptr.String("admin"),
+	}
+	require.NoError(t, fleet.LogRoleChangeActivities(ctx, svc, user, nil, nil, user, true))
+	require.Len(t, recorded, 1)
+	require.Equal(t, "changed_user_global_role", recorded[0].name)
+	require.True(t, recorded[0].jit)
+
+	recorded = recorded[:0]
+	require.NoError(t, fleet.LogRoleChangeActivities(ctx, svc, user, ptr.String("admin"), nil, user, false))
+	require.Empty(t, recorded)
+
+	recorded = recorded[:0]
+	noRole := &fleet.User{ID: 1, Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: "observer"}}}
+	require.NoError(t, fleet.LogRoleChangeActivities(ctx, svc, user, ptr.String("admin"), nil, noRole, false))
+	require.Len(t, recorded, 2)
+	require.Equal(t, "deleted_user_global_role", recorded[0].name)
+	require.False(t, recorded[0].jit)
+	require.Equal(t, "changed_user_team_role", recorded[1].name)
+	require.False(t, recorded[1].jit)
+}
+
 func TestCancelHostUpcomingActivityAuth(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}})

--- a/server/service/activities_test.go
+++ b/server/service/activities_test.go
@@ -98,7 +98,7 @@ func Test_logRoleChangeActivities(t *testing.T) {
 				GlobalRole: tt.newRole,
 				Teams:      newTeams,
 			}
-			require.NoError(t, fleet.LogRoleChangeActivities(ctx, svc, &fleet.User{}, tt.oldRole, oldTeams, newUser))
+			require.NoError(t, fleet.LogRoleChangeActivities(ctx, svc, &fleet.User{}, tt.oldRole, oldTeams, newUser, false))
 			require.Equal(t, tt.expectActivities, activities)
 		})
 	}

--- a/server/service/activities_test.go
+++ b/server/service/activities_test.go
@@ -147,7 +147,9 @@ func Test_logRoleChangeActivitiesJIT(t *testing.T) {
 	require.Empty(t, recorded)
 
 	recorded = recorded[:0]
-	noRole := &fleet.User{ID: 1, Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: "observer"}}}
+	teamRole := fleet.UserTeam{Role: "observer"}
+	teamRole.ID = 1
+	noRole := &fleet.User{ID: 1, Teams: []fleet.UserTeam{teamRole}}
 	require.NoError(t, fleet.LogRoleChangeActivities(ctx, svc, user, ptr.String("admin"), nil, noRole, false))
 	require.Len(t, recorded, 2)
 	require.Equal(t, "deleted_user_global_role", recorded[0].name)

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
+
 func (svc *Service) CreateInitialUser(ctx context.Context, p fleet.UserPayload) (*fleet.User, error) {
 	// skipauth: Only the initial user creation should be allowed to skip
 	// authorization (because there is not yet a user context to check against).
@@ -69,7 +70,7 @@ func (svc *Service) NewUser(ctx context.Context, p fleet.UserPayload) (*fleet.Us
 	); err != nil {
 		return nil, err
 	}
-	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, nil, nil, user, false); err != nil {
+	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, nil, nil, user, fleet.IsJITContext(ctx)); err != nil {
 		return nil, err
 	}
 

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
-
 func (svc *Service) CreateInitialUser(ctx context.Context, p fleet.UserPayload) (*fleet.User, error) {
 	// skipauth: Only the initial user creation should be allowed to skip
 	// authorization (because there is not yet a user context to check against).
@@ -70,7 +69,7 @@ func (svc *Service) NewUser(ctx context.Context, p fleet.UserPayload) (*fleet.Us
 	); err != nil {
 		return nil, err
 	}
-	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, nil, nil, user, fleet.IsJITContext(ctx)); err != nil {
+	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, nil, nil, user, p.JITProvisioned); err != nil {
 		return nil, err
 	}
 

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -69,7 +69,7 @@ func (svc *Service) NewUser(ctx context.Context, p fleet.UserPayload) (*fleet.Us
 	); err != nil {
 		return nil, err
 	}
-	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, nil, nil, user); err != nil {
+	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, nil, nil, user, false); err != nil {
 		return nil, err
 	}
 

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -951,7 +951,7 @@ func (svc *Service) ModifyUser(ctx context.Context, userID uint, p fleet.UserPay
 		return nil, err
 	}
 	adminUser := authz.UserFromContext(ctx)
-	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, oldGlobalRole, oldTeams, user); err != nil {
+	if err := fleet.LogRoleChangeActivities(ctx, svc, adminUser, oldGlobalRole, oldTeams, user, false); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
> Generated by Claude on behalf of Sharon FDM

**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/46741

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

#### Before

<img width="697" height="645" alt="Screenshot 2026-09-14 at 9 17 02 PM" src="https://github.com/user-attachments/assets/76b70515-f88d-492f-b00e-09f93cd36f1d" />


#### After

<img width="697" height="704" alt="Screenshot 2026-09-14 at 9 19 47 PM" src="https://github.com/user-attachments/assets/5682930c-a33b-46b5-962d-ebe2310f900b" />


## What changed

When SSO users have their roles changed via just-in-time (JIT) provisioning, the activity feed showed the user as both actor and subject (e.g., "**Noah** removed **noah@example.com** from **Team**").

### Before/After

| Activity | Before | After |
|---|---|---|
| JIT removed from fleet | **Noah** removed **noah@example.com** from the **Team** fleet. | **noah@example.com** was removed from the **Team** fleet via just-in-time (JIT) provisioning. |
| JIT removed global role | **Noah** removed **noah@example.com** as **admin** for all fleets. | **noah@example.com** was removed as **admin** for all fleets via just-in-time (JIT) provisioning. |
| JIT changed fleet role | **noah@example.com** was assigned the **admin** role for the **Team** fleet. | **noah@example.com** was assigned the **admin** role for the **Team** fleet via just-in-time (JIT) provisioning. |
| JIT changed global role | **noah@example.com** was assigned the **admin** role for all fleets. | **noah@example.com** was assigned the **admin** role for all fleets via just-in-time (JIT) provisioning. |

## How reproduced

Traced the code path from SSO login -> `GetSSOUser` -> `LogRoleChangeActivities` -> `NewActivity`. The JIT path at `ee/server/service/users.go:79` passed the same `user` as both actor and target. The frontend had no way to distinguish JIT from admin-initiated changes.

---

Supersedes https://github.com/fleetdm/fleet/pull/52429 (clean branch, same changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected activity feed messages for role changes made through just-in-time (JIT) provisioning.
  * JIT role additions, updates, and removals now use clearer passive wording without displaying the affected user as both actor and subject.
  * Improved activity history for newly provisioned SSO users so their initial role assignments are identified as JIT provisioning events.
  * Non-JIT role changes now display wording appropriate to their activity context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->