### PR TITLE
For R.C. - Fleet UI: Fix white page flash and redirect loop on logout (#52786)

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -250,7 +250,14 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
   ]);
 
   useEffect(() => {
-    if (authToken.get() && !location?.pathname.includes("/device/")) {
+    // Skip on `/logout`: this request races the session-destroy call, and
+    // a 401 back here triggers the hard-reload branch below, which flashes
+    // the viewport white in dark mode.
+    if (
+      authToken.get() &&
+      !location?.pathname.includes("/device/") &&
+      !location?.pathname.includes("/logout")
+    ) {
       fetchCurrentUser();
     }
   }, [location?.pathname, fetchCurrentUser]);

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -93,7 +93,12 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
   }, []);
 
   useEffect(() => {
+    // Requiring `authToken.get()` matters after a SPA-navigated logout: the
+    // AppContext user/teams/config linger from the destroyed session, and
+    // without this check LoginPage would keep pushing to /dashboard while
+    // AuthenticatedRoutes keeps pushing back to /login on a missing token.
     if (
+      authToken.get() &&
       availableTeams &&
       config &&
       currentUser &&

--- a/frontend/pages/LogoutPage/LogoutPage.tsx
+++ b/frontend/pages/LogoutPage/LogoutPage.tsx
@@ -1,8 +1,7 @@
-import { useContext, useEffect } from "react";
+import { useEffect } from "react";
 import { InjectedRouter } from "react-router";
 
 import PATHS from "router/paths";
-import { AppContext } from "context/app";
 import { notify } from "components/ToastNotification";
 import sessionsAPI from "services/entities/sessions";
 import authToken from "utilities/auth_token";
@@ -12,18 +11,15 @@ interface ILogoutPageProps {
 }
 
 const LogoutPage = ({ router }: ILogoutPageProps) => {
-  const { isSandboxMode } = useContext(AppContext);
-
   useEffect(() => {
     const logoutUser = async () => {
       try {
         await sessionsAPI.destroy();
         authToken.remove();
-        setTimeout(() => {
-          window.location.href = isSandboxMode
-            ? "https://www.fleetdm.com/logout"
-            : PATHS.ROOT;
-        }, 500);
+        // SPA-navigate, not a reload: on a reload body.dark-mode isn't set
+        // until bundle.js runs, so dark-mode users see the viewport flash
+        // white during the gap.
+        router.replace(PATHS.LOGIN);
       } catch (response) {
         console.error(response);
         router.goBack();
@@ -32,7 +28,7 @@ const LogoutPage = ({ router }: ILogoutPageProps) => {
     };
 
     logoutUser();
-  }, []);
+  }, [router]);
 
   return null;
 };


### PR DESCRIPTION
## Issue
Closes #52809

## Description
- Previously merged into `main` with #52786
- This is for the 4.92.0 R.C.


## Screenrecording
- Logout in dark mode: viewport stays dark end-to-end; login lands on dashboard on first try.


https://github.com/user-attachments/assets/e26034a2-8cf3-4331-888e-a4b2a218574e

- Confirmed fixed on Firefox


https://github.com/user-attachments/assets/5a8133cd-8fbe-4fe6-b03c-96500a40dfef


## Testing
- [x] QA'd all new/changed functionality manually