### PR TITLE
For R.C. - Fleet UI: Show Install/Uninstall for script-only packages with an uninstall script (#52747)

### DIFF
--- a/changes/51238-script-package-uninstall-action
+++ b/changes/51238-script-package-uninstall-action
@@ -1,0 +1,1 @@
+- Fixed script-only packages (.sh/.ps1/.py) with an uninstall script showing "Run/Rerun" and "Ran" instead of "Install/Reinstall", "Uninstall", and "Installed" on the host details and self-service pages.

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -507,10 +507,19 @@ const InstallStatusCell = ({
     const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(software.source);
 
     // Status groups and their click handlers
+    // Script packages route ALL install-side statuses (including "Installed"
+    // and "Install (pending)" for script packages with an uninstall script)
+    // to the script execution details modal, since the install is a script run.
     const displayStatusConfig = [
       {
         condition: isScriptPackage, // Still allows click even if no last install to see details modal
-        statuses: ["Failed", "Run (pending)", "Ran"],
+        statuses: [
+          "Failed",
+          "Run (pending)",
+          "Ran",
+          "Install (pending)",
+          "Installed",
+        ],
         onClick: onClickScriptStatus,
       },
       {

--- a/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
@@ -437,11 +437,16 @@ describe("getUiStatus", () => {
     expect(getUiStatus(sw, true)).toBe("uninstalled");
   });
 
-  describe("Script packages UI statuses", () => {
+  describe("Script packages UI statuses (no uninstall script)", () => {
+    const scriptOnlyPackage = createMockHostSoftwarePackage({
+      has_uninstall_script: false,
+    });
+
     it("returns 'failed_script' when status is failed_install and isScriptPackage", () => {
       const sw = createMockHostSoftware({
         status: "failed_install",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("failed_script");
     });
@@ -450,6 +455,7 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: "pending_install",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("running_script");
     });
@@ -458,6 +464,7 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: "pending_install",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, false)).toBe("pending_script");
     });
@@ -466,6 +473,7 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: "installed",
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("ran_script");
     });
@@ -474,8 +482,75 @@ describe("getUiStatus", () => {
       const sw = createMockHostSoftware({
         status: null,
         source: "sh_packages",
+        software_package: scriptOnlyPackage,
       });
       expect(getUiStatus(sw, true)).toBe("never_ran_script");
+    });
+  });
+
+  describe("Script packages with uninstall script use install statuses", () => {
+    const scriptPackageWithUninstall = createMockHostSoftwarePackage({
+      has_uninstall_script: true,
+    });
+
+    it("returns 'installed' (not 'ran_script') when a script-only package with an uninstall script is installed", () => {
+      const sw = createMockHostSoftware({
+        status: "installed",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("installed");
+    });
+
+    it("returns 'failed_install' (not 'failed_script') when a script-only package with an uninstall script fails to install", () => {
+      const sw = createMockHostSoftware({
+        status: "failed_install",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("failed_install");
+    });
+
+    it("returns 'installing' (not 'running_script') when a script-only package with an uninstall script is pending on an online host", () => {
+      const sw = createMockHostSoftware({
+        status: "pending_install",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("installing");
+    });
+
+    it("returns 'uninstalled' (not 'never_ran_script') when a script-only package with an uninstall script has no install record", () => {
+      const sw = createMockHostSoftware({
+        status: null,
+        source: "sh_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: null,
+      });
+      expect(getUiStatus(sw, true)).toBe("uninstalled");
+    });
+
+    it("returns 'failed_install' (not 'failed_install_installed') when installed_versions is an empty array", () => {
+      const sw = createMockHostSoftware({
+        status: "failed_install",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: [],
+      });
+      expect(getUiStatus(sw, true)).toBe("failed_install");
+    });
+
+    it("returns 'failed_uninstall' (not 'failed_uninstall_installed') when installed_versions is an empty array", () => {
+      const sw = createMockHostSoftware({
+        status: "failed_uninstall",
+        source: "ps1_packages",
+        software_package: scriptPackageWithUninstall,
+        installed_versions: [],
+      });
+      expect(getUiStatus(sw, true)).toBe("failed_uninstall");
     });
   });
 });

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -220,8 +220,11 @@ export const getUiStatus = (
   const recentUserActionDetected =
     recentlyUpdatedIds && recentlyUpdatedIds.has(software.id);
 
-  // 0. Script Packages states
-  if (isScriptPackage) {
+  // 0. Script Packages states — only when there's no uninstall script.
+  // Script packages with an uninstall script fall through to the regular
+  // install statuses so the UI shows Install/Reinstall/Uninstall/Installed
+  // instead of Run/Rerun/Ran.
+  if (isScriptPackage && !software.software_package?.has_uninstall_script) {
     if (status === "failed_install") {
       return "failed_script";
     }
@@ -238,8 +241,15 @@ export const getUiStatus = (
   }
 
   // 1. Failed install states
+  // Require length > 0: empty array is truthy, so `installed_versions: []`
+  // would otherwise render "Installed" for a package that was never installed
+  // (matters for script packages, which never populate installed_versions).
   if (status === "failed_install") {
-    if (installerVersion && installed_versions) {
+    if (
+      installerVersion &&
+      installed_versions &&
+      installed_versions.length > 0
+    ) {
       if (
         installed_versions.some(
           (iv) => compareVersions(iv.version, installerVersion) === -1
@@ -256,7 +266,11 @@ export const getUiStatus = (
 
   // 2. Failed uninstall states
   if (status === "failed_uninstall") {
-    if (installerVersion && installed_versions) {
+    if (
+      installerVersion &&
+      installed_versions &&
+      installed_versions.length > 0
+    ) {
       if (
         installed_versions.some(
           (iv) => compareVersions(iv.version, installerVersion) === -1


### PR DESCRIPTION
## Issue
Closes #51238

## Description
- Previously merged into `main` with #52747
- This is for the 4.92.0 R.C.

## Screenrecording
- Script-only .py with uninstall script: Install → Installed pill → Uninstall action visible, on host details and self-service


https://github.com/user-attachments/assets/03e10de0-d92c-4319-84cc-cd48d4ccde83


https://github.com/user-attachments/assets/c7347157-f755-4ba4-9619-3ce777ff7f99

Device end user


https://github.com/user-attachments/assets/7e8db0da-7293-4ff8-b0f5-7de00203e8a8



## Testing
- [x] QA'd all new/changed functionality manually