### PR TITLE
Document Windows managed local account rotation

### DIFF
--- a/articles/windows-linux-setup-experience.md
+++ b/articles/windows-linux-setup-experience.md
@@ -157,6 +157,18 @@ reported the password back.
 
 Go to **Host details** > **Actions** > **Show managed account**. The password is unique per host and is stored encrypted in Fleet.
 
+### Rotate the password
+
+Go to **Host details** > **Actions** > **Show managed account**, then press **Rotate password**. Fleet also rotates the password
+automatically about an hour after someone views it.
+
+Fleet asks the host to generate a new password, set it, and report it back, so a rotation finishes on the host's next check-in
+rather than immediately. Fleet keeps showing the current password until the new one arrives.
+
+If the host can't set the new password, Fleet shows the reason and keeps showing the previous password. The host never changed the
+password, so that one still works. Fix the cause and rotate again. The failures a host can report, and the hour it waits before
+retrying on its own, are covered in Troubleshoot the managed local account below.
+
 ### Sign in as the managed account
 
 The account is hidden from the Windows sign-in screen and from **Settings** > **Accounts**, so it won't appear in the list of users.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7363,7 +7363,9 @@ Remotely clear the passcode on a host. Requires iOS/iPadOS host to have sent its
 
 _Available in Fleet Premium_
 
-Rotates the managed local account password for a host.
+Rotates the managed local account password for a macOS or Windows host.
+
+On macOS, Fleet generates the new password and sends it to the host in an MDM command. On Windows, Fleet asks fleetd to generate a new password, set it, and send it back, so the rotation completes on the host's next check-in.
 
 `POST /api/v1/fleet/hosts/:id/managed_account_password/rotate`
 
@@ -7385,7 +7387,7 @@ Rotates the managed local account password for a host.
 
 Retrieves the managed account password for an eligible macOS or Windows host.
 
-The host will only return a password if its managed account password status is "Verified".
+On macOS, a password is returned only while its managed account password status is "Verified". On Windows, a password is returned whenever one has been escrowed, including after a failed rotation: the host keeps its previous password when a rotation fails, so that password still works.
 
 `GET /api/v1/fleet/hosts/:id/managed_account_password`
 


### PR DESCRIPTION
**Related issue:** #43489 (docs for #52683; merge after it)

Documents Windows managed local account password rotation, added in #52683.

- `articles/windows-linux-setup-experience.md`: new "Rotate the password" section. Covers rotating from the UI, the automatic rotation after a view, that a rotation lands on the host's next check-in rather than immediately, and what happens when a rotation fails, including that Fleet keeps showing the last password the host reported and does not retry. Points at the existing troubleshooting section rather than repeating it.
- `docs/REST API/rest-api.md`: the rotate endpoint now says macOS or Windows and describes the two mechanisms. The get endpoint's "only if Verified" line was accurate for macOS only, so it now splits by platform.

# Checklist for submitter

- [x] No changes file: docs only.

## Testing

- [x] QA'd all new/changed functionality manually: content verified against the behavior of #52683 on an Autopilot-enrolled Windows 11 VM (manual rotation, automatic rotation after a view, and a failed rotation that kept the previous password working).
- [ ] Not tested: local rendering of fleetdm.com. The added markdown follows the style of the surrounding section.

