### PR TITLE
Fix confusing policy label modal wording (#51632)

### DIFF
--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tests.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tests.tsx
@@ -125,23 +125,23 @@ describe("getLabelModalData", () => {
   });
 
   describe("exclude labels", () => {
-    it("resolves labels_exclude_any with the 'exclude any' scope", () => {
+    it("resolves labels_exclude_any with the 'have any' scope", () => {
       const result = getLabelModalData(
         createMockPolicy({ labels_exclude_any: labels("A") })
       );
 
       expect(result.excludeLabels).toEqual(labels("A"));
-      expect(result.excludeScopeLabel).toBe("exclude any");
+      expect(result.excludeScopeLabel).toBe("have any");
       expect(result.includeLabels).toBeUndefined();
     });
 
-    it("resolves labels_exclude_all with the 'exclude all' scope", () => {
+    it("resolves labels_exclude_all with the 'have all' scope", () => {
       const result = getLabelModalData(
         createMockPolicy({ labels_exclude_all: labels("A") })
       );
 
       expect(result.excludeLabels).toEqual(labels("A"));
-      expect(result.excludeScopeLabel).toBe("exclude all");
+      expect(result.excludeScopeLabel).toBe("have all");
     });
 
     it("prefers labels_exclude_any over labels_exclude_all", () => {
@@ -153,7 +153,7 @@ describe("getLabelModalData", () => {
       );
 
       expect(result.excludeLabels).toEqual(labels("Any"));
-      expect(result.excludeScopeLabel).toBe("exclude any");
+      expect(result.excludeScopeLabel).toBe("have any");
     });
   });
 
@@ -167,7 +167,7 @@ describe("getLabelModalData", () => {
       );
 
       expect(result.includeScopeLabel).toBe("have any");
-      expect(result.excludeScopeLabel).toBe("exclude any");
+      expect(result.excludeScopeLabel).toBe("have any");
     });
 
     it("resolves include_any + exclude_all", () => {
@@ -179,7 +179,7 @@ describe("getLabelModalData", () => {
       );
 
       expect(result.includeScopeLabel).toBe("have any");
-      expect(result.excludeScopeLabel).toBe("exclude all");
+      expect(result.excludeScopeLabel).toBe("have all");
     });
 
     it("resolves include_all + exclude_any", () => {
@@ -191,7 +191,7 @@ describe("getLabelModalData", () => {
       );
 
       expect(result.includeScopeLabel).toBe("have all");
-      expect(result.excludeScopeLabel).toBe("exclude any");
+      expect(result.excludeScopeLabel).toBe("have any");
     });
 
     it("resolves include_all + exclude_all", () => {
@@ -203,7 +203,7 @@ describe("getLabelModalData", () => {
       );
 
       expect(result.includeScopeLabel).toBe("have all");
-      expect(result.excludeScopeLabel).toBe("exclude all");
+      expect(result.excludeScopeLabel).toBe("have all");
     });
   });
 });

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -90,10 +90,10 @@ export const getLabelModalData = (policy: IPolicy): ILabelModalData => {
   let excludeScopeLabel: string | undefined;
   if (policy.labels_exclude_any?.length) {
     excludeLabels = policy.labels_exclude_any;
-    excludeScopeLabel = "exclude any";
+    excludeScopeLabel = "have any";
   } else if (policy.labels_exclude_all?.length) {
     excludeLabels = policy.labels_exclude_all;
-    excludeScopeLabel = "exclude all";
+    excludeScopeLabel = "have all";
   }
 
   return { includeLabels, includeScopeLabel, excludeLabels, excludeScopeLabel };

--- a/frontend/pages/policies/details/components/PolicyLabelModal/PolicyLabelModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyLabelModal/PolicyLabelModal.tests.tsx
@@ -51,13 +51,13 @@ describe("PolicyLabelModal", () => {
     render(
       <PolicyLabelModal
         excludeLabels={EXCLUDE_LABELS}
-        excludeScopeLabel="exclude all"
+        excludeScopeLabel="have all"
         onClose={jest.fn()}
       />
     );
 
     expect(screen.getByText(/Policy excludes hosts that/)).toBeInTheDocument();
-    expect(screen.getByText("exclude all")).toBeInTheDocument();
+    expect(screen.getByText("have all")).toBeInTheDocument();
     expect(screen.getByText("Servers")).toBeInTheDocument();
 
     expect(
@@ -71,7 +71,7 @@ describe("PolicyLabelModal", () => {
         includeLabels={INCLUDE_LABELS}
         includeScopeLabel="have all"
         excludeLabels={EXCLUDE_LABELS}
-        excludeScopeLabel="exclude any"
+        excludeScopeLabel="have any"
         onClose={jest.fn()}
       />
     );
@@ -79,7 +79,7 @@ describe("PolicyLabelModal", () => {
     expect(screen.getByText(/Policy targets hosts that/)).toBeInTheDocument();
     expect(screen.getByText("have all")).toBeInTheDocument();
     expect(screen.getByText(/Policy excludes hosts that/)).toBeInTheDocument();
-    expect(screen.getByText("exclude any")).toBeInTheDocument();
+    expect(screen.getByText("have any")).toBeInTheDocument();
     expect(screen.getByText("Engineering")).toBeInTheDocument();
     expect(screen.getByText("Servers")).toBeInTheDocument();
   });


### PR DESCRIPTION
**Related issue:** Resolves #51632

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## AI

**AI:** Claude Code (claude-opus-4-6)

## Summary

The policy label modal previously read "Policy excludes hosts that **exclude any** of these labels" which is a confusing double negative. This changes the exclude scope labels from "exclude any"/"exclude all" to "have any"/"have all" so the modal now reads:

- "Policy excludes hosts that **have any** of these labels"
- "Policy excludes hosts that **have all** of these labels"

This matches the clearer pattern already used for include labels ("Policy targets hosts that **have any/all** of these labels").

### Changes (2 lines changed + test updates)

- `PolicyDetailsPage.tsx`: Changed `excludeScopeLabel` values from `"exclude any"`/`"exclude all"` to `"have any"`/`"have all"`
- `PolicyDetailsPage.tests.tsx`: Updated test expectations to match
- `PolicyLabelModal.tests.tsx`: Updated test fixture props and assertions to match

Generated by Claude on behalf of Sharon FDM.

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.