### PR TITLE
Fleet UI: Truncate long report names on Host details > Reports card

### DIFF
--- a/frontend/pages/hosts/details/HostReportsTab/HostReportCard.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportCard.tsx
@@ -172,7 +172,9 @@ const HostReportCard = ({
       <div className={`${baseClass}__header`}>
         <div className={`${baseClass}__header-left`}>
           <div className={`${baseClass}__title-row`}>
-            <h3 className={`${baseClass}__name`}>{report.name}</h3>
+            <h3 className={`${baseClass}__name`}>
+              <TooltipTruncatedText value={report.name} fixedPositionStrategy />
+            </h3>
             {renderLastUpdated()}
           </div>
           {report.description && (

--- a/frontend/pages/hosts/details/HostReportsTab/_styles.scss
+++ b/frontend/pages/hosts/details/HostReportsTab/_styles.scss
@@ -106,6 +106,9 @@
     font-size: $small;
     font-weight: $bold;
     margin: 0;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
   }
 
   &__last-updated {


### PR DESCRIPTION
## Issue
Closes #52298

## Description
- Bug fix (root cause): a report name at the 255-char input cap rendered raw in the `host-report-card__name` h3 with no truncation and no tooltip, running under the Actions dropdown and forcing ~1300px of horizontal page overflow. The h3 sat in a flex container whose parent already had `flex: 1; min-width: 0`, but the h3 itself had no width constraint or overflow handling, so the content dictated width unchecked.
- Wrapped `report.name` in `<TooltipTruncatedText value={report.name} fixedPositionStrategy />` and gave `.host-report-card__name` `flex: 1; min-width: 0; overflow: hidden;` so the h3 shrinks inside the row and TooltipTruncatedText's `text-overflow: ellipsis` kicks in. Hover exposes the full name. `fixedPositionStrategy` positions the tooltip correctly given the `overflow: hidden` ancestor.
- Same pattern as #48154 (HQRTable, PolicyDetailsPage, QueryDetailsPage). This card was the last surface still unhandled — issue explicitly called it out as a miss from that PR.

## Screenshot
- Long (255-char) report name on Host details > Reports: truncates to card width with ellipsis, tooltip shows full name on hover, no horizontal page overflow.

<img width="646" height="677" alt="Screenshot 2026-09-08 at 4 58 33 PM" src="https://github.com/user-attachments/assets/4cdc9078-309b-4b8e-a1ae-522b81029bad" />


## Testing

- [x] QA'd all new/changed functionality manually

## AI
**AI:** Claude Code (claude-opus-4-7[1m])

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long report names in host report cards are now truncated to fit the card header.
  - Hovering over a truncated name displays the full report name in a tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->