### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.19.13",
+      "version": "3.19.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.19.13') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.19.19') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.cursor.com/production/dd066f332fcea7382764400fde902f61920648d5/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/6496ea8a068aebfcd21990e70ff522e9abf10c8c/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "1ae48b55",
       "uninstall_script_ref": "03b9aece",
-      "sha256": "e870dfefc6feb19f283e69cdcf2af17fcb542afdcb9968bc9a1a7a1beeaf9e11",
+      "sha256": "cd329fcbc5c1fa2fc66ddc911beebbc9d594e3ff8677f50ccd4757abda0a7c67",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/eclipse-ide/darwin.json
+++ b/ee/maintained-apps/outputs/eclipse-ide/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "4.40",
+      "version": "4.41",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers' AND version_compare(bundle_short_version, '4.40') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers' AND version_compare(bundle_short_version, '4.41') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'epp.package.committers' AND a.bundle_executable != '');"
       },
       "installer_url": "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2026-06/R/eclipse-committers-2026-06-R-macosx-cocoa-aarch64.dmg&r=1",

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.190.0",
+      "version": "1.191.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.190.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.191.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.grammarly.ProjectLlama' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.190.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.191.0.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "586a57a6deac4cc0dfa3d9639780ff1cc640824ac3a69bddd6a5c4e9feaa960e",
+      "sha256": "ef565aa404552e2af642574e452dc301736c7acc611af0ff0d308948f6ec4ca0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/home-assistant/darwin.json
+++ b/ee/maintained-apps/outputs/home-assistant/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.9.0",
+      "version": "2026.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant' AND version_compare(bundle_short_version, '2026.9.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant' AND version_compare(bundle_short_version, '2026.9.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.robbie.HomeAssistant' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/home-assistant/iOS/releases/download/release%2F2026.9.0%2F2026.2874/home-assistant-mac.zip",
+      "installer_url": "https://github.com/home-assistant/iOS/releases/download/release%2F2026.9.1%2F2026.2985/home-assistant-mac.zip",
       "install_script_ref": "3485600f",
       "uninstall_script_ref": "b46351a1",
-      "sha256": "760fca25e5801355bc29869a63b8441699ac07dd039f6955b397995c1508ab27",
+      "sha256": "63e44280b8f0b8b56ef0f8b7bf5f400e83f51d4e2300f78784a9926d466ee0bf",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/darwin.json
+++ b/ee/maintained-apps/outputs/prisma-browser/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.8.5.83",
+      "version": "153.3.3.37",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '152.8.5.83') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '153.3.3.37') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.talon-sec.Work' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-152.8.5.83-2b4ba508.pkg",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-153.3.3.37-502f22a6.pkg",
       "install_script_ref": "827875fd",
       "uninstall_script_ref": "ff947f47",
-      "sha256": "93a82c7ade5c5dd972306f2c3ac7f72b7d8bf396c5e3bb497c63f21588b6589d",
+      "sha256": "2b52fcbc8db1e65f16763863db2cbd7fdcfabb18428c0376fe3a7aaf548e9fac",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/proton-mail/darwin.json
+++ b/ee/maintained-apps/outputs/proton-mail/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.13.4",
+      "version": "1.14.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop' AND version_compare(bundle_short_version, '1.13.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop' AND version_compare(bundle_short_version, '1.14.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'ch.protonmail.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://proton.me/download/mail/macos/1.13.4/ProtonMail-desktop.dmg",
+      "installer_url": "https://proton.me/download/mail/macos/1.14.0/ProtonMail-desktop.dmg",
       "install_script_ref": "1f588a8f",
       "uninstall_script_ref": "a5eb828a",
-      "sha256": "e3211f353f3db0ea000218e3655698d7283a005b98a7ab4cfc0ae7157fb5599c",
+      "sha256": "343802be033408ce91364968d95b8c4596ffa13e726a25bb42ac89540afa847a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -1,13 +1,13 @@
 {
   "versions": [
     {
-      "version": "1.136.2",
+      "version": "1.137.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.136.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.137.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.microsoft.VSCode' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.136.2/darwin-universal/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.137.0/darwin-universal/stable",
       "install_script_ref": "58ade691",
       "uninstall_script_ref": "38d65803",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/wavebox/darwin.json
+++ b/ee/maintained-apps/outputs/wavebox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.2.193.2",
+      "version": "153.2.196.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox' AND version_compare(bundle_short_version, '152.2.193.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox' AND version_compare(bundle_short_version, '153.2.196.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.wavebox.wavebox' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download.wavebox.app/stable/macarm64/Wavebox_152.2.193.2.zip",
+      "installer_url": "https://download.wavebox.app/stable/macarm64/Wavebox_153.2.196.2.zip",
       "install_script_ref": "316254ed",
       "uninstall_script_ref": "ecfbed36",
-      "sha256": "dfea80029c6332e9f9307603d50e8d6d3a14e9c956b49a006ce1d4751737e5f5",
+      "sha256": "dd65ed9d04e975e01c69a64c513f0dfc42f426d106677673fb9c83a0cc66e153",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/zeplin/darwin.json
+++ b/ee/maintained-apps/outputs/zeplin/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "10.32.0",
+      "version": "10.33.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx' AND version_compare(bundle_short_version, '10.32.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx' AND version_compare(bundle_short_version, '10.33.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.zeplin.osx' AND a.bundle_executable != '');"
       },
       "installer_url": "https://pkg.zeplin.io/macos/latest/zeplin-darwin-universal.zip",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS app definitions to track newer releases:
    * Cursor 3.19.19
    * Eclipse IDE 4.41
    * Grammarly Desktop 1.191.0
    * Home Assistant 2026.9.1
    * Prisma Access Browser 153.3.3.37
    * Proton Mail 1.14.0
    * Visual Studio Code 1.137.0
    * Wavebox 153.2.196.2
    * Zeplin 10.33.0
  * Updated download references and verification data where applicable to ensure installers match the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->