### PR TITLE
Reject host_expiry_window <= 0 in global config when host expiry is enabled

### DIFF
--- a/changes/52416-host-expiry-window-validation
+++ b/changes/52416-host-expiry-window-validation
@@ -1,0 +1,1 @@
+- Fixed `PATCH /api/v1/fleet/config`, `fleetctl apply`, and `fleetctl gitops` accepting a `host_expiry_window` of 0 or less while `host_expiry_enabled` is true. The request now fails with a 422, matching the fleet-level setting.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1038,6 +1038,10 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		invalid.Append("activity_expiry_settings.activity_expiry_window", "must be greater than 0")
 	}
 
+	if appConfig.HostExpirySettings.HostExpiryEnabled && appConfig.HostExpirySettings.HostExpiryWindow < 1 {
+		invalid.Append("host_expiry_settings.host_expiry_window", "must be greater than 0")
+	}
+
 	if appConfig.OrgInfo.ContactURL == "" {
 		appConfig.OrgInfo.ContactURL = fleet.DefaultOrgInfoContactURL
 	}

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -157,6 +157,36 @@ func TestAppConfigAuth(t *testing.T) {
 	}
 }
 
+// TestModifyAppConfigHostExpiryWindow covers the validation that rejects the
+// apply before persisting. The accepted cases (positive window, and a window
+// that is ignored while host expiry is disabled) are covered by integration
+// tests, like the sibling activity_expiry_window check.
+func TestModifyAppConfigHostExpiryWindow(t *testing.T) {
+	for _, window := range []int{-1, 0} {
+		t.Run(fmt.Sprintf("enabled with window %d is rejected", window), func(t *testing.T) {
+			ds := new(mock.Store)
+			svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{
+				License: &fleet.LicenseInfo{Tier: fleet.TierFree},
+			})
+			ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+				}, nil
+			}
+			ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error { return nil }
+
+			body := fmt.Sprintf(`{"host_expiry_settings":{"host_expiry_enabled":true,"host_expiry_window":%d}}`, window)
+			_, err := svc.ModifyAppConfig(ctx, []byte(body), fleet.ApplySpecOptions{})
+			var invalid *fleet.InvalidArgumentError
+			require.ErrorAs(t, err, &invalid)
+			require.Contains(t, fmt.Sprintf("%+v", invalid.Errors), "host_expiry_settings.host_expiry_window")
+			require.False(t, ds.SaveAppConfigFuncInvoked, "config should not be saved when rejected")
+		})
+	}
+}
+
 // TestModifyAppConfigVulnExposureFilters covers the GitOps wiring for the
 // vulnerability-exposure chart filter defaults: the premium gate and the
 // payload validation, both of which reject the apply before persisting. The

--- a/server/service/integration_core_appconfig_test.go
+++ b/server/service/integration_core_appconfig_test.go
@@ -39,7 +39,7 @@ func (s *integrationTestSuite) TestAppConfigAdditionalQueriesCanBeRemoved() {
 	spec := []byte(`
   host_expiry_settings:
     host_expiry_enabled: true
-    host_expiry_window: 0
+    host_expiry_window: 30
   features:
     additional_queries:
       time: SELECT * FROM time
@@ -1498,6 +1498,52 @@ func (s *integrationTestSuite) TestAppConfig() {
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	require.True(t, acResp.ActivityExpirySettings.ActivityExpiryEnabled)
 	require.Equal(t, 42, acResp.ActivityExpirySettings.ActivityExpiryWindow)
+
+	// Invalid host expiry window (0 and negative) while enabled.
+	for _, window := range []int{-1, 0} {
+		acResp = appConfigResponse{}
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
+    "host_expiry_settings": {
+        "host_expiry_enabled": true,
+        "host_expiry_window": %d
+    }
+  }`, window)), http.StatusUnprocessableEntity, &acResp)
+		s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+		require.False(t, acResp.HostExpirySettings.HostExpiryEnabled)
+		require.Zero(t, acResp.HostExpirySettings.HostExpiryWindow)
+	}
+
+	// Valid host expiry window.
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+    "host_expiry_settings": {
+        "host_expiry_enabled": true,
+        "host_expiry_window": 42
+    }
+  }`), http.StatusOK, &acResp)
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	require.True(t, acResp.HostExpirySettings.HostExpiryEnabled)
+	require.Equal(t, 42, acResp.HostExpirySettings.HostExpiryWindow)
+
+	// The window is not validated while host expiry is disabled, matching the
+	// fleet-level setting. This also resets the suite to the default (disabled).
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+    "host_expiry_settings": {
+        "host_expiry_enabled": false,
+        "host_expiry_window": -1
+    }
+  }`), http.StatusOK, &acResp)
+	require.False(t, acResp.HostExpirySettings.HostExpiryEnabled)
+	require.Equal(t, -1, acResp.HostExpirySettings.HostExpiryWindow)
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+    "host_expiry_settings": {
+        "host_expiry_enabled": false,
+        "host_expiry_window": 0
+    }
+  }`), http.StatusOK, &acResp)
+	require.Zero(t, acResp.HostExpirySettings.HostExpiryWindow)
 
 	// preserve_host_activities_on_reenrollment round-trip.
 	initialPreserve := acResp.ActivityExpirySettings.PreserveHostActivitiesOnReenrollment


### PR DESCRIPTION
**Related issue:** Resolves #52416

## Problem

- `PATCH /api/v1/fleet/config` accepted `host_expiry_window` of `0` or less while `host_expiry_enabled` was `true`, and saved it.
- Same through `fleetctl apply` and `fleetctl gitops`. All three call `ModifyAppConfig`.
- The API docs say the window must be greater than 0 when enabled. The fleet-level setting already rejects this with a 422.
- With a negative window, the host expiry cron would treat every host as expired.

## Fix

- `ModifyAppConfig` now returns a 422 when host expiry is enabled and the window is less than 1.
- The check sits next to the existing `activity_expiry_window` check and uses the same error format.
- The window is not checked while host expiry is disabled. Same as the fleet-level setting.
- The error name is `host_expiry_settings.host_expiry_window`, matching the activity check. The fleet-level endpoint uses the bare `host_expiry_window`. Happy to match that instead.

## Notes for reviewers

- Validation runs on the merged config. An instance that already stored an invalid window will get this 422 on every `PATCH /config` until the window is fixed. Only the API, `fleetctl apply`, or gitops could have stored one; the UI blocks it. The activity expiry check already behaves this way.
- One integration fixture (`TestAppConfigAdditionalQueriesCanBeRemoved`) applied `host_expiry_enabled: true` with window `0`. Changed it to `30`. That test only checks the enabled flag.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
  - `TestModifyAppConfigHostExpiryWindow`: window `-1` and `0` are rejected, config is not saved.
  - `TestIntegrations/TestAppConfig`: `PATCH /config` with `-1` and `0` returns 422 and the stored config is unchanged. `42` is accepted. Disabled with `-1` is accepted.
- [x] QA'd all new/changed functionality manually

## Manual QA

Setup:

- Fresh dev server and database, once built from `main` (`6443302dd8`) and once from this branch.
- Same requests against both. Full output and the script are in the first comment.

1. `PATCH /api/v1/fleet/config` with `{"host_expiry_settings":{"host_expiry_enabled":true,"host_expiry_window":-1}}`
   - before: `200`. `GET /config` shows `-1` saved.
   - after: `422` with `{"name":"host_expiry_settings.host_expiry_window","reason":"must be greater than 0"}`. Config unchanged.
2. Same request with window `0`
   - before: `200`, saved.
   - after: `422`, config unchanged.
3. Same request with window `30`
   - before and after: `200`, saved.
4. `host_expiry_enabled: false` with window `-1`
   - before and after: `200`. The window is not checked while disabled.
5. `fleetctl apply -f config.yml` with `host_expiry_enabled: true` and `host_expiry_window: 0`
   - before: `[+] applied fleet config`.
   - after: `Error: applying fleet config: Validation Failed: must be greater than 0`, exit 1.
6. `fleetctl gitops --dry-run -f global.yml` with `host_expiry_enabled: true` and `host_expiry_window: -1`
   - before: `gitops dry run succeeded`.
   - after: `Validation Failed: must be greater than 0`, exit 1.
   - Same file with window `30`: dry run succeeds.
