### PR TITLE
Align authorization handling across host MDM endpoints

### DIFF
--- a/changes/45734-technician-clear-ios-passcode
+++ b/changes/45734-technician-clear-ios-passcode
@@ -1,2 +1,3 @@
 - Added the ability for users with the Technician role to clear passcodes on iOS and iPadOS hosts.
 - Fixed fleet-level admins and maintainers receiving a permission error when clearing passcodes on hosts in their fleets.
+- Made authorization errors consistent across the host MDM endpoints. Lock, unlock, wipe, clear passcode, Recovery Lock and managed local account password rotation, MDM command cancellation, and turning off MDM now return a `404` instead of a `403` when the target host is not in one of the caller's fleets.

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
+	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/google/uuid"
 	"google.golang.org/api/androidmanagement/v1"
 	"google.golang.org/api/googleapi"
@@ -854,16 +855,19 @@ func (svc *Service) UnenrollAndroidHost(ctx context.Context, hostID uint) error 
 		return ctxerr.Wrap(ctx, err, "getting host for android unenrollment")
 	}
 
+	// Check authorization again based on host info for team-based permissions.
+	// Runs before the platform check below, which would otherwise answer for
+	// hosts the caller has no access to.
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(hostID), "unenroll android host")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, fleet.MDMCommandAuthz{
+		TeamID: host.TeamID,
+	}, fleet.ActionWrite, notFoundErr); err != nil {
+		return err
+	}
+
 	if !fleet.IsAndroidPlatform(host.Platform) {
 		svc.logger.DebugContext(ctx, "Skipping Android unenrollment for non-Android host", "host_id", host.ID, "platform", host.Platform)
 		return nil // no-op for non-Android hosts
-	}
-
-	// Check authorization again based on host info for team-based permissions.
-	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{
-		TeamID: host.TeamID,
-	}, fleet.ActionWrite); err != nil {
-		return err
 	}
 
 	// Resolve Android device and enterprise
@@ -978,14 +982,17 @@ func (svc *Service) resolveAndroidCommandTarget(ctx context.Context, hostID uint
 		return nil, "", ctxerr.Wrap(ctx, err, "getting host for android "+opLabel)
 	}
 
-	if !fleet.IsAndroidPlatform(host.Platform) {
-		return nil, "", &fleet.BadRequestError{Message: "host is not an Android host"}
+	// Runs before the platform check below, which would otherwise answer for
+	// hosts the caller has no access to.
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(hostID), "resolve android command target")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, fleet.MDMCommandAuthz{
+		TeamID: host.TeamID,
+	}, fleet.ActionWrite, notFoundErr); err != nil {
+		return nil, "", err
 	}
 
-	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{
-		TeamID: host.TeamID,
-	}, fleet.ActionWrite); err != nil {
-		return nil, "", err
+	if !fleet.IsAndroidPlatform(host.Platform) {
+		return nil, "", &fleet.BadRequestError{Message: "host is not an Android host"}
 	}
 
 	ah, err := svc.ds.AndroidHostLiteByHostUUID(ctx, host.UUID)

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2497,6 +2497,17 @@ func TestMDMCommandAuthz(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
+		// This matrix only cares that the caller is denied, not which form the
+		// denial takes.
+		requireDenied := func(t *testing.T, err error) {
+			t.Helper()
+			require.Error(t, err)
+			if fleet.IsNotFound(err) {
+				return
+			}
+			require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
 
@@ -2505,8 +2516,7 @@ func TestMDMCommandAuthz(t *testing.T) {
 			if !tt.shouldFailGlobal {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
+				requireDenied(t, err)
 			}
 
 			mdmEnabled.Store(true)
@@ -2514,8 +2524,7 @@ func TestMDMCommandAuthz(t *testing.T) {
 			if !tt.shouldFailTeam {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
+				requireDenied(t, err)
 			}
 		})
 	}

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -5048,6 +5048,42 @@ func TestSuppressAndroidBYODWipeStatus(t *testing.T) {
 // Android hosts, since Wipe is COBO-only (BYO uses Unenroll). The non-Android license gate is already covered by the
 // free-tier TestPremiumEndpointsWithoutLicense integration test, and the Premium BYO rejection by
 // TestAndroidLockWipeClearPasscode; this guards the same rejection in the core implementation.
+// A caller who can list hosts but has no access to the host's fleet must not be
+// able to tell an existing host from a missing one.
+func TestHostMDMEndpointsMaskCrossFleetDenial(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	const teamHostID = 1
+	teamHost := &fleet.Host{ID: teamHostID, TeamID: new(uint(1)), Platform: "android", UUID: "android-uuid"}
+	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return teamHost, nil
+	}
+	ds.HostLiteFunc = mock.HostLiteFunc(ds.HostFunc)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true, AndroidEnabledAndConfigured: true}}, nil
+	}
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
+		return &fleet.HostLockWipeStatus{}, nil
+	}
+
+	otherFleet := fleet.Team{ID: 2}
+	otherFleetUser := &fleet.User{Teams: []fleet.UserTeam{{Team: otherFleet, Role: fleet.RoleAdmin}}}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: otherFleetUser})
+
+	t.Run("UnenrollMDM", func(t *testing.T) {
+		err := svc.UnenrollMDM(ctx, teamHostID)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err), "expected a not-found error, got %v", err)
+	})
+
+	t.Run("WipeHost", func(t *testing.T) {
+		err := svc.WipeHost(ctx, teamHostID, nil)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err), "expected a not-found error, got %v", err)
+	})
+}
+
 func TestWipeHostFreeTierAndroidBYORejected(t *testing.T) {
 	ds := new(mock.Store)
 	// Default newTestService license is Fleet Free.

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -36,6 +36,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
+	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/gorilla/mux"
 
 	"github.com/fleetdm/fleet/v4/server/mdm"
@@ -4498,9 +4499,10 @@ func (svc *Service) UnenrollMDM(ctx context.Context, hostID uint) error {
 	}
 
 	// Check authorization again based on host info for team-based permissions.
-	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(hostID), "unenroll mdm")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, fleet.MDMCommandAuthz{
 		TeamID: host.TeamID,
-	}, fleet.ActionWrite); err != nil {
+	}, fleet.ActionWrite, notFoundErr); err != nil {
 		return err
 	}
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1322,7 +1323,8 @@ func (svc *Service) WipeHost(ctx context.Context, hostID uint, _ *fleet.MDMWipeM
 	// Authorize again with team loaded now that we have the host's team_id.
 	// Authorize as "execute mdm_command", which is the correct access
 	// requirement and is what happens for macOS platforms.
-	if err := svc.authz.Authorize(ctx, fleet.MDMCommandAuthz{TeamID: host.TeamID}, fleet.ActionWrite); err != nil {
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(hostID), "wipe host")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, fleet.MDMCommandAuthz{TeamID: host.TeamID}, fleet.ActionWrite, notFoundErr); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Follow up for this: https://github.com/fleetdm/fleet/pull/52294#pullrequestreview-5094910357

Relates to #45734

Apply the AuthorizeOrNotFound pattern already used elsewhere to the remaining host-scoped MDM endpoints, and reorder the Android platform checks to run after authorization. No change for authorized callers.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - MDM actions targeting hosts outside the caller’s fleet now return a not-found response instead of an authorization error.
  - Updated behavior applies to host unenrollment, wiping, Android command targeting, and related MDM operations.
  - This prevents unauthorized callers from determining whether a host exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->