### PR TITLE
Unfreeze DBeaver Lite (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/dbeaverlite.json
+++ b/ee/maintained-apps/inputs/homebrew/dbeaverlite.json
@@ -4,6 +4,5 @@
   "token": "dbeaverlite",
   "installer_format": "dmg",
   "slug": "dbeaverlite/darwin",
-  "default_categories": ["Developer tools"],
-  "frozen": true
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/outputs/dbeaverlite/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverlite/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.1.0",
+      "version": "26.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite' AND version_compare(bundle_short_version, '26.1.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.lite' AND version_compare(bundle_short_version, '26.2.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.dbeaver.product.lite' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.dbeaver.net/lite/26.1.0/dbeaver-le-26.1.0-macos-aarch64.dmg",
+      "installer_url": "https://downloads.dbeaver.net/lite/26.2.0/dbeaver-le-26.2.0-macos-aarch64.dmg",
       "install_script_ref": "3c86b0f4",
       "uninstall_script_ref": "4e5f63ae",
-      "sha256": "9821764efce6be58c9bc87e31730e6943d07bdb9fb1d2ccb358138b5709e0acf",
+      "sha256": "4dd92df1f5670bd2c6d10278a080f7cd91beded5179a69ab82ba9de94d3b9459",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `dbeaverlite/darwin` at its current upstream version.

Frozen since: 2026-07-30
Version: 26.1.0 -> 26.2.0

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

https://claude.ai/code/session_01Ab8LyMUnuMkyGYWWag6ouA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab8LyMUnuMkyGYWWag6ouA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated DBeaver Lite for macOS to version 26.2.0.
  - Refreshed the installer download and verification details for the new release.
  - DBeaver Lite is no longer marked as frozen, allowing its catalog entry to continue receiving updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->