### PR TITLE
OS updates empty states

### DIFF
--- a/changes/52474-os-updates-mdm-empty-states
+++ b/changes/52474-os-updates-mdm-empty-states
@@ -1,0 +1,1 @@
+- Added empty state to Controls > OS updates tabs when MDM isn't turned on for a platform.

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tests.tsx
@@ -25,6 +25,7 @@ const defaultProps = {
   onSelectPlatform: noop,
   refetchAppConfig: noop,
   refetchTeamConfig: noop,
+  isAppleMdmEnabled: true,
   isWindowsMdmEnabled: true,
   isAndroidMdmEnabled: true,
 };
@@ -68,22 +69,39 @@ describe("PlatformTabs", () => {
     expect(screen.getByText(/Android updates are coming soon/i)).toBeVisible();
   });
 
-  it("hides the Windows and Android tabs when their MDM isn't enabled", () => {
+  it("shows the Windows tab with an empty state when Windows MDM isn't enabled", () => {
     render(
       <PlatformTabs
         {...defaultProps}
-        selectedPlatform="darwin"
+        selectedPlatform="windows"
         isWindowsMdmEnabled={false}
         isAndroidMdmEnabled={false}
       />
     );
 
     expect(screen.getByRole("tab", { name: /macOS/i })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("tab", { name: /Windows/i })
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Windows/i })).toBeInTheDocument();
     expect(
       screen.queryByRole("tab", { name: /Android/i })
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Turn on MDM to enforce OS updates/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows Apple tabs with empty states when Apple MDM isn't enabled", () => {
+    render(
+      <PlatformTabs
+        {...defaultProps}
+        selectedPlatform="darwin"
+        isAppleMdmEnabled={false}
+      />
+    );
+
+    expect(screen.getByRole("tab", { name: /macOS/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Turn on MDM to enforce OS updates/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Minimum version/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
@@ -8,10 +8,7 @@ import { LEARN_MORE_ABOUT_BASE_LINK, SUPPORT_LINK } from "utilities/constants";
 
 import EndUserOSRequirementPreview from "../EndUserOSRequirementPreview";
 import WindowsTargetForm from "../WindowsTargetForm";
-import {
-  OSUpdatesSupportedPlatform,
-  OSUpdatesTargetPlatform,
-} from "../../OSUpdates";
+import { OSUpdatesTargetPlatform } from "../../OSUpdates";
 import AppleOSTargetForm from "../AppleOSTargetForm";
 
 const baseClass = "platform-tabs";
@@ -167,9 +164,7 @@ const PlatformTabs = ({
                   refetchTeamConfig={refetchTeamConfig}
                 />
                 <div className={`${baseClass}__nudge-preview`}>
-                  <EndUserOSRequirementPreview
-                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
-                  />
+                  <EndUserOSRequirementPreview platform="darwin" />
                 </div>
               </>
             ) : (
@@ -188,9 +183,7 @@ const PlatformTabs = ({
                   refetchTeamConfig={refetchTeamConfig}
                 />
                 <div className={`${baseClass}__nudge-preview`}>
-                  <EndUserOSRequirementPreview
-                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
-                  />
+                  <EndUserOSRequirementPreview platform="windows" />
                 </div>
               </>
             ) : (
@@ -211,9 +204,7 @@ const PlatformTabs = ({
                   refetchTeamConfig={refetchTeamConfig}
                 />
                 <div className={`${baseClass}__nudge-preview`}>
-                  <EndUserOSRequirementPreview
-                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
-                  />
+                  <EndUserOSRequirementPreview platform="ios" />
                 </div>
               </>
             ) : (
@@ -234,9 +225,7 @@ const PlatformTabs = ({
                   refetchTeamConfig={refetchTeamConfig}
                 />
                 <div className={`${baseClass}__nudge-preview`}>
-                  <EndUserOSRequirementPreview
-                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
-                  />
+                  <EndUserOSRequirementPreview platform="ipados" />
                 </div>
               </>
             ) : (

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
@@ -3,7 +3,8 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import CustomLink from "components/CustomLink";
-import { SUPPORT_LINK } from "utilities/constants";
+import EmptyState from "components/EmptyState";
+import { LEARN_MORE_ABOUT_BASE_LINK, SUPPORT_LINK } from "utilities/constants";
 
 import EndUserOSRequirementPreview from "../EndUserOSRequirementPreview";
 import WindowsTargetForm from "../WindowsTargetForm";
@@ -33,6 +34,7 @@ interface IPlatformTabsProps {
   onSelectPlatform: (platform: OSUpdatesTargetPlatform) => void;
   refetchAppConfig: () => void;
   refetchTeamConfig: () => void;
+  isAppleMdmEnabled: boolean;
   isWindowsMdmEnabled: boolean;
   isAndroidMdmEnabled: boolean;
 }
@@ -55,15 +57,19 @@ const PlatformTabs = ({
   onSelectPlatform,
   refetchAppConfig,
   refetchTeamConfig,
+  isAppleMdmEnabled,
   isWindowsMdmEnabled,
   isAndroidMdmEnabled,
 }: IPlatformTabsProps) => {
   // FIXME: This behaves unexpectedly when a user switches tabs or changes the teams dropdown while a form is
   // submitting.
 
-  const platformByIndex: OSUpdatesTargetPlatform[] = isWindowsMdmEnabled
-    ? ["darwin", "windows", "ios", "ipados"]
-    : ["darwin", "ios", "ipados"];
+  const platformByIndex: OSUpdatesTargetPlatform[] = [
+    "darwin",
+    "windows",
+    "ios",
+    "ipados",
+  ];
 
   if (isAndroidMdmEnabled) {
     platformByIndex.push("android");
@@ -80,6 +86,46 @@ const PlatformTabs = ({
   const isIOSConfigured = !!defaultIOSVersion;
   const isIPadOSConfigured = !!defaultIPadOSVersion;
 
+  const appleMdmEmptyState = (platformName: string) => (
+    <div className={`${baseClass}__mdm-empty-state`}>
+      <EmptyState
+        header="Turn on MDM to enforce OS updates"
+        info={
+          <>
+            You must turn on Apple MDM to enforce OS updates for {platformName}{" "}
+            hosts.{" "}
+            <CustomLink
+              url={`${LEARN_MORE_ABOUT_BASE_LINK}/turn-on-apple-mdm`}
+              text="Learn more"
+              newTab
+            />
+          </>
+        }
+        variant="form"
+      />
+    </div>
+  );
+
+  const windowsMdmEmptyState = (
+    <div className={`${baseClass}__mdm-empty-state`}>
+      <EmptyState
+        header="Turn on MDM to enforce OS updates"
+        info={
+          <>
+            You must turn on Windows MDM to enforce OS updates for Windows
+            hosts.{" "}
+            <CustomLink
+              url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-windows-mdm`}
+              text="Learn more"
+              newTab
+            />
+          </>
+        }
+        variant="form"
+      />
+    </div>
+  );
+
   return (
     <div className={baseClass}>
       <TabNav secondary>
@@ -91,11 +137,9 @@ const PlatformTabs = ({
             <Tab key="macOS" data-text="macOS">
               <TabText showCheck={isMacOSConfigured}>macOS</TabText>
             </Tab>
-            {isWindowsMdmEnabled && (
-              <Tab key="Windows" data-text="Windows">
-                <TabText showCheck={isWindowsConfigured}>Windows</TabText>
-              </Tab>
-            )}
+            <Tab key="Windows" data-text="Windows">
+              <TabText showCheck={isWindowsConfigured}>Windows</TabText>
+            </Tab>
             <Tab key="iOS" data-text="iOS">
               <TabText showCheck={isIOSConfigured}>iOS</TabText>
             </Tab>
@@ -109,73 +153,95 @@ const PlatformTabs = ({
             )}
           </TabList>
           <TabPanel className={`${baseClass}__tab-panel`}>
-            <AppleOSTargetForm
-              currentTeamId={currentTeamId}
-              applePlatform="darwin"
-              defaultMinOsVersion={defaultMacOSVersion}
-              defaultDeadline={defaultMacOSDeadline}
-              defaultDeadlineDays={defaultMacOSDeadlineDays}
-              defaultUpdateNewHosts={defaultMacOSUpdateNewHosts}
-              key={currentTeamId}
-              refetchAppConfig={refetchAppConfig}
-              refetchTeamConfig={refetchTeamConfig}
-            />
-            <div className={`${baseClass}__nudge-preview`}>
-              <EndUserOSRequirementPreview
-                platform={selectedPlatform as OSUpdatesSupportedPlatform}
-              />
-            </div>
-          </TabPanel>
-          {isWindowsMdmEnabled && (
-            <TabPanel className={`${baseClass}__tab-panel`}>
-              <WindowsTargetForm
-                currentTeamId={currentTeamId}
-                defaultDeadlineDays={defaultWindowsDeadlineDays}
-                defaultGracePeriodDays={defaultWindowsGracePeriodDays}
-                key={currentTeamId}
-                refetchAppConfig={refetchAppConfig}
-                refetchTeamConfig={refetchTeamConfig}
-              />
-              <div className={`${baseClass}__nudge-preview`}>
-                <EndUserOSRequirementPreview
-                  platform={selectedPlatform as OSUpdatesSupportedPlatform}
+            {isAppleMdmEnabled ? (
+              <>
+                <AppleOSTargetForm
+                  currentTeamId={currentTeamId}
+                  applePlatform="darwin"
+                  defaultMinOsVersion={defaultMacOSVersion}
+                  defaultDeadline={defaultMacOSDeadline}
+                  defaultDeadlineDays={defaultMacOSDeadlineDays}
+                  defaultUpdateNewHosts={defaultMacOSUpdateNewHosts}
+                  key={currentTeamId}
+                  refetchAppConfig={refetchAppConfig}
+                  refetchTeamConfig={refetchTeamConfig}
                 />
-              </div>
-            </TabPanel>
-          )}
-          <TabPanel className={`${baseClass}__tab-panel`}>
-            <AppleOSTargetForm
-              currentTeamId={currentTeamId}
-              applePlatform="ios"
-              defaultMinOsVersion={defaultIOSVersion}
-              defaultDeadline={defaultIOSDeadline}
-              defaultDeadlineDays={defaultIOSDeadlineDays}
-              key={currentTeamId}
-              refetchAppConfig={refetchAppConfig}
-              refetchTeamConfig={refetchTeamConfig}
-            />
-            <div className={`${baseClass}__nudge-preview`}>
-              <EndUserOSRequirementPreview
-                platform={selectedPlatform as OSUpdatesSupportedPlatform}
-              />
-            </div>
+                <div className={`${baseClass}__nudge-preview`}>
+                  <EndUserOSRequirementPreview
+                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
+                  />
+                </div>
+              </>
+            ) : (
+              appleMdmEmptyState("macOS")
+            )}
           </TabPanel>
           <TabPanel className={`${baseClass}__tab-panel`}>
-            <AppleOSTargetForm
-              currentTeamId={currentTeamId}
-              applePlatform="ipados"
-              defaultMinOsVersion={defaultIPadOSVersion}
-              defaultDeadline={defaultIPadOSDeadline}
-              defaultDeadlineDays={defaultIPadOSDeadlineDays}
-              key={currentTeamId}
-              refetchAppConfig={refetchAppConfig}
-              refetchTeamConfig={refetchTeamConfig}
-            />
-            <div className={`${baseClass}__nudge-preview`}>
-              <EndUserOSRequirementPreview
-                platform={selectedPlatform as OSUpdatesSupportedPlatform}
-              />
-            </div>
+            {isWindowsMdmEnabled ? (
+              <>
+                <WindowsTargetForm
+                  currentTeamId={currentTeamId}
+                  defaultDeadlineDays={defaultWindowsDeadlineDays}
+                  defaultGracePeriodDays={defaultWindowsGracePeriodDays}
+                  key={currentTeamId}
+                  refetchAppConfig={refetchAppConfig}
+                  refetchTeamConfig={refetchTeamConfig}
+                />
+                <div className={`${baseClass}__nudge-preview`}>
+                  <EndUserOSRequirementPreview
+                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
+                  />
+                </div>
+              </>
+            ) : (
+              windowsMdmEmptyState
+            )}
+          </TabPanel>
+          <TabPanel className={`${baseClass}__tab-panel`}>
+            {isAppleMdmEnabled ? (
+              <>
+                <AppleOSTargetForm
+                  currentTeamId={currentTeamId}
+                  applePlatform="ios"
+                  defaultMinOsVersion={defaultIOSVersion}
+                  defaultDeadline={defaultIOSDeadline}
+                  defaultDeadlineDays={defaultIOSDeadlineDays}
+                  key={currentTeamId}
+                  refetchAppConfig={refetchAppConfig}
+                  refetchTeamConfig={refetchTeamConfig}
+                />
+                <div className={`${baseClass}__nudge-preview`}>
+                  <EndUserOSRequirementPreview
+                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
+                  />
+                </div>
+              </>
+            ) : (
+              appleMdmEmptyState("iOS")
+            )}
+          </TabPanel>
+          <TabPanel className={`${baseClass}__tab-panel`}>
+            {isAppleMdmEnabled ? (
+              <>
+                <AppleOSTargetForm
+                  currentTeamId={currentTeamId}
+                  applePlatform="ipados"
+                  defaultMinOsVersion={defaultIPadOSVersion}
+                  defaultDeadline={defaultIPadOSDeadline}
+                  defaultDeadlineDays={defaultIPadOSDeadlineDays}
+                  key={currentTeamId}
+                  refetchAppConfig={refetchAppConfig}
+                  refetchTeamConfig={refetchTeamConfig}
+                />
+                <div className={`${baseClass}__nudge-preview`}>
+                  <EndUserOSRequirementPreview
+                    platform={selectedPlatform as OSUpdatesSupportedPlatform}
+                  />
+                </div>
+              </>
+            ) : (
+              appleMdmEmptyState("iPadOS")
+            )}
           </TabPanel>
           {isAndroidMdmEnabled && (
             <TabPanel className={`${baseClass}__tab-panel`}>

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
@@ -84,43 +84,38 @@ const PlatformTabs = ({
   const isIPadOSConfigured = !!defaultIPadOSVersion;
 
   const appleMdmEmptyState = (platformName: string) => (
-    <div className={`${baseClass}__mdm-empty-state`}>
-      <EmptyState
-        header="Turn on MDM to enforce OS updates"
-        info={
-          <>
-            You must turn on Apple MDM to enforce OS updates for {platformName}{" "}
-            hosts.{" "}
-            <CustomLink
-              url={`${LEARN_MORE_ABOUT_BASE_LINK}/turn-on-apple-mdm`}
-              text="Learn more"
-              newTab
-            />
-          </>
-        }
-        variant="form"
-      />
-    </div>
+    <EmptyState
+      header="Turn on MDM to enforce OS updates"
+      info={
+        <>
+          You must turn on Apple MDM to enforce OS updates for {platformName}{" "}
+          hosts.{" "}
+          <CustomLink
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/turn-on-apple-mdm`}
+            text="Learn more"
+            newTab
+          />
+        </>
+      }
+      variant="form"
+    />
   );
 
   const windowsMdmEmptyState = (
-    <div className={`${baseClass}__mdm-empty-state`}>
-      <EmptyState
-        header="Turn on MDM to enforce OS updates"
-        info={
-          <>
-            You must turn on Windows MDM to enforce OS updates for Windows
-            hosts.{" "}
-            <CustomLink
-              url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-windows-mdm`}
-              text="Learn more"
-              newTab
-            />
-          </>
-        }
-        variant="form"
-      />
-    </div>
+    <EmptyState
+      header="Turn on MDM to enforce OS updates"
+      info={
+        <>
+          You must turn on Windows MDM to enforce OS updates for Windows hosts.{" "}
+          <CustomLink
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-windows-mdm`}
+            text="Learn more"
+            newTab
+          />
+        </>
+      }
+      variant="form"
+    />
   );
 
   return (
@@ -149,7 +144,11 @@ const PlatformTabs = ({
               </Tab>
             )}
           </TabList>
-          <TabPanel className={`${baseClass}__tab-panel`}>
+          <TabPanel
+            className={`${baseClass}__tab-panel${
+              isAppleMdmEnabled ? "" : "--empty"
+            }`}
+          >
             {isAppleMdmEnabled ? (
               <>
                 <AppleOSTargetForm
@@ -171,7 +170,11 @@ const PlatformTabs = ({
               appleMdmEmptyState("macOS")
             )}
           </TabPanel>
-          <TabPanel className={`${baseClass}__tab-panel`}>
+          <TabPanel
+            className={`${baseClass}__tab-panel${
+              isWindowsMdmEnabled ? "" : "--empty"
+            }`}
+          >
             {isWindowsMdmEnabled ? (
               <>
                 <WindowsTargetForm
@@ -190,7 +193,11 @@ const PlatformTabs = ({
               windowsMdmEmptyState
             )}
           </TabPanel>
-          <TabPanel className={`${baseClass}__tab-panel`}>
+          <TabPanel
+            className={`${baseClass}__tab-panel${
+              isAppleMdmEnabled ? "" : "--empty"
+            }`}
+          >
             {isAppleMdmEnabled ? (
               <>
                 <AppleOSTargetForm

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/_styles.scss
@@ -13,6 +13,10 @@
     }
   }
 
+  &__mdm-empty-state {
+    grid-column: 1 / -1;
+  }
+
   &__target-container {
     grid-area: target;
   }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/_styles.scss
@@ -13,10 +13,6 @@
     }
   }
 
-  &__mdm-empty-state {
-    grid-column: 1 / -1;
-  }
-
   &__target-container {
     grid-area: target;
   }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/TargetSection/TargetSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/TargetSection/TargetSection.tsx
@@ -6,7 +6,6 @@ import { ApplePlatform } from "interfaces/platform";
 
 import Spinner from "components/Spinner";
 
-import WindowsTargetForm from "../WindowsTargetForm";
 import PlatformTabs from "../PlatformTabs";
 import { OSUpdatesTargetPlatform } from "../../OSUpdates";
 
@@ -230,17 +229,6 @@ const TargetSection = ({
   });
 
   const renderTargetForms = () => {
-    if (isWindowsMdmEnabled && !isAppleMdmEnabled && !isAndroidMdmEnabled) {
-      return (
-        <WindowsTargetForm
-          currentTeamId={currentTeamId}
-          defaultDeadlineDays={defaultWindowsDeadlineDays}
-          defaultGracePeriodDays={defaultWindowsGracePeriodDays}
-          refetchAppConfig={refetchAppConfig}
-          refetchTeamConfig={refetchTeamConfig}
-        />
-      );
-    }
     return (
       <PlatformTabs
         currentTeamId={currentTeamId}
@@ -260,6 +248,7 @@ const TargetSection = ({
         onSelectPlatform={onSelectPlatform}
         refetchAppConfig={refetchAppConfig}
         refetchTeamConfig={refetchTeamConfig}
+        isAppleMdmEnabled={isAppleMdmEnabled}
         isWindowsMdmEnabled={isWindowsMdmEnabled}
         isAndroidMdmEnabled={isAndroidMdmEnabled}
       />


### PR DESCRIPTION
Adding empty states for OS updates tabs, instead of hiding the tab for a platform if MDM isn't turned on, to match the existing pattern we have for platform tabs in controls.

This also fixes a bug where the Apple platform tabs are shown when Windows MDM and Android MDM are on, but Apple MDM is off.

**Related issue:** Part of the resolution for #52474

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

---

**Before (notice no Windows tab):**

<img width="2956" height="2002" alt="Screenshot 2026-09-07 at 13-29-24 Controls Fleet" src="https://github.com/user-attachments/assets/051096e9-f366-41af-8e70-26740a623db1" />
<img width="2986" height="2002" alt="Image" src="https://github.com/user-attachments/assets/52800252-722c-4b78-88c3-7b16072f1b44" />

Copy updates

<img width="441" height="351" alt="Screenshot 2026-09-15 at 11 52 12" src="https://github.com/user-attachments/assets/d2a49855-dc79-4b29-af48-df2969b02cc4" />
<img width="960" height="560" alt="Screenshot 2026-09-15 at 11 55 27" src="https://github.com/user-attachments/assets/51b65505-de30-440c-95d1-f9c9e69b44ac" />

**After:**

Learn more goes to https://fleetdm.com/guides/windows-mdm-setup

<img width="2956" height="2374" alt="Screenshot 2026-09-07 at 13-25-17 Controls Fleet" src="https://github.com/user-attachments/assets/94cc3495-38a5-4c0b-9100-d4605243aad0" />

Learn more goes to https://fleetdm.com/guides/apple-mdm-setup#turn-on-apple-mdm

<img width="2956" height="2194" alt="Screenshot 2026-09-07 at 14-04-50 Controls Fleet" src="https://github.com/user-attachments/assets/aca25330-6c4e-44c7-b521-754555e38934" />
<img width="2956" height="2194" alt="Screenshot 2026-09-07 at 14-04-56 Controls Fleet" src="https://github.com/user-attachments/assets/525a79bd-4af6-443b-bb7c-9050c7502429" />
<img width="2956" height="2194" alt="Screenshot 2026-09-07 at 14-05-04 Controls Fleet" src="https://github.com/user-attachments/assets/911e3660-9add-4509-933b-72924de7add1" />

Learn more goes to https://fleetdm.com/guides/enforce-os-updates

<img width="2956" height="2194" alt="Screenshot 2026-09-15 at 12-02-51 Controls Fleet" src="https://github.com/user-attachments/assets/bc6bf23d-9e25-4aac-a3df-dc25b0f1a067" />

Copy updates

<img width="442" height="351" alt="Screenshot 2026-09-15 at 11 53 07" src="https://github.com/user-attachments/assets/310ccb3a-d605-4ee5-85f5-2f2aaf850061" />
<img width="967" height="568" alt="Screenshot 2026-09-15 at 11 55 37" src="https://github.com/user-attachments/assets/d8ac00b0-57ec-4b5a-9759-5418dc7725d0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform tabs for macOS, Windows, iOS, iPadOS, and Android now remain available even when MDM is disabled.
  * Added informative empty states explaining when MDM must be enabled or when Android updates will be available.
* **Improvements**
  * Updated operating system detection messaging to clarify that data appears after the next scheduled check-in.
  * Refined the last-updated tooltip to describe software data refreshes, vulnerabilities, and host counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->