### PR TITLE
Unfreeze DBeaver Ultimate (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/dbeaverultimate.json
+++ b/ee/maintained-apps/inputs/homebrew/dbeaverultimate.json
@@ -4,6 +4,5 @@
   "token": "dbeaverultimate",
   "installer_format": "dmg",
   "slug": "dbeaverultimate/darwin",
-  "default_categories": ["Developer tools"],
-  "frozen": true
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.1.0",
+      "version": "26.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate' AND version_compare(bundle_short_version, '26.1.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dbeaver.product.ultimate' AND version_compare(bundle_short_version, '26.2.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.dbeaver.product.ultimate' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.dbeaver.net/ultimate/26.1.0/dbeaver-ue-26.1.0-macos-aarch64.dmg",
+      "installer_url": "https://downloads.dbeaver.net/ultimate/26.2.0/dbeaver-ue-26.2.0-macos-aarch64.dmg",
       "install_script_ref": "a8066f3f",
       "uninstall_script_ref": "23b82863",
-      "sha256": "ac134703e8cf541e8489d61367f9c0d29bd8fa048a1f18239978fe7355957786",
+      "sha256": "93c8611b343385525a47463942929d7489d6cdbdc9c0452293e3ed3247fd7759",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `dbeaverultimate/darwin` at its current upstream version.

Frozen since: 2026-07-30
Version: 26.1.0 -> 26.2.0

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

https://claude.ai/code/session_01Ab8LyMUnuMkyGYWWag6ouA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab8LyMUnuMkyGYWWag6ouA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the macOS DBeaver Ultimate package to version 26.2.0.

* **Bug Fixes**
  * Removed the frozen status from the maintained-app configuration, allowing normal updates.
  * Updated the installer download and integrity verification for the latest macOS release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->