### PR TITLE
Validate script_id when applying policy specs

### DIFF
--- a/changes/51353-policy-spec-script-validation
+++ b/changes/51353-policy-spec-script-validation
@@ -1,0 +1,1 @@
+- Fixed `POST /api/v1/fleet/spec/policies` (GitOps) accepting a `script_id` on a global policy or a script from another fleet, and returning a database error instead of a clear message for a nonexistent script.

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1754,6 +1754,9 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 		if spec.ProfileUUID != nil && *spec.ProfileUUID != "" && spec.Team == "" {
 			return ctxerr.Wrap(ctx, errProfileUUIDOnGlobalPolicy, "create policy from spec")
 		}
+		if spec.ScriptID != nil && *spec.ScriptID != 0 && spec.Team == "" {
+			return ctxerr.Wrap(ctx, errScriptIDOnGlobalPolicy, "create policy from spec")
+		}
 
 		if spec.FleetMaintainedAppSlug != "" {
 			var fmaTitleID *uint
@@ -1971,6 +1974,13 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 				scriptID := spec.ScriptID
 				if spec.ScriptID != nil && *spec.ScriptID == 0 {
 					scriptID = nil
+				}
+				if scriptID != nil {
+					// Same reasoning as the profile check below: this path never
+					// reaches assertTeamMatches, and global specs were rejected above.
+					if err := assertTeamMatches(ctx, tx, *teamID, nil, scriptID, nil, nil); err != nil {
+						return ctxerr.Wrap(ctx, err, "apply policy specs")
+					}
 				}
 
 				resendProf, err := fleet.ResolvePolicyResendProfile(spec.ProfileUUID)

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -84,6 +84,7 @@ func TestPolicies(t *testing.T) {
 		{"TestPoliciesTeamPoliciesWithScript", testTeamPoliciesWithScript},
 		{"TestPoliciesTeamPoliciesWithResendProfile", testTeamPoliciesWithResendProfile},
 		{"TestPoliciesApplyPolicySpecsWithResendProfile", testApplyPolicySpecsWithResendProfile},
+		{"TestPoliciesApplyPolicySpecsWithScript", testApplyPolicySpecsWithScript},
 		{"TestPoliciesResendProfileRejectsFleetManaged", testPoliciesResendProfileRejectsFleetManaged},
 		{"TestPoliciesGetPoliciesWithAssociatedProfile", testGetPoliciesWithAssociatedProfile},
 		{"TestPoliciesApplyPolicySpecsResendProfileChangeResetsStats", testApplyPolicySpecsResendProfileChangeResetsStats},
@@ -5719,6 +5720,100 @@ func testApplyPolicySpecsWithResendProfile(t *testing.T, ds *Datastore) {
 	for _, c := range errCases {
 		t.Run(c.name, func(t *testing.T) {
 			err := ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{c.spec})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.wantErrMsg)
+
+			// The rejected policy must not have been created.
+			var count int
+			err = ds.writer(ctx).GetContext(ctx, &count, `SELECT COUNT(*) FROM policies WHERE name = ?`, c.spec.Name)
+			require.NoError(t, err)
+			require.Zero(t, count)
+		})
+	}
+}
+
+func testApplyPolicySpecsWithScript(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "Mercutio", "mercutio@example.com", true)
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team specs script"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "other team specs script"})
+	require.NoError(t, err)
+
+	newScript := func(name string, teamID *uint) *fleet.Script {
+		script, err := ds.NewScript(ctx, &fleet.Script{
+			Name:           name,
+			ScriptContents: "echo",
+			TeamID:         teamID,
+		})
+		require.NoError(t, err)
+		return script
+	}
+	team1Script := newScript("specs-team1.sh", &team1.ID)
+	team2Script := newScript("specs-team2.sh", &team2.ID)
+	noTeamScript := newScript("specs-no-team.sh", nil)
+
+	spec := func(name, team string, scriptID *uint) *fleet.PolicySpec {
+		return &fleet.PolicySpec{
+			Name:     name,
+			Team:     team,
+			Query:    "SELECT 1;",
+			ScriptID: scriptID,
+		}
+	}
+
+	// A script on the same team, and a "No team" script on a "No team" policy, are accepted.
+	err = ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
+		spec("team script", team1.Name, &team1Script.ID),
+		spec("no team script", "No team", &noTeamScript.ID),
+	})
+	require.NoError(t, err)
+
+	teamPolicies, _, err := ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, teamPolicies, 1)
+	require.Equal(t, &team1Script.ID, teamPolicies[0].ScriptID)
+
+	noTeamPolicies, _, err := ds.ListTeamPolicies(ctx, 0, fleet.ListOptions{}, fleet.ListOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, noTeamPolicies, 1)
+	require.Equal(t, &noTeamScript.ID, noTeamPolicies[0].ScriptID)
+
+	// script_id: 0 clears the script on an existing policy.
+	err = ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{
+		spec("team script", team1.Name, new(uint(0))),
+	})
+	require.NoError(t, err)
+	cleared, err := ds.Policy(ctx, teamPolicies[0].ID)
+	require.NoError(t, err)
+	require.Nil(t, cleared.ScriptID)
+
+	errCases := []struct {
+		name       string
+		spec       *fleet.PolicySpec
+		wantErrMsg string
+	}{
+		{
+			name:       "script on a global policy is rejected",
+			spec:       spec("global script", "", &team1Script.ID),
+			wantErrMsg: errScriptIDOnGlobalPolicy.Error(),
+		},
+		{
+			name:       "script belonging to another team is rejected",
+			spec:       spec("cross team script", team1.Name, &team2Script.ID),
+			wantErrMsg: "does not belong to team ID",
+		},
+		{
+			name:       "nonexistent script is rejected",
+			spec:       spec("missing script", team1.Name, new(uint(999999))),
+			wantErrMsg: "does not exist",
+		},
+	}
+
+	for _, c := range errCases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ds.ApplyPolicySpecs(ctx, user.ID, []*fleet.PolicySpec{c.spec})
 			require.Error(t, err)
 			require.Contains(t, err.Error(), c.wantErrMsg)
 

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -257,6 +257,7 @@ const (
 	errPolicyAllFleetsForConditionalAccess          = "\"All fleets\" policy cannot have conditional_access_enabled set"
 	errPolicyAllFleetsForContinuousAutomations      = "\"All fleets\" policy cannot have continuous_automations_enabled set"
 	errPolicyAllFleetsForProfiles                   = "\"All fleets\" policy cannot have profile_uuid set"
+	errPolicyAllFleetsForScripts                    = "\"All fleets\" policy cannot have script_id set"
 	errPatchWhenClosedRequiresContinuousAutomations = "If \"patch_when_closed\" is true, \"continuous_automations_enabled\" can't be set to false."
 )
 
@@ -489,6 +490,12 @@ func (svc *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.Poli
 		if policy.Team == "" && policy.ProfileUUID != nil && *policy.ProfileUUID != "" {
 			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
 				Message: fmt.Sprintf("policy spec payload verification: %s", errPolicyAllFleetsForProfiles),
+			})
+		}
+
+		if policy.Team == "" && policy.ScriptID != nil && *policy.ScriptID != 0 {
+			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: fmt.Sprintf("policy spec payload verification: %s", errPolicyAllFleetsForScripts),
 			})
 		}
 

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -898,6 +898,64 @@ func TestNewGlobalPolicyQueryIDAuth(t *testing.T) {
 	}
 }
 
+func TestApplyPolicySpecsScriptID(t *testing.T) {
+	setupDS := func() *mock.Store {
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			return &fleet.Team{ID: 1, Name: name}, nil
+		}
+		ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+			return nil
+		}
+		return ds
+	}
+	adminCtx := func(ctx context.Context) context.Context {
+		return viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+			ID:         1,
+			GlobalRole: new(fleet.RoleAdmin),
+		}})
+	}
+	spec := func(team string, scriptID *uint) *fleet.PolicySpec {
+		return &fleet.PolicySpec{
+			Name:     "script spec policy",
+			Query:    "SELECT 1;",
+			Team:     team,
+			Platform: "darwin",
+			ScriptID: scriptID,
+		}
+	}
+
+	// "All fleets" (empty team) cannot carry a script.
+	t.Run("global spec rejects script_id", func(t *testing.T) {
+		ds := setupDS()
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{
+			License: &fleet.LicenseInfo{Tier: fleet.TierPremium},
+		})
+
+		err := svc.ApplyPolicySpecs(adminCtx(ctx), []*fleet.PolicySpec{spec("", new(uint(1)))})
+		require.ErrorContains(t, err, errPolicyAllFleetsForScripts)
+		require.False(t, ds.ApplyPolicySpecsFuncInvoked)
+	})
+
+	// script_id: 0 means "no script", so it is fine on a global spec; team
+	// ownership of a real script is the datastore's job.
+	t.Run("zero and team script_id pass through", func(t *testing.T) {
+		ds := setupDS()
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{
+			License: &fleet.LicenseInfo{Tier: fleet.TierPremium},
+		})
+
+		err := svc.ApplyPolicySpecs(adminCtx(ctx), []*fleet.PolicySpec{spec("", new(uint(0)))})
+		require.NoError(t, err)
+		err = svc.ApplyPolicySpecs(adminCtx(ctx), []*fleet.PolicySpec{spec("team1", new(uint(1)))})
+		require.NoError(t, err)
+		require.True(t, ds.ApplyPolicySpecsFuncInvoked)
+	})
+}
+
 func TestApplyPolicySpecsResendConfigProfile(t *testing.T) {
 	const (
 		teamName  = "team1"

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -37205,7 +37205,7 @@ func (s *integrationEnterpriseTestSuite) TestApplyPolicySpecsScriptValidation() 
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team.ID), nil, http.StatusOK, list)
 	require.Len(t, list.Policies, 1)
 	globalList := &fleet.ListGlobalPoliciesResponse{}
-	s.DoJSON("GET", "/api/latest/fleet/global/policies", nil, http.StatusOK, globalList)
+	s.DoJSON("GET", "/api/v1/fleet/global/policies", nil, http.StatusOK, globalList)
 	for _, p := range globalList.Policies {
 		require.NotEqual(t, "gitops global script", p.Name)
 	}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -37145,3 +37145,68 @@ func (s *integrationEnterpriseTestSuite) TestTeamPolicyResendConfigProfileCRUD()
 		require.Contains(t, extractServerErrorText(res.Body), "does not belong to team ID")
 	})
 }
+
+func (s *integrationEnterpriseTestSuite) TestApplyPolicySpecsScriptValidation() {
+	t := s.T()
+	ctx := t.Context()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+	otherTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-other"})
+	require.NoError(t, err)
+
+	newScript := func(name string, teamID *uint) *fleet.Script {
+		script, err := s.ds.NewScript(ctx, &fleet.Script{
+			Name:           name,
+			ScriptContents: "echo",
+			TeamID:         teamID,
+		})
+		require.NoError(t, err)
+		return script
+	}
+	teamScript := newScript("spec-team.sh", &team.ID)
+	otherTeamScript := newScript("spec-other-team.sh", &otherTeam.ID)
+
+	const specURL = "/api/latest/fleet/spec/policies"
+	spec := func(name, teamName string, scriptID uint) fleet.ApplyPolicySpecsRequest {
+		return fleet.ApplyPolicySpecsRequest{
+			Specs: []*fleet.PolicySpec{{
+				Name:     name,
+				Query:    "SELECT 1;",
+				Platform: "darwin",
+				Team:     teamName,
+				ScriptID: new(scriptID),
+			}},
+		}
+	}
+
+	// A script on the policy's own team is accepted.
+	s.Do("POST", specURL, spec("gitops script", team.Name, teamScript.ID), http.StatusOK)
+	list := &fleet.ListTeamPoliciesResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team.ID), nil, http.StatusOK, list)
+	require.Len(t, list.Policies, 1)
+	require.NotNil(t, list.Policies[0].RunScript)
+	require.Equal(t, teamScript.ID, list.Policies[0].RunScript.ID)
+
+	// A spec with no team cannot carry a script.
+	res := s.Do("POST", specURL, spec("gitops global script", "", teamScript.ID), http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(res.Body), "cannot have script_id set")
+
+	// A script owned by another team is rejected.
+	res = s.Do("POST", specURL, spec("gitops cross team script", team.Name, otherTeamScript.ID), http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(res.Body), "does not belong to team ID")
+
+	// A script that does not exist is rejected with a clear message rather than a database error.
+	res = s.Do("POST", specURL, spec("gitops missing script", team.Name, otherTeamScript.ID+999), http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(res.Body), "does not exist")
+
+	// None of the rejected specs created a policy.
+	list = &fleet.ListTeamPoliciesResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", team.ID), nil, http.StatusOK, list)
+	require.Len(t, list.Policies, 1)
+	globalList := &fleet.ListGlobalPoliciesResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/global/policies", nil, http.StatusOK, globalList)
+	for _, p := range globalList.Policies {
+		require.NotEqual(t, "gitops global script", p.Name)
+	}
+}


### PR DESCRIPTION
**Related issue:** Resolves #51353

`POST /api/v1/fleet/spec/policies` (the GitOps path) copied `script_id` straight into the policy upsert with no validation. A `script_id` on an "All fleets" spec was silently stored even though the UI/API path rejects it, a script belonging to another fleet was accepted, and a nonexistent id came back as a foreign key error from MySQL.

This mirrors the existing `profile_uuid` checks on the same path:
- Service layer: an "All fleets" spec with a non-zero `script_id` is rejected with a 400, same wording as the `profile_uuid` case. This is one step beyond the plan in my claim comment: the datastore already has `errScriptIDOnGlobalPolicy`, but it is a plain error that would surface as a 500, so the service check is what turns it into a 400, the same way the profile check does.
- Datastore: before the upsert, `assertTeamMatches` (already used by the single-policy create/modify path) verifies the script exists and belongs to the policy's fleet, so the caller gets a 400 with a clear message instead of a database error. `script_id: 0` still means "no script".

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

`TestPolicies/TestPoliciesApplyPolicySpecsWithScript` (datastore) covers the valid same-fleet and "No team" cases, `script_id: 0` clearing the script, and the three rejections, asserting no policy row is left behind. `TestApplyPolicySpecsScriptID` (service) covers the "All fleets" rejection before the datastore is reached. `TestApplyPolicySpecsScriptValidation` (enterprise integration) drives the four cases over HTTP and checks the response codes and messages.

- [x] QA'd all new/changed functionality manually

Local `fleet serve --dev --dev_license`, two fleets each with a script named `remediate.sh`, then four `POST /api/v1/fleet/spec/policies` calls. Script `qa-51353.sh`, output verbatim.

Before (`main` at 5c8cf05c13, 2026-09-09):

<img width="1197" height="902" alt="qa-51353-before" src="https://github.com/user-attachments/assets/e27c0187-4542-41dc-9bf0-9f13c7f1b8b5" />

Bogus script_id: 422 with a raw MySQL foreign key error. Script from another fleet: 200, stored. Script on an "All fleets" policy: 200, stored. Valid script_id: 200.


<details>
<summary>Transcript</summary>

```
Fleet server build:
{"version":"5c8cf05c13","branch":"main"}

fleets: QA 51353 = 19, QA 51353 other = 20
scripts: remediate.sh on QA 51353 = 19, on QA 51353 other = 20

### bogus script_id
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 bogus",
      "query": "SELECT 1;",
      "team": "QA 51353",
      "script_id": 999999
    }
  ]
}
-> HTTP 422
{
  "message": "Validation Failed",
  "errors": [
    {
      "name": "base",
      "reason": "Error 1452 (23000): Cannot add or update a child row: a foreign key constraint fails (`fleet`.`policies`, CONSTRAINT `policies_ibfk_4` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`))"
    }
  ]
}

### script_id from another fleet
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 cross fleet",
      "query": "SELECT 1;",
      "team": "QA 51353",
      "script_id": 20
    }
  ]
}
-> HTTP 200
{}

### script_id on an All fleets policy
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 global",
      "query": "SELECT 1;",
      "script_id": 19
    }
  ]
}
-> HTTP 200
{}

### valid script_id
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 valid",
      "query": "SELECT 1;",
      "team": "QA 51353",
      "script_id": 19
    }
  ]
}
-> HTTP 200
{}

### policies afterwards
QA 51353:
{"name":"QA 51353 cross fleet","run_script":{"id":20,"name":"remediate.sh"}}
{"name":"QA 51353 valid","run_script":{"id":19,"name":"remediate.sh"}}
All fleets (names starting with QA 51353):
["QA 51353 global"]
cleanup fleet 19: 200
cleanup fleet 20: 200
```

</details>

The cross-fleet spec is stored pointing at the other fleet's script and the "All fleets" spec is stored with a script. The script's cleanup deletes that leaked "All fleets" policy before the fleets, otherwise the fleet deletes fail with 422 because the policy still references one of their scripts.

After (this branch, b62023e6b7, rebased on that same main):

<img width="1197" height="902" alt="qa-51353-after" src="https://github.com/user-attachments/assets/bbf505b9-938a-47d2-b94f-678701ec4592" />

Bogus script_id: 400 "does not exist". Script from another fleet: 400 "does not belong to team". Script on an "All fleets" policy: 400 "cannot have script_id set". Valid script_id: 200, and only that policy is stored.

<details>
<summary>Transcript</summary>

```
Fleet server build:
{"version":"b62023e6b7","branch":"51353-policy-spec-script-validation"}

fleets: QA 51353 = 21, QA 51353 other = 22
scripts: remediate.sh on QA 51353 = 21, on QA 51353 other = 22

### bogus script_id
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 bogus",
      "query": "SELECT 1;",
      "team": "QA 51353",
      "script_id": 999999
    }
  ]
}
-> HTTP 400
{
  "message": "Bad request",
  "errors": [
    {
      "name": "base",
      "reason": "Script with ID 999999 does not exist"
    }
  ],
  "uuid": "d2436364-99fe-48f5-b38b-379d470825d6"
}

### script_id from another fleet
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 cross fleet",
      "query": "SELECT 1;",
      "team": "QA 51353",
      "script_id": 22
    }
  ]
}
-> HTTP 400
{
  "message": "Bad request",
  "errors": [
    {
      "name": "base",
      "reason": "Script with ID 22 does not belong to team ID 21"
    }
  ],
  "uuid": "5caf3e76-2373-4ff6-8749-2e31f451c53c"
}

### script_id on an All fleets policy
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 global",
      "query": "SELECT 1;",
      "script_id": 21
    }
  ]
}
-> HTTP 400
{
  "message": "Bad request",
  "errors": [
    {
      "name": "base",
      "reason": "policy spec payload verification: \"All fleets\" policy cannot have script_id set"
    }
  ],
  "uuid": "b34c4d75-2bde-4405-9ca4-f33f91963613"
}

### valid script_id
POST /api/v1/fleet/spec/policies
{
  "specs": [
    {
      "name": "QA 51353 valid",
      "query": "SELECT 1;",
      "team": "QA 51353",
      "script_id": 21
    }
  ]
}
-> HTTP 200
{}

### policies afterwards
QA 51353:
{"name":"QA 51353 valid","run_script":{"id":21,"name":"remediate.sh"}}
All fleets (names starting with QA 51353):
[]
cleanup fleet 21: 200
cleanup fleet 22: 200
```

</details>


## AI

**AI:** Claude Code (claude-fable-5-1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved script validation when applying fleet policy specifications.
  - Global policies now reject references to scripts.
  - Team policies now reject scripts assigned to another team or scripts that do not exist.
  - Valid team-owned scripts continue to be accepted.
  - Invalid policy requests now return clear error messages instead of database errors.
  - Rejected policy specifications no longer create policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

