### PR TITLE
Cherry-pick #52834: Fix doubled "about" in report "Collecting results..." empty state

### DIFF
--- a/changes/52241-noresults-about-about
+++ b/changes/52241-noresults-about-about
@@ -1,0 +1,1 @@
+* Fixed the "Collecting results..." empty state on the report details page reading "about about X hours".

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tests.tsx
@@ -75,6 +75,23 @@ describe("NoResults", () => {
     });
   });
 
+  describe("collecting results", () => {
+    it("says 'about' only once before the check-back time", () => {
+      render(
+        <NoResults
+          {...baseProps}
+          queryInterval={12 * 60 * 60}
+          queryUpdatedAt={new Date().toISOString()}
+        />
+      );
+
+      expect(screen.getByText("Collecting results...")).toBeInTheDocument();
+      expect(screen.getByText(/about 12 hours/)).toBeInTheDocument();
+      // regression test for https://github.com/fleetdm/fleet/issues/52241
+      expect(screen.queryByText(/about about/)).not.toBeInTheDocument();
+    });
+  });
+
   describe("has interval but no results yet", () => {
     it("shows live report link when user can run live", () => {
       render(

--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { add, differenceInSeconds, formatDistance } from "date-fns";
+import { add, differenceInSeconds, formatDistanceStrict } from "date-fns";
 
 import PATHS from "router/paths";
 import TooltipWrapper from "components/TooltipWrapper/TooltipWrapper";
@@ -46,7 +46,7 @@ const NoResults = ({
     (queryInterval ?? 0) > 0 && secondsCheckbackTime() > 0;
 
   // Converts seconds takes to update to human readable format
-  const readableCheckbackTime = formatDistance(
+  const readableCheckbackTime = formatDistanceStrict(
     add(new Date(), { seconds: secondsCheckbackTime() }),
     new Date()
   );


### PR DESCRIPTION
Cherry-pick of #52834 into the RC branch.