### PR TITLE
Fixed GitOps mode blocking edits to a manual label's host membership

### DIFF
--- a/changes/50527-gitops-mode-manual-label-membership
+++ b/changes/50527-gitops-mode-manual-label-membership
@@ -1,0 +1,1 @@
+- Fixed GitOps mode blocking edits to a manual label's host membership. Hosts can now be added and removed in the Fleet UI while the label's name and description stay managed in YAML.

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
@@ -8,6 +8,7 @@ import {
   getLabelHostsHandler,
 } from "test/handlers/label-handlers";
 import createMockConfig from "__mocks__/configMock";
+import { createMockLabel } from "__mocks__/labelsMock";
 import labelsAPI from "services/entities/labels";
 
 import EditLabelPage from "./EditLabelPage";
@@ -106,8 +107,6 @@ describe("EditLabelPage", () => {
   });
 
   describe("saving a manual label", () => {
-    // createMockConfig supplies the fields MainContent reads (license, MDM); the AppContext
-    // value replaces initialState wholesale rather than merging into it.
     const gitOpsContext = {
       app: {
         config: createMockConfig({
@@ -124,22 +123,10 @@ describe("EditLabelPage", () => {
       app: { config: createMockConfig() },
     };
 
-    const renderManualLabelPage = (context?: Record<string, unknown>) => {
+    const renderManualLabelPage = (context: typeof gitOpsContext) => {
       mockServer.use(getLabelHandler({ label_membership_type: "manual" }));
-      mockServer.use(
-        getLabelHostsHandler([
-          {
-            id: 1,
-            hostname: "hosty numero uno",
-            display_name: "Test host #1",
-            hardware_serial: "test-serial-1",
-          },
-        ])
-      );
-      const render = createCustomRenderer({
-        withBackendMock: true,
-        ...(context ? { context } : {}),
-      });
+      mockServer.use(getLabelHostsHandler([]));
+      const render = createCustomRenderer({ withBackendMock: true, context });
       return render(
         <EditLabelPage
           {...generateMockRouterProps({ routeParams: { label_id: "1" } })}
@@ -148,7 +135,9 @@ describe("EditLabelPage", () => {
     };
 
     beforeEach(() => {
-      jest.spyOn(labelsAPI, "update").mockResolvedValue({ label: {} } as never);
+      jest
+        .spyOn(labelsAPI, "update")
+        .mockResolvedValue({ label: createMockLabel() });
     });
 
     afterEach(() => {

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import mockServer from "test/mock-server";
 import {
   getLabelHandler,
   getLabelHostsHandler,
 } from "test/handlers/label-handlers";
+import createMockConfig from "__mocks__/configMock";
+import labelsAPI from "services/entities/labels";
 
 import EditLabelPage from "./EditLabelPage";
 
@@ -101,5 +103,86 @@ describe("EditLabelPage", () => {
     // expect host info to be on the page
     await screen.findByText("Test host #1");
     await screen.findByText("Test host #2");
+  });
+
+  describe("saving a manual label", () => {
+    // createMockConfig supplies the fields MainContent reads (license, MDM); the AppContext
+    // value replaces initialState wholesale rather than merging into it.
+    const gitOpsContext = {
+      app: {
+        config: createMockConfig({
+          gitops: {
+            gitops_mode_enabled: true,
+            repository_url: "https://github.com/example/fleet-gitops",
+            exceptions: { labels: false, software: false, secrets: false },
+          },
+        }),
+      },
+    };
+
+    const noGitOpsContext = {
+      app: { config: createMockConfig() },
+    };
+
+    const renderManualLabelPage = (context?: Record<string, unknown>) => {
+      mockServer.use(getLabelHandler({ label_membership_type: "manual" }));
+      mockServer.use(
+        getLabelHostsHandler([
+          {
+            id: 1,
+            hostname: "hosty numero uno",
+            display_name: "Test host #1",
+            hardware_serial: "test-serial-1",
+          },
+        ])
+      );
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        ...(context ? { context } : {}),
+      });
+      return render(
+        <EditLabelPage
+          {...generateMockRouterProps({ routeParams: { label_id: "1" } })}
+        />
+      );
+    };
+
+    beforeEach(() => {
+      jest.spyOn(labelsAPI, "update").mockResolvedValue({ label: {} } as never);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("sends a membership-only update for a GitOps-managed manual label", async () => {
+      const { user } = renderManualLabelPage(gitOpsContext);
+
+      await screen.findByText("Select hosts");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(labelsAPI.update).toHaveBeenCalledWith(
+          1,
+          expect.anything(),
+          expect.objectContaining({ membershipOnly: true })
+        );
+      });
+    });
+
+    it("sends the full update when GitOps mode is off", async () => {
+      const { user } = renderManualLabelPage(noGitOpsContext);
+
+      await screen.findByText("Select hosts");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(labelsAPI.update).toHaveBeenCalledWith(
+          1,
+          expect.anything(),
+          expect.objectContaining({ membershipOnly: false })
+        );
+      });
+    });
   });
 });

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -14,6 +14,7 @@ import { ILabel } from "interfaces/label";
 import { IHost } from "interfaces/host";
 import { notify } from "components/ToastNotification";
 import { AppContext } from "context/app";
+import useGitOpsMode from "hooks/useGitOpsMode";
 
 import MainContent from "components/MainContent";
 import Spinner from "components/Spinner";
@@ -38,6 +39,7 @@ type IEditLabelPageProps = RouteComponentProps<
 
 const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
   const { currentUser } = useContext(AppContext);
+  const { gitOpsModeEnabled: labelsGitOpsManaged } = useGitOpsMode("labels");
   const queryClient = useQueryClient();
 
   const labelId = parseInt(routeParams.label_id, 10);
@@ -93,8 +95,14 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
   const onUpdateLabel = async (
     formData: IDynamicLabelFormData | IManualLabelFormData
   ) => {
+    // Git owns a GitOps-managed manual label's definition, so send only the membership the user
+    // edited. Echoing name and description back could overwrite a change made in git since this
+    // page loaded.
+    const membershipOnly =
+      labelsGitOpsManaged && label?.label_membership_type === "manual";
+
     try {
-      await labelsAPI.update(labelId, formData);
+      await labelsAPI.update(labelId, formData, { membershipOnly });
       notify.success("Label updated successfully.");
       queryClient.invalidateQueries(["label", labelId, currentUser]);
       queryClient.invalidateQueries(["hosts", labelId]);
@@ -156,6 +164,7 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
         defaultDescription={label.description}
         defaultTargetedHosts={targetedHosts}
         teamName={label.team_name || null}
+        isEditing
         onSave={onUpdateLabel}
         onCancel={onCancelEdit}
       />

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -164,7 +164,6 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
         defaultDescription={label.description}
         defaultTargetedHosts={targetedHosts}
         teamName={label.team_name || null}
-        isEditing
         onSave={onUpdateLabel}
         onCancel={onCancelEdit}
       />

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -95,11 +95,10 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
   const onUpdateLabel = async (
     formData: IDynamicLabelFormData | IManualLabelFormData
   ) => {
-    // Git owns a GitOps-managed manual label's definition, so send only the membership the user
-    // edited. Echoing name and description back could overwrite a change made in git since this
-    // page loaded.
-    const membershipOnly =
-      labelsGitOpsManaged && label?.label_membership_type === "manual";
+    // Git owns a GitOps-managed label's definition, so send only the membership the user edited.
+    // Echoing name and description back could overwrite a change made in git since this page
+    // loaded. labelsAPI.update applies this to manual form data only.
+    const membershipOnly = labelsGitOpsManaged;
 
     try {
       await labelsAPI.update(labelId, formData, { membershipOnly });

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tests.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tests.tsx
@@ -155,7 +155,9 @@ describe("LabelForm", () => {
   });
 
   describe("GitOps mode", () => {
-    it("should disable Save when git owns the whole form", () => {
+    // Default path: dynamic and host vitals labels, plus label creation. Save only unlocks when
+    // ManualLabelForm passes gitOpsLocksDefinitionOnly on the edit page.
+    it("should keep Save gated when gitOpsLocksDefinitionOnly is not set", () => {
       renderInGitOpsMode(
         <LabelForm
           onSave={noop}

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tests.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tests.tsx
@@ -1,11 +1,24 @@
 import React from "react";
-import { renderWithSetup } from "test/test-utils";
+import { createCustomRenderer, renderWithSetup } from "test/test-utils";
 import { screen, render } from "@testing-library/react";
 import { noop } from "lodash";
 
 import InputField from "components/forms/fields/InputField";
 
 import LabelForm from "./LabelForm";
+
+const renderInGitOpsMode = createCustomRenderer({
+  context: {
+    app: {
+      config: {
+        gitops: {
+          gitops_mode_enabled: true,
+          repository_url: "https://github.com/example/fleet-gitops",
+        },
+      },
+    },
+  },
+});
 
 describe("LabelForm", () => {
   it("should validate the name to be required", async () => {
@@ -139,5 +152,37 @@ describe("LabelForm", () => {
         "Label fleets, queries, and platforms are immutable. To make changes, delete this label and create a new one."
       )
     ).toBeInTheDocument();
+  });
+
+  describe("GitOps mode", () => {
+    it("should disable Save when git owns the whole form", () => {
+      renderInGitOpsMode(
+        <LabelForm
+          onSave={noop}
+          onCancel={noop}
+          teamName={null}
+          immutableFields={[]}
+        />
+      );
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+      expect(screen.getByLabelText("Name")).toBeEnabled();
+    });
+
+    it("should lock only the definition fields when git owns the definition alone", () => {
+      renderInGitOpsMode(
+        <LabelForm
+          onSave={noop}
+          onCancel={noop}
+          teamName={null}
+          immutableFields={[]}
+          gitOpsLocksDefinitionOnly
+        />
+      );
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+      expect(screen.getByLabelText("Name")).toBeDisabled();
+      expect(screen.getByLabelText("Description")).toBeDisabled();
+    });
   });
 });

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -21,10 +21,7 @@ interface ILabelFormProps {
   teamName: string | null;
   onCancel: () => void;
   immutableFields: string[];
-  /** In GitOps mode, lock only the name and description rather than the whole form, leaving
-   * `additionalFields` and Save enabled. Manual labels use this so their host membership stays
-   * editable: GitOps preserves membership when a label's YAML omits the `hosts` key, so git can
-   * own the definition while membership is managed here. */
+  /** In GitOps mode, lock only the name and description rather than the whole form, for manual labels. */
   gitOpsLocksDefinitionOnly?: boolean;
   onSave: (formData: ILabelFormData, isValid: boolean) => void;
 }

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -21,6 +21,11 @@ interface ILabelFormProps {
   teamName: string | null;
   onCancel: () => void;
   immutableFields: string[];
+  /** In GitOps mode, lock only the name and description rather than the whole form, leaving
+   * `additionalFields` and Save enabled. Manual labels use this so their host membership stays
+   * editable: GitOps preserves membership when a label's YAML omits the `hosts` key, so git can
+   * own the definition while membership is managed here. */
+  gitOpsLocksDefinitionOnly?: boolean;
   onSave: (formData: ILabelFormData, isValid: boolean) => void;
 }
 
@@ -58,6 +63,7 @@ const LabelForm = ({
   onCancel,
   onSave,
   immutableFields,
+  gitOpsLocksDefinitionOnly = false,
 }: ILabelFormProps) => {
   const [name, setName] = useState(defaultName);
   const [description, setDescription] = useState(defaultDescription);
@@ -134,32 +140,63 @@ const LabelForm = ({
     onSave(currentData, fullValidation.isValid);
   };
 
+  // When git owns only the definition, each field carries its own GitOps tooltip and Save stays
+  // enabled. Otherwise the fields render as-is and Save carries the gate for the whole form.
+  const renderDefinitionField = (
+    field: (disabled?: boolean) => React.ReactNode
+  ) =>
+    gitOpsLocksDefinitionOnly ? (
+      <GitOpsModeTooltipWrapper
+        entityType="labels"
+        isInputField
+        renderChildren={field}
+      />
+    ) : (
+      field()
+    );
+
+  const renderSaveButton = (disabled?: boolean) => (
+    <Button
+      type="submit"
+      isLoading={isUpdatingLabel}
+      disabled={disabled || !formValidation.isValid}
+    >
+      Save
+    </Button>
+  );
+
   return (
     <form className={`${baseClass}__wrapper`} onSubmit={onSubmitForm}>
-      <InputField
-        error={formValidation.name?.message}
-        parseTarget
-        name="name"
-        onChange={onFormChange}
-        onBlur={handleBlur}
-        value={name}
-        inputClassName={`${baseClass}__label-title`}
-        label="Name"
-        placeholder="Label name"
-        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
-      />
-      <InputField
-        parseTarget
-        name="description"
-        onChange={onFormChange}
-        onBlur={handleBlur}
-        value={description}
-        inputClassName={`${baseClass}__label-description`}
-        label="Description"
-        type="textarea"
-        placeholder="Label description (optional)"
-        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
-      />
+      {renderDefinitionField((disabled) => (
+        <InputField
+          error={formValidation.name?.message}
+          parseTarget
+          name="name"
+          onChange={onFormChange}
+          onBlur={handleBlur}
+          value={name}
+          disabled={disabled}
+          inputClassName={`${baseClass}__label-title`}
+          label="Name"
+          placeholder="Label name"
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
+        />
+      ))}
+      {renderDefinitionField((disabled) => (
+        <InputField
+          parseTarget
+          name="description"
+          onChange={onFormChange}
+          onBlur={handleBlur}
+          value={description}
+          disabled={disabled}
+          inputClassName={`${baseClass}__label-description`}
+          label="Description"
+          type="textarea"
+          placeholder="Label description (optional)"
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
+        />
+      ))}
       {immutableFields.length > 0 ? (
         <span className={`${baseClass}__help-text`}>
           {generateDescriptionHelpText(immutableFields)}
@@ -168,18 +205,14 @@ const LabelForm = ({
       {teamName ? <TeamNameField name={teamName} /> : null}
       {additionalFields}
       <div className="button-wrap">
-        <GitOpsModeTooltipWrapper
-          entityType="labels"
-          renderChildren={(disableChildren) => (
-            <Button
-              type="submit"
-              isLoading={isUpdatingLabel}
-              disabled={disableChildren || !formValidation.isValid}
-            >
-              Save
-            </Button>
-          )}
-        />
+        {gitOpsLocksDefinitionOnly ? (
+          renderSaveButton()
+        ) : (
+          <GitOpsModeTooltipWrapper
+            entityType="labels"
+            renderChildren={renderSaveButton}
+          />
+        )}
         <Button onClick={onCancel} variant="secondary">
           Cancel
         </Button>

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tests.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tests.tsx
@@ -47,4 +47,67 @@ describe("ManualLabelForm", () => {
       targetedHosts,
     });
   });
+
+  describe("GitOps mode", () => {
+    const gitOpsContext = {
+      app: {
+        config: {
+          gitops: {
+            gitops_mode_enabled: true,
+            repository_url: "https://github.com/example/fleet-gitops",
+          },
+        },
+      },
+    };
+
+    it("should keep host membership editable while editing a label managed in git", async () => {
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: gitOpsContext,
+      });
+      const onSave = jest.fn();
+
+      const name = "Remediation exclusion";
+      const description = "Hosts temporarily excluded";
+      const targetedHosts = [
+        createMockHost({ id: 1 }),
+        createMockHost({ id: 2 }),
+      ];
+
+      const { user } = render(
+        <ManualLabelForm
+          isEditing
+          onSave={onSave}
+          onCancel={noop}
+          defaultName={name}
+          defaultDescription={description}
+          defaultTargetedHosts={targetedHosts}
+          teamName={null}
+        />
+      );
+
+      // git owns the definition
+      expect(screen.getByLabelText("Name")).toBeDisabled();
+      expect(screen.getByLabelText("Description")).toBeDisabled();
+
+      // ...but membership is managed here
+      const saveButton = screen.getByRole("button", { name: "Save" });
+      expect(saveButton).toBeEnabled();
+
+      await user.click(saveButton);
+
+      expect(onSave).toHaveBeenCalledWith({ name, description, targetedHosts });
+    });
+
+    it("should disable Save when creating a label while git owns labels", () => {
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: gitOpsContext,
+      });
+
+      render(<ManualLabelForm onSave={noop} onCancel={noop} teamName={null} />);
+
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+  });
 });

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tests.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tests.tsx
@@ -60,10 +60,7 @@ describe("ManualLabelForm", () => {
       },
     };
 
-    // Field-level locking is LabelForm's contract, covered in LabelForm.tests.tsx. This pins the
-    // isEditing -> gitOpsLocksDefinitionOnly wiring: with the flag off Save is gated, the click is
-    // a no-op, and onSave never fires.
-    it("should submit host membership when editing a label managed in git", async () => {
+    it("should submit host membership when editing a label managed in GitOps", async () => {
       const render = createCustomRenderer({
         withBackendMock: true,
         context: gitOpsContext,
@@ -79,7 +76,6 @@ describe("ManualLabelForm", () => {
 
       const { user } = render(
         <ManualLabelForm
-          isEditing
           onSave={onSave}
           onCancel={noop}
           defaultName={name}
@@ -92,17 +88,6 @@ describe("ManualLabelForm", () => {
       await user.click(screen.getByRole("button", { name: "Save" }));
 
       expect(onSave).toHaveBeenCalledWith({ name, description, targetedHosts });
-    });
-
-    it("should disable Save when creating a label while git owns labels", () => {
-      const render = createCustomRenderer({
-        withBackendMock: true,
-        context: gitOpsContext,
-      });
-
-      render(<ManualLabelForm onSave={noop} onCancel={noop} teamName={null} />);
-
-      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     });
   });
 });

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tests.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tests.tsx
@@ -60,7 +60,10 @@ describe("ManualLabelForm", () => {
       },
     };
 
-    it("should keep host membership editable while editing a label managed in git", async () => {
+    // Field-level locking is LabelForm's contract, covered in LabelForm.tests.tsx. This pins the
+    // isEditing -> gitOpsLocksDefinitionOnly wiring: with the flag off Save is gated, the click is
+    // a no-op, and onSave never fires.
+    it("should submit host membership when editing a label managed in git", async () => {
       const render = createCustomRenderer({
         withBackendMock: true,
         context: gitOpsContext,
@@ -86,15 +89,7 @@ describe("ManualLabelForm", () => {
         />
       );
 
-      // git owns the definition
-      expect(screen.getByLabelText("Name")).toBeDisabled();
-      expect(screen.getByLabelText("Description")).toBeDisabled();
-
-      // ...but membership is managed here
-      const saveButton = screen.getByRole("button", { name: "Save" });
-      expect(saveButton).toBeEnabled();
-
-      await user.click(saveButton);
+      await user.click(screen.getByRole("button", { name: "Save" }));
 
       expect(onSave).toHaveBeenCalledWith({ name, description, targetedHosts });
     });

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
@@ -5,7 +5,9 @@ import { useDebouncedCallback } from "use-debounce";
 
 import { IHost } from "interfaces/host";
 import targetsAPI, { ITargetsSearchResponse } from "services/entities/targets";
+import useGitOpsMode from "hooks/useGitOpsMode";
 
+import CustomLink from "components/CustomLink";
 import TargetsInput from "components/TargetsInput";
 
 import LabelForm from "../LabelForm";
@@ -18,6 +20,8 @@ export const LABEL_TARGET_HOSTS_INPUT_LABEL = "Select hosts";
 const LABEL_TARGET_HOSTS_INPUT_PLACEHOLDER =
   "Search name, hostname, or serial number";
 const DEBOUNCE_DELAY = 500;
+const LABEL_YAML_DOCS_URL =
+  "https://fleetdm.com/docs/configuration/yaml-files#labels";
 
 export interface IManualLabelFormData {
   name: string;
@@ -35,6 +39,7 @@ interface IManualLabelFormProps {
   defaultName?: string;
   defaultDescription?: string;
   defaultTargetedHosts?: IHost[];
+  isEditing?: boolean;
   teamName: string | null;
   onSave: (formData: IManualLabelFormData) => void;
   onCancel: () => void;
@@ -44,10 +49,12 @@ const ManualLabelForm = ({
   defaultName = "",
   defaultDescription = "",
   defaultTargetedHosts = [],
+  isEditing = false,
   teamName,
   onSave,
   onCancel,
 }: IManualLabelFormProps) => {
+  const { gitOpsModeEnabled: labelsGitOpsManaged } = useGitOpsMode("labels");
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [isDebouncing, setIsDebouncing] = useState(false);
@@ -125,6 +132,10 @@ const ManualLabelForm = ({
   const resultsTableConfig = generateTableHeaders();
   const selectedHostsTableConfig = generateTableHeaders(onHostRemove);
 
+  // Only editing gets the split gate. Creating a label is a definition change, so GitOps mode
+  // still locks the whole form there.
+  const gitOpsLocksDefinitionOnly = isEditing;
+
   return (
     <div className={baseClass}>
       <LabelForm
@@ -134,20 +145,34 @@ const ManualLabelForm = ({
         onCancel={onCancel}
         onSave={onSaveNewLabel}
         immutableFields={teamName ? ["fleets"] : []}
+        gitOpsLocksDefinitionOnly={gitOpsLocksDefinitionOnly}
         additionalFields={
-          <TargetsInput
-            label={LABEL_TARGET_HOSTS_INPUT_LABEL}
-            placeholder={LABEL_TARGET_HOSTS_INPUT_PLACEHOLDER}
-            searchText={searchQuery}
-            searchResultsTableConfig={resultsTableConfig}
-            selectedHostsTableConifg={selectedHostsTableConfig}
-            isTargetsLoading={isLoadingSearchResults || isDebouncing}
-            hasFetchError={isErrorSearchResults}
-            searchResults={searchResults ?? []}
-            targetedHosts={targetedHosts}
-            setSearchText={onChangeSearchQuery}
-            handleRowSelect={onHostSelect}
-          />
+          <>
+            <TargetsInput
+              label={LABEL_TARGET_HOSTS_INPUT_LABEL}
+              placeholder={LABEL_TARGET_HOSTS_INPUT_PLACEHOLDER}
+              searchText={searchQuery}
+              searchResultsTableConfig={resultsTableConfig}
+              selectedHostsTableConifg={selectedHostsTableConfig}
+              isTargetsLoading={isLoadingSearchResults || isDebouncing}
+              hasFetchError={isErrorSearchResults}
+              searchResults={searchResults ?? []}
+              targetedHosts={targetedHosts}
+              setSearchText={onChangeSearchQuery}
+              handleRowSelect={onHostSelect}
+            />
+            {gitOpsLocksDefinitionOnly && labelsGitOpsManaged && (
+              <span className="form-field__help-text">
+                Hosts are managed here. If this label&apos;s YAML sets a{" "}
+                <b>hosts</b> key, the next GitOps run replaces them.{" "}
+                <CustomLink
+                  newTab
+                  text="Learn more"
+                  url={LABEL_YAML_DOCS_URL}
+                />
+              </span>
+            )}
+          </>
         }
       />
     </div>

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
@@ -163,8 +163,8 @@ const ManualLabelForm = ({
             />
             {gitOpsLocksDefinitionOnly && labelsGitOpsManaged && (
               <span className="form-field__help-text">
-                Hosts are managed here. If this label&apos;s YAML sets a{" "}
-                <b>hosts</b> key, the next GitOps run replaces them.{" "}
+                Omitting <b>hosts</b> in YAML preserves these hosts. Setting{" "}
+                <b>hosts</b> in YAML replaces them on the next GitOps run.{" "}
                 <CustomLink
                   newTab
                   text="Learn more"

--- a/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/ManualLabelForm.tsx
@@ -39,7 +39,6 @@ interface IManualLabelFormProps {
   defaultName?: string;
   defaultDescription?: string;
   defaultTargetedHosts?: IHost[];
-  isEditing?: boolean;
   teamName: string | null;
   onSave: (formData: IManualLabelFormData) => void;
   onCancel: () => void;
@@ -49,7 +48,6 @@ const ManualLabelForm = ({
   defaultName = "",
   defaultDescription = "",
   defaultTargetedHosts = [],
-  isEditing = false,
   teamName,
   onSave,
   onCancel,
@@ -132,10 +130,6 @@ const ManualLabelForm = ({
   const resultsTableConfig = generateTableHeaders();
   const selectedHostsTableConfig = generateTableHeaders(onHostRemove);
 
-  // Only editing gets the split gate. Creating a label is a definition change, so GitOps mode
-  // still locks the whole form there.
-  const gitOpsLocksDefinitionOnly = isEditing;
-
   return (
     <div className={baseClass}>
       <LabelForm
@@ -145,7 +139,7 @@ const ManualLabelForm = ({
         onCancel={onCancel}
         onSave={onSaveNewLabel}
         immutableFields={teamName ? ["fleets"] : []}
-        gitOpsLocksDefinitionOnly={gitOpsLocksDefinitionOnly}
+        gitOpsLocksDefinitionOnly
         additionalFields={
           <>
             <TargetsInput
@@ -161,7 +155,7 @@ const ManualLabelForm = ({
               setSearchText={onChangeSearchQuery}
               handleRowSelect={onHostSelect}
             />
-            {gitOpsLocksDefinitionOnly && labelsGitOpsManaged && (
+            {labelsGitOpsManaged && (
               <span className="form-field__help-text">
                 Omitting <b>hosts</b> in YAML preserves these hosts. Setting{" "}
                 <b>hosts</b> in YAML replaces them on the next GitOps run.{" "}

--- a/frontend/services/entities/labels.tests.ts
+++ b/frontend/services/entities/labels.tests.ts
@@ -1,4 +1,57 @@
-import { listNamesFromSelectedLabels } from "./labels";
+import sendRequest from "services";
+
+import labelsAPI, { listNamesFromSelectedLabels } from "./labels";
+import createMockHost from "../../__mocks__/hostMock";
+
+jest.mock("services", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockSendRequest = sendRequest as jest.MockedFunction<typeof sendRequest>;
+
+describe("labelsAPI.update", () => {
+  beforeEach(() => {
+    mockSendRequest.mockReset();
+    mockSendRequest.mockResolvedValue({});
+  });
+
+  const manualFormData = {
+    name: "Remediation exclusion",
+    description: "Hosts temporarily excluded",
+    targetedHosts: [createMockHost({ id: 7 }), createMockHost({ id: 9 })],
+  };
+
+  it("sends the definition alongside membership by default", async () => {
+    await labelsAPI.update(1, manualFormData);
+
+    expect(mockSendRequest).toHaveBeenCalledWith("PATCH", expect.any(String), {
+      name: "Remediation exclusion",
+      description: "Hosts temporarily excluded",
+      host_ids: [7, 9],
+    });
+  });
+
+  it("sends only membership when the definition is managed in git", async () => {
+    await labelsAPI.update(1, manualFormData, { membershipOnly: true });
+
+    expect(mockSendRequest).toHaveBeenCalledWith("PATCH", expect.any(String), {
+      host_ids: [7, 9],
+    });
+  });
+
+  it("sends an empty host list when the last host is removed", async () => {
+    await labelsAPI.update(
+      1,
+      { ...manualFormData, targetedHosts: [] },
+      { membershipOnly: true }
+    );
+
+    expect(mockSendRequest).toHaveBeenCalledWith("PATCH", expect.any(String), {
+      host_ids: [],
+    });
+  });
+});
 
 describe("listNamesFromSelectedLabels", () => {
   it("returns names of selected labels", () => {

--- a/frontend/services/entities/labels.ts
+++ b/frontend/services/entities/labels.ts
@@ -37,15 +37,26 @@ const isManualLabelFormData = (
   return "targetedHosts" in formData;
 };
 
+export interface IUpdateLabelOptions {
+  /** Send only the label's host membership, leaving its definition untouched. Used for a manual
+   * label whose definition is managed in git while its membership is managed in Fleet. */
+  membershipOnly?: boolean;
+}
+
 const generateUpdateLabelBody = (
-  formData: IDynamicLabelFormData | IManualLabelFormData
+  formData: IDynamicLabelFormData | IManualLabelFormData,
+  { membershipOnly = false }: IUpdateLabelOptions = {}
 ) => {
   // we need to prepare the post body for only manual labels.
   if (isManualLabelFormData(formData)) {
+    const hostIds = formData.targetedHosts.map((host) => host.id);
+    if (membershipOnly) {
+      return { host_ids: hostIds };
+    }
     return {
       name: formData.name,
       description: formData.description,
-      host_ids: formData.targetedHosts.map((host) => host.id),
+      host_ids: hostIds,
     };
   }
   return formData;
@@ -179,10 +190,11 @@ export default {
 
   update: async (
     labelId: number,
-    formData: IDynamicLabelFormData | IManualLabelFormData
+    formData: IDynamicLabelFormData | IManualLabelFormData,
+    options?: IUpdateLabelOptions
   ): Promise<IUpdateLabelResponse> => {
     const { LABEL } = endpoints;
-    const updateAttrs = generateUpdateLabelBody(formData);
+    const updateAttrs = generateUpdateLabelBody(formData, options);
     return sendRequest("PATCH", LABEL(labelId), updateAttrs);
   },
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50527 

<img width="788" height="732" alt="image" src="https://github.com/user-attachments/assets/01d7a203-e1bc-4ba3-8418-fafab5367136" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * In GitOps mode, manually managed label host membership can now be added or removed directly in Fleet.
  * Label names and descriptions remain managed through YAML while host membership is edited in the UI.
  * Added guidance explaining how YAML host settings affect membership during the next GitOps run.

* **Bug Fixes**
  * Prevented membership updates from overwriting Git-managed label definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->