### PR TITLE
Remove trailing horizontal rule and CTA line from article drafts

### DIFF
--- a/.claude/skills/fleet-article-formatting/SKILL.md
+++ b/.claude/skills/fleet-article-formatting/SKILL.md
@@ -49,9 +49,6 @@ Use this skeleton for Fleet articles — thought-leadership posts, how-to articl
 
 ## See it live
 [Optional next-steps block: a guide link plus one or two demo/workshop bullets.]
-
----
-*Italic CTA line with links.*
 ```
 
 ### Title
@@ -106,7 +103,7 @@ A short section that restates the stakes ("The risk of waiting is real") and lan
 Fleet pieces typically carry two calls to action, and they play different roles:
 
 - **The post-takeaways button** (above) — one button, high on the page, for the reader who's already convinced.
-- **The closing CTA** — at the foot of the article, a fuller menu of next steps. This can be a short "See it live" block (a guide link plus one or two bullets such as **Get a demo** → `/contact` and **Join a GitOps training session** → `/gitops-workshop`) and/or an italic CTA line with links. Keep it to the actions that genuinely fit the piece; real links only.
+- **The closing CTA** — at the foot of the article, a fuller menu of next steps. This is a short "See it live" block (a guide link plus one or two bullets such as **Get a demo** → `/contact` and **Join a GitOps training session** → `/gitops-workshop`). Keep it to the actions that genuinely fit the piece; real links only. Don't add a horizontal rule or a trailing italic CTA line after it — the website renders its own divider below the article.
 
 ### Endmatter
 

--- a/.claude/skills/fleet-article-formatting/assets/article-template.md
+++ b/.claude/skills/fleet-article-formatting/assets/article-template.md
@@ -37,6 +37,3 @@
 ## See it live
 
 [Optional next-steps block: a guide link plus one or two demo/workshop bullets.]
-
----
-*Italic CTA line with real links.*


### PR DESCRIPTION
**Related issue:** N/A — internal Claude Code skill tweak

## Summary

Article drafts produced by the `fleet-article-formatting` skill always ended with a `---` horizontal rule followed by an italic call-to-action line. The website already renders its own divider below a published article, so this produced a redundant second rule and an orphaned CTA sentence that had to be hand-deleted before publishing.

This removes that footer from the skill in the three places it was prescribed:

- `assets/article-template.md` — dropped the trailing `---` and italic CTA placeholder.
- `SKILL.md` structure skeleton — removed the same two lines.
- `SKILL.md` closing-CTA guidance — now describes only the "See it live" block and explicitly tells the model not to add a horizontal rule or trailing italic line.

The "See it live" next-steps block is unchanged; it's a normal section, not the footer. The guide-formatting and content-style skills never prescribed this footer, so nothing changed there.

# Checklist for submitter

- [x] No changes file needed — this only affects Claude Code skill instructions under `.claude/`, not user-visible product behavior.

## Testing

- [x] Manually reviewed the diff; no other references to the italic CTA footer remain in `.claude/skills/`.
