### PR TITLE
Fix edge case where recovery password is missing when restoring Bitlocker protection

### DIFF
--- a/orbit/pkg/bitlocker/bitlocker_management_windows.go
+++ b/orbit/pkg/bitlocker/bitlocker_management_windows.go
@@ -607,6 +607,21 @@ func hasTPMFamilyProtectorOnCOMThread(targetVolume string) (bool, error) {
 	return false, nil
 }
 
+// hasRecoveryPasswordOnCOMThread reports whether the volume has a numerical password protector
+func hasRecoveryPasswordOnCOMThread(targetVolume string) (bool, error) {
+	vol, err := bitlockerConnect(targetVolume)
+	if err != nil {
+		return false, fmt.Errorf("connecting to the volume: %w", err)
+	}
+	defer vol.bitlockerClose()
+
+	ids, err := vol.getKeyProtectorIDs(KeyProtectorTypeNumericalPassword)
+	if err != nil {
+		return false, fmt.Errorf("listing recovery password protectors: %w", err)
+	}
+	return len(ids) > 0, nil
+}
+
 // addTPMProtectorOnCOMThread adds a TPM-only protector. ErrorCodeProtectorExists means the desired state is already
 // satisfied and is reported as success.
 func addTPMProtectorOnCOMThread(targetVolume string) error {

--- a/orbit/pkg/bitlocker/bitlocker_worker_notwindows.go
+++ b/orbit/pkg/bitlocker/bitlocker_worker_notwindows.go
@@ -22,6 +22,8 @@ func (w *COMWorker) RotateRecoveryKey(string) (string, error) { return "", nil }
 
 func (w *COMWorker) HasTPMFamilyProtector(string) (bool, error) { return false, nil }
 
+func (w *COMWorker) HasRecoveryPassword(string) (bool, error) { return false, nil }
+
 func (w *COMWorker) AddTPMProtector(string) error { return nil }
 
 func (w *COMWorker) EnableProtection(string) error { return nil }

--- a/orbit/pkg/bitlocker/bitlocker_worker_windows.go
+++ b/orbit/pkg/bitlocker/bitlocker_worker_windows.go
@@ -122,6 +122,13 @@ func (w *COMWorker) HasTPMFamilyProtector(targetVolume string) (bool, error) {
 	return has, r.err
 }
 
+// HasRecoveryPassword reports whether the volume has a 48-digit recovery password protector.
+func (w *COMWorker) HasRecoveryPassword(targetVolume string) (bool, error) {
+	r := w.exec(func() (any, error) { return hasRecoveryPasswordOnCOMThread(targetVolume) })
+	has, _ := r.val.(bool)
+	return has, r.err
+}
+
 // AddTPMProtector adds a TPM-only protector, treating "already exists" as success.
 func (w *COMWorker) AddTPMProtector(targetVolume string) error {
 	return w.exec(func() (any, error) { return nil, addTPMProtectorOnCOMThread(targetVolume) }).err

--- a/orbit/pkg/update/notifications.go
+++ b/orbit/pkg/update/notifications.go
@@ -682,31 +682,37 @@ func (w *windowsMDMBitlockerConfigReceiver) attemptEnableBitlockerProtection() {
 	// password is actually gone. This does not cover a recovery password that was replaced rather than removed. Fleet would still
 	// hold a stale key, because it only knows it can decrypt the value it stored, never that the volume still accepts it. Recording
 	// the protector GUID at escrow time would close that gap. Tracked as https://github.com/fleetdm/fleet/issues/40430
-	hasRecoveryPassword, err := w.execHasRecoveryPasswordFn(targetVolume)
-	if err != nil {
-		// Unknown is treated as missing. A needless rotation costs an escrow; a missing recovery password can cost the disk.
-		log.Warn().Err(err).Msg("cannot determine whether a recovery password is present, rotating to be sure")
-		hasRecoveryPassword = false
-	}
-	if !hasRecoveryPassword {
-		log.Info().Msgf("no recovery password on %s, rotating before restoring protection", targetVolume)
-		recoveryKey, err := w.execRotateRecoveryKeyFn(targetVolume)
+	if w.pendingRecoveryKey == "" {
+		hasRecoveryPassword, err := w.execHasRecoveryPasswordFn(targetVolume)
 		if err != nil {
-			log.Error().Err(err).Msg("could not rotate the recovery key, not restoring protection")
-			w.reportProtectionOutcome(fleet.DiskEncryptionProtectionFailed,
-				fmt.Sprintf("could not rotate the recovery key, so protection was not re-enabled: %v", err))
-			w.protectionRetryAfter = time.Now().Add(w.Frequency)
-			return
+			// Unknown is treated as missing. A needless rotation costs an escrow; a missing recovery password can cost the disk.
+			log.Warn().Err(err).Msg("cannot determine whether a recovery password is present, rotating to be sure")
+			hasRecoveryPassword = false
 		}
-		if err := w.updateFleetServer(recoveryKey, nil); err != nil {
-			// The volume now carries a key Fleet does not have. Leave protection off so this host comes back here and
-			// rotates again, rather than settling into the state this rotation exists to prevent.
+		if !hasRecoveryPassword {
+			log.Info().Msgf("no recovery password on %s, rotating before restoring protection", targetVolume)
+			recoveryKey, err := w.execRotateRecoveryKeyFn(targetVolume)
+			if err != nil {
+				log.Error().Err(err).Msg("could not rotate the recovery key, not restoring protection")
+				w.reportProtectionOutcome(fleet.DiskEncryptionProtectionFailed,
+					fmt.Sprintf("could not rotate the recovery key, so protection was not re-enabled: %v", err))
+				w.protectionRetryAfter = time.Now().Add(w.Frequency)
+				return
+			}
+			// Hold it before attempting the escrow, so a failure below leaves the key recoverable on the next pass.
+			w.pendingRecoveryKey = recoveryKey
+		}
+	}
+	if w.pendingRecoveryKey != "" {
+		if err := w.updateFleetServer(w.pendingRecoveryKey, nil); err != nil {
+			// Protection stays off, so the server keeps asking and this runs again with the key still held.
 			log.Error().Err(err).Msg("could not escrow the rotated recovery key, not restoring protection")
 			w.reportProtectionOutcome(fleet.DiskEncryptionProtectionFailed,
 				fmt.Sprintf("could not send the rotated recovery key to Fleet, so protection was not re-enabled: %v", err))
 			w.protectionRetryAfter = time.Now().Add(w.Frequency)
 			return
 		}
+		w.pendingRecoveryKey = ""
 	}
 
 	// Finally, enable protection.

--- a/orbit/pkg/update/notifications.go
+++ b/orbit/pkg/update/notifications.go
@@ -497,6 +497,9 @@ type execGetEncryptionStatusFunc func() (status []bitlocker.VolumeStatus, err er
 // execHasTPMProtectorFunc reports whether the volume has a protector able to unseal the key at boot.
 type execHasTPMProtectorFunc func(volumeID string) (bool, error)
 
+// execHasRecoveryPasswordFunc reports whether the volume has a 48-digit recovery password protector.
+type execHasRecoveryPasswordFunc func(volumeID string) (bool, error)
+
 // execAddTPMProtectorFunc adds a TPM-only protector.
 type execAddTPMProtectorFunc func(volumeID string) error
 
@@ -536,9 +539,10 @@ type windowsMDMBitlockerConfigReceiver struct {
 	execRotateRecoveryKeyFn execRotateRecoveryKeyFunc
 
 	// Protection-restore hooks. Set by the middleware from the COMWorker, or overridden in tests.
-	execHasTPMProtectorFn  execHasTPMProtectorFunc
-	execAddTPMProtectorFn  execAddTPMProtectorFunc
-	execEnableProtectionFn execEnableProtectionFunc
+	execHasTPMProtectorFn     execHasTPMProtectorFunc
+	execHasRecoveryPasswordFn execHasRecoveryPasswordFunc
+	execAddTPMProtectorFn     execAddTPMProtectorFunc
+	execEnableProtectionFn    execEnableProtectionFunc
 
 	// restartPendingFn reports whether a restart is staged. Overridden in tests.
 	restartPendingFn func() (bool, error)
@@ -560,6 +564,7 @@ func ApplyWindowsMDMBitlockerFetcherMiddleware(
 		execGetEncryptionStatusFn: comWorker.GetEncryptionStatus,
 		execRotateRecoveryKeyFn:   comWorker.RotateRecoveryKey,
 		execHasTPMProtectorFn:     comWorker.HasTPMFamilyProtector,
+		execHasRecoveryPasswordFn: comWorker.HasRecoveryPassword,
 		execAddTPMProtectorFn:     comWorker.AddTPMProtector,
 		execEnableProtectionFn:    comWorker.EnableProtection,
 	}
@@ -668,6 +673,37 @@ func (w *windowsMDMBitlockerConfigReceiver) attemptEnableBitlockerProtection() {
 			log.Error().Err(err).Msg("could not add a TPM protector, not restoring protection")
 			w.reportProtectionOutcome(fleet.DiskEncryptionProtectionFailed,
 				fmt.Sprintf("could not add a TPM protector, so protection was not re-enabled: %v", err))
+			w.protectionRetryAfter = time.Now().Add(w.Frequency)
+			return
+		}
+	}
+
+	// Whatever disturbed this volume's protectors may have taken the recovery password with it. Only rotate when the recovery
+	// password is actually gone. This does not cover a recovery password that was replaced rather than removed. Fleet would still
+	// hold a stale key, because it only knows it can decrypt the value it stored, never that the volume still accepts it. Recording
+	// the protector GUID at escrow time would close that gap. Tracked as https://github.com/fleetdm/fleet/issues/40430
+	hasRecoveryPassword, err := w.execHasRecoveryPasswordFn(targetVolume)
+	if err != nil {
+		// Unknown is treated as missing. A needless rotation costs an escrow; a missing recovery password can cost the disk.
+		log.Warn().Err(err).Msg("cannot determine whether a recovery password is present, rotating to be sure")
+		hasRecoveryPassword = false
+	}
+	if !hasRecoveryPassword {
+		log.Info().Msgf("no recovery password on %s, rotating before restoring protection", targetVolume)
+		recoveryKey, err := w.execRotateRecoveryKeyFn(targetVolume)
+		if err != nil {
+			log.Error().Err(err).Msg("could not rotate the recovery key, not restoring protection")
+			w.reportProtectionOutcome(fleet.DiskEncryptionProtectionFailed,
+				fmt.Sprintf("could not rotate the recovery key, so protection was not re-enabled: %v", err))
+			w.protectionRetryAfter = time.Now().Add(w.Frequency)
+			return
+		}
+		if err := w.updateFleetServer(recoveryKey, nil); err != nil {
+			// The volume now carries a key Fleet does not have. Leave protection off so this host comes back here and
+			// rotates again, rather than settling into the state this rotation exists to prevent.
+			log.Error().Err(err).Msg("could not escrow the rotated recovery key, not restoring protection")
+			w.reportProtectionOutcome(fleet.DiskEncryptionProtectionFailed,
+				fmt.Sprintf("could not send the rotated recovery key to Fleet, so protection was not re-enabled: %v", err))
 			w.protectionRetryAfter = time.Now().Add(w.Frequency)
 			return
 		}

--- a/orbit/pkg/update/notifications_test.go
+++ b/orbit/pkg/update/notifications_test.go
@@ -622,6 +622,7 @@ func TestBitlockerOperations(t *testing.T) {
 
 				return "123456", nil
 			},
+			execHasRecoveryPasswordFn: func(string) (bool, error) { return false, nil },
 			execRotateRecoveryKeyFn: func(string) (string, error) {
 				rotateKeyFnCalled = true
 				if shouldFailKeyRotation {
@@ -959,21 +960,98 @@ func TestBitlockerOperations(t *testing.T) {
 				}
 				// The restore path must never reach the encrypt path, whose first act is deleting every key protector.
 				require.False(t, encryptFnCalled, "restoring protection must never delete key protectors")
-				require.False(t, rotateKeyFnCalled)
-				require.False(t, clientMock.SetOrUpdateDiskEncryptionKeyInvoked, "must not touch the escrowed recovery key")
+				// setupTest reports no recovery password, which is the case this repair exists for, so every pass that
+				// gets as far as enabling protection first rotates and escrows. The decision itself is covered below.
+				require.Equal(t, tc.wantEnable, rotateKeyFnCalled, "rotating the recovery key")
+				require.Equal(t, tc.wantEnable, clientMock.SetOrUpdateDiskEncryptionKeyInvoked, "escrowing the rotated key")
 			})
 		}
 
-		t.Run("adds a TPM protector before enabling when none exists", func(t *testing.T) {
+		// Rotating on every restore would also hit the ordinary case of a volume suspended for servicing, whose
+		// protectors were never touched, and would invalidate a recovery key an admin may already hold.
+		t.Run("rotates only when the recovery password is gone", func(t *testing.T) {
+			for _, tc := range []struct {
+				name       string
+				hasKey     bool
+				hasKeyErr  error
+				wantRotate bool
+			}{
+				{name: "recovery password present, so nothing is rotated", hasKey: true, wantRotate: false},
+				{name: "recovery password missing, so it is rotated", hasKey: false, wantRotate: true},
+				{name: "unknown counts as missing", hasKeyErr: errors.New("WMI unavailable"), wantRotate: true},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					setupTest()
+					var enableCalled bool
+					enrollReceiver.execGetEncryptionStatusFn = suspended
+					enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return true, nil }
+					enrollReceiver.execHasRecoveryPasswordFn = func(string) (bool, error) { return tc.hasKey, tc.hasKeyErr }
+					enrollReceiver.execEnableProtectionFn = func(string) error { enableCalled = true; return nil }
+
+					require.NoError(t, enrollReceiver.Run(protectionCfg))
+
+					require.Equal(t, tc.wantRotate, rotateKeyFnCalled, "rotating the recovery key")
+					require.Equal(t, tc.wantRotate, clientMock.SetOrUpdateDiskEncryptionKeyInvoked, "escrowing the rotated key")
+					require.True(t, enableCalled, "protection is restored either way")
+					require.Equal(t, fleet.DiskEncryptionProtectionRestored, clientMock.ProtectionOutcome)
+				})
+			}
+		})
+
+		t.Run("adds a TPM protector, then rotates, then enables", func(t *testing.T) {
 			setupTest()
 			var order []string
 			enrollReceiver.execGetEncryptionStatusFn = suspended
 			enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return false, nil }
 			enrollReceiver.execAddTPMProtectorFn = func(string) error { order = append(order, "add"); return nil }
+			enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) { order = append(order, "rotate"); return "k", nil }
 			enrollReceiver.execEnableProtectionFn = func(string) error { order = append(order, "enable"); return nil }
 
 			require.NoError(t, enrollReceiver.Run(protectionCfg))
-			require.Equal(t, []string{"add", "enable"}, order)
+			require.Equal(t, []string{"add", "rotate", "enable"}, order)
+		})
+
+		// A rotation Fleet cannot complete must stop the repair. Enabling protection anyway is what leaves a host
+		// looking healthy while the key Fleet shows an admin does not open the disk.
+		t.Run("a rotation or escrow failure stops the repair", func(t *testing.T) {
+			for _, tc := range []struct {
+				name            string
+				rotateErr       error
+				escrowErr       error
+				wantErrContains string
+			}{
+				{
+					name:            "rotation fails",
+					rotateErr:       errors.New("WMI refused"),
+					wantErrContains: "could not rotate the recovery key",
+				},
+				{
+					name:            "escrow fails",
+					escrowErr:       errors.New("server unreachable"),
+					wantErrContains: "could not send the rotated recovery key to Fleet",
+				},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					setupTest()
+					var enableCalled bool
+					enrollReceiver.execGetEncryptionStatusFn = suspended
+					enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return true, nil }
+					enrollReceiver.execHasRecoveryPasswordFn = func(string) (bool, error) { return false, nil }
+					enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) { return "k", tc.rotateErr }
+					enrollReceiver.execEnableProtectionFn = func(string) error { enableCalled = true; return nil }
+					prevEscrow := clientMock.SetOrUpdateDiskEncryptionKeyImpl
+					t.Cleanup(func() { clientMock.SetOrUpdateDiskEncryptionKeyImpl = prevEscrow })
+					clientMock.SetOrUpdateDiskEncryptionKeyImpl = func(fleet.OrbitHostDiskEncryptionKeyPayload) error {
+						return tc.escrowErr
+					}
+
+					require.NoError(t, enrollReceiver.Run(protectionCfg))
+
+					require.False(t, enableCalled, "protection must stay off so the host comes back and retries")
+					require.Equal(t, fleet.DiskEncryptionProtectionFailed, clientMock.ProtectionOutcome)
+					require.Contains(t, clientMock.ProtectionClientError, tc.wantErrContains)
+				})
+			}
 		})
 
 		t.Run("skips a second attempt inside the throttle window", func(t *testing.T) {

--- a/orbit/pkg/update/notifications_test.go
+++ b/orbit/pkg/update/notifications_test.go
@@ -967,18 +967,33 @@ func TestBitlockerOperations(t *testing.T) {
 			})
 		}
 
-		// Rotating on every restore would also hit the ordinary case of a volume suspended for servicing, whose
-		// protectors were never touched, and would invalidate a recovery key an admin may already hold.
-		t.Run("rotates only when the recovery password is gone", func(t *testing.T) {
+		// One decision, so one table: what the volume looks like going in, and what the agent does about it. Rotating on
+		// every restore would also hit the ordinary case of a volume suspended for servicing, whose protectors were
+		// never touched, and would invalidate a recovery key an admin may already hold. A rotation Fleet cannot
+		// complete must stop the repair instead, because enabling protection anyway is what leaves a host looking
+		// healthy while the key Fleet shows an admin does not open the disk.
+		t.Run("rotates only when the recovery password is gone, and stops the repair when it cannot", func(t *testing.T) {
 			for _, tc := range []struct {
 				name       string
 				hasKey     bool
 				hasKeyErr  error
+				rotateErr  error
+				escrowErr  error
 				wantRotate bool
+				wantEnable bool
+				wantErr    string // empty means the repair is expected to succeed
 			}{
-				{name: "recovery password present, so nothing is rotated", hasKey: true, wantRotate: false},
-				{name: "recovery password missing, so it is rotated", hasKey: false, wantRotate: true},
-				{name: "unknown counts as missing", hasKeyErr: errors.New("WMI unavailable"), wantRotate: true},
+				{name: "recovery password present, so nothing is rotated", hasKey: true, wantEnable: true},
+				{name: "recovery password missing, so it is rotated", wantRotate: true, wantEnable: true},
+				{name: "unknown counts as missing", hasKeyErr: errors.New("WMI unavailable"), wantRotate: true, wantEnable: true},
+				{
+					name: "a failed rotation stops the repair", rotateErr: errors.New("WMI refused"),
+					wantRotate: true, wantErr: "could not rotate the recovery key",
+				},
+				{
+					name: "a failed escrow stops the repair", escrowErr: errors.New("server unreachable"),
+					wantRotate: true, wantErr: "could not send the rotated recovery key to Fleet",
+				},
 			} {
 				t.Run(tc.name, func(t *testing.T) {
 					setupTest()
@@ -986,58 +1001,10 @@ func TestBitlockerOperations(t *testing.T) {
 					enrollReceiver.execGetEncryptionStatusFn = suspended
 					enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return true, nil }
 					enrollReceiver.execHasRecoveryPasswordFn = func(string) (bool, error) { return tc.hasKey, tc.hasKeyErr }
-					enrollReceiver.execEnableProtectionFn = func(string) error { enableCalled = true; return nil }
-
-					require.NoError(t, enrollReceiver.Run(protectionCfg))
-
-					require.Equal(t, tc.wantRotate, rotateKeyFnCalled, "rotating the recovery key")
-					require.Equal(t, tc.wantRotate, clientMock.SetOrUpdateDiskEncryptionKeyInvoked, "escrowing the rotated key")
-					require.True(t, enableCalled, "protection is restored either way")
-					require.Equal(t, fleet.DiskEncryptionProtectionRestored, clientMock.ProtectionOutcome)
-				})
-			}
-		})
-
-		t.Run("adds a TPM protector, then rotates, then enables", func(t *testing.T) {
-			setupTest()
-			var order []string
-			enrollReceiver.execGetEncryptionStatusFn = suspended
-			enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return false, nil }
-			enrollReceiver.execAddTPMProtectorFn = func(string) error { order = append(order, "add"); return nil }
-			enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) { order = append(order, "rotate"); return "k", nil }
-			enrollReceiver.execEnableProtectionFn = func(string) error { order = append(order, "enable"); return nil }
-
-			require.NoError(t, enrollReceiver.Run(protectionCfg))
-			require.Equal(t, []string{"add", "rotate", "enable"}, order)
-		})
-
-		// A rotation Fleet cannot complete must stop the repair. Enabling protection anyway is what leaves a host
-		// looking healthy while the key Fleet shows an admin does not open the disk.
-		t.Run("a rotation or escrow failure stops the repair", func(t *testing.T) {
-			for _, tc := range []struct {
-				name            string
-				rotateErr       error
-				escrowErr       error
-				wantErrContains string
-			}{
-				{
-					name:            "rotation fails",
-					rotateErr:       errors.New("WMI refused"),
-					wantErrContains: "could not rotate the recovery key",
-				},
-				{
-					name:            "escrow fails",
-					escrowErr:       errors.New("server unreachable"),
-					wantErrContains: "could not send the rotated recovery key to Fleet",
-				},
-			} {
-				t.Run(tc.name, func(t *testing.T) {
-					setupTest()
-					var enableCalled bool
-					enrollReceiver.execGetEncryptionStatusFn = suspended
-					enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return true, nil }
-					enrollReceiver.execHasRecoveryPasswordFn = func(string) (bool, error) { return false, nil }
-					enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) { return "k", tc.rotateErr }
+					enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) {
+						rotateKeyFnCalled = true
+						return "rotated-key", tc.rotateErr
+					}
 					enrollReceiver.execEnableProtectionFn = func(string) error { enableCalled = true; return nil }
 					prevEscrow := clientMock.SetOrUpdateDiskEncryptionKeyImpl
 					t.Cleanup(func() { clientMock.SetOrUpdateDiskEncryptionKeyImpl = prevEscrow })
@@ -1047,11 +1014,83 @@ func TestBitlockerOperations(t *testing.T) {
 
 					require.NoError(t, enrollReceiver.Run(protectionCfg))
 
-					require.False(t, enableCalled, "protection must stay off so the host comes back and retries")
-					require.Equal(t, fleet.DiskEncryptionProtectionFailed, clientMock.ProtectionOutcome)
-					require.Contains(t, clientMock.ProtectionClientError, tc.wantErrContains)
+					require.Equal(t, tc.wantRotate, rotateKeyFnCalled, "rotating the recovery key")
+					// The escrow is only reached when a rotation produced a key to send.
+					wantEscrow := tc.wantRotate && tc.rotateErr == nil
+					require.Equal(t, wantEscrow, clientMock.SetOrUpdateDiskEncryptionKeyInvoked, "escrowing the rotated key")
+					require.Equal(t, tc.wantEnable, enableCalled, "restoring protection")
+					if tc.wantErr == "" {
+						require.Equal(t, fleet.DiskEncryptionProtectionRestored, clientMock.ProtectionOutcome)
+					} else {
+						require.Equal(t, fleet.DiskEncryptionProtectionFailed, clientMock.ProtectionOutcome)
+						require.Contains(t, clientMock.ProtectionClientError, tc.wantErr)
+					}
 				})
 			}
+		})
+
+		t.Run("adds a TPM protector, then rotates, then escrows, then enables", func(t *testing.T) {
+			setupTest()
+			var order []string
+			enrollReceiver.execGetEncryptionStatusFn = suspended
+			enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return false, nil }
+			enrollReceiver.execAddTPMProtectorFn = func(string) error { order = append(order, "add"); return nil }
+			enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) { order = append(order, "rotate"); return "k", nil }
+			enrollReceiver.execEnableProtectionFn = func(string) error { order = append(order, "enable"); return nil }
+			prevEscrow := clientMock.SetOrUpdateDiskEncryptionKeyImpl
+			t.Cleanup(func() { clientMock.SetOrUpdateDiskEncryptionKeyImpl = prevEscrow })
+			clientMock.SetOrUpdateDiskEncryptionKeyImpl = func(fleet.OrbitHostDiskEncryptionKeyPayload) error {
+				order = append(order, "escrow")
+				return nil
+			}
+
+			require.NoError(t, enrollReceiver.Run(protectionCfg))
+			// Escrow has to land before protection is enabled. Leaving it out of this assertion is what would let a
+			// regression enable protection on a volume whose recovery key Fleet never received.
+			require.Equal(t, []string{"add", "rotate", "escrow", "enable"}, order)
+		})
+
+		// Rotation puts the new protector on the volume before the escrow is attempted, so a second pass would find a
+		// recovery password, skip rotating, and enable protection on a volume whose key Fleet never received. The key
+		// has to survive the failed escrow and be retried.
+		t.Run("a failed escrow is retried on the next pass without rotating again", func(t *testing.T) {
+			setupTest()
+			var rotations, escrows, enables int
+			escrowFails := true
+			enrollReceiver.execGetEncryptionStatusFn = suspended
+			enrollReceiver.execHasTPMProtectorFn = func(string) (bool, error) { return true, nil }
+			// After the first rotation the volume carries a recovery password again, which is the trap.
+			enrollReceiver.execHasRecoveryPasswordFn = func(string) (bool, error) { return rotations > 0, nil }
+			enrollReceiver.execRotateRecoveryKeyFn = func(string) (string, error) { rotations++; return "rotated-key", nil }
+			enrollReceiver.execEnableProtectionFn = func(string) error { enables++; return nil }
+			prevEscrow := clientMock.SetOrUpdateDiskEncryptionKeyImpl
+			t.Cleanup(func() { clientMock.SetOrUpdateDiskEncryptionKeyImpl = prevEscrow })
+			var escrowed string
+			clientMock.SetOrUpdateDiskEncryptionKeyImpl = func(p fleet.OrbitHostDiskEncryptionKeyPayload) error {
+				escrows++
+				if escrowFails {
+					return errors.New("server unreachable")
+				}
+				escrowed = string(p.EncryptionKey)
+				return nil
+			}
+
+			require.NoError(t, enrollReceiver.Run(protectionCfg))
+			require.Equal(t, 1, rotations)
+			require.Equal(t, 1, escrows)
+			require.Zero(t, enables, "protection must not be enabled before the key reaches Fleet")
+			require.Equal(t, "rotated-key", enrollReceiver.pendingRecoveryKey, "the key must survive a failed escrow")
+
+			// Second pass: the server keeps asking because protection is still off.
+			escrowFails = false
+			enrollReceiver.protectionRetryAfter = time.Time{}
+			require.NoError(t, enrollReceiver.Run(protectionCfg))
+
+			require.Equal(t, 1, rotations, "must not rotate a second time and orphan the first key")
+			require.Equal(t, 2, escrows)
+			require.Equal(t, "rotated-key", escrowed, "the key Fleet receives must be the one on the volume")
+			require.Equal(t, 1, enables, "protection is restored only once the key is escrowed")
+			require.Empty(t, enrollReceiver.pendingRecoveryKey, "the held key is cleared after a successful escrow")
 		})
 
 		t.Run("skips a second attempt inside the throttle window", func(t *testing.T) {

--- a/orbit/pkg/update/notifications_test.go
+++ b/orbit/pkg/update/notifications_test.go
@@ -967,11 +967,6 @@ func TestBitlockerOperations(t *testing.T) {
 			})
 		}
 
-		// One decision, so one table: what the volume looks like going in, and what the agent does about it. Rotating on
-		// every restore would also hit the ordinary case of a volume suspended for servicing, whose protectors were
-		// never touched, and would invalidate a recovery key an admin may already hold. A rotation Fleet cannot
-		// complete must stop the repair instead, because enabling protection anyway is what leaves a host looking
-		// healthy while the key Fleet shows an admin does not open the disk.
 		t.Run("rotates only when the recovery password is gone, and stops the repair when it cannot", func(t *testing.T) {
 			for _, tc := range []struct {
 				name       string


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52204

Unreleased bug.
Handling edge case where recovery password is missing when restoring Bitlocker protection.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - BitLocker protection now verifies that a recovery password is available before enabling protection.
  - Automatically rotates and escrows a new recovery key when the existing key is missing or cannot be verified.
  - Protection remains disabled and reports failure when escrow is unsuccessful.
  - Failed escrow retries with the retained recovery key instead of rotating another key.

- **Reliability**
  - Recovery-key checks now behave consistently across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->