### PR TITLE
Cherry pick: Hide QR code for company-owned Android enrollment

### DIFF
--- a/changes/android-remove-company-owned-qr-code
+++ b/changes/android-remove-company-owned-qr-code
@@ -1,0 +1,1 @@
+- Removed the QR code from the "Add hosts" enrollment instructions for company-owned Android hosts, since fully-managed enrollment isn't done by scanning a code.

--- a/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
+++ b/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
@@ -216,7 +216,7 @@ describe("AddHostsModal", () => {
     expect(screen.getByTestId("enroll-qr-code")).toBeInTheDocument();
   });
 
-  it("updates the android qr code when the enrollment type changes", async () => {
+  it("hides the android qr code when company-owned is selected", async () => {
     const render = createCustomRenderer({
       withBackendMock: true,
       context: {
@@ -245,8 +245,7 @@ describe("AddHostsModal", () => {
         new RegExp(`/enroll\\?enroll_secret=${ENROLL_SECRET}$`)
       )
     ).toBeInTheDocument();
-    const workProfileQrData = getQrCodeData();
-    expect(workProfileQrData).toBeTruthy();
+    expect(getQrCodeData()).toBeTruthy();
 
     await user.click(screen.getByLabelText("Company-owned (fully-managed)"));
 
@@ -257,7 +256,10 @@ describe("AddHostsModal", () => {
         )
       )
     ).toBeInTheDocument();
-    expect(getQrCodeData()).not.toEqual(workProfileQrData);
+    expect(
+      screen.queryByText("To test, scan the QR code:")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("enroll-qr-code")).not.toBeInTheDocument();
   });
 
   it("updates the ios & ipadOS qr code when the enrollment type changes", async () => {

--- a/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
@@ -94,7 +94,7 @@ const AndroidPanel = ({ enrollSecret }: IAndroidPanelProps) => {
           name="enroll-link"
           value={url}
         />
-        <EnrollQrCode url={url} />
+        {enrollmentType === "workProfile" && <EnrollQrCode url={url} />}
       </form>
     </div>
   );


### PR DESCRIPTION
**Related issue:** #52688

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.
Before:
<img width="788" height="687" alt="Screenshot 2026-09-09 at 12 08 15 PM" src="https://github.com/user-attachments/assets/e827281f-8c5a-4040-9c3f-a3fbced256d8" />
After:
<img width="794" height="439" alt="Screenshot 2026-09-09 at 12 12 06 PM" src="https://github.com/user-attachments/assets/454d94df-63d5-49e7-8da7-7e72d18650f7" />

---

Direct backport of the company-owned Android QR code removal (not yet merged to `main` — cherry-picked from `leann-remove-company-owned-android-qr` onto this RC branch at the requester's direction).