### PR TITLE
Fleet UI: Show Install/Uninstall for script-only packages with an uninstall script

### DIFF
--- a/changes/51238-script-package-uninstall-action
+++ b/changes/51238-script-package-uninstall-action
@@ -1,0 +1,1 @@
+- Fixed script-only packages (.sh/.ps1/.py) with an uninstall script showing "Run/Rerun" and "Ran" instead of "Install/Reinstall", "Uninstall", and "Installed" on the host details and self-service pages.

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -507,10 +507,19 @@ const InstallStatusCell = ({
     const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(software.source);
 
     // Status groups and their click handlers
+    // Script packages route ALL install-side statuses (including "Installed"
+    // and "Install (pending)" for script packages with an uninstall script)
+    // to the script execution details modal, since the install is a script run.
     const displayStatusConfig = [
       {
         condition: isScriptPackage, // Still allows click even if no last install to see details modal
-        statuses: ["Failed", "Run (pending)", "Ran"],
+        statuses: [
+          "Failed",
+          "Run (pending)",
+          "Ran",
+          "Install (pending)",
+          "Installed",
+        ],
         onClick: onClickScriptStatus,
       },
       {

--- a/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
@@ -532,6 +532,26 @@ describe("getUiStatus", () => {
       });
       expect(getUiStatus(sw, true)).toBe("uninstalled");
     });
+
+    it("returns 'failed_install' (not 'failed_install_installed') when installed_versions is an empty array", () => {
+      const sw = createMockHostSoftware({
+        status: "failed_install",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: [],
+      });
+      expect(getUiStatus(sw, true)).toBe("failed_install");
+    });
+
+    it("returns 'failed_uninstall' (not 'failed_uninstall_installed') when installed_versions is an empty array", () => {
+      const sw = createMockHostSoftware({
+        status: "failed_uninstall",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: [],
+      });
+      expect(getUiStatus(sw, true)).toBe("failed_uninstall");
+    });
   });
 });
 

--- a/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
@@ -488,9 +488,6 @@ describe("getUiStatus", () => {
     });
   });
 
-  // Regression coverage for #51238: script-only packages with an uninstall
-  // script must surface Install/Reinstall/Uninstall/Installed semantics, not
-  // Run/Rerun/Ran.
   describe("Script packages with uninstall script use install statuses", () => {
     const scriptPackageWithUninstall = createMockHostSoftwarePackage({
       has_uninstall_script: true,

--- a/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
@@ -437,11 +437,16 @@ describe("getUiStatus", () => {
     expect(getUiStatus(sw, true)).toBe("uninstalled");
   });
 
-  describe("Script packages UI statuses", () => {
+  describe("Script packages UI statuses (no uninstall script)", () => {
+    const scriptOnlyPackage = createMockHostSoftwarePackage({
+      has_uninstall_script: false,
+    });
+
     it("returns 'failed_script' when status is failed_install and isScriptPackage", () => {
       const sw = createMockHostSoftware({
         status: "failed_install",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("failed_script");
     });
@@ -450,6 +455,7 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: "pending_install",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("running_script");
     });
@@ -458,6 +464,7 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: "pending_install",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, false)).toBe("pending_script");
     });
@@ -466,6 +473,7 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: "installed",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("ran_script");
     });
@@ -474,8 +482,58 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: null,
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("never_ran_script");
+    });
+  });
+
+  // Regression coverage for #51238: script-only packages with an uninstall
+  // script must surface Install/Reinstall/Uninstall/Installed semantics, not
+  // Run/Rerun/Ran.
+  describe("Script packages with uninstall script use install statuses", () => {
+    const scriptPackageWithUninstall = createMockHostSoftwarePackage({
+      has_uninstall_script: true,
+    });
+
+    it("returns 'installed' (not 'ran_script') when a script-only package with an uninstall script is installed", () => {
+      const sw = createMockHostSoftware({
+        status: "installed",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("installed");
+    });
+
+    it("returns 'failed_install' (not 'failed_script') when a script-only package with an uninstall script fails to install", () => {
+      const sw = createMockHostSoftware({
+        status: "failed_install",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("failed_install");
+    });
+
+    it("returns 'installing' (not 'running_script') when a script-only package with an uninstall script is pending on an online host", () => {
+      const sw = createMockHostSoftware({
+        status: "pending_install",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("installing");
+    });
+
+    it("returns 'uninstalled' (not 'never_ran_script') when a script-only package with an uninstall script has no install record", () => {
+      const sw = createMockHostSoftware({
+        status: null,
+        source: "sh_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("uninstalled");
     });
   });
 });

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -220,8 +220,11 @@ export const getUiStatus = (
   const recentUserActionDetected =
     recentlyUpdatedIds && recentlyUpdatedIds.has(software.id);
 
-  // 0. Script Packages states
-  if (isScriptPackage) {
+  // 0. Script Packages states — only when there's no uninstall script.
+  // Script packages with an uninstall script fall through to the regular
+  // install statuses so the UI shows Install/Reinstall/Uninstall/Installed
+  // instead of Run/Rerun/Ran.
+  if (isScriptPackage && !software.software_package?.has_uninstall_script) {
     if (status === "failed_install") {
       return "failed_script";
     }

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -241,8 +241,11 @@ export const getUiStatus = (
   }
 
   // 1. Failed install states
+  // Require length > 0: empty array is truthy, so `installed_versions: []`
+  // would otherwise render "Installed" for a package that was never installed
+  // (matters for script packages, which never populate installed_versions).
   if (status === "failed_install") {
-    if (installerVersion && installed_versions) {
+    if (installerVersion && installed_versions && installed_versions.length > 0) {
       if (
         installed_versions.some(
           (iv) => compareVersions(iv.version, installerVersion) === -1
@@ -259,7 +262,7 @@ export const getUiStatus = (
 
   // 2. Failed uninstall states
   if (status === "failed_uninstall") {
-    if (installerVersion && installed_versions) {
+    if (installerVersion && installed_versions && installed_versions.length > 0) {
       if (
         installed_versions.some(
           (iv) => compareVersions(iv.version, installerVersion) === -1

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -245,7 +245,11 @@ export const getUiStatus = (
   // would otherwise render "Installed" for a package that was never installed
   // (matters for script packages, which never populate installed_versions).
   if (status === "failed_install") {
-    if (installerVersion && installed_versions && installed_versions.length > 0) {
+    if (
+      installerVersion &&
+      installed_versions &&
+      installed_versions.length > 0
+    ) {
       if (
         installed_versions.some(
           (iv) => compareVersions(iv.version, installerVersion) === -1
@@ -262,7 +266,11 @@ export const getUiStatus = (
 
   // 2. Failed uninstall states
   if (status === "failed_uninstall") {
-    if (installerVersion && installed_versions && installed_versions.length > 0) {
+    if (
+      installerVersion &&
+      installed_versions &&
+      installed_versions.length > 0
+    ) {
       if (
         installed_versions.some(
           (iv) => compareVersions(iv.version, installerVersion) === -1


### PR DESCRIPTION
## Issue
Closes #51238

## Description
- Bug fix (root cause): `getUiStatus()` in `frontend/pages/hosts/details/cards/Software/helpers.tsx` mapped every script-only source (`.sh` / `.ps1` / `.py`) to the script-only UI statuses (`ran_script` / `never_ran_script` / `failed_script` / `running_script` / `pending_script`) regardless of whether the installer had an uninstall script configured. That collapsed the whole flow to Run/Rerun + no Uninstall + "Ran" status, contradicting the shipped 4.90 behavior that says script-only packages with an uninstall script get the same lifecycle as custom packages.
- Fix: gate that branch on `!software_package.has_uninstall_script`. Script-only packages **without** an uninstall script keep the existing Run/Rerun/Ran semantics; script-only packages **with** an uninstall script now fall through to the normal install statuses, so `getInstallerActionButtonConfig` naturally returns Install / Reinstall, `canUninstallSoftware` in `HostInstallerActionCell` unhides the Uninstall action (its `ui_status === "installed"` clause already covers the new path), and `INSTALL_STATUS_DISPLAY_OPTIONS.installed` renders the pill as "Installed".
- Click routing: extended the `isScriptPackage` group in `InstallStatusCell.renderDisplayStatus()` to also match "Installed" and "Install (pending)", so the status pill on the new path opens the script execution details modal rather than the (non-existent) install-package details.
- Scope: change is entirely in `getUiStatus` + `InstallStatusCell` click routing. Host details Library and self-service (desktop table + mobile tiles) share the same `IHostSoftwareWithUiStatus` pipeline, so both surfaces are covered by the single helper change.

## Screenrecording
- Script-only .py with uninstall script: Install → Installed pill → Uninstall action visible, on host details and self-service


https://github.com/user-attachments/assets/03e10de0-d92c-4319-84cc-cd48d4ccde83


https://github.com/user-attachments/assets/c7347157-f755-4ba4-9619-3ce777ff7f99

Device end user


https://github.com/user-attachments/assets/7e8db0da-7293-4ff8-b0f5-7de00203e8a8



## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

Automated coverage in `frontend/pages/hosts/details/cards/Software/helpers.tests.ts`:
- Existing "Script packages UI statuses" block now pins `has_uninstall_script: false` so the Run/Rerun/Ran path stays covered.
- New "Script packages with uninstall script use install statuses" block asserts `installed` / `failed_install` / `installing` / `uninstalled` for the fixed path — each test fails against `main` without the helper change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected software status labels for script packages with uninstall actions. These now display **Install**, **Reinstall**, **Uninstall**, and **Installed** as appropriate.
  - Updated installation-related status interactions to open the correct script details view.
  - Fixed status handling for script packages with no installed versions so they no longer appear as installed after failed operations.
  - Improved status accuracy for script packages with and without uninstall actions across host details and self-service views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->