### PR TITLE
Fix GitOps for Fleet deployments that do not have server private key

### DIFF
--- a/changes/52545-gitops-ca-private-key-check
+++ b/changes/52545-gitops-ca-private-key-check
@@ -1,0 +1,1 @@
+- Fixed GitOps runs failing with "Server private key must be configured" when no certificate authorities are configured.

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -494,7 +494,9 @@ func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incomi
 		return fleet.NewInvalidArgumentError("gitops", "certificate_authorities: batch apply is intended only for use with gitops")
 	}
 
-	if len(svc.config.Server.PrivateKey) == 0 {
+	// The private key is only needed to encrypt CA secrets, so don't require it when
+	// no CAs are configured (the common case for GitOps users without CAs).
+	if !incoming.IsEmpty() && len(svc.config.Server.PrivateKey) == 0 {
 		return &fleet.BadRequestError{Message: "Server private key must be configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key"}
 	}
 

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -240,7 +240,7 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		require.Nil(t, createdCA)
 	})
 
-	t.Run("Batch apply errors when no private key is configured", func(t *testing.T) {
+	t.Run("Batch apply errors when CAs are configured but no private key is configured", func(t *testing.T) {
 		ds := new(mock.Store)
 		authorizer, err := authz.NewAuthorizer()
 		require.NoError(t, err)
@@ -252,8 +252,37 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		svc.config.Server.PrivateKey = ""
 		ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
 
-		err = svc.BatchApplyCertificateAuthorities(ctx, fleet.GroupedCertificateAuthorities{}, fleet.BatchApplyCertificateAuthoritiesOpts{ViaGitOps: true})
+		incoming := fleet.GroupedCertificateAuthorities{
+			DigiCert: []fleet.DigiCertCA{{Name: "DigicertWIFI", URL: digicertURL}},
+		}
+		err = svc.BatchApplyCertificateAuthorities(ctx, incoming, fleet.BatchApplyCertificateAuthoritiesOpts{ViaGitOps: true})
 		require.EqualError(t, err, "Server private key must be configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+	})
+
+	t.Run("Batch apply with no CAs succeeds when no private key is configured", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+		ds.BatchApplyCertificateAuthoritiesFunc = func(ctx context.Context, ops fleet.CertificateAuthoritiesBatchOperations) error {
+			require.Empty(t, ops.Add)
+			require.Empty(t, ops.Update)
+			require.Empty(t, ops.Delete)
+			return nil
+		}
+		authorizer, err := authz.NewAuthorizer()
+		require.NoError(t, err)
+		svc := &Service{
+			logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+			ds:     ds,
+			authz:  authorizer,
+		}
+		svc.config.Server.PrivateKey = ""
+		ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+		err = svc.BatchApplyCertificateAuthorities(ctx, fleet.GroupedCertificateAuthorities{}, fleet.BatchApplyCertificateAuthoritiesOpts{ViaGitOps: true})
+		require.NoError(t, err)
+		require.True(t, ds.BatchApplyCertificateAuthoritiesFuncInvoked)
 	})
 
 	t.Run("Create DigiCert CA - Happy path", func(t *testing.T) {

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -518,6 +518,16 @@ type GroupedCertificateAuthorities struct {
 	Smallstep       []SmallstepSCEPProxyCA `json:"smallstep"`
 }
 
+// IsEmpty returns true if no certificate authorities of any type are configured.
+func (g *GroupedCertificateAuthorities) IsEmpty() bool {
+	return len(g.EST) == 0 &&
+		len(g.Hydrant) == 0 &&
+		len(g.DigiCert) == 0 &&
+		g.NDESSCEP == nil &&
+		len(g.CustomScepProxy) == 0 &&
+		len(g.Smallstep) == 0
+}
+
 // ToCustomSCEPProxyCAMap converts the CustomScepProxy slice to a map keyed by CA name
 func (g *GroupedCertificateAuthorities) ToCustomSCEPProxyCAMap() map[string]*CustomSCEPProxyCA {
 	customSCEPCAs := make(map[string]*CustomSCEPProxyCA, len(g.CustomScepProxy))


### PR DESCRIPTION
Resolves #52545.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitOps certificate authority updates failing when no certificate authorities are configured.
  * Empty certificate authority configurations can now be applied successfully without requiring a server private key.
  * Added validation coverage to ensure configurations containing certificate authorities continue to require the necessary private key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->