### PR TITLE
VEX fleetctl for CVE-2026-84445

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -324,6 +324,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-03-23 16:44:57
 
+### [CVE-2026-84445](https://nvd.nist.gov/vuln/detail/CVE-2026-84445)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The vulnerability affects gRPC-Go xDS servers (crash via requests missing the :authority and Host headers); fleetctl does not run a gRPC server (grpc is a transitive dependency used by the Fleet server).
+- **Products:** `fleetctl`,`pkg:golang/google.golang.org/grpc`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-09-09 11:41:36
+
 ### [CVE-2026-84304](https://nvd.nist.gov/vuln/detail/CVE-2026-84304)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-84445.vex.json
+++ b/security/vex/fleetctl/CVE-2026-84445.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-ca996a2692e66b8230187f5c2c16a0ec172b5b768ab8c65eb7540189ab913a9c",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-84445"
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/google.golang.org/grpc"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The vulnerability affects gRPC-Go xDS servers (crash via requests missing the :authority and Host headers); fleetctl does not run a gRPC server (grpc is a transitive dependency used by the Fleet server).",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-09-09T11:41:36.062799Z"
+    }
+  ],
+  "timestamp": "2026-09-09T11:41:36Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/34318300431.

New run: https://github.com/fleetdm/fleet/actions/runs/34347240374.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a vulnerability assessment for CVE-2026-84445.
  * Documented that the issue does not affect fleetctl because it does not run a gRPC server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->