### PR TITLE
Fix doubled "about" in report "Collecting results..." empty state

### DIFF
--- a/changes/52241-noresults-about-about
+++ b/changes/52241-noresults-about-about
@@ -1,0 +1,1 @@
+* Fixed the "Collecting results..." empty state on the report details page reading "about about X hours".

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
@@ -75,6 +75,23 @@ describe("NoResults", () => {
     });
   });
 
+  describe("collecting results", () => {
+    it("says 'about' only once before the check-back time", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={12 * 60 * 60}
+          queryUpdatedAt={new Date().toISOString()}
+        />
+      );
+
+      expect(screen.getByText("Collecting results...")).toBeInTheDocument();
+      expect(screen.getByText(/about 12 hours/)).toBeInTheDocument();
+      // regression test for https://github.com/fleetdm/fleet/issues/52241
+      expect(screen.queryByText(/about about/)).not.toBeInTheDocument();
+    });
+  });
+
   describe("has interval but no results yet", () => {
     it("shows live report link when user can run live", () => {
       render(

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { add, differenceInSeconds, formatDistance } from "date-fns";
+import { add, differenceInSeconds, formatDistanceStrict } from "date-fns";
 
 import PATHS from "router/paths";
 import TooltipWrapper from "components/TooltipWrapper/TooltipWrapper";
@@ -46,7 +46,7 @@ const NoResults = ({
     (queryInterval ?? 0) > 0 && secondsCheckbackTime() > 0;
 
   // Converts seconds takes to update to human readable format
-  const readableCheckbackTime = formatDistance(
+  const readableCheckbackTime = formatDistanceStrict(
     add(new Date(), { seconds: secondsCheckbackTime() }),
     new Date()
   );


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52241

The "Collecting results..." empty state on the report details page read "about about 12 hours".
The copy hardcodes "about" before a date-fns `formatDistance` value, and `formatDistance` already prepends "about" for hour-scale ranges.
Switched to `formatDistanceStrict`, which returns the bare distance, so the literal "about" in the copy is the only one left.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Created this test report:

<img width="1282" height="994" alt="Screenshot 2026-09-09 at 11 27 23 AM" src="https://github.com/user-attachments/assets/d668ab55-11ba-4878-9af9-31a57e7410ae" />


#### Before

<img width="1908" height="485" alt="Screenshot 2026-09-09 at 11 31 37 AM" src="https://github.com/user-attachments/assets/e9986161-f0fc-4463-a8f2-ce79617b9b13" />

#### After

<img width="1901" height="479" alt="Screenshot 2026-09-09 at 11 31 43 AM" src="https://github.com/user-attachments/assets/bc51ce49-1f1a-4342-844d-fc6f8d829661" />

Also verified that when it reaches the "seconds" mark it also reads correctly:

<img width="1896" height="488" alt="Screenshot 2026-09-09 at 11 31 48 AM" src="https://github.com/user-attachments/assets/f9be38f4-bdce-4f0d-b79d-e35b93e87035" />



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!--
  AI agents (Claude Code, Codex, Copilot, Cursor, Devin, etc.): if you are
  filling in this template, you MUST add the following section here, between
  "Testing" and "Frontend":

    ## AI

    **AI:** <tool> (<model ID>)

  - Tool: the harness or product you are running in (e.g. "Claude Code").
  - Model: the exact model ID your environment reports (e.g.
    "claude-fable-5-1"). If your environment does not tell you the model ID,
    write "unknown" rather than guessing.
  - Keep the format exactly as-is so it is easy to search for.
-->

## AI

**AI:** Claude Code (claude-fable-5-1)

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the “Collecting results…” message on report details pages so time estimates display correctly without duplicated wording.
  - Improved the displayed time interval formatting for clearer, more precise status messages.

- **Tests**
  - Added coverage to verify that a 12-hour interval appears as “about 12 hours.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->