### PR TITLE
Bump Linux Claude Desktop patch policy to 1.49585.0

### DIFF
--- a/it-and-security/lib/linux/policies/update-claude.yml
+++ b/it-and-security/lib/linux/policies/update-claude.yml
@@ -1,5 +1,5 @@
 - name: Claude up to date (Linux)
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM deb_packages WHERE name = 'claude-desktop' AND version_compare(version, '1.46388.2') < 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM deb_packages WHERE name = 'claude-desktop' AND version_compare(version, '1.49585.0') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Claude is managed by IT and is upgraded automatically from Anthropic's apt repository when this policy fails. You can also run `sudo apt update && sudo apt install claude-desktop`, or install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."


### PR DESCRIPTION
**Related issue:** NA

# Checklist for submitter

## AI

**AI:** Claude Code (claude-sonnet-5)

## Summary

Bumps the pinned version in the "Claude up to date (Linux)" dogfood policy (`it-and-security/lib/linux/policies/update-claude.yml`) from `1.46388.2` to `1.49585.0`, the newest version published to Anthropic's apt repository for both `amd64` and `arm64`.

- Old pinned version: `1.46388.2`
- New pinned version: `1.49585.0`
- Newest amd64 observed: `1.49585.0` — https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages
- Newest arm64 observed: `1.49585.0` — https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-arm64/Packages

No changes file is needed — this is dogfood GitOps configuration, not a product change.

https://claude.ai/code/session_01PtL16mDFx94TLv1SK2UbzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtL16mDFx94TLv1SK2UbzB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Linux policy checks to correctly identify outdated Claude Desktop installations against the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->