### PR TITLE
Apply min_cvss_score together with max_cvss_score when listing software versions

### DIFF
--- a/changes/50959-software-versions-min-cvss-score
+++ b/changes/50959-software-versions-min-cvss-score
@@ -1,0 +1,1 @@
+- Fixed the software versions list (`GET /api/v1/fleet/software/versions`, and the deprecated `GET /api/v1/fleet/software`) ignoring `min_cvss_score` when `max_cvss_score` was also set, so severity filters like "High" or "Critical" returned lower-severity software.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2302,17 +2302,20 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 				baseJoinConditions["c.cisa_known_exploit"] = true
 			}
 
+			// The bounds can't share the goqu.Ex map entry for c.cvss_score (the
+			// second write replaces the first) and can't share a goqu.Op either
+			// (multiple operators are ORed), so append them as separate conditions.
+			joinConditions := goqu.And(baseJoinConditions)
 			if opts.MinimumCVSS > 0 {
-				baseJoinConditions["c.cvss_score"] = goqu.Op{"gte": opts.MinimumCVSS}
+				joinConditions = joinConditions.Append(goqu.I("c.cvss_score").Gte(opts.MinimumCVSS))
 			}
-
 			if opts.MaximumCVSS > 0 {
-				baseJoinConditions["c.cvss_score"] = goqu.Op{"lte": opts.MaximumCVSS}
+				joinConditions = joinConditions.Append(goqu.I("c.cvss_score").Lte(opts.MaximumCVSS))
 			}
 
 			ds = ds.InnerJoin(
 				goqu.I("cve_meta").As("c"),
-				goqu.On(baseJoinConditions),
+				goqu.On(joinConditions),
 			)
 
 		} else {

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -7481,6 +7481,7 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 	var brave003 uint
 	var opera003 uint
 	var ie003 uint
+	var netscape003 uint
 	for s := range sw.Inserted {
 		switch {
 		case sw.Inserted[s].Name == "chrome" && sw.Inserted[s].Version == "0.0.1":
@@ -7497,6 +7498,8 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 			opera003 = sw.Inserted[s].ID
 		case sw.Inserted[s].Name == "internet explorer" && sw.Inserted[s].Version == "0.0.3":
 			ie003 = sw.Inserted[s].ID
+		case sw.Inserted[s].Name == "netscape" && sw.Inserted[s].Version == "0.0.3":
+			netscape003 = sw.Inserted[s].ID
 		}
 	}
 
@@ -7533,6 +7536,11 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 	_, err = ds.InsertSoftwareVulnerability(ctx, fleet.SoftwareVulnerability{
 		SoftwareID: ie003,
 		CVE:        "CVE-2024-1240",
+	}, fleet.NVDSource)
+	require.NoError(t, err)
+	_, err = ds.InsertSoftwareVulnerability(ctx, fleet.SoftwareVulnerability{
+		SoftwareID: netscape003,
+		CVE:        "CVE-2024-1241",
 	}, fleet.NVDSource)
 	require.NoError(t, err)
 
@@ -7573,6 +7581,12 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 			CVE:              "CVE-2024-1240",
 			CVSSScore:        nil,
 			CISAKnownExploit: nil,
+		},
+		{
+			// netscape: the only score below 7.5, so minimum-bound filters must exclude it
+			CVE:              "CVE-2024-1241",
+			CVSSScore:        new(4.0),
+			CISAKnownExploit: new(false),
 		},
 	})
 	require.NoError(t, err)
@@ -7616,6 +7630,10 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 				},
 				{
 					Name:    "internet explorer",
+					Version: "0.0.3",
+				},
+				{
+					Name:    "netscape",
 					Version: "0.0.3",
 				},
 				{
@@ -7755,6 +7773,10 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 					Version: "0.0.1",
 				},
 				{
+					Name:    "netscape",
+					Version: "0.0.3",
+				},
+				{
 					Name:    "safari",
 					Version: "0.0.1",
 				},
@@ -7772,6 +7794,10 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 				{
 					Name:    "chrome",
 					Version: "0.0.1",
+				},
+				{
+					Name:    "netscape",
+					Version: "0.0.3",
 				},
 				{
 					Name:    "safari",
@@ -7805,6 +7831,38 @@ func testListSoftwareVersionsVulnerabilityFilters(t *testing.T, ds *Datastore) {
 				MaximumCVSS:      8.0,
 			},
 			expected: []swVersion{
+				{
+					Name:    "chrome",
+					Version: "0.0.1",
+				},
+				{
+					Name:    "edge",
+					Version: "0.0.3",
+				},
+				{
+					Name:    "firefox",
+					Version: "0.0.3",
+				},
+				{
+					Name:    "safari",
+					Version: "0.0.1",
+				},
+			},
+		},
+		{
+			name: "minimum cvss 5.0 and maximum cvss 10.0",
+			opts: fleet.SoftwareListOptions{
+				ListOptions:      fleet.ListOptions{OrderKey: "name", OrderDirection: fleet.OrderAscending},
+				IncludeCVEScores: true,
+				VulnerableOnly:   true,
+				MinimumCVSS:      5.0,
+				MaximumCVSS:      10.0,
+			},
+			expected: []swVersion{
+				{
+					Name:    "brave",
+					Version: "0.0.3",
+				},
 				{
 					Name:    "chrome",
 					Version: "0.0.1",


### PR DESCRIPTION
**Related issue:** Resolves #50959

## Problem

- `GET /api/v1/fleet/software/versions` ignored `min_cvss_score` whenever `max_cvss_score` was also set.
- Cause: `selectSoftwareSQL` wrote both bounds to the same `goqu.Ex` map key, `c.cvss_score`. The second write replaced the first.
- The UI severity presets always send both bounds. So "High" also returned Medium and Low software, and "Critical" had no floor at all.
- The `count` in the same response was already correct, because it is built with plain SQL. Count and rows did not match.
- The deprecated `GET /api/v1/fleet/software` uses the same query and had the same bug.

## Fix

- Add the two bounds as separate `AND` conditions on the `cve_meta` join instead of map entries.
- A single `goqu.Op{"gte": min, "lte": max}` does not work either. goqu joins multiple operators in one `Op` with `OR`. Left a comment in the code so this is not reintroduced.
- The `LEFT JOIN` branch (no filters) is unchanged.
- The other CVSS filters in this file use plain SQL with separate placeholders and are not affected.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
  - The existing "minimum cvss 7.5 and maximum cvss 8.0" case passed only because no fixture CVE scored below 7.5.
  - Added a `netscape` fixture with CVSS 4.0, and a "minimum cvss 5.0 and maximum cvss 10.0" case.
  - Without the fix, both range cases fail because the 4.0 row leaks in. With the fix, all cases pass.
- [x] QA'd all new/changed functionality manually

## Manual QA

Setup:

- Fresh dev server and database, once built from `main` (`6443302dd8`) and once from this branch.
- Seeded one host with four vulnerable apps by SQL: `critical-app` (CVSS 9.8), `high-app` (7.5), `medium-app` (5.0), `low-app` (2.0).
- Called `GET /api/v1/fleet/software/versions?vulnerable=true&...` with the same filters against both. Full output and the script, including the seed SQL, are in the first comment.

1. `min_cvss_score=9&max_cvss_score=10` (the "Critical" preset)
   - before: `count: 1`, rows: critical-app, high-app, low-app, medium-app.
   - after: `count: 1`, rows: critical-app.
2. `min_cvss_score=7&max_cvss_score=8.9` ("High")
   - before: `count: 1`, rows: high-app, low-app, medium-app.
   - after: `count: 1`, rows: high-app.
3. `min_cvss_score=4&max_cvss_score=6.9` ("Medium")
   - before: `count: 1`, rows: low-app, medium-app.
   - after: `count: 1`, rows: medium-app.
4. `min_cvss_score=7` only
   - before and after: critical-app, high-app.
5. `max_cvss_score=6.9` only
   - before and after: low-app, medium-app.
