### PR TITLE
Fleet UI: Fix white page flash and redirect loop on logout

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -250,7 +250,14 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
   ]);
 
   useEffect(() => {
-    if (authToken.get() && !location?.pathname.includes("/device/")) {
+    // Skip on `/logout` so the request doesn't race the session-destroy call
+    // and land in the 401 branch below, which hard-reloads and reintroduces
+    // the dark-mode white flash the SPA-navigating logout was meant to fix.
+    if (
+      authToken.get() &&
+      !location?.pathname.includes("/device/") &&
+      !location?.pathname.includes("/logout")
+    ) {
       fetchCurrentUser();
     }
   }, [location?.pathname, fetchCurrentUser]);

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -250,9 +250,9 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
   ]);
 
   useEffect(() => {
-    // Skip on `/logout` so the request doesn't race the session-destroy call
-    // and land in the 401 branch below, which hard-reloads and reintroduces
-    // the dark-mode white flash the SPA-navigating logout was meant to fix.
+    // Skip on `/logout`: this request races the session-destroy call, and
+    // a 401 back here triggers the hard-reload branch below, which flashes
+    // the viewport white in dark mode.
     if (
       authToken.get() &&
       !location?.pathname.includes("/device/") &&

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -93,7 +93,12 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
   }, []);
 
   useEffect(() => {
+    // Requiring `authToken.get()` matters after a SPA-navigated logout: the
+    // AppContext user/teams/config linger from the destroyed session, and
+    // without this check LoginPage would keep pushing to /dashboard while
+    // AuthenticatedRoutes keeps pushing back to /login on a missing token.
     if (
+      authToken.get() &&
       availableTeams &&
       config &&
       currentUser &&

--- a/frontend/pages/LogoutPage/LogoutPage.tsx
+++ b/frontend/pages/LogoutPage/LogoutPage.tsx
@@ -1,8 +1,7 @@
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { InjectedRouter } from "react-router";
 
 import PATHS from "router/paths";
-import { AppContext } from "context/app";
 import { notify } from "components/ToastNotification";
 import sessionsAPI from "services/entities/sessions";
 import authToken from "utilities/auth_token";
@@ -12,18 +11,15 @@ interface ILogoutPageProps {
 }
 
 const LogoutPage = ({ router }: ILogoutPageProps) => {
-  const { isSandboxMode } = useContext(AppContext);
-
   useEffect(() => {
     const logoutUser = async () => {
       try {
         await sessionsAPI.destroy();
         authToken.remove();
-        setTimeout(() => {
-          window.location.href = isSandboxMode
-            ? "https://www.fleetdm.com/logout"
-            : PATHS.ROOT;
-        }, 500);
+        // Prefer SPA navigation over a full reload: a reload paints the
+        // viewport white until bundle.js reapplies body.dark-mode, which
+        // dark-mode users see as the whole page flashing white.
+        router.replace(PATHS.LOGIN);
       } catch (response) {
         console.error(response);
         router.goBack();

--- a/frontend/pages/LogoutPage/LogoutPage.tsx
+++ b/frontend/pages/LogoutPage/LogoutPage.tsx
@@ -16,9 +16,9 @@ const LogoutPage = ({ router }: ILogoutPageProps) => {
       try {
         await sessionsAPI.destroy();
         authToken.remove();
-        // Prefer SPA navigation over a full reload: a reload paints the
-        // viewport white until bundle.js reapplies body.dark-mode, which
-        // dark-mode users see as the whole page flashing white.
+        // SPA-navigate, not a reload: on a reload body.dark-mode isn't set
+        // until bundle.js runs, so dark-mode users see the viewport flash
+        // white during the gap.
         router.replace(PATHS.LOGIN);
       } catch (response) {
         console.error(response);
@@ -28,7 +28,7 @@ const LogoutPage = ({ router }: ILogoutPageProps) => {
     };
 
     logoutUser();
-  }, []);
+  }, [router]);
 
   return null;
 };


### PR DESCRIPTION
## Issue
Closes #52809

## Description
- Bug fix (root cause): logging out in dark mode flashed the entire browser viewport white. `LogoutPage` was doing `window.location.href = "/"`, and the resulting hard reload paints the new document's default light canvas until `bundle.js` runs `initTheme()` and reapplies `body.dark-mode`. Existed in 4.91 too — the fix in #51221 (autofill dark-mode) made it more perceptible on the login flow because inputs no longer stay pinned white through the flip, but did not cause it.
- SPA-navigate to `/login` from `LogoutPage` instead of a full reload — same destination the App auth-redirect chain used to reach anyway, no viewport blank in between. Also drops the dead `isSandboxMode` branch (sandbox mode is gone) and the vestigial `setTimeout(..., 500)` — `sessionsAPI.destroy()` is already `await`ed, so the delay was just added logout latency.
- `App.tsx` guards `fetchCurrentUser()` from running on `/logout`. Without this, the `/me` request races the session-destroy call; if `/me` lands second it 401s, the error path at line 240 hits `window.location.href = PATHS.LOGIN`, and we're back to a hard reload flashing white.
- `LoginPage` requires `authToken.get()` before the auto-redirect to `/dashboard`. Because we no longer hard-reload on logout, the previous session's `currentUser` / `availableTeams` / `config` linger in `AppContext`. Without this guard, `LoginPage`'s effect would see that state and push to `/dashboard`, `AuthenticatedRoutes` would immediately bounce back to `/login` on the missing token, and the pair would loop — visible as rapid flicker and a login form that appears not to submit.

## Screenrecording
- Logout in dark mode: viewport stays dark end-to-end; login lands on dashboard on first try.


https://github.com/user-attachments/assets/e26034a2-8cf3-4331-888e-a4b2a218574e

- Confirmed fixed on Firefox


https://github.com/user-attachments/assets/5a8133cd-8fbe-4fe6-b03c-96500a40dfef



## Testing

- [x] QA'd all new/changed functionality manually

## AI
**AI:** Claude Code (claude-opus-4-7[1m])


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout navigation by taking users directly to the login page after their session ends.
  * Prevented stale session data from redirecting users back to the dashboard after logging out through in-app navigation.
  * Prevented unnecessary account checks during logout, avoiding a brief white screen flash in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->