### PR TITLE
Add Oktane 2026 announcement

### DIFF
--- a/articles/fleet-at-oktane-2026.md
+++ b/articles/fleet-at-oktane-2026.md
@@ -8,7 +8,7 @@ Mike will talk about how IT and security teams can bring Linux devices under the
 
 ## Linux and Okta
 
-At the booth, we'll show the work we're doing to bring deeper Linux integrations to Okta, including FastPass. Linux is often the platform left out of device trust rollouts. Fleet already manages Linux hosts alongside macOS and Windows, and we're extending that to Okta device posture and passwordless sign-in so Linux users get the same experience as everyone else.
+At the booth, we'll show the work we're doing to bring deeper Linux integrations to Okta, including FastPass. Linux is often the platform left out of device trust rollouts. Fleet already manages Linux hosts alongside macOS and Windows, and we're partnering with Okta to extend that to device posture and passwordless sign-in so Linux users get the same experience as everyone else.
 
 Come by to see a demo, ask questions, and tell us what your Linux fleet needs from Okta.
 

--- a/articles/fleet-at-oktane-2026.md
+++ b/articles/fleet-at-oktane-2026.md
@@ -6,11 +6,18 @@ Mike McNeil, Fleet's CEO, will speak at [Oktane 2026](https://www.okta.com/oktan
 
 Mike will talk about how IT and security teams can bring Linux devices under the same identity controls as macOS and Windows. Session title, time, and room will be posted here once the Oktane schedule is final.
 
-## Linux and Okta
+## Fleet and Okta
 
 At the booth, we'll show the work we're doing to bring deeper Linux integrations to Okta, including FastPass. Linux is often the platform left out of device trust rollouts. Fleet already manages Linux hosts alongside macOS and Windows, and we're partnering with Okta to extend that to device posture and passwordless sign-in so Linux users get the same experience as everyone else.
 
-Come by to see a demo, ask questions, and tell us what your Linux fleet needs from Okta.
+We'll also demo the Okta integrations Fleet already ships for macOS and Windows:
+
+- **Okta Verify:** Deploy Okta Verify to macOS and Windows hosts as a [Fleet-maintained app](https://fleetdm.com/guides/fleet-maintained-apps). Fleet keeps it patched as Okta releases new versions.
+- **Okta Device Access:** Roll out [Platform SSO on macOS](https://fleetdm.com/guides/deploying-okta-platform-sso-with-fleet) and [Desktop MFA on Windows](https://fleetdm.com/guides/deploying-okta-desktop-mfa-with-fleet) with configuration profiles, including the SCEP certificates that register devices with Okta.
+- **Single sign-on:** Sign in to Fleet with [Okta as your SAML identity provider](https://fleetdm.com/docs/deploy/single-sign-on-sso#okta), and require Okta authentication when end users enroll a new host.
+- **SCIM:** Sync users and groups from Okta to [map each host to its end user](https://fleetdm.com/guides/foreign-vitals-map-idp-users-to-hosts), then target configuration profiles and labels by IdP group or department.
+
+Come by to see a demo, ask questions, and tell us what your macOS, Windows, and Linux hosts need from Okta.
 
 ## Run Fleet at home
 
@@ -29,4 +36,4 @@ Not attending Oktane? You can still [try Fleet](https://fleetdm.com/try-fleet) o
 <meta name="authorGitHubUsername" value="allenhouchins">
 <meta name="publishedOn" value="2026-09-08">
 <meta name="articleTitle" value="Join Fleet at Oktane 2026">
-<meta name="description" value="Fleet CEO Mike McNeil speaks at Oktane 2026. Visit our booth to see Linux integrations for Okta, including FastPass, and get a free 10-device NFR.">
+<meta name="description" value="Fleet CEO Mike McNeil speaks at Oktane 2026. See our Okta integrations for macOS, Windows, and Linux, including FastPass, and get a free NFR license.">

--- a/articles/fleet-at-oktane-2026.md
+++ b/articles/fleet-at-oktane-2026.md
@@ -18,7 +18,7 @@ Everyone who visits the booth can get a not-for-resale (NFR) license to run Flee
 
 ## Find us
 
-- **Booth:** [BOOTH NUMBER]
+- **Booth:** TBD
 - **Dates:** Tuesday, September 22 through Thursday, September 24, 2026
 - **Venue:** Caesars Forum, Las Vegas
 

--- a/articles/fleet-at-oktane-2026.md
+++ b/articles/fleet-at-oktane-2026.md
@@ -8,11 +8,11 @@ Mike will talk about how IT and security teams can bring Linux devices under the
 
 ## Fleet and Okta
 
-At the booth, we'll show the work we're doing to bring deeper Linux integrations to Okta, including FastPass. Linux is often the platform left out of device trust rollouts. Fleet already manages Linux hosts alongside macOS and Windows, and we're partnering with Okta to extend that to device posture and passwordless sign-in so Linux users get the same experience as everyone else.
+At the booth, we'll talk about the work we're doing to bring deeper Linux integrations to Okta, including FastPass. Linux is often the platform left out of device trust rollouts. Fleet already manages Linux hosts alongside macOS and Windows, and we're partnering with Okta to extend that to device posture and passwordless sign-in so Linux users get the same experience as everyone else.
 
 We'll also demo the Okta integrations Fleet already ships for macOS and Windows:
 
-- **Okta Verify:** Deploy Okta Verify to macOS and Windows hosts as a [Fleet-maintained app](https://fleetdm.com/guides/fleet-maintained-apps). Fleet keeps it patched as Okta releases new versions.
+- **Okta Verify:** Deploy Okta Verify to macOS and Windows hosts as a [Fleet-maintained app](https://fleetdm.com/guides/fleet-maintained-apps). Fleet keeps it patched automatically as Okta releases new versions.
 - **Okta Device Access:** Roll out [Platform SSO on macOS](https://fleetdm.com/guides/deploying-okta-platform-sso-with-fleet) and [Desktop MFA on Windows](https://fleetdm.com/guides/deploying-okta-desktop-mfa-with-fleet) with configuration profiles, including the SCEP certificates that register devices with Okta.
 - **Single sign-on:** Sign in to Fleet with [Okta as your SAML identity provider](https://fleetdm.com/docs/deploy/single-sign-on-sso#okta), and require Okta authentication when end users enroll a new host.
 - **SCIM:** Sync users and groups from Okta to [map each host to its end user](https://fleetdm.com/guides/foreign-vitals-map-idp-users-to-hosts), then target configuration profiles and labels by IdP group or department.

--- a/articles/fleet-at-oktane-2026.md
+++ b/articles/fleet-at-oktane-2026.md
@@ -1,0 +1,32 @@
+# Join Fleet at Oktane 2026
+
+Mike McNeil, Fleet's CEO, will speak at [Oktane 2026](https://www.okta.com/oktane/), September 22-24 in Las Vegas. Fleet will also have a booth on the expo floor at Caesars Forum.
+
+## Mike's session
+
+Mike will talk about how IT and security teams can bring Linux devices under the same identity controls as macOS and Windows. Session title, time, and room will be posted here once the Oktane schedule is final.
+
+## Linux and Okta
+
+At the booth, we'll show the work we're doing to bring deeper Linux integrations to Okta, including FastPass. Linux is often the platform left out of device trust rollouts. Fleet already manages Linux hosts alongside macOS and Windows, and we're extending that to Okta device posture and passwordless sign-in so Linux users get the same experience as everyone else.
+
+Come by to see a demo, ask questions, and tell us what your Linux fleet needs from Okta.
+
+## Run Fleet at home
+
+Everyone who visits the booth can get a not-for-resale (NFR) license to run Fleet Premium at home: up to 10 devices for 2 years. Use it to manage your own computers, phones, and lab machines, or to try Fleet before bringing it to work.
+
+## Find us
+
+- **Booth:** [BOOTH NUMBER]
+- **Dates:** Tuesday, September 22 through Thursday, September 24, 2026
+- **Venue:** Caesars Forum, Las Vegas
+
+Not attending Oktane? You can still [try Fleet](https://fleetdm.com/try-fleet) or [talk to us](https://fleetdm.com/contact) anytime.
+
+<meta name="category" value="announcements">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="publishedOn" value="2026-09-08">
+<meta name="articleTitle" value="Join Fleet at Oktane 2026">
+<meta name="description" value="Fleet CEO Mike McNeil speaks at Oktane 2026. Visit our booth to see Linux integrations for Okta, including FastPass, and get a free 10-device NFR.">


### PR DESCRIPTION
**Related issue:** NA

Adds an announcement article, `articles/fleet-at-oktane-2026.md`, saying Mike McNeil will speak at Oktane 2026 (September 22-24, Caesars Forum, Las Vegas), that Fleet will have a booth showing the Linux integration work for Okta including FastPass, and that booth visitors can get a 10-device, 2-year NFR license to run Fleet at home.

Still needs before publishing:

- Booth number (currently `[BOOTH NUMBER]`)
- Mike's session title, time, and room
- Confirmation that the NFR is a Fleet Premium license
- Optional social image, as in past event announcements

Event dates and venue were checked against the [Oktane FAQ](https://www.okta.com/oktane/faqs/).

# Checklist for submitter

- [x] Content follows the Fleet writing style guide (sentence case, no em dashes, no hype)
- [x] Article endmatter is complete and `description` is under the 150-character build limit (146)

## Testing

- [ ] QA'd all new/changed functionality manually

## AI

**AI:** Claude Code (claude-fable-5-1)

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.
