### PR TITLE
Notify before patching - delay and forced installs

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2766,13 +2766,13 @@ func newEndUserNotificationsSchedule(
 		defaultInterval = 1 * time.Minute
 	)
 	logger = logger.With("cron", name)
-	// The countdown runs first because jobs run in registration order, so a reminder
+	// remind_and_install_due_patches runs first because jobs run in registration order, so a reminder
 	// it queues goes out in this minute rather than the next one.
 	s := schedule.New(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
-		schedule.WithJob("patch_notification_countdowns", func(ctx context.Context) error {
-			return patchNotificationKind.RunPatchNotificationCountdowns(ctx)
+		schedule.WithJob("remind_and_install_due_patches", func(ctx context.Context) error {
+			return patchNotificationKind.RemindAndInstallDuePatches(ctx)
 		}),
 		schedule.WithJob("expire_and_queue_notifications", func(ctx context.Context) error {
 			return notificationsSvc.ExpireAndQueueNotifications(ctx)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2766,16 +2766,14 @@ func newEndUserNotificationsSchedule(
 		defaultInterval = 1 * time.Minute
 	)
 	logger = logger.With("cron", name)
-	// remind_and_install_due_patches runs first because jobs run in registration order, so a reminder
-	// it queues goes out in this minute rather than the next one.
 	s := schedule.New(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
-		schedule.WithJob("remind_and_install_due_patches", func(ctx context.Context) error {
-			return patchNotificationKind.RemindAndInstallDuePatches(ctx)
-		}),
 		schedule.WithJob("expire_and_queue_notifications", func(ctx context.Context) error {
 			return notificationsSvc.ExpireAndQueueNotifications(ctx)
+		}),
+		schedule.WithJob("remind_and_install_due_patches", func(ctx context.Context) error {
+			return patchNotificationKind.RemindAndInstallDuePatches(ctx)
 		}),
 	)
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2758,6 +2758,7 @@ func newEndUserNotificationsSchedule(
 	instanceID string,
 	ds fleet.Datastore,
 	notificationsSvc notifications_api.Service,
+	patchNotificationKind service.PatchNotificationKind,
 	logger *slog.Logger,
 ) (*schedule.Schedule, error) {
 	const (
@@ -2765,9 +2766,14 @@ func newEndUserNotificationsSchedule(
 		defaultInterval = 1 * time.Minute
 	)
 	logger = logger.With("cron", name)
+	// The countdown runs first because jobs run in registration order, so a reminder
+	// it queues goes out in this minute rather than the next one.
 	s := schedule.New(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
+		schedule.WithJob("patch_notification_countdowns", func(ctx context.Context) error {
+			return patchNotificationKind.RunPatchNotificationCountdowns(ctx)
+		}),
 		schedule.WithJob("expire_and_queue_notifications", func(ctx context.Context) error {
 			return notificationsSvc.ExpireAndQueueNotifications(ctx)
 		}),

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	notifications_api "github.com/fleetdm/fleet/v4/server/notifications/api"
+	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"github.com/fleetdm/fleet/v4/server/service/schedule"
 )
@@ -50,6 +51,7 @@ type cronSchedulesDeps struct {
 	androidSvc             android.Service
 	activitySvc            activity_api.Service
 	notificationsSvc       notifications_api.Service
+	patchNotificationKind  service.PatchNotificationKind
 	acmeSvc                acme_api.Service
 	chartSvc               chart_api.Service
 	auditLogger            fleet.JSONLogger
@@ -359,7 +361,7 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 	})
 
 	deps.register("failed to register end user notifications schedule", func() (fleet.CronSchedule, error) {
-		return newEndUserNotificationsSchedule(ctx, deps.instanceID, deps.ds, deps.notificationsSvc, deps.logger)
+		return newEndUserNotificationsSchedule(ctx, deps.instanceID, deps.ds, deps.notificationsSvc, deps.patchNotificationKind, deps.logger)
 	})
 
 	if deps.config.Activity.EnableAuditLog {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -650,7 +650,8 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	// Inject the notifications bounded context into the main service
 	svc.SetNotificationsService(notificationsSvc)
 	// Register kinds here, and nowhere else.
-	notificationsSvc.RegisterKind(service.NewPatchNotificationKind(ds, svc, notificationsSvc, logger))
+	patchNotificationKind := service.NewPatchNotificationKind(ds, svc, notificationsSvc, logger)
+	notificationsSvc.RegisterKind(patchNotificationKind)
 
 	// Bootstrap ACME service module
 	acmeSigner := &acmeCSRSigner{signer: scepdepot.NewSigner(scepStorage, scepdepot.WithValidityDays(config.MDM.AppleSCEPSignerValidityDays), scepdepot.WithAllowRenewalDays(14))}
@@ -689,6 +690,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		androidSvc:             androidSvc,
 		activitySvc:            activitySvc,
 		notificationsSvc:       notificationsSvc,
+		patchNotificationKind:  patchNotificationKind,
 		acmeSvc:                acmeSvc,
 		chartSvc:               chartSvc,
 		auditLogger:            auditLogger,

--- a/server/datastore/mysql/migrations/tables/20260831184623_CreatePatchNotifications.go
+++ b/server/datastore/mysql/migrations/tables/20260831184623_CreatePatchNotifications.go
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS patch_notification_apps (
   software_title_id     INT UNSIGNED NOT NULL,
   software_installer_id INT UNSIGNED NULL DEFAULT NULL,
   install_queued        TINYINT(1) NOT NULL DEFAULT 0,
+  created_at            DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (notification_uuid, software_title_id),
   KEY idx_patch_notification_apps_policy (policy_id),
   KEY idx_patch_notification_apps_software_installer (software_installer_id),

--- a/server/datastore/mysql/migrations/tables/20260831184623_CreatePatchNotifications.go
+++ b/server/datastore/mysql/migrations/tables/20260831184623_CreatePatchNotifications.go
@@ -14,7 +14,6 @@ func Up_20260831184623(tx *sql.Tx) error {
 CREATE TABLE IF NOT EXISTS patch_notifications (
   notification_uuid VARCHAR(36) COLLATE utf8mb4_unicode_ci NOT NULL,
   install_at        DATETIME(6) NULL DEFAULT NULL,
-  reminder_sent_at  DATETIME(6) NULL DEFAULT NULL,
   PRIMARY KEY (notification_uuid),
   KEY idx_patch_notifications_install_at (install_at),
   CONSTRAINT fk_patch_notifications_notification_uuid FOREIGN KEY (notification_uuid)

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -236,28 +236,3 @@ WHERE pna.notification_uuid IN (?)
 	}
 	return byNotification, nil
 }
-
-// ListHostSoftwareVersionsForTitles reports what the given hosts have installed for the given titles.
-// Driven by the index on software.title_id, so it reads only the titles asked for instead of whole
-// inventories.
-func (ds *Datastore) ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
-	if len(hostIDs) == 0 || len(softwareTitleIDs) == 0 {
-		return nil, nil
-	}
-
-	stmt, args, err := sqlx.In(`
-SELECT hs.host_id, s.title_id, s.version
-FROM software s
-	JOIN host_software hs ON hs.software_id = s.id
-WHERE s.title_id IN (?) AND hs.host_id IN (?)
-`, softwareTitleIDs, hostIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "build list host software versions statement")
-	}
-
-	var versions []fleet.HostSoftwareTitleVersion
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &versions, stmt, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list host software versions for titles")
-	}
-	return versions, nil
-}

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -140,14 +140,29 @@ SELECT
 	neu.status,
 	neu.payload,
 	neu.displayed_at
-FROM patch_notifications pn
+FROM
+	patch_notifications pn
 	JOIN notifications_end_user neu ON neu.uuid = pn.notification_uuid
 -- a notification with no deadline was never displayed, so nothing is due for it yet
-WHERE pn.install_at IS NOT NULL
+WHERE
+	pn.install_at IS NOT NULL
 	AND pn.install_at <= ?
-	-- acted notifications have already been patched, failed and expired ones never will be
-	AND neu.status IN (?, ?)
-	-- a notice that has not been displayed is owed nothing, whatever its deadline says
+	-- failed and expired notifications will never be patched
+	AND (
+		-- still being delivered
+		neu.status IN (?, ?)
+		-- or acted on and left with an app whose install never queued
+		OR (
+			neu.status = ?
+			AND EXISTS (
+				SELECT 1
+				FROM patch_notification_apps unhandled
+				WHERE unhandled.notification_uuid = pn.notification_uuid AND unhandled.install_queued = 0
+			)
+		)
+	)
+	-- the reminder needs a displayed first notice and the install needs a displayed reminder, so a
+	-- null displayed_at rules out both
 	AND neu.displayed_at IS NOT NULL
 ORDER BY pn.install_at
 LIMIT ?
@@ -156,7 +171,8 @@ LIMIT ?
 	var due []fleet.PatchNotificationDue
 	// reads the primary because the display that sets the deadline can be seconds old
 	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &due, selectStmt,
-		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched, limit,
+		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched,
+		notifications_api.EndUserNotificationActed, limit,
 	); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list patch notifications due")
 	}

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -148,8 +148,7 @@ SELECT
 	neu.host_id,
 	neu.status,
 	neu.payload,
-	neu.displayed_at,
-	neu.created_at
+	neu.displayed_at
 FROM patch_notifications pn
 	JOIN notifications_end_user neu ON neu.uuid = pn.notification_uuid
 -- a notification with no deadline was never displayed, so nothing is due for it yet
@@ -157,6 +156,8 @@ WHERE pn.install_at IS NOT NULL
 	AND pn.install_at <= ?
 	-- acted notifications have already been patched, failed and expired ones never will be
 	AND neu.status IN (?, ?)
+	-- before install_at the only thing to do is remind, and only a displayed notification gets one
+	AND (pn.install_at <= NOW(6) OR (neu.status = ? AND neu.displayed_at IS NOT NULL))
 ORDER BY pn.install_at
 LIMIT ?
 `
@@ -164,7 +165,8 @@ LIMIT ?
 	var due []fleet.PatchNotificationDue
 	// reads the primary because the display that sets the deadline can be seconds old
 	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &due, selectStmt,
-		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched, limit,
+		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched,
+		notifications_api.EndUserNotificationDispatched, limit,
 	); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list patch notifications due")
 	}
@@ -216,6 +218,7 @@ SELECT
 	pna.software_title_id,
 	pna.software_installer_id,
 	pna.install_queued,
+	pna.created_at,
 	COALESCE(si.version, '') AS installer_version
 FROM patch_notification_apps pna
 	LEFT JOIN software_installers si ON si.id = pna.software_installer_id

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -80,6 +82,96 @@ WHERE notification_uuid = ? AND software_title_id IN (?)
 		return ctxerr.Wrap(ctx, err, "set patch notification apps queued")
 	}
 	return nil
+}
+
+func (ds *Datastore) DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error {
+	if len(softwareTitleIDs) == 0 {
+		return nil
+	}
+
+	stmt, args, err := sqlx.In(`
+DELETE FROM patch_notification_apps
+WHERE notification_uuid = ? AND software_title_id IN (?)
+`, notificationUUID, softwareTitleIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build delete patch notification apps statement")
+	}
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "delete patch notification apps")
+	}
+	return nil
+}
+
+// The COALESCE sets the deadline once, so a retry, a re-dispatch or a duplicate script result can't
+// move it. The insert covers a notification whose patch_notifications row was never written, which
+// would otherwise never be patched.
+func (ds *Datastore) SetPatchNotificationInstallAt(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error) {
+	const upsertStmt = `
+INSERT INTO patch_notifications (notification_uuid, install_at) VALUES (?, ?)
+ON DUPLICATE KEY UPDATE install_at = COALESCE(install_at, VALUES(install_at))
+`
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, upsertStmt, notificationUUID, installAt); err != nil {
+		return time.Time{}, ctxerr.Wrap(ctx, err, "set patch notification install at")
+	}
+
+	const selectStmt = `SELECT install_at FROM patch_notifications WHERE notification_uuid = ?`
+
+	var stored *time.Time
+	if err := sqlx.GetContext(ctx, ds.writer(ctx), &stored, selectStmt, notificationUUID); err != nil {
+		return time.Time{}, ctxerr.Wrap(ctx, err, "get patch notification install at")
+	}
+	// only reachable if the deadline was cleared between the two statements
+	if stored == nil {
+		return time.Time{}, ctxerr.Errorf(ctx, "patch notification %s has no install at", notificationUUID)
+	}
+	return *stored, nil
+}
+
+func (ds *Datastore) ResetPatchNotification(ctx context.Context, notificationUUID string) error {
+	const updateStmt = `UPDATE patch_notifications SET install_at = NULL WHERE notification_uuid = ?`
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, updateStmt, notificationUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "reset patch notification")
+	}
+	return nil
+}
+
+func (ds *Datastore) ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
+	// host_online uses the same expression as the online host filter, so the countdown and the host
+	// list agree on what offline means.
+	selectStmt := fmt.Sprintf(`
+SELECT
+	pn.notification_uuid,
+	pn.install_at,
+	eun.host_id,
+	eun.status,
+	eun.payload,
+	eun.displayed_at,
+	eun.created_at,
+	DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND) > NOW(6) AS host_online
+FROM patch_notifications pn
+	JOIN notifications_end_user eun ON eun.uuid = pn.notification_uuid
+	JOIN hosts h ON h.id = eun.host_id
+	LEFT JOIN host_seen_times hst ON hst.host_id = h.id
+-- a notification with no deadline was never displayed, so it has no countdown to run
+WHERE pn.install_at IS NOT NULL
+	AND pn.install_at <= ?
+	-- acted notifications have already been patched, failed and expired ones never will be
+	AND eun.status IN (?, ?)
+ORDER BY pn.install_at
+LIMIT ?
+`, fleet.OnlineIntervalBuffer)
+
+	var due []fleet.PatchNotificationDue
+	// primary, not the replica: the display that sets the deadline can be seconds old
+	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &due, selectStmt,
+		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched, limit,
+	); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list patch notifications due")
+	}
+	return due, nil
 }
 
 func (ds *Datastore) ListPatchNotificationApps(ctx context.Context, notificationUUID string) ([]fleet.PatchNotificationAppDetail, error) {

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -103,13 +102,16 @@ WHERE notification_uuid = ? AND software_title_id IN (?)
 	return nil
 }
 
-// The COALESCE sets the deadline once, so a retry, a re-dispatch or a duplicate script result can't
-// move it. The insert covers a notification whose patch_notifications row was never written, which
-// would otherwise never be patched.
 func (ds *Datastore) SetPatchNotificationInstallAt(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error) {
+	// GREATEST means the deadline only ever moves later, so every notice the end user actually sees
+	// gets its full lead time even when the toast takes a while to reach the screen.
+	//
+	// The insert makes the deadline recordable even for a notification with no patch_notifications
+	// row. Creation writes that row first so it is always there, and a notification without one would
+	// otherwise display to the end user and never be patched.
 	const upsertStmt = `
 INSERT INTO patch_notifications (notification_uuid, install_at) VALUES (?, ?)
-ON DUPLICATE KEY UPDATE install_at = COALESCE(install_at, VALUES(install_at))
+ON DUPLICATE KEY UPDATE install_at = GREATEST(COALESCE(install_at, VALUES(install_at)), VALUES(install_at))
 `
 
 	if _, err := ds.writer(ctx).ExecContext(ctx, upsertStmt, notificationUUID, installAt); err != nil {
@@ -139,9 +141,7 @@ func (ds *Datastore) ResetPatchNotification(ctx context.Context, notificationUUI
 }
 
 func (ds *Datastore) ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
-	// host_online uses the same expression as the online host filter, so the countdown and the host
-	// list agree on what offline means.
-	selectStmt := fmt.Sprintf(`
+	const selectStmt = `
 SELECT
 	pn.notification_uuid,
 	pn.install_at,
@@ -149,12 +149,9 @@ SELECT
 	eun.status,
 	eun.payload,
 	eun.displayed_at,
-	eun.created_at,
-	DATE_ADD(COALESCE(hst.seen_time, h.created_at), INTERVAL LEAST(h.distributed_interval, h.config_tls_refresh) + %d SECOND) > NOW(6) AS host_online
+	eun.created_at
 FROM patch_notifications pn
 	JOIN notifications_end_user eun ON eun.uuid = pn.notification_uuid
-	JOIN hosts h ON h.id = eun.host_id
-	LEFT JOIN host_seen_times hst ON hst.host_id = h.id
 -- a notification with no deadline was never displayed, so it has no countdown to run
 WHERE pn.install_at IS NOT NULL
 	AND pn.install_at <= ?
@@ -162,10 +159,10 @@ WHERE pn.install_at IS NOT NULL
 	AND eun.status IN (?, ?)
 ORDER BY pn.install_at
 LIMIT ?
-`, fleet.OnlineIntervalBuffer)
+`
 
 	var due []fleet.PatchNotificationDue
-	// primary, not the replica: the display that sets the deadline can be seconds old
+	// reads the primary because the display that sets the deadline can be seconds old
 	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &due, selectStmt,
 		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched, limit,
 	); err != nil {

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -152,7 +152,7 @@ SELECT
 	neu.created_at
 FROM patch_notifications pn
 	JOIN notifications_end_user neu ON neu.uuid = pn.notification_uuid
--- a notification with no deadline was never displayed, so it has no countdown to run
+-- a notification with no deadline was never displayed, so nothing is due for it yet
 WHERE pn.install_at IS NOT NULL
 	AND pn.install_at <= ?
 	-- acted notifications have already been patched, failed and expired ones never will be
@@ -203,7 +203,7 @@ ORDER BY display_name, pna.software_title_id
 }
 
 // ListPatchNotificationAppsForNotifications leaves out the names and icons the toast is built from,
-// because the countdown pass compares versions and queues installs without displaying anything.
+// because RemindAndInstallDuePatches matches versions and queues installs without displaying anything.
 func (ds *Datastore) ListPatchNotificationAppsForNotifications(ctx context.Context, notificationUUIDs []string) (map[string][]fleet.PatchNotificationAppDetail, error) {
 	if len(notificationUUIDs) == 0 {
 		return nil, nil

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -145,18 +145,18 @@ func (ds *Datastore) ListPatchNotificationsDue(ctx context.Context, cutoff time.
 SELECT
 	pn.notification_uuid,
 	pn.install_at,
-	eun.host_id,
-	eun.status,
-	eun.payload,
-	eun.displayed_at,
-	eun.created_at
+	neu.host_id,
+	neu.status,
+	neu.payload,
+	neu.displayed_at,
+	neu.created_at
 FROM patch_notifications pn
-	JOIN notifications_end_user eun ON eun.uuid = pn.notification_uuid
+	JOIN notifications_end_user neu ON neu.uuid = pn.notification_uuid
 -- a notification with no deadline was never displayed, so it has no countdown to run
 WHERE pn.install_at IS NOT NULL
 	AND pn.install_at <= ?
 	-- acted notifications have already been patched, failed and expired ones never will be
-	AND eun.status IN (?, ?)
+	AND neu.status IN (?, ?)
 ORDER BY pn.install_at
 LIMIT ?
 `
@@ -180,11 +180,13 @@ SELECT
 	pna.install_queued,
 	COALESCE(st.name, '') AS name,
 	COALESCE(NULLIF(stdn.display_name, ''), st.name, '') AS display_name,
+	COALESCE(si.version, '') AS installer_version,
 	sti.software_title_id IS NOT NULL AS has_icon
 FROM patch_notification_apps pna
 	JOIN notifications_end_user neu ON neu.uuid = pna.notification_uuid
 	JOIN hosts h ON h.id = neu.host_id
 	LEFT JOIN software_titles st ON st.id = pna.software_title_id
+	LEFT JOIN software_installers si ON si.id = pna.software_installer_id
 	LEFT JOIN software_title_display_names stdn
 		ON stdn.software_title_id = pna.software_title_id AND stdn.team_id = COALESCE(h.team_id, 0)
 	LEFT JOIN software_title_icons sti
@@ -198,4 +200,64 @@ ORDER BY display_name, pna.software_title_id
 		return nil, ctxerr.Wrap(ctx, err, "list patch notification apps")
 	}
 	return apps, nil
+}
+
+// ListPatchNotificationAppsForNotifications leaves out the names and icons the toast is built from,
+// because the countdown pass compares versions and queues installs without displaying anything.
+func (ds *Datastore) ListPatchNotificationAppsForNotifications(ctx context.Context, notificationUUIDs []string) (map[string][]fleet.PatchNotificationAppDetail, error) {
+	if len(notificationUUIDs) == 0 {
+		return nil, nil
+	}
+
+	stmt, args, err := sqlx.In(`
+SELECT
+	pna.notification_uuid,
+	pna.policy_id,
+	pna.software_title_id,
+	pna.software_installer_id,
+	pna.install_queued,
+	COALESCE(si.version, '') AS installer_version
+FROM patch_notification_apps pna
+	LEFT JOIN software_installers si ON si.id = pna.software_installer_id
+WHERE pna.notification_uuid IN (?)
+`, notificationUUIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build list patch notification apps for notifications statement")
+	}
+
+	var apps []fleet.PatchNotificationAppDetail
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &apps, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list patch notification apps for notifications")
+	}
+
+	byNotification := make(map[string][]fleet.PatchNotificationAppDetail, len(notificationUUIDs))
+	for _, app := range apps {
+		byNotification[app.NotificationUUID] = append(byNotification[app.NotificationUUID], app)
+	}
+	return byNotification, nil
+}
+
+// ListHostSoftwareVersionsForTitles reports what the given hosts have installed for the given titles.
+// Driven by the index on software.title_id, so it reads only the titles asked for instead of whole
+// inventories.
+func (ds *Datastore) ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+	if len(hostIDs) == 0 || len(softwareTitleIDs) == 0 {
+		return nil, nil
+	}
+
+	stmt, args, err := sqlx.In(`
+SELECT hs.host_id, s.title_id, s.version
+FROM software s
+	JOIN host_software hs ON hs.software_id = s.id
+WHERE s.title_id IN (?) AND hs.host_id IN (?)
+`, softwareTitleIDs, hostIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build list host software versions statement")
+	}
+
+	var versions []fleet.HostSoftwareTitleVersion
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &versions, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list host software versions for titles")
+	}
+	return versions, nil
 }

--- a/server/datastore/mysql/patch_notifications.go
+++ b/server/datastore/mysql/patch_notifications.go
@@ -131,15 +131,6 @@ ON DUPLICATE KEY UPDATE install_at = GREATEST(COALESCE(install_at, VALUES(instal
 	return *stored, nil
 }
 
-func (ds *Datastore) ResetPatchNotification(ctx context.Context, notificationUUID string) error {
-	const updateStmt = `UPDATE patch_notifications SET install_at = NULL WHERE notification_uuid = ?`
-
-	if _, err := ds.writer(ctx).ExecContext(ctx, updateStmt, notificationUUID); err != nil {
-		return ctxerr.Wrap(ctx, err, "reset patch notification")
-	}
-	return nil
-}
-
 func (ds *Datastore) ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
 	const selectStmt = `
 SELECT
@@ -156,8 +147,8 @@ WHERE pn.install_at IS NOT NULL
 	AND pn.install_at <= ?
 	-- acted notifications have already been patched, failed and expired ones never will be
 	AND neu.status IN (?, ?)
-	-- before install_at the only thing to do is remind, and only a displayed notification gets one
-	AND (pn.install_at <= NOW(6) OR (neu.status = ? AND neu.displayed_at IS NOT NULL))
+	-- a notice that has not been displayed is owed nothing, whatever its deadline says
+	AND neu.displayed_at IS NOT NULL
 ORDER BY pn.install_at
 LIMIT ?
 `
@@ -165,8 +156,7 @@ LIMIT ?
 	var due []fleet.PatchNotificationDue
 	// reads the primary because the display that sets the deadline can be seconds old
 	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &due, selectStmt,
-		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched,
-		notifications_api.EndUserNotificationDispatched, limit,
+		cutoff, notifications_api.EndUserNotificationPending, notifications_api.EndUserNotificationDispatched, limit,
 	); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list patch notifications due")
 	}

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -260,15 +260,22 @@ func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.WithinDuration(t, deadline, stored, time.Second)
 
-	// the reminder's display, a retry and a duplicate script result all report the
-	// deadline already stored rather than moving it
-	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline.Add(time.Hour))
+	// an earlier deadline never wins, so a duplicate script result or a retry can't cut the lead
+	// time the end user was promised short
+	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline.Add(-time.Minute))
 	require.NoError(t, err)
 	assert.WithinDuration(t, deadline, stored, time.Second)
 
+	// a later one does, which is how a reminder that took a while to reach the screen still leaves
+	// its full five minutes before the apps close
+	pushedOut := deadline.Add(time.Minute)
+	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, pushedOut)
+	require.NoError(t, err)
+	assert.WithinDuration(t, pushedOut, stored, time.Second)
+
 	// an offline host's restart clears the deadline, so its next display sets a fresh one
 	require.NoError(t, ds.ResetPatchNotification(ctx, notificationUUID))
-	restarted := deadline.Add(2 * time.Hour)
+	restarted := deadline.Add(-2 * time.Hour)
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, restarted)
 	require.NoError(t, err)
 	assert.WithinDuration(t, restarted, stored, time.Second)
@@ -305,22 +312,31 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 		})
 	}
 
-	// online: seen just now. offline: seen well past the online window.
-	onlineHost := test.NewHost(t, ds, "due-online", "", "due-online-key", "due-online-uuid", now)
-	offlineHost := test.NewHost(t, ds, "due-offline", "", "due-offline-key", "due-offline-uuid", now.Add(-2*time.Hour))
-	require.NoError(t, ds.MarkHostsSeen(ctx, []uint{offlineHost.ID}, now.Add(-2*time.Hour)))
+	markDisplayed := func(notificationUUID string) {
+		t.Helper()
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx,
+				`UPDATE notifications_end_user SET displayed_at = NOW(6) WHERE uuid = ?`, notificationUUID)
+			return err
+		})
+	}
+
+	host := test.NewHost(t, ds, "due-host", "", "due-key", "due-uuid", now)
 
 	// 6 minutes out is outside the reminder window, 5 minutes is on its edge, and
 	// the deadline itself is past due
-	tooEarly := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	tooEarly := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 	setInstallAt(tooEarly, now.Add(6*time.Minute))
-	inReminderWindow := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	markDisplayed(tooEarly)
+	inReminderWindow := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 	setInstallAt(inReminderWindow, now.Add(4*time.Minute))
-	pastDeadline := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	markDisplayed(inReminderWindow)
+	pastDeadline := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 	setInstallAt(pastDeadline, now.Add(-time.Minute))
+	markDisplayed(pastDeadline)
 
 	// a notification that was never displayed has no deadline to count down
-	noDeadline := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationPending, 0)
+	noDeadline := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 0)
 
 	// terminal notifications can no longer be patched, so they stay out of the batch
 	terminal := make([]string, 0, 3)
@@ -329,13 +345,15 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 		notifications_api.EndUserNotificationFailed,
 		notifications_api.EndUserNotificationExpired,
 	} {
-		notificationUUID := newPatchNotification(t, ds, onlineHost.ID, status, 1)
+		notificationUUID := newPatchNotification(t, ds, host.ID, status, 1)
 		setInstallAt(notificationUUID, now.Add(-time.Minute))
 		terminal = append(terminal, notificationUUID)
 	}
 
-	offline := newPatchNotification(t, ds, offlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
-	setInstallAt(offline, now.Add(-time.Minute))
+	// a re-dispatch clears displayed_at, so a notice on its way to the screen still
+	// has to come back: the pass restarts its countdown instead of patching
+	onTheWay := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
+	setInstallAt(onTheWay, now.Add(-time.Minute))
 
 	due, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 500)
 	require.NoError(t, err)
@@ -352,16 +370,15 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	}
 
 	require.Contains(t, byUUID, inReminderWindow)
-	assert.True(t, byUUID[inReminderWindow].HostOnline)
-	assert.Equal(t, onlineHost.ID, byUUID[inReminderWindow].HostID)
+	assert.Equal(t, host.ID, byUUID[inReminderWindow].HostID)
 	assert.Equal(t, notifications_api.EndUserNotificationDispatched, byUUID[inReminderWindow].Status)
+	assert.NotNil(t, byUUID[inReminderWindow].DisplayedAt)
 
 	require.Contains(t, byUUID, pastDeadline)
-	assert.True(t, byUUID[pastDeadline].HostOnline)
+	assert.NotNil(t, byUUID[pastDeadline].DisplayedAt)
 
-	// the offline host restarts its countdown instead of being patched on sight
-	require.Contains(t, byUUID, offline)
-	assert.False(t, byUUID[offline].HostOnline)
+	require.Contains(t, byUUID, onTheWay)
+	assert.Nil(t, byUUID[onTheWay].DisplayedAt)
 
 	// the batch is ordered by deadline, so the oldest countdown is handled first
 	require.Len(t, due, 3)

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -411,12 +411,31 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 		terminal = append(terminal, notificationUUID)
 	}
 
-	// a re-dispatched reminder has a null displayed_at until it is displayed, and nothing is owed on
-	// it either side of install_at
+	// a re-dispatched reminder has a null displayed_at until it is displayed, so it stays out of the
+	// batch either side of install_at
 	notDisplayed := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
 	setInstallAt(notDisplayed, now.Add(-time.Minute))
 	reminderQueued := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
 	setInstallAt(reminderQueued, now.Add(time.Minute))
+
+	// an app left unhandled on an acted notification is what a pass stopping between acting and
+	// queueing leaves behind, so this notification comes back to be finished
+	actedUnhandled := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationActed, 1)
+	setInstallAt(actedUnhandled, now.Add(-time.Minute))
+	markDisplayed(actedUnhandled)
+	require.NoError(t, ds.AddPatchNotificationApp(ctx, actedUnhandled, fleet.PatchNotificationApp{
+		SoftwareTitleID: newTestSoftwareTitle(t, ds, "Unhandled App"),
+	}))
+
+	// every app handled, so the acted notification has nothing left to queue
+	actedHandled := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationActed, 1)
+	setInstallAt(actedHandled, now.Add(-time.Minute))
+	markDisplayed(actedHandled)
+	handledTitleID := newTestSoftwareTitle(t, ds, "Handled App")
+	require.NoError(t, ds.AddPatchNotificationApp(ctx, actedHandled, fleet.PatchNotificationApp{
+		SoftwareTitleID: handledTitleID,
+	}))
+	require.NoError(t, ds.SetPatchNotificationAppsQueued(ctx, actedHandled, []uint{handledTitleID}))
 
 	due, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 500)
 	require.NoError(t, err)
@@ -425,11 +444,13 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	for _, notification := range due {
 		byUUID[notification.NotificationUUID] = notification
 	}
-	require.Len(t, byUUID, 2)
+	require.Len(t, byUUID, 3)
 	require.NotContains(t, byUUID, tooEarly)
 	require.NotContains(t, byUUID, noDeadline)
 	require.NotContains(t, byUUID, reminderQueued)
 	require.NotContains(t, byUUID, notDisplayed)
+	require.NotContains(t, byUUID, actedHandled)
+	require.Contains(t, byUUID, actedUnhandled)
 	for _, notificationUUID := range terminal {
 		require.NotContains(t, byUUID, notificationUUID)
 	}
@@ -443,7 +464,7 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	require.NotNil(t, byUUID[pastDeadline].DisplayedAt)
 
 	// the batch is ordered by deadline, so the oldest deadline is handled first
-	require.Len(t, due, 2)
+	require.Len(t, due, 3)
 	require.True(t, due[0].InstallAt.Before(due[len(due)-1].InstallAt))
 
 	// the limit caps the batch

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -23,6 +23,9 @@ func TestPatchNotifications(t *testing.T) {
 	}{
 		{"ExistsForApp", testPatchNotificationExistsForApp},
 		{"AddAndListApps", testPatchNotificationAddAndListApps},
+		{"DeleteApps", testPatchNotificationDeleteApps},
+		{"InstallAt", testPatchNotificationInstallAt},
+		{"ListDue", testPatchNotificationListDue},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -204,4 +207,168 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 			`SELECT COUNT(*) FROM patch_notifications WHERE notification_uuid = ?`, notificationUUID)
 	})
 	assert.Zero(t, remaining)
+}
+
+func testPatchNotificationDeleteApps(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	// a host with no fleet, since ListPatchNotificationApps joins display names on COALESCE(h.team_id, 0)
+	host := test.NewHost(t, ds, "delete-apps-host", "", "delete-apps-key", "delete-apps-uuid", time.Now())
+	require.Nil(t, host.TeamID)
+
+	notificationUUID := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
+	updated := newTestSoftwareTitle(t, ds, "Updated App")
+	stillOpen := newTestSoftwareTitle(t, ds, "Still Open App")
+	for _, titleID := range []uint{updated, stillOpen} {
+		require.NoError(t, ds.AddPatchNotificationApp(ctx, notificationUUID,
+			fleet.PatchNotificationApp{SoftwareTitleID: titleID}))
+	}
+
+	// deleting nothing leaves the notification's apps alone
+	require.NoError(t, ds.DeletePatchNotificationApps(ctx, notificationUUID, nil))
+	apps, err := ds.ListPatchNotificationApps(ctx, notificationUUID)
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+
+	// the app the end user already updated stops being listed, so the reminder can't name it
+	require.NoError(t, ds.DeletePatchNotificationApps(ctx, notificationUUID, []uint{updated}))
+	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
+	require.NoError(t, err)
+	require.Len(t, apps, 1)
+	assert.Equal(t, stillOpen, apps[0].SoftwareTitleID)
+
+	// another notification's copy of the same app is untouched
+	otherUUID := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
+	require.NoError(t, ds.AddPatchNotificationApp(ctx, otherUUID,
+		fleet.PatchNotificationApp{SoftwareTitleID: stillOpen}))
+	require.NoError(t, ds.DeletePatchNotificationApps(ctx, notificationUUID, []uint{stillOpen}))
+	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
+	require.NoError(t, err)
+	assert.Empty(t, apps)
+	apps, err = ds.ListPatchNotificationApps(ctx, otherUUID)
+	require.NoError(t, err)
+	assert.Len(t, apps, 1)
+}
+
+func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "install-at-host", "", "install-at-key", "install-at-uuid", time.Now())
+	notificationUUID := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
+
+	// the first display sets the deadline
+	deadline := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	stored, err := ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline)
+	require.NoError(t, err)
+	assert.WithinDuration(t, deadline, stored, time.Second)
+
+	// the reminder's display, a retry and a duplicate script result all report the
+	// deadline already stored rather than moving it
+	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline.Add(time.Hour))
+	require.NoError(t, err)
+	assert.WithinDuration(t, deadline, stored, time.Second)
+
+	// an offline host's restart clears the deadline, so its next display sets a fresh one
+	require.NoError(t, ds.ResetPatchNotification(ctx, notificationUUID))
+	restarted := deadline.Add(2 * time.Hour)
+	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, restarted)
+	require.NoError(t, err)
+	assert.WithinDuration(t, restarted, stored, time.Second)
+
+	// a notification whose patch_notifications row was never written still gets a
+	// deadline, otherwise it would never be patched
+	rowless := uuid.NewString()
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO notifications_end_user (uuid, host_id, status, kind, payload, expires_at)
+			VALUES (?, ?, ?, ?, '{}', NOW(6) + INTERVAL 1 DAY)`,
+			rowless, host.ID, notifications_api.EndUserNotificationDispatched, fleet.PatchNotificationKind)
+		return err
+	})
+	stored, err = ds.SetPatchNotificationInstallAt(ctx, rowless, deadline)
+	require.NoError(t, err)
+	assert.WithinDuration(t, deadline, stored, time.Second)
+
+	// a uuid no notification has cannot hold a deadline
+	_, err = ds.SetPatchNotificationInstallAt(ctx, "no-such-notification", deadline)
+	require.Error(t, err)
+}
+
+func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	now := time.Now().UTC()
+
+	setInstallAt := func(notificationUUID string, installAt time.Time) {
+		t.Helper()
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `UPDATE patch_notifications SET install_at = ? WHERE notification_uuid = ?`,
+				installAt, notificationUUID)
+			return err
+		})
+	}
+
+	// online: seen just now. offline: seen well past the online window.
+	onlineHost := test.NewHost(t, ds, "due-online", "", "due-online-key", "due-online-uuid", now)
+	offlineHost := test.NewHost(t, ds, "due-offline", "", "due-offline-key", "due-offline-uuid", now.Add(-2*time.Hour))
+	require.NoError(t, ds.MarkHostsSeen(ctx, []uint{offlineHost.ID}, now.Add(-2*time.Hour)))
+
+	// 6 minutes out is outside the reminder window, 5 minutes is on its edge, and
+	// the deadline itself is past due
+	tooEarly := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	setInstallAt(tooEarly, now.Add(6*time.Minute))
+	inReminderWindow := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	setInstallAt(inReminderWindow, now.Add(4*time.Minute))
+	pastDeadline := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	setInstallAt(pastDeadline, now.Add(-time.Minute))
+
+	// a notification that was never displayed has no deadline to count down
+	noDeadline := newPatchNotification(t, ds, onlineHost.ID, notifications_api.EndUserNotificationPending, 0)
+
+	// terminal notifications can no longer be patched, so they stay out of the batch
+	terminal := make([]string, 0, 3)
+	for _, status := range []string{
+		notifications_api.EndUserNotificationActed,
+		notifications_api.EndUserNotificationFailed,
+		notifications_api.EndUserNotificationExpired,
+	} {
+		notificationUUID := newPatchNotification(t, ds, onlineHost.ID, status, 1)
+		setInstallAt(notificationUUID, now.Add(-time.Minute))
+		terminal = append(terminal, notificationUUID)
+	}
+
+	offline := newPatchNotification(t, ds, offlineHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	setInstallAt(offline, now.Add(-time.Minute))
+
+	due, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 500)
+	require.NoError(t, err)
+
+	byUUID := make(map[string]fleet.PatchNotificationDue, len(due))
+	for _, notification := range due {
+		byUUID[notification.NotificationUUID] = notification
+	}
+	require.Len(t, byUUID, 3)
+	assert.NotContains(t, byUUID, tooEarly)
+	assert.NotContains(t, byUUID, noDeadline)
+	for _, notificationUUID := range terminal {
+		assert.NotContains(t, byUUID, notificationUUID)
+	}
+
+	require.Contains(t, byUUID, inReminderWindow)
+	assert.True(t, byUUID[inReminderWindow].HostOnline)
+	assert.Equal(t, onlineHost.ID, byUUID[inReminderWindow].HostID)
+	assert.Equal(t, notifications_api.EndUserNotificationDispatched, byUUID[inReminderWindow].Status)
+
+	require.Contains(t, byUUID, pastDeadline)
+	assert.True(t, byUUID[pastDeadline].HostOnline)
+
+	// the offline host restarts its countdown instead of being patched on sight
+	require.Contains(t, byUUID, offline)
+	assert.False(t, byUUID[offline].HostOnline)
+
+	// the batch is ordered by deadline, so the oldest countdown is handled first
+	require.Len(t, due, 3)
+	assert.True(t, due[0].InstallAt.Before(due[len(due)-1].InstallAt))
+
+	// the limit caps the batch
+	limited, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
 }

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -71,10 +71,9 @@ func testPatchNotificationExistsForApp(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "exists-host", "", "exists-key", "exists-uuid", time.Now())
 
-	// a pending or dispatched notification still has its apps to install, so a
-	// second skip for one of those apps is dropped. A failed or expired
-	// notification never installed them, and an acted notification already
-	// queued the installs, so a later skip starts a new notification either way.
+	// A pending or dispatched notification has not queued its install requests yet, so a second
+	// app-open skip for one of its software titles is dropped. A failed, expired or acted
+	// notification will not queue them, so a later skip creates a new notification instead.
 	stillCounts := map[string]bool{
 		notifications_api.EndUserNotificationPending:    true,
 		notifications_api.EndUserNotificationDispatched: true,
@@ -101,7 +100,7 @@ func testPatchNotificationExistsForApp(t *testing.T, ds *Datastore) {
 		assert.False(t, exists)
 	}
 
-	// an app that no notification lists
+	// a software title no notification lists at all is not reported as existing
 	exists, err := ds.PatchNotificationExistsForApp(ctx, host.ID, newTestSoftwareTitle(t, ds, "unlisted"))
 	require.NoError(t, err)
 	assert.False(t, exists)
@@ -148,8 +147,8 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 	// adding the same app again does nothing rather than failing
 	require.NoError(t, ds.AddPatchNotificationApp(ctx, notificationUUID, app))
 
-	// the host's fleet has no display name or icon for this software title, so
-	// the app's display name falls back to the software title's name
+	// the host's fleet has no display name or icon for this software title, so display_name falls
+	// back to the software title's name
 	apps, err := ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
@@ -233,8 +232,8 @@ func testPatchNotificationListAppsForNotifications(t *testing.T, ds *Datastore) 
 		SoftwareTitleID: installerTitleID, SoftwareInstallerID: &installerID,
 	}))
 
-	// an app whose installer was deleted still has to be listed, since Fleet has no version of it to
-	// match the host against
+	// Deleting an installer nulls patch_notification_apps.software_installer_id rather than removing
+	// the row, so the app still comes back, with no installer id and no installer version.
 	noInstallerTitleID := newTestSoftwareTitle(t, ds, "Uninstallable App")
 	noInstallerNotification := newPatchNotification(t, ds, noInstallerHost.ID, notifications_api.EndUserNotificationDispatched, 1)
 	require.NoError(t, ds.AddPatchNotificationApp(ctx, noInstallerNotification, fleet.PatchNotificationApp{
@@ -266,7 +265,7 @@ func testPatchNotificationListAppsForNotifications(t *testing.T, ds *Datastore) 
 	assert.Nil(t, noInstallerApp.SoftwareInstallerID)
 	assert.Empty(t, noInstallerApp.InstallerVersion)
 
-	// the flag that stops a second attempt queueing the same install twice
+	// install_queued, which stops a second attempt queueing the same install request
 	require.NoError(t, ds.SetPatchNotificationAppsQueued(ctx, installerNotification, []uint{installerTitleID}))
 	byNotification, err = ds.ListPatchNotificationAppsForNotifications(ctx, []string{installerNotification})
 	require.NoError(t, err)
@@ -298,14 +297,14 @@ func testPatchNotificationDeleteApps(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, apps, 2)
 
-	// the app the end user already updated stops being listed, so the reminder can't name it
+	// a software title that no longer needs updating stops being returned, so the reminder omits it
 	require.NoError(t, ds.DeletePatchNotificationApps(ctx, notificationUUID, []uint{updated}))
 	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
 	assert.Equal(t, stillOpen, apps[0].SoftwareTitleID)
 
-	// another notification's copy of the same app is untouched
+	// another notification's row for the same software title is untouched
 	otherUUID := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 	require.NoError(t, ds.AddPatchNotificationApp(ctx, otherUUID,
 		fleet.PatchNotificationApp{SoftwareTitleID: stillOpen}))
@@ -323,34 +322,33 @@ func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
 	host := test.NewHost(t, ds, "install-at-host", "", "install-at-key", "install-at-uuid", time.Now())
 	notificationUUID := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 
-	// the first display sets the deadline
+	// the first displayed_at sets install_at
 	deadline := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
 	stored, err := ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline)
 	require.NoError(t, err)
 	assert.WithinDuration(t, deadline, stored, time.Second)
 
-	// an earlier deadline never wins, so a duplicate script result or a retry can't cut the lead
-	// time the end user was promised short
+	// an earlier install_at is ignored, so a duplicate script result or a retry cannot shorten the
+	// lead time
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline.Add(-time.Minute))
 	require.NoError(t, err)
 	assert.WithinDuration(t, deadline, stored, time.Second)
 
-	// a later one does, which is how a reminder that took a while to reach the screen still leaves
-	// its full five minutes before the apps close
+	// a later install_at is stored, which is how a reminder displayed late keeps its full 5 minutes
 	pushedOut := deadline.Add(time.Minute)
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, pushedOut)
 	require.NoError(t, err)
 	assert.WithinDuration(t, pushedOut, stored, time.Second)
 
-	// an offline host's restart clears the deadline, so its next display sets a fresh one
+	// resetting clears install_at, so the next displayed_at sets it again
 	require.NoError(t, ds.ResetPatchNotification(ctx, notificationUUID))
 	restarted := deadline.Add(-2 * time.Hour)
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, restarted)
 	require.NoError(t, err)
 	assert.WithinDuration(t, restarted, stored, time.Second)
 
-	// a notification whose patch_notifications row was never written still gets a
-	// deadline, otherwise it would never be patched
+	// a notification with no patch_notifications row gets one inserted, so it still records an
+	// install_at
 	rowless := uuid.NewString()
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx, `
@@ -363,7 +361,7 @@ func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.WithinDuration(t, deadline, stored, time.Second)
 
-	// a uuid no notification has cannot hold a deadline
+	// a uuid with no notification row fails the foreign key
 	_, err = ds.SetPatchNotificationInstallAt(ctx, "no-such-notification", deadline)
 	require.Error(t, err)
 }
@@ -392,13 +390,13 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 
 	host := test.NewHost(t, ds, "due-host", "", "due-key", "due-uuid", now)
 
-	// 6 minutes out is outside the reminder window, 5 minutes is on its edge, and
-	// the deadline itself is past due
+	// A deadline 6 minutes out is outside the reminder window, one exactly 5 minutes out sits on its
+	// edge and is included, and one already past is due to install.
 	tooEarly := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 	setInstallAt(tooEarly, now.Add(6*time.Minute))
 	markDisplayed(tooEarly)
 	inReminderWindow := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
-	setInstallAt(inReminderWindow, now.Add(4*time.Minute))
+	setInstallAt(inReminderWindow, now.Add(5*time.Minute))
 	markDisplayed(inReminderWindow)
 	pastDeadline := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
 	setInstallAt(pastDeadline, now.Add(-time.Minute))
@@ -419,10 +417,10 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 		terminal = append(terminal, notificationUUID)
 	}
 
-	// a re-dispatch clears displayed_at, so a notice on its way to the screen still
-	// has to come back: the pass sends the first notice again instead of patching
-	onTheWay := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
-	setInstallAt(onTheWay, now.Add(-time.Minute))
+	// a re-dispatched notification is pending with a null displayed_at, and is still returned so the
+	// caller can clear install_at and re-dispatch the first notification
+	notDisplayed := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
+	setInstallAt(notDisplayed, now.Add(-time.Minute))
 
 	due, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 500)
 	require.NoError(t, err)
@@ -446,8 +444,8 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	require.Contains(t, byUUID, pastDeadline)
 	assert.NotNil(t, byUUID[pastDeadline].DisplayedAt)
 
-	require.Contains(t, byUUID, onTheWay)
-	assert.Nil(t, byUUID[onTheWay].DisplayedAt)
+	require.Contains(t, byUUID, notDisplayed)
+	assert.Nil(t, byUUID[notDisplayed].DisplayedAt)
 
 	// the batch is ordered by deadline, so the oldest deadline is handled first
 	require.Len(t, due, 3)

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,20 +89,20 @@ func testPatchNotificationExistsForApp(t *testing.T, ds *Datastore) {
 
 		exists, err := ds.PatchNotificationExistsForApp(ctx, host.ID, titleID)
 		require.NoError(t, err)
-		assert.Equal(t, wantExists, exists, "status %s", status)
+		require.Equal(t, wantExists, exists, "status %s", status)
 
 		// a notification is only ever for one host, so the same app on another
 		// host is not listed by this notification
 		otherHost := test.NewHost(t, ds, "other-host-"+status, "", "key-"+status, "uuid-"+status, time.Now())
 		exists, err = ds.PatchNotificationExistsForApp(ctx, otherHost.ID, titleID)
 		require.NoError(t, err)
-		assert.False(t, exists)
+		require.False(t, exists)
 	}
 
 	// a software title no notification lists at all is not reported as existing
 	exists, err := ds.PatchNotificationExistsForApp(ctx, host.ID, newTestSoftwareTitle(t, ds, "unlisted"))
 	require.NoError(t, err)
-	assert.False(t, exists)
+	require.False(t, exists)
 }
 
 func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
@@ -152,14 +151,14 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 	apps, err := ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
-	assert.Equal(t, titleID, apps[0].SoftwareTitleID)
+	require.Equal(t, titleID, apps[0].SoftwareTitleID)
 	require.NotNil(t, apps[0].PolicyID)
-	assert.Equal(t, policy.ID, *apps[0].PolicyID)
+	require.Equal(t, policy.ID, *apps[0].PolicyID)
 	require.NotNil(t, apps[0].SoftwareInstallerID)
-	assert.Equal(t, installerID, *apps[0].SoftwareInstallerID)
-	assert.Equal(t, "Notified App", apps[0].Name)
-	assert.Equal(t, "Notified App", apps[0].DisplayName)
-	assert.False(t, apps[0].HasIcon)
+	require.Equal(t, installerID, *apps[0].SoftwareInstallerID)
+	require.Equal(t, "Notified App", apps[0].Name)
+	require.Equal(t, "Notified App", apps[0].DisplayName)
+	require.False(t, apps[0].HasIcon)
 
 	// give the software title a display name and an icon in the host's fleet
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -176,8 +175,8 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
-	assert.Equal(t, "Notified App (renamed)", apps[0].DisplayName)
-	assert.True(t, apps[0].HasIcon)
+	require.Equal(t, "Notified App (renamed)", apps[0].DisplayName)
+	require.True(t, apps[0].HasIcon)
 
 	// deleting the policy sets patch_notification_apps.policy_id to null, and the app stays listed
 	_, err = ds.DeleteTeamPolicies(ctx, team.ID, []uint{policy.ID})
@@ -185,7 +184,7 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
-	assert.Nil(t, apps[0].PolicyID)
+	require.Nil(t, apps[0].PolicyID)
 
 	// deleting the software title cascades and deletes the patch_notification_apps row
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -194,7 +193,7 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 	})
 	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
-	assert.Empty(t, apps)
+	require.Empty(t, apps)
 
 	// deleting the notification cascades and deletes the patch_notifications row
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -206,7 +205,7 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 		return sqlx.GetContext(ctx, q, &remaining,
 			`SELECT COUNT(*) FROM patch_notifications WHERE notification_uuid = ?`, notificationUUID)
 	})
-	assert.Zero(t, remaining)
+	require.Zero(t, remaining)
 }
 
 func testPatchNotificationListAppsForNotifications(t *testing.T, ds *Datastore) {
@@ -251,30 +250,32 @@ func testPatchNotificationListAppsForNotifications(t *testing.T, ds *Datastore) 
 
 	require.Len(t, byNotification[installerNotification], 1)
 	installerApp := byNotification[installerNotification][0]
-	assert.Equal(t, installerNotification, installerApp.NotificationUUID)
-	assert.Equal(t, installerTitleID, installerApp.SoftwareTitleID)
+	require.Equal(t, installerNotification, installerApp.NotificationUUID)
+	require.Equal(t, installerTitleID, installerApp.SoftwareTitleID)
 	require.NotNil(t, installerApp.SoftwareInstallerID)
-	assert.Equal(t, installerID, *installerApp.SoftwareInstallerID)
-	assert.Equal(t, "2.0.0", installerApp.InstallerVersion)
-	assert.False(t, installerApp.InstallQueued)
+	require.Equal(t, installerID, *installerApp.SoftwareInstallerID)
+	require.Equal(t, "2.0.0", installerApp.InstallerVersion)
+	require.False(t, installerApp.InstallQueued)
+	// when the app was added, which is what an install has to be newer than to count as an update
+	require.WithinDuration(t, time.Now(), installerApp.CreatedAt, time.Minute)
 
 	require.Len(t, byNotification[noInstallerNotification], 1)
 	noInstallerApp := byNotification[noInstallerNotification][0]
-	assert.Equal(t, noInstallerNotification, noInstallerApp.NotificationUUID)
-	assert.Equal(t, noInstallerTitleID, noInstallerApp.SoftwareTitleID)
-	assert.Nil(t, noInstallerApp.SoftwareInstallerID)
-	assert.Empty(t, noInstallerApp.InstallerVersion)
+	require.Equal(t, noInstallerNotification, noInstallerApp.NotificationUUID)
+	require.Equal(t, noInstallerTitleID, noInstallerApp.SoftwareTitleID)
+	require.Nil(t, noInstallerApp.SoftwareInstallerID)
+	require.Empty(t, noInstallerApp.InstallerVersion)
 
 	// install_queued, which stops a second attempt queueing the same install request
 	require.NoError(t, ds.SetPatchNotificationAppsQueued(ctx, installerNotification, []uint{installerTitleID}))
 	byNotification, err = ds.ListPatchNotificationAppsForNotifications(ctx, []string{installerNotification})
 	require.NoError(t, err)
 	require.Len(t, byNotification[installerNotification], 1)
-	assert.True(t, byNotification[installerNotification][0].InstallQueued)
+	require.True(t, byNotification[installerNotification][0].InstallQueued)
 
 	byNotification, err = ds.ListPatchNotificationAppsForNotifications(ctx, nil)
 	require.NoError(t, err)
-	assert.Empty(t, byNotification)
+	require.Empty(t, byNotification)
 }
 
 func testPatchNotificationDeleteApps(t *testing.T, ds *Datastore) {
@@ -302,7 +303,7 @@ func testPatchNotificationDeleteApps(t *testing.T, ds *Datastore) {
 	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
 	require.Len(t, apps, 1)
-	assert.Equal(t, stillOpen, apps[0].SoftwareTitleID)
+	require.Equal(t, stillOpen, apps[0].SoftwareTitleID)
 
 	// another notification's row for the same software title is untouched
 	otherUUID := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationDispatched, 1)
@@ -311,10 +312,10 @@ func testPatchNotificationDeleteApps(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.DeletePatchNotificationApps(ctx, notificationUUID, []uint{stillOpen}))
 	apps, err = ds.ListPatchNotificationApps(ctx, notificationUUID)
 	require.NoError(t, err)
-	assert.Empty(t, apps)
+	require.Empty(t, apps)
 	apps, err = ds.ListPatchNotificationApps(ctx, otherUUID)
 	require.NoError(t, err)
-	assert.Len(t, apps, 1)
+	require.Len(t, apps, 1)
 }
 
 func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
@@ -326,26 +327,26 @@ func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
 	deadline := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
 	stored, err := ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline)
 	require.NoError(t, err)
-	assert.WithinDuration(t, deadline, stored, time.Second)
+	require.WithinDuration(t, deadline, stored, time.Second)
 
 	// an earlier install_at is ignored, so a duplicate script result or a retry cannot shorten the
 	// lead time
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, deadline.Add(-time.Minute))
 	require.NoError(t, err)
-	assert.WithinDuration(t, deadline, stored, time.Second)
+	require.WithinDuration(t, deadline, stored, time.Second)
 
 	// a later install_at is stored, which is how a reminder displayed late keeps its full 5 minutes
 	pushedOut := deadline.Add(time.Minute)
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, pushedOut)
 	require.NoError(t, err)
-	assert.WithinDuration(t, pushedOut, stored, time.Second)
+	require.WithinDuration(t, pushedOut, stored, time.Second)
 
 	// resetting clears install_at, so the next displayed_at sets it again
 	require.NoError(t, ds.ResetPatchNotification(ctx, notificationUUID))
 	restarted := deadline.Add(-2 * time.Hour)
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, restarted)
 	require.NoError(t, err)
-	assert.WithinDuration(t, restarted, stored, time.Second)
+	require.WithinDuration(t, restarted, stored, time.Second)
 
 	// a notification with no patch_notifications row gets one inserted, so it still records an
 	// install_at
@@ -359,7 +360,7 @@ func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
 	})
 	stored, err = ds.SetPatchNotificationInstallAt(ctx, rowless, deadline)
 	require.NoError(t, err)
-	assert.WithinDuration(t, deadline, stored, time.Second)
+	require.WithinDuration(t, deadline, stored, time.Second)
 
 	// a uuid with no notification row fails the foreign key
 	_, err = ds.SetPatchNotificationInstallAt(ctx, "no-such-notification", deadline)
@@ -422,6 +423,11 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	notDisplayed := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
 	setInstallAt(notDisplayed, now.Add(-time.Minute))
 
+	// its reminder already re-dispatched, so it is pending before install_at with nothing left to do
+	// until install_at passes
+	reminderQueued := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
+	setInstallAt(reminderQueued, now.Add(time.Minute))
+
 	due, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 500)
 	require.NoError(t, err)
 
@@ -430,26 +436,27 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 		byUUID[notification.NotificationUUID] = notification
 	}
 	require.Len(t, byUUID, 3)
-	assert.NotContains(t, byUUID, tooEarly)
-	assert.NotContains(t, byUUID, noDeadline)
+	require.NotContains(t, byUUID, tooEarly)
+	require.NotContains(t, byUUID, noDeadline)
+	require.NotContains(t, byUUID, reminderQueued)
 	for _, notificationUUID := range terminal {
-		assert.NotContains(t, byUUID, notificationUUID)
+		require.NotContains(t, byUUID, notificationUUID)
 	}
 
 	require.Contains(t, byUUID, inReminderWindow)
-	assert.Equal(t, host.ID, byUUID[inReminderWindow].HostID)
-	assert.Equal(t, notifications_api.EndUserNotificationDispatched, byUUID[inReminderWindow].Status)
-	assert.NotNil(t, byUUID[inReminderWindow].DisplayedAt)
+	require.Equal(t, host.ID, byUUID[inReminderWindow].HostID)
+	require.Equal(t, notifications_api.EndUserNotificationDispatched, byUUID[inReminderWindow].Status)
+	require.NotNil(t, byUUID[inReminderWindow].DisplayedAt)
 
 	require.Contains(t, byUUID, pastDeadline)
-	assert.NotNil(t, byUUID[pastDeadline].DisplayedAt)
+	require.NotNil(t, byUUID[pastDeadline].DisplayedAt)
 
 	require.Contains(t, byUUID, notDisplayed)
-	assert.Nil(t, byUUID[notDisplayed].DisplayedAt)
+	require.Nil(t, byUUID[notDisplayed].DisplayedAt)
 
 	// the batch is ordered by deadline, so the oldest deadline is handled first
 	require.Len(t, due, 3)
-	assert.True(t, due[0].InstallAt.Before(due[len(due)-1].InstallAt))
+	require.True(t, due[0].InstallAt.Before(due[len(due)-1].InstallAt))
 
 	// the limit caps the batch
 	limited, err := ds.ListPatchNotificationsDue(ctx, now.Add(5*time.Minute), 1)

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -341,13 +341,6 @@ func testPatchNotificationInstallAt(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.WithinDuration(t, pushedOut, stored, time.Second)
 
-	// resetting clears install_at, so the next displayed_at sets it again
-	require.NoError(t, ds.ResetPatchNotification(ctx, notificationUUID))
-	restarted := deadline.Add(-2 * time.Hour)
-	stored, err = ds.SetPatchNotificationInstallAt(ctx, notificationUUID, restarted)
-	require.NoError(t, err)
-	require.WithinDuration(t, restarted, stored, time.Second)
-
 	// a notification with no patch_notifications row gets one inserted, so it still records an
 	// install_at
 	rowless := uuid.NewString()
@@ -418,13 +411,10 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 		terminal = append(terminal, notificationUUID)
 	}
 
-	// a re-dispatched notification is pending with a null displayed_at, and is still returned so the
-	// caller can clear install_at and re-dispatch the first notification
+	// a re-dispatched reminder has a null displayed_at until it is displayed, and nothing is owed on
+	// it either side of install_at
 	notDisplayed := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
 	setInstallAt(notDisplayed, now.Add(-time.Minute))
-
-	// its reminder already re-dispatched, so it is pending before install_at with nothing left to do
-	// until install_at passes
 	reminderQueued := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
 	setInstallAt(reminderQueued, now.Add(time.Minute))
 
@@ -435,10 +425,11 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	for _, notification := range due {
 		byUUID[notification.NotificationUUID] = notification
 	}
-	require.Len(t, byUUID, 3)
+	require.Len(t, byUUID, 2)
 	require.NotContains(t, byUUID, tooEarly)
 	require.NotContains(t, byUUID, noDeadline)
 	require.NotContains(t, byUUID, reminderQueued)
+	require.NotContains(t, byUUID, notDisplayed)
 	for _, notificationUUID := range terminal {
 		require.NotContains(t, byUUID, notificationUUID)
 	}
@@ -451,11 +442,8 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	require.Contains(t, byUUID, pastDeadline)
 	require.NotNil(t, byUUID[pastDeadline].DisplayedAt)
 
-	require.Contains(t, byUUID, notDisplayed)
-	require.Nil(t, byUUID[notDisplayed].DisplayedAt)
-
 	// the batch is ordered by deadline, so the oldest deadline is handled first
-	require.Len(t, due, 3)
+	require.Len(t, due, 2)
 	require.True(t, due[0].InstallAt.Before(due[len(due)-1].InstallAt))
 
 	// the limit caps the batch

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -23,6 +23,7 @@ func TestPatchNotifications(t *testing.T) {
 	}{
 		{"ExistsForApp", testPatchNotificationExistsForApp},
 		{"AddAndListApps", testPatchNotificationAddAndListApps},
+		{"ListAppsForNotifications", testPatchNotificationListAppsForNotifications},
 		{"DeleteApps", testPatchNotificationDeleteApps},
 		{"InstallAt", testPatchNotificationInstallAt},
 		{"ListDue", testPatchNotificationListDue},
@@ -207,6 +208,74 @@ func testPatchNotificationAddAndListApps(t *testing.T, ds *Datastore) {
 			`SELECT COUNT(*) FROM patch_notifications WHERE notification_uuid = ?`, notificationUUID)
 	})
 	assert.Zero(t, remaining)
+}
+
+func testPatchNotificationListAppsForNotifications(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	installerHost := test.NewHost(t, ds, "batch-installer-host", "", "batch-installer-key", "batch-installer-uuid", time.Now())
+	noInstallerHost := test.NewHost(t, ds, "batch-no-installer-host", "", "batch-no-installer-key", "batch-no-installer-uuid", time.Now())
+
+	user, err := ds.NewUser(ctx, &fleet.User{
+		Name: "Admin", Password: []byte("p4ssw0rd.123"), Email: "patch-notification-batch@example.com",
+		GlobalRole: new(fleet.RoleAdmin),
+	})
+	require.NoError(t, err)
+
+	installerID, installerTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript: "echo", Filename: "batched.pkg", StorageID: uuid.NewString(),
+		Title: "Batched App", Version: "2.0.0", Source: "apps", Platform: "darwin",
+		UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	installerNotification := newPatchNotification(t, ds, installerHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	require.NoError(t, ds.AddPatchNotificationApp(ctx, installerNotification, fleet.PatchNotificationApp{
+		SoftwareTitleID: installerTitleID, SoftwareInstallerID: &installerID,
+	}))
+
+	// an app whose installer was deleted still has to be listed, since the countdown has no version to
+	// compare it against and cannot drop it
+	noInstallerTitleID := newTestSoftwareTitle(t, ds, "Uninstallable App")
+	noInstallerNotification := newPatchNotification(t, ds, noInstallerHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+	require.NoError(t, ds.AddPatchNotificationApp(ctx, noInstallerNotification, fleet.PatchNotificationApp{
+		SoftwareTitleID: noInstallerTitleID,
+	}))
+
+	// a notification listed with no apps of its own is left out of the map rather than keyed to nothing
+	emptyNotification := newPatchNotification(t, ds, installerHost.ID, notifications_api.EndUserNotificationDispatched, 1)
+
+	byNotification, err := ds.ListPatchNotificationAppsForNotifications(ctx,
+		[]string{installerNotification, noInstallerNotification, emptyNotification})
+	require.NoError(t, err)
+	require.Len(t, byNotification, 2)
+	require.NotContains(t, byNotification, emptyNotification)
+
+	require.Len(t, byNotification[installerNotification], 1)
+	installerApp := byNotification[installerNotification][0]
+	assert.Equal(t, installerNotification, installerApp.NotificationUUID)
+	assert.Equal(t, installerTitleID, installerApp.SoftwareTitleID)
+	require.NotNil(t, installerApp.SoftwareInstallerID)
+	assert.Equal(t, installerID, *installerApp.SoftwareInstallerID)
+	assert.Equal(t, "2.0.0", installerApp.InstallerVersion)
+	assert.False(t, installerApp.InstallQueued)
+
+	require.Len(t, byNotification[noInstallerNotification], 1)
+	noInstallerApp := byNotification[noInstallerNotification][0]
+	assert.Equal(t, noInstallerNotification, noInstallerApp.NotificationUUID)
+	assert.Equal(t, noInstallerTitleID, noInstallerApp.SoftwareTitleID)
+	assert.Nil(t, noInstallerApp.SoftwareInstallerID)
+	assert.Empty(t, noInstallerApp.InstallerVersion)
+
+	// the flag that stops a second attempt queueing the same install twice
+	require.NoError(t, ds.SetPatchNotificationAppsQueued(ctx, installerNotification, []uint{installerTitleID}))
+	byNotification, err = ds.ListPatchNotificationAppsForNotifications(ctx, []string{installerNotification})
+	require.NoError(t, err)
+	require.Len(t, byNotification[installerNotification], 1)
+	assert.True(t, byNotification[installerNotification][0].InstallQueued)
+
+	byNotification, err = ds.ListPatchNotificationAppsForNotifications(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, byNotification)
 }
 
 func testPatchNotificationDeleteApps(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/patch_notifications_test.go
+++ b/server/datastore/mysql/patch_notifications_test.go
@@ -233,8 +233,8 @@ func testPatchNotificationListAppsForNotifications(t *testing.T, ds *Datastore) 
 		SoftwareTitleID: installerTitleID, SoftwareInstallerID: &installerID,
 	}))
 
-	// an app whose installer was deleted still has to be listed, since the countdown has no version to
-	// compare it against and cannot drop it
+	// an app whose installer was deleted still has to be listed, since Fleet has no version of it to
+	// match the host against
 	noInstallerTitleID := newTestSoftwareTitle(t, ds, "Uninstallable App")
 	noInstallerNotification := newPatchNotification(t, ds, noInstallerHost.ID, notifications_api.EndUserNotificationDispatched, 1)
 	require.NoError(t, ds.AddPatchNotificationApp(ctx, noInstallerNotification, fleet.PatchNotificationApp{
@@ -420,7 +420,7 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	}
 
 	// a re-dispatch clears displayed_at, so a notice on its way to the screen still
-	// has to come back: the pass restarts its countdown instead of patching
+	// has to come back: the pass sends the first notice again instead of patching
 	onTheWay := newPatchNotification(t, ds, host.ID, notifications_api.EndUserNotificationPending, 1)
 	setInstallAt(onTheWay, now.Add(-time.Minute))
 
@@ -449,7 +449,7 @@ func testPatchNotificationListDue(t *testing.T, ds *Datastore) {
 	require.Contains(t, byUUID, onTheWay)
 	assert.Nil(t, byUUID[onTheWay].DisplayedAt)
 
-	// the batch is ordered by deadline, so the oldest countdown is handled first
+	// the batch is ordered by deadline, so the oldest deadline is handled first
 	require.Len(t, due, 3)
 	assert.True(t, due[0].InstallAt.Before(due[len(due)-1].InstallAt))
 

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -2779,7 +2779,6 @@ CREATE TABLE `patch_notification_apps` (
 CREATE TABLE `patch_notifications` (
   `notification_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `install_at` datetime(6) DEFAULT NULL,
-  `reminder_sent_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`notification_uuid`),
   KEY `idx_patch_notifications_install_at` (`install_at`),
   CONSTRAINT `fk_patch_notifications_notification_uuid` FOREIGN KEY (`notification_uuid`) REFERENCES `notifications_end_user` (`uuid`) ON DELETE CASCADE

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -2763,6 +2763,7 @@ CREATE TABLE `patch_notification_apps` (
   `software_title_id` int unsigned NOT NULL,
   `software_installer_id` int unsigned DEFAULT NULL,
   `install_queued` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`notification_uuid`,`software_title_id`),
   KEY `idx_patch_notification_apps_policy` (`policy_id`),
   KEY `idx_patch_notification_apps_software_installer` (`software_installer_id`),

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4869,3 +4869,118 @@ func deletePinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeam
 	`, globalOrTeamID, titleID)
 	return err
 }
+
+func (ds *Datastore) ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+	if len(hostIDs) == 0 || len(softwareTitleIDs) == 0 {
+		return nil, nil
+	}
+
+	// The install tables are indexed on (host_id, software_installer_id), so the titles are turned into
+	// installers first instead of filtering on the nullable software_title_id columns. Replaced
+	// installers come along, which is the point: an install that went through the installer a title had
+	// an hour ago still counts as that app being installed.
+	const installersStmt = `SELECT si.id, si.title_id FROM software_installers si WHERE si.title_id IN (?)`
+
+	stmt, args, err := sqlx.In(installersStmt, softwareTitleIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build list installers for titles statement")
+	}
+
+	var installerRows []struct {
+		InstallerID uint `db:"id"`
+		TitleID     uint `db:"title_id"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &installerRows, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list installers for titles")
+	}
+	if len(installerRows) == 0 {
+		return nil, nil
+	}
+
+	titleIDsByInstaller := make(map[uint]uint, len(installerRows))
+	installerIDs := make([]uint, 0, len(installerRows))
+	for _, row := range installerRows {
+		titleIDsByInstaller[row.InstallerID] = row.TitleID
+		installerIDs = append(installerIDs, row.InstallerID)
+	}
+	slices.Sort(installerIDs)
+
+	// Same two reads GetHostLastInstallData does, over every host and installer at once. The window
+	// picks the latest row per pair, which is what MAX(id) picks for a single pair. It orders by id
+	// alone rather than by created_at first the way hostSoftwareInstalls does, because created_at is
+	// taken when the inserting statement starts and can leave a row with a lower id carrying a later
+	// timestamp, and this has to pick the row GetHostLastInstallData would.
+	const pastStmt = `
+WITH latest_past_install AS (
+	SELECT
+		hsi.host_id,
+		hsi.software_installer_id,
+		hsi.execution_id,
+		hsi.status,
+		hsi.updated_at,
+		ROW_NUMBER() OVER (PARTITION BY hsi.host_id, hsi.software_installer_id ORDER BY hsi.id DESC) AS row_num
+	FROM host_software_installs hsi
+	WHERE hsi.canceled = 0 AND hsi.host_id IN (?) AND hsi.software_installer_id IN (?)
+)
+SELECT host_id, software_installer_id, execution_id, status, updated_at
+FROM latest_past_install
+WHERE row_num = 1
+`
+
+	const upcomingStmt = `
+WITH latest_upcoming_install AS (
+	SELECT
+		ua.host_id,
+		siua.software_installer_id,
+		ua.execution_id,
+		'pending_install' AS status,
+		ua.updated_at,
+		ROW_NUMBER() OVER (PARTITION BY ua.host_id, siua.software_installer_id ORDER BY ua.id DESC) AS row_num
+	FROM upcoming_activities ua
+		JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
+	WHERE ua.activity_type = 'software_install' AND ua.host_id IN (?) AND siua.software_installer_id IN (?)
+)
+SELECT host_id, software_installer_id, execution_id, status, updated_at
+FROM latest_upcoming_install
+WHERE row_num = 1
+`
+
+	type lastInstallRow struct {
+		HostID      uint                           `db:"host_id"`
+		InstallerID uint                           `db:"software_installer_id"`
+		ExecutionID string                         `db:"execution_id"`
+		Status      *fleet.SoftwareInstallerStatus `db:"status"`
+		UpdatedAt   time.Time                      `db:"updated_at"`
+	}
+
+	type hostInstaller struct {
+		hostID      uint
+		installerID uint
+	}
+
+	// Past first so upcoming lands on top of it, which is the precedence GetHostLastInstallData reads
+	// them in.
+	lastInstalls := make(map[hostInstaller]*fleet.HostLastInstallData)
+	for _, selectStmt := range []string{pastStmt, upcomingStmt} {
+		stmt, args, err := sqlx.In(selectStmt, hostIDs, installerIDs)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build list host last title install data statement")
+		}
+
+		var rows []lastInstallRow
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "list host last title install data")
+		}
+		for _, row := range rows {
+			lastInstalls[hostInstaller{hostID: row.HostID, installerID: row.InstallerID}] =
+				&fleet.HostLastInstallData{ExecutionID: row.ExecutionID, Status: row.Status, UpdatedAt: row.UpdatedAt}
+		}
+	}
+
+	installsByTitle := make(map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, len(lastInstalls))
+	for key, lastInstall := range lastInstalls {
+		titleKey := fleet.HostSoftwareTitleKey{HostID: key.hostID, SoftwareTitleID: titleIDsByInstaller[key.installerID]}
+		installsByTitle[titleKey] = append(installsByTitle[titleKey], lastInstall)
+	}
+	return installsByTitle, nil
+}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4870,7 +4870,7 @@ func deletePinnedVersionDB(ctx context.Context, ex sqlx.ExtContext, globalOrTeam
 	return err
 }
 
-func (ds *Datastore) ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+func (ds *Datastore) ListLastTitleInstallDataForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 	if len(hostIDs) == 0 || len(softwareTitleIDs) == 0 {
 		return nil, nil
 	}
@@ -4918,7 +4918,10 @@ WITH latest_past_install AS (
 		hsi.execution_id,
 		hsi.status,
 		hsi.updated_at,
-		ROW_NUMBER() OVER (PARTITION BY hsi.host_id, hsi.software_installer_id ORDER BY hsi.id DESC) AS row_num
+		ROW_NUMBER() OVER (
+			PARTITION BY hsi.host_id, hsi.software_installer_id
+			ORDER BY hsi.id DESC
+		) AS row_num
 	FROM host_software_installs hsi
 	WHERE hsi.canceled = 0 AND hsi.host_id IN (?) AND hsi.software_installer_id IN (?)
 )
@@ -4935,7 +4938,10 @@ WITH latest_upcoming_install AS (
 		ua.execution_id,
 		'pending_install' AS status,
 		ua.updated_at,
-		ROW_NUMBER() OVER (PARTITION BY ua.host_id, siua.software_installer_id ORDER BY ua.id DESC) AS row_num
+		ROW_NUMBER() OVER (
+			PARTITION BY ua.host_id, siua.software_installer_id
+			ORDER BY ua.id DESC
+		) AS row_num
 	FROM upcoming_activities ua
 		JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
 	WHERE ua.activity_type = 'software_install' AND ua.host_id IN (?) AND siua.software_installer_id IN (?)
@@ -4985,10 +4991,10 @@ WHERE row_num = 1
 	return installsByTitle, nil
 }
 
-// ListHostSoftwareVersionsForTitles reports what the given hosts have installed for the given titles.
+// ListSoftwareTitleVersionsForHosts reports what the given hosts have installed for the given titles.
 // Driven by the index on software.title_id, so it reads only the titles asked for instead of whole
 // inventories.
-func (ds *Datastore) ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+func (ds *Datastore) ListSoftwareTitleVersionsForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
 	if len(hostIDs) == 0 || len(softwareTitleIDs) == 0 {
 		return nil, nil
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4984,3 +4984,28 @@ WHERE row_num = 1
 	}
 	return installsByTitle, nil
 }
+
+// ListHostSoftwareVersionsForTitles reports what the given hosts have installed for the given titles.
+// Driven by the index on software.title_id, so it reads only the titles asked for instead of whole
+// inventories.
+func (ds *Datastore) ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+	if len(hostIDs) == 0 || len(softwareTitleIDs) == 0 {
+		return nil, nil
+	}
+
+	stmt, args, err := sqlx.In(`
+SELECT hs.host_id, s.title_id, s.version
+FROM software s
+	JOIN host_software hs ON hs.software_id = s.id
+WHERE s.title_id IN (?) AND hs.host_id IN (?)
+`, softwareTitleIDs, hostIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build list host software versions statement")
+	}
+
+	var versions []fleet.HostSoftwareTitleVersion
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &versions, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list host software versions for titles")
+	}
+	return versions, nil
+}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2709,7 +2709,8 @@ func (ds *Datastore) getLatestUpcomingInstall(ctx context.Context, hostID, insta
 SELECT
 	execution_id,
 	'pending_install' AS status,
-	updated_at
+	updated_at,
+	payload->'$.override_pre_install_query' IS TRUE AS override_pre_install_query
 FROM
 	upcoming_activities
 WHERE
@@ -2736,7 +2737,8 @@ func (ds *Datastore) getLatestPastInstall(ctx context.Context, hostID, installer
 SELECT
 	execution_id,
 	status,
-	updated_at
+	updated_at,
+	override_pre_install_query
 FROM
 	host_software_installs
 WHERE
@@ -4918,6 +4920,7 @@ WITH latest_past_install AS (
 		hsi.execution_id,
 		hsi.status,
 		hsi.updated_at,
+		hsi.override_pre_install_query,
 		ROW_NUMBER() OVER (
 			PARTITION BY hsi.host_id, hsi.software_installer_id
 			ORDER BY hsi.id DESC
@@ -4925,7 +4928,7 @@ WITH latest_past_install AS (
 	FROM host_software_installs hsi
 	WHERE hsi.canceled = 0 AND hsi.host_id IN (?) AND hsi.software_installer_id IN (?)
 )
-SELECT host_id, software_installer_id, execution_id, status, updated_at
+SELECT host_id, software_installer_id, execution_id, status, updated_at, override_pre_install_query
 FROM latest_past_install
 WHERE row_num = 1
 `
@@ -4938,6 +4941,7 @@ WITH latest_upcoming_install AS (
 		ua.execution_id,
 		'pending_install' AS status,
 		ua.updated_at,
+		ua.payload->'$.override_pre_install_query' IS TRUE AS override_pre_install_query,
 		ROW_NUMBER() OVER (
 			PARTITION BY ua.host_id, siua.software_installer_id
 			ORDER BY ua.id DESC
@@ -4946,17 +4950,18 @@ WITH latest_upcoming_install AS (
 		JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
 	WHERE ua.activity_type = 'software_install' AND ua.host_id IN (?) AND siua.software_installer_id IN (?)
 )
-SELECT host_id, software_installer_id, execution_id, status, updated_at
+SELECT host_id, software_installer_id, execution_id, status, updated_at, override_pre_install_query
 FROM latest_upcoming_install
 WHERE row_num = 1
 `
 
 	type lastInstallRow struct {
-		HostID      uint                           `db:"host_id"`
-		InstallerID uint                           `db:"software_installer_id"`
-		ExecutionID string                         `db:"execution_id"`
-		Status      *fleet.SoftwareInstallerStatus `db:"status"`
-		UpdatedAt   time.Time                      `db:"updated_at"`
+		HostID                  uint                           `db:"host_id"`
+		InstallerID             uint                           `db:"software_installer_id"`
+		ExecutionID             string                         `db:"execution_id"`
+		Status                  *fleet.SoftwareInstallerStatus `db:"status"`
+		UpdatedAt               time.Time                      `db:"updated_at"`
+		OverridePreInstallQuery bool                           `db:"override_pre_install_query"`
 	}
 
 	type hostInstaller struct {
@@ -4979,7 +4984,12 @@ WHERE row_num = 1
 		}
 		for _, row := range rows {
 			lastInstalls[hostInstaller{hostID: row.HostID, installerID: row.InstallerID}] =
-				&fleet.HostLastInstallData{ExecutionID: row.ExecutionID, Status: row.Status, UpdatedAt: row.UpdatedAt}
+				&fleet.HostLastInstallData{
+					ExecutionID:             row.ExecutionID,
+					Status:                  row.Status,
+					UpdatedAt:               row.UpdatedAt,
+					OverridePreInstallQuery: row.OverridePreInstallQuery,
+				}
 		}
 	}
 

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -3272,8 +3272,7 @@ func testListHostLastTitleInstallData(t *testing.T, ds *Datastore) {
 	installedHost := test.NewHost(t, ds, "title-installs-1", "1", "title-installs-1-key", "title-installs-1-uuid", time.Now(), test.WithTeamID(team.ID))
 	untouchedHost := test.NewHost(t, ds, "title-installs-2", "2", "title-installs-2-key", "title-installs-2-uuid", time.Now(), test.WithTeamID(team.ID))
 
-	// two installers of the same software title, which is what a package replaced during a countdown
-	// leaves behind
+	// two installers of the same software title, which is what replacing a package leaves behind
 	firstInstallerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 		InstallScript: "install", StorageID: uuid.NewString(), Filename: "first.pkg",
 		Title: "Replaced App", Version: "1.0.0", Source: "apps", Platform: "darwin",

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -47,7 +47,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"DeleteSoftwareInstallerRepointsPolicies", testDeleteSoftwareInstallerRepointsPolicies},
 		{"testDeletePendingSoftwareInstallsForPolicy", testDeletePendingSoftwareInstallsForPolicy},
 		{"GetHostLastInstallData", testGetHostLastInstallData},
-		{"ListHostLastTitleInstallData", testListHostLastTitleInstallData},
+		{"BatchInstallVerificationReads", testBatchInstallVerificationReads},
 		{"GetOrGenerateSoftwareInstallerTitleID", testGetOrGenerateSoftwareInstallerTitleID},
 		{"BatchSetSoftwareInstallersScopedViaLabels", testBatchSetSoftwareInstallersScopedViaLabels},
 		{"MatchOrCreateSoftwareInstallerWithAutomaticPolicies", testMatchOrCreateSoftwareInstallerWithAutomaticPolicies},
@@ -3263,7 +3263,9 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 	require.Nil(t, host2LastInstall)
 }
 
-func testListHostLastTitleInstallData(t *testing.T, ds *Datastore) {
+// The two batch reads RemindAndInstallDuePatches does before deciding whether a software title
+// still needs updating: the host's install requests, and the host's software inventory.
+func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "title-installs-team"})
@@ -3296,7 +3298,7 @@ func testListHostLastTitleInstallData(t *testing.T, ds *Datastore) {
 	}, nil)
 	require.NoError(t, err)
 
-	// the install through the second installer is still on its way
+	// the second install request is still pending
 	secondExecutionID, err := ds.InsertSoftwareInstallRequest(ctx, installedHost.ID, secondInstallerID, fleet.HostSoftwareInstallOptions{})
 	require.NoError(t, err)
 
@@ -3322,6 +3324,36 @@ func testListHostLastTitleInstallData(t *testing.T, ds *Datastore) {
 	installsByTitle, err = ds.ListHostLastTitleInstallData(ctx, []uint{installedHost.ID}, []uint{otherTitleID})
 	require.NoError(t, err)
 	assert.Empty(t, installsByTitle)
+
+	// The host's software inventory, the second read RemindAndInstallDuePatches does. A software
+	// title with two versions in host_software returns both rows, since the caller treats the title
+	// as up to date only when every version matches the installer's.
+	_, err = ds.UpdateHostSoftware(ctx, installedHost.ID, []fleet.Software{
+		{Name: "Replaced App", Version: "1.0.0", Source: "apps"},
+		{Name: "Replaced App", Version: "2.0.0", Source: "apps"},
+		{Name: "Unrelated App", Version: "9.9.9", Source: "apps"},
+	})
+	require.NoError(t, err)
+
+	versions, err := ds.ListHostSoftwareVersionsForTitles(ctx,
+		[]uint{installedHost.ID, untouchedHost.ID}, []uint{titleID})
+	require.NoError(t, err)
+
+	installedVersions := make([]string, 0, len(versions))
+	for _, version := range versions {
+		assert.Equal(t, installedHost.ID, version.HostID, "the host with no inventory reports nothing")
+		assert.Equal(t, titleID, version.SoftwareTitleID, "a title that wasn't asked for stays out")
+		installedVersions = append(installedVersions, version.Version)
+	}
+	assert.ElementsMatch(t, []string{"1.0.0", "2.0.0"}, installedVersions)
+
+	// neither an empty host list nor an empty title list reads the whole table
+	versions, err = ds.ListHostSoftwareVersionsForTitles(ctx, nil, []uint{titleID})
+	require.NoError(t, err)
+	assert.Empty(t, versions)
+	versions, err = ds.ListHostSoftwareVersionsForTitles(ctx, []uint{installedHost.ID}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, versions)
 }
 
 func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -47,6 +47,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"DeleteSoftwareInstallerRepointsPolicies", testDeleteSoftwareInstallerRepointsPolicies},
 		{"testDeletePendingSoftwareInstallsForPolicy", testDeletePendingSoftwareInstallsForPolicy},
 		{"GetHostLastInstallData", testGetHostLastInstallData},
+		{"ListHostLastTitleInstallData", testListHostLastTitleInstallData},
 		{"GetOrGenerateSoftwareInstallerTitleID", testGetOrGenerateSoftwareInstallerTitleID},
 		{"BatchSetSoftwareInstallersScopedViaLabels", testBatchSetSoftwareInstallersScopedViaLabels},
 		{"MatchOrCreateSoftwareInstallerWithAutomaticPolicies", testMatchOrCreateSoftwareInstallerWithAutomaticPolicies},
@@ -3260,6 +3261,68 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 	host2LastInstall, err = ds.GetHostLastInstallData(ctx, host2.ID, softwareInstallerID2)
 	require.NoError(t, err)
 	require.Nil(t, host2LastInstall)
+}
+
+func testListHostLastTitleInstallData(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "title-installs-team"})
+	require.NoError(t, err)
+	user := test.NewUser(t, ds, "Title Installs", "title-installs@example.com", true)
+	installedHost := test.NewHost(t, ds, "title-installs-1", "1", "title-installs-1-key", "title-installs-1-uuid", time.Now(), test.WithTeamID(team.ID))
+	untouchedHost := test.NewHost(t, ds, "title-installs-2", "2", "title-installs-2-key", "title-installs-2-uuid", time.Now(), test.WithTeamID(team.ID))
+
+	// two installers of the same software title, which is what a package replaced during a countdown
+	// leaves behind
+	firstInstallerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript: "install", StorageID: uuid.NewString(), Filename: "first.pkg",
+		Title: "Replaced App", Version: "1.0.0", Source: "apps", Platform: "darwin",
+		TeamID: &team.ID, UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+	secondInstallerID, secondTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript: "install", StorageID: uuid.NewString(), Filename: "second.pkg",
+		Title: "Replaced App", Version: "2.0.0", Source: "apps", Platform: "darwin",
+		TeamID: &team.ID, UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, firstInstallerID, secondInstallerID)
+	require.Equal(t, titleID, secondTitleID)
+
+	// the install through the first installer finished
+	firstExecutionID, err := ds.InsertSoftwareInstallRequest(ctx, installedHost.ID, firstInstallerID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+	_, err = ds.SetHostSoftwareInstallResult(ctx, &fleet.HostSoftwareInstallResultPayload{
+		HostID: installedHost.ID, InstallUUID: firstExecutionID, InstallScriptExitCode: new(0),
+	}, nil)
+	require.NoError(t, err)
+
+	// the install through the second installer is still on its way
+	secondExecutionID, err := ds.InsertSoftwareInstallRequest(ctx, installedHost.ID, secondInstallerID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+
+	installsByTitle, err := ds.ListHostLastTitleInstallData(ctx, []uint{installedHost.ID, untouchedHost.ID}, []uint{titleID})
+	require.NoError(t, err)
+
+	// both installs report against the one software title, whichever installer they went through
+	installs := installsByTitle[fleet.HostSoftwareTitleKey{HostID: installedHost.ID, SoftwareTitleID: titleID}]
+	require.Len(t, installs, 2)
+	statusByExecutionID := make(map[string]fleet.SoftwareInstallerStatus, len(installs))
+	for _, install := range installs {
+		require.NotNil(t, install.Status)
+		statusByExecutionID[install.ExecutionID] = *install.Status
+	}
+	assert.Equal(t, fleet.SoftwareInstalled, statusByExecutionID[firstExecutionID])
+	assert.Equal(t, fleet.SoftwareInstallPending, statusByExecutionID[secondExecutionID])
+
+	// a host Fleet has installed nothing on is left out
+	assert.NotContains(t, installsByTitle, fleet.HostSoftwareTitleKey{HostID: untouchedHost.ID, SoftwareTitleID: titleID})
+
+	// a software title with no installer of its own has nothing to report
+	otherTitleID := newTestSoftwareTitle(t, ds, "Uninstallable App")
+	installsByTitle, err = ds.ListHostLastTitleInstallData(ctx, []uint{installedHost.ID}, []uint{otherTitleID})
+	require.NoError(t, err)
+	assert.Empty(t, installsByTitle)
 }
 
 func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -3313,17 +3313,17 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 		require.NotNil(t, install.Status)
 		statusByExecutionID[install.ExecutionID] = *install.Status
 	}
-	assert.Equal(t, fleet.SoftwareInstalled, statusByExecutionID[firstExecutionID])
-	assert.Equal(t, fleet.SoftwareInstallPending, statusByExecutionID[secondExecutionID])
+	require.Equal(t, fleet.SoftwareInstalled, statusByExecutionID[firstExecutionID])
+	require.Equal(t, fleet.SoftwareInstallPending, statusByExecutionID[secondExecutionID])
 
 	// a host Fleet has installed nothing on is left out
-	assert.NotContains(t, installsByTitle, fleet.HostSoftwareTitleKey{HostID: untouchedHost.ID, SoftwareTitleID: titleID})
+	require.NotContains(t, installsByTitle, fleet.HostSoftwareTitleKey{HostID: untouchedHost.ID, SoftwareTitleID: titleID})
 
 	// a software title with no installer of its own has nothing to report
 	otherTitleID := newTestSoftwareTitle(t, ds, "Uninstallable App")
 	installsByTitle, err = ds.ListHostLastTitleInstallData(ctx, []uint{installedHost.ID}, []uint{otherTitleID})
 	require.NoError(t, err)
-	assert.Empty(t, installsByTitle)
+	require.Empty(t, installsByTitle)
 
 	// The host's software inventory, the second read RemindAndInstallDuePatches does. A software
 	// title with two versions in host_software returns both rows, since the caller treats the title
@@ -3341,19 +3341,19 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 
 	installedVersions := make([]string, 0, len(versions))
 	for _, version := range versions {
-		assert.Equal(t, installedHost.ID, version.HostID, "the host with no inventory reports nothing")
-		assert.Equal(t, titleID, version.SoftwareTitleID, "a title that wasn't asked for stays out")
+		require.Equal(t, installedHost.ID, version.HostID, "the host with no inventory reports nothing")
+		require.Equal(t, titleID, version.SoftwareTitleID, "a title that wasn't asked for stays out")
 		installedVersions = append(installedVersions, version.Version)
 	}
-	assert.ElementsMatch(t, []string{"1.0.0", "2.0.0"}, installedVersions)
+	require.ElementsMatch(t, []string{"1.0.0", "2.0.0"}, installedVersions)
 
 	// neither an empty host list nor an empty title list reads the whole table
 	versions, err = ds.ListHostSoftwareVersionsForTitles(ctx, nil, []uint{titleID})
 	require.NoError(t, err)
-	assert.Empty(t, versions)
+	require.Empty(t, versions)
 	versions, err = ds.ListHostSoftwareVersionsForTitles(ctx, []uint{installedHost.ID}, nil)
 	require.NoError(t, err)
-	assert.Empty(t, versions)
+	require.Empty(t, versions)
 }
 
 func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -3302,7 +3302,7 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 	secondExecutionID, err := ds.InsertSoftwareInstallRequest(ctx, installedHost.ID, secondInstallerID, fleet.HostSoftwareInstallOptions{})
 	require.NoError(t, err)
 
-	installsByTitle, err := ds.ListHostLastTitleInstallData(ctx, []uint{installedHost.ID, untouchedHost.ID}, []uint{titleID})
+	installsByTitle, err := ds.ListLastTitleInstallDataForHosts(ctx, []uint{installedHost.ID, untouchedHost.ID}, []uint{titleID})
 	require.NoError(t, err)
 
 	// both installs report against the one software title, whichever installer they went through
@@ -3321,7 +3321,7 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 
 	// a software title with no installer of its own has nothing to report
 	otherTitleID := newTestSoftwareTitle(t, ds, "Uninstallable App")
-	installsByTitle, err = ds.ListHostLastTitleInstallData(ctx, []uint{installedHost.ID}, []uint{otherTitleID})
+	installsByTitle, err = ds.ListLastTitleInstallDataForHosts(ctx, []uint{installedHost.ID}, []uint{otherTitleID})
 	require.NoError(t, err)
 	require.Empty(t, installsByTitle)
 
@@ -3335,7 +3335,7 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	versions, err := ds.ListHostSoftwareVersionsForTitles(ctx,
+	versions, err := ds.ListSoftwareTitleVersionsForHosts(ctx,
 		[]uint{installedHost.ID, untouchedHost.ID}, []uint{titleID})
 	require.NoError(t, err)
 
@@ -3348,10 +3348,10 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 	require.ElementsMatch(t, []string{"1.0.0", "2.0.0"}, installedVersions)
 
 	// neither an empty host list nor an empty title list reads the whole table
-	versions, err = ds.ListHostSoftwareVersionsForTitles(ctx, nil, []uint{titleID})
+	versions, err = ds.ListSoftwareTitleVersionsForHosts(ctx, nil, []uint{titleID})
 	require.NoError(t, err)
 	require.Empty(t, versions)
-	versions, err = ds.ListHostSoftwareVersionsForTitles(ctx, []uint{installedHost.ID}, nil)
+	versions, err = ds.ListSoftwareTitleVersionsForHosts(ctx, []uint{installedHost.ID}, nil)
 	require.NoError(t, err)
 	require.Empty(t, versions)
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -1101,9 +1101,11 @@ func testGetSoftwareInstallResult(t *testing.T, ds *Datastore) {
 			res, err := ds.GetSoftwareInstallResults(ctx, installUUID)
 			require.NoError(t, err)
 			require.NotNil(t, res.UpdatedAt)
-			require.Less(t, beforeInstallRequest, res.CreatedAt)
+			// MySQL writes these off its own clock, which can sit a fraction of a millisecond behind
+			// the one time.Now() reads, so compare with a tolerance rather than strictly ordering them
+			require.WithinDuration(t, beforeInstallRequest, res.CreatedAt, time.Minute)
 			createdAt := res.CreatedAt
-			require.Less(t, beforeInstallRequest, *res.UpdatedAt)
+			require.WithinDuration(t, beforeInstallRequest, *res.UpdatedAt, time.Minute)
 
 			beforeInstallResult := time.Now()
 			_, err = ds.SetHostSoftwareInstallResult(ctx, &fleet.HostSoftwareInstallResultPayload{
@@ -1168,7 +1170,7 @@ func testGetSoftwareInstallResult(t *testing.T, ds *Datastore) {
 			require.NotNil(t, res.CreatedAt)
 			require.Equal(t, createdAt, res.CreatedAt)
 			require.NotNil(t, res.UpdatedAt)
-			require.Less(t, beforeInstallResult, *res.UpdatedAt)
+			require.WithinDuration(t, beforeInstallResult, *res.UpdatedAt, time.Minute)
 		})
 	}
 }
@@ -3298,8 +3300,9 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 	}, nil)
 	require.NoError(t, err)
 
-	// the second install request is still pending
-	secondExecutionID, err := ds.InsertSoftwareInstallRequest(ctx, installedHost.ID, secondInstallerID, fleet.HostSoftwareInstallOptions{})
+	// the second install request is still pending, and runs the app open query as a policy install does
+	secondExecutionID, err := ds.InsertSoftwareInstallRequest(ctx, installedHost.ID, secondInstallerID,
+		fleet.HostSoftwareInstallOptions{OverridePreInstallQuery: true})
 	require.NoError(t, err)
 
 	installsByTitle, err := ds.ListLastTitleInstallDataForHosts(ctx, []uint{installedHost.ID, untouchedHost.ID}, []uint{titleID})
@@ -3309,12 +3312,19 @@ func testBatchInstallVerificationReads(t *testing.T, ds *Datastore) {
 	installs := installsByTitle[fleet.HostSoftwareTitleKey{HostID: installedHost.ID, SoftwareTitleID: titleID}]
 	require.Len(t, installs, 2)
 	statusByExecutionID := make(map[string]fleet.SoftwareInstallerStatus, len(installs))
+	overrideByExecutionID := make(map[string]bool, len(installs))
 	for _, install := range installs {
 		require.NotNil(t, install.Status)
 		statusByExecutionID[install.ExecutionID] = *install.Status
+		overrideByExecutionID[install.ExecutionID] = install.OverridePreInstallQuery
 	}
 	require.Equal(t, fleet.SoftwareInstalled, statusByExecutionID[firstExecutionID])
 	require.Equal(t, fleet.SoftwareInstallPending, statusByExecutionID[secondExecutionID])
+
+	// the patch countdown reads override_pre_install_query to tell an install that would skip while
+	// the app is open from one it can wait on
+	require.False(t, overrideByExecutionID[firstExecutionID])
+	require.True(t, overrideByExecutionID[secondExecutionID])
 
 	// a host Fleet has installed nothing on is left out
 	require.NotContains(t, installsByTitle, fleet.HostSoftwareTitleKey{HostID: untouchedHost.ID, SoftwareTitleID: titleID})

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -767,9 +767,6 @@ type Datastore interface {
 	// notifications at once, keyed by notification uuid, without the names and
 	// icons the toast is displayed with.
 	ListPatchNotificationAppsForNotifications(ctx context.Context, notificationUUIDs []string) (map[string][]PatchNotificationAppDetail, error)
-	// ListHostSoftwareVersionsForTitles reports what the given hosts have installed
-	// for the given software titles.
-	ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]HostSoftwareTitleVersion, error)
 	// DeletePatchNotificationApps drops apps from a notification, so the reminder
 	// stops naming an app the end user already updated.
 	DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
@@ -2992,6 +2989,9 @@ type Datastore interface {
 	// titles at once, grouped by title so an install that went through an installer
 	// since replaced still counts. Same precedence: an upcoming install wins over a past one.
 	ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[HostSoftwareTitleKey][]*HostLastInstallData, error)
+	// ListHostSoftwareVersionsForTitles reports what the given hosts have installed
+	// for the given software titles.
+	ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]HostSoftwareTitleVersion, error)
 
 	// MatchOrCreateSoftwareInstaller matches or creates a new software installer.
 	MatchOrCreateSoftwareInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (installerID, titleID uint, err error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -776,8 +776,8 @@ type Datastore interface {
 	// ResetPatchNotification clears the deadline, so the next display sets a new one.
 	ResetPatchNotification(ctx context.Context, notificationUUID string) error
 	// ListPatchNotificationsDue returns the notifications still being delivered
-	// whose deadline is at or before the cutoff, along with whether their host is
-	// online.
+	// whose install_at is at or before the cutoff and that the caller can act on:
+	// past install_at, or displayed and waiting on their reminder.
 	ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]PatchNotificationDue, error)
 
 	///////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -763,6 +763,13 @@ type Datastore interface {
 	// ListPatchNotificationApps returns a notification's apps, with names and icons
 	// for the host's fleet.
 	ListPatchNotificationApps(ctx context.Context, notificationUUID string) ([]PatchNotificationAppDetail, error)
+	// ListPatchNotificationAppsForNotifications returns the apps of several
+	// notifications at once, keyed by notification uuid, without the names and
+	// icons the toast is displayed with.
+	ListPatchNotificationAppsForNotifications(ctx context.Context, notificationUUIDs []string) (map[string][]PatchNotificationAppDetail, error)
+	// ListHostSoftwareVersionsForTitles reports what the given hosts have installed
+	// for the given software titles.
+	ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]HostSoftwareTitleVersion, error)
 	// DeletePatchNotificationApps drops apps from a notification, so the reminder
 	// stops naming an app the end user already updated.
 	DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
@@ -2981,6 +2988,10 @@ type Datastore interface {
 
 	// GetHostLastInstallData returns the data for the last installation of a package on a host.
 	GetHostLastInstallData(ctx context.Context, hostID, installerID uint) (*HostLastInstallData, error)
+	// ListHostLastTitleInstallData is GetHostLastInstallData for many hosts and software
+	// titles at once, grouped by title so an install that went through an installer
+	// since replaced still counts. Same precedence: an upcoming install wins over a past one.
+	ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[HostSoftwareTitleKey][]*HostLastInstallData, error)
 
 	// MatchOrCreateSoftwareInstaller matches or creates a new software installer.
 	MatchOrCreateSoftwareInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (installerID, titleID uint, err error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2985,13 +2985,13 @@ type Datastore interface {
 
 	// GetHostLastInstallData returns the data for the last installation of a package on a host.
 	GetHostLastInstallData(ctx context.Context, hostID, installerID uint) (*HostLastInstallData, error)
-	// ListHostLastTitleInstallData is GetHostLastInstallData for many hosts and software
+	// ListLastTitleInstallDataForHosts is GetHostLastInstallData for many hosts and software
 	// titles at once, grouped by title so an install that went through an installer
 	// since replaced still counts. Same precedence: an upcoming install wins over a past one.
-	ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[HostSoftwareTitleKey][]*HostLastInstallData, error)
-	// ListHostSoftwareVersionsForTitles reports what the given hosts have installed
+	ListLastTitleInstallDataForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[HostSoftwareTitleKey][]*HostLastInstallData, error)
+	// ListSoftwareTitleVersionsForHosts reports what the given hosts have installed
 	// for the given software titles.
-	ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]HostSoftwareTitleVersion, error)
+	ListSoftwareTitleVersionsForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]HostSoftwareTitleVersion, error)
 
 	// MatchOrCreateSoftwareInstaller matches or creates a new software installer.
 	MatchOrCreateSoftwareInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (installerID, titleID uint, err error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -763,6 +763,18 @@ type Datastore interface {
 	// ListPatchNotificationApps returns a notification's apps, with names and icons
 	// for the host's fleet.
 	ListPatchNotificationApps(ctx context.Context, notificationUUID string) ([]PatchNotificationAppDetail, error)
+	// DeletePatchNotificationApps drops apps from a notification, so the reminder
+	// stops naming an app the end user already updated.
+	DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
+	// SetPatchNotificationInstallAt records when the patch is forced, unless the
+	// notification already has a deadline, and returns the deadline in effect.
+	SetPatchNotificationInstallAt(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
+	// ResetPatchNotification clears the deadline, so the next display sets a new one.
+	ResetPatchNotification(ctx context.Context, notificationUUID string) error
+	// ListPatchNotificationsDue returns the notifications still being delivered
+	// whose deadline is at or before the cutoff, along with whether their host is
+	// online.
+	ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]PatchNotificationDue, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// SoftwareStore

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -766,8 +766,8 @@ type Datastore interface {
 	// DeletePatchNotificationApps drops apps from a notification, so the reminder
 	// stops naming an app the end user already updated.
 	DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
-	// SetPatchNotificationInstallAt records when the patch is forced, unless the
-	// notification already has a deadline, and returns the deadline in effect.
+	// SetPatchNotificationInstallAt moves when the patch is forced out to installAt,
+	// never earlier, and returns the deadline in effect.
 	SetPatchNotificationInstallAt(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
 	// ResetPatchNotification clears the deadline, so the next display sets a new one.
 	ResetPatchNotification(ctx context.Context, notificationUUID string) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -773,8 +773,6 @@ type Datastore interface {
 	// SetPatchNotificationInstallAt moves when the patch is forced out to installAt,
 	// never earlier, and returns the deadline in effect.
 	SetPatchNotificationInstallAt(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
-	// ResetPatchNotification clears the deadline, so the next display sets a new one.
-	ResetPatchNotification(ctx context.Context, notificationUUID string) error
 	// ListPatchNotificationsDue returns the notifications still being delivered
 	// whose install_at is at or before the cutoff and that the caller can act on:
 	// past install_at, or displayed and waiting on their reminder.

--- a/server/fleet/patch_notifications.go
+++ b/server/fleet/patch_notifications.go
@@ -23,7 +23,6 @@ type PatchNotificationDue struct {
 	DisplayedAt      *time.Time      `db:"displayed_at"`
 	CreatedAt        time.Time       `db:"created_at"`
 	InstallAt        time.Time       `db:"install_at"`
-	HostOnline       bool            `db:"host_online"`
 }
 
 type PatchNotificationAppDetail struct {

--- a/server/fleet/patch_notifications.go
+++ b/server/fleet/patch_notifications.go
@@ -25,7 +25,21 @@ type PatchNotificationDue struct {
 	InstallAt        time.Time       `db:"install_at"`
 }
 
+// What a host has installed for one software title. A title can have more than one row when several
+// copies are installed.
+type HostSoftwareTitleVersion struct {
+	HostID          uint   `db:"host_id"`
+	SoftwareTitleID uint   `db:"title_id"`
+	Version         string `db:"version"`
+}
+
 type PatchNotificationAppDetail struct {
+	// NotificationUUID is only set when the apps of several notifications are listed at once.
+	NotificationUUID string `db:"notification_uuid"`
+	// InstallerVersion is the version the installer would put on the host, empty when the installer
+	// is gone.
+	InstallerVersion string `db:"installer_version"`
+
 	PolicyID            *uint  `db:"policy_id"`
 	SoftwareTitleID     uint   `db:"software_title_id"`
 	SoftwareInstallerID *uint  `db:"software_installer_id"`

--- a/server/fleet/patch_notifications.go
+++ b/server/fleet/patch_notifications.go
@@ -13,8 +13,8 @@ type PatchNotificationApp struct {
 	SoftwareInstallerID *uint `db:"software_installer_id"`
 }
 
-// A patch notification whose deadline is close enough that the countdown pass has something to do
-// with it: send the reminder, or force the install.
+// A patch notification whose deadline is close enough that Fleet has something to do with it now:
+// send the reminder, or force the install.
 type PatchNotificationDue struct {
 	NotificationUUID string          `db:"notification_uuid"`
 	HostID           uint            `db:"host_id"`

--- a/server/fleet/patch_notifications.go
+++ b/server/fleet/patch_notifications.go
@@ -25,14 +25,6 @@ type PatchNotificationDue struct {
 	InstallAt        time.Time       `db:"install_at"`
 }
 
-// What a host has installed for one software title. A title can have more than one row when several
-// copies are installed.
-type HostSoftwareTitleVersion struct {
-	HostID          uint   `db:"host_id"`
-	SoftwareTitleID uint   `db:"title_id"`
-	Version         string `db:"version"`
-}
-
 type PatchNotificationAppDetail struct {
 	// NotificationUUID is only set when the apps of several notifications are listed at once.
 	NotificationUUID string `db:"notification_uuid"`

--- a/server/fleet/patch_notifications.go
+++ b/server/fleet/patch_notifications.go
@@ -21,7 +21,6 @@ type PatchNotificationDue struct {
 	Status           string          `db:"status"`
 	Payload          json.RawMessage `db:"payload"`
 	DisplayedAt      *time.Time      `db:"displayed_at"`
-	CreatedAt        time.Time       `db:"created_at"`
 	InstallAt        time.Time       `db:"install_at"`
 }
 
@@ -39,4 +38,6 @@ type PatchNotificationAppDetail struct {
 	DisplayName         string `db:"display_name"`
 	HasIcon             bool   `db:"has_icon"`
 	InstallQueued       bool   `db:"install_queued"`
+	// CreatedAt is when the app was added to the notification
+	CreatedAt time.Time `db:"created_at"`
 }

--- a/server/fleet/patch_notifications.go
+++ b/server/fleet/patch_notifications.go
@@ -1,11 +1,29 @@
 package fleet
 
+import (
+	"encoding/json"
+	"time"
+)
+
 const PatchNotificationKind = "patch"
 
 type PatchNotificationApp struct {
 	PolicyID            *uint `db:"policy_id"`
 	SoftwareTitleID     uint  `db:"software_title_id"`
 	SoftwareInstallerID *uint `db:"software_installer_id"`
+}
+
+// A patch notification whose deadline is close enough that the countdown pass has something to do
+// with it: send the reminder, or force the install.
+type PatchNotificationDue struct {
+	NotificationUUID string          `db:"notification_uuid"`
+	HostID           uint            `db:"host_id"`
+	Status           string          `db:"status"`
+	Payload          json.RawMessage `db:"payload"`
+	DisplayedAt      *time.Time      `db:"displayed_at"`
+	CreatedAt        time.Time       `db:"created_at"`
+	InstallAt        time.Time       `db:"install_at"`
+	HostOnline       bool            `db:"host_online"`
 }
 
 type PatchNotificationAppDetail struct {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -467,6 +467,14 @@ type HostSoftwareTitleKey struct {
 	SoftwareTitleID uint
 }
 
+// What a host has installed for one software title. A title can have more than one row when several
+// copies are installed.
+type HostSoftwareTitleVersion struct {
+	HostID          uint   `db:"host_id"`
+	SoftwareTitleID uint   `db:"title_id"`
+	Version         string `db:"version"`
+}
+
 // HostLastInstallData contains data for the last installation of a package on a host.
 type HostLastInstallData struct {
 	// ExecutionID is the installation ID of the package on the host.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -461,6 +461,12 @@ func (s SoftwareInstallerStatus) IsValid() bool {
 	}
 }
 
+// HostSoftwareTitleKey identifies one software title on one host.
+type HostSoftwareTitleKey struct {
+	HostID          uint
+	SoftwareTitleID uint
+}
+
 // HostLastInstallData contains data for the last installation of a package on a host.
 type HostLastInstallData struct {
 	// ExecutionID is the installation ID of the package on the host.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -486,6 +486,8 @@ type HostLastInstallData struct {
 	// requests the host refetch; it is used to throttle continuous policy automation
 	// re-installs (see continuousAutomationOnCooldown).
 	UpdatedAt time.Time `db:"updated_at"`
+	// OverridePreInstallQuery means the install runs the app open query as its pre-install condition
+	OverridePreInstallQuery bool `db:"override_pre_install_query"`
 }
 
 // HostSoftwareInstaller represents a software installer package that has been installed on a host.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -550,7 +550,7 @@ type ListPatchNotificationAppsFunc func(ctx context.Context, notificationUUID st
 
 type ListPatchNotificationAppsForNotificationsFunc func(ctx context.Context, notificationUUIDs []string) (map[string][]fleet.PatchNotificationAppDetail, error)
 
-type ListHostSoftwareVersionsForTitlesFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error)
+type ListSoftwareTitleVersionsForHostsFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error)
 
 type DeletePatchNotificationAppsFunc func(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
 
@@ -1688,7 +1688,7 @@ type ListReadyToExecuteSoftwareInstallsFunc func(ctx context.Context, hostID uin
 
 type GetHostLastInstallDataFunc func(ctx context.Context, hostID uint, installerID uint) (*fleet.HostLastInstallData, error)
 
-type ListHostLastTitleInstallDataFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error)
+type ListLastTitleInstallDataForHostsFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error)
 
 type MatchOrCreateSoftwareInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error)
 
@@ -3150,8 +3150,8 @@ type DataStore struct {
 	ListPatchNotificationAppsForNotificationsFunc        ListPatchNotificationAppsForNotificationsFunc
 	ListPatchNotificationAppsForNotificationsFuncInvoked bool
 
-	ListHostSoftwareVersionsForTitlesFunc        ListHostSoftwareVersionsForTitlesFunc
-	ListHostSoftwareVersionsForTitlesFuncInvoked bool
+	ListSoftwareTitleVersionsForHostsFunc        ListSoftwareTitleVersionsForHostsFunc
+	ListSoftwareTitleVersionsForHostsFuncInvoked bool
 
 	DeletePatchNotificationAppsFunc        DeletePatchNotificationAppsFunc
 	DeletePatchNotificationAppsFuncInvoked bool
@@ -4857,8 +4857,8 @@ type DataStore struct {
 	GetHostLastInstallDataFunc        GetHostLastInstallDataFunc
 	GetHostLastInstallDataFuncInvoked bool
 
-	ListHostLastTitleInstallDataFunc        ListHostLastTitleInstallDataFunc
-	ListHostLastTitleInstallDataFuncInvoked bool
+	ListLastTitleInstallDataForHostsFunc        ListLastTitleInstallDataForHostsFunc
+	ListLastTitleInstallDataForHostsFuncInvoked bool
 
 	MatchOrCreateSoftwareInstallerFunc        MatchOrCreateSoftwareInstallerFunc
 	MatchOrCreateSoftwareInstallerFuncInvoked bool
@@ -7709,11 +7709,11 @@ func (s *DataStore) ListPatchNotificationAppsForNotifications(ctx context.Contex
 	return s.ListPatchNotificationAppsForNotificationsFunc(ctx, notificationUUIDs)
 }
 
-func (s *DataStore) ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+func (s *DataStore) ListSoftwareTitleVersionsForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
 	s.mu.Lock()
-	s.ListHostSoftwareVersionsForTitlesFuncInvoked = true
+	s.ListSoftwareTitleVersionsForHostsFuncInvoked = true
 	s.mu.Unlock()
-	return s.ListHostSoftwareVersionsForTitlesFunc(ctx, hostIDs, softwareTitleIDs)
+	return s.ListSoftwareTitleVersionsForHostsFunc(ctx, hostIDs, softwareTitleIDs)
 }
 
 func (s *DataStore) DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error {
@@ -11692,11 +11692,11 @@ func (s *DataStore) GetHostLastInstallData(ctx context.Context, hostID uint, ins
 	return s.GetHostLastInstallDataFunc(ctx, hostID, installerID)
 }
 
-func (s *DataStore) ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+func (s *DataStore) ListLastTitleInstallDataForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 	s.mu.Lock()
-	s.ListHostLastTitleInstallDataFuncInvoked = true
+	s.ListLastTitleInstallDataForHostsFuncInvoked = true
 	s.mu.Unlock()
-	return s.ListHostLastTitleInstallDataFunc(ctx, hostIDs, softwareTitleIDs)
+	return s.ListLastTitleInstallDataForHostsFunc(ctx, hostIDs, softwareTitleIDs)
 }
 
 func (s *DataStore) MatchOrCreateSoftwareInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -554,8 +554,6 @@ type DeletePatchNotificationAppsFunc func(ctx context.Context, notificationUUID 
 
 type SetPatchNotificationInstallAtFunc func(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
 
-type ResetPatchNotificationFunc func(ctx context.Context, notificationUUID string) error
-
 type ListPatchNotificationsDueFunc func(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error)
 
 type ListSoftwareForVulnDetectionFunc func(ctx context.Context, filter fleet.VulnSoftwareFilter) ([]fleet.Software, error)
@@ -3155,9 +3153,6 @@ type DataStore struct {
 
 	SetPatchNotificationInstallAtFunc        SetPatchNotificationInstallAtFunc
 	SetPatchNotificationInstallAtFuncInvoked bool
-
-	ResetPatchNotificationFunc        ResetPatchNotificationFunc
-	ResetPatchNotificationFuncInvoked bool
 
 	ListPatchNotificationsDueFunc        ListPatchNotificationsDueFunc
 	ListPatchNotificationsDueFuncInvoked bool
@@ -7721,13 +7716,6 @@ func (s *DataStore) SetPatchNotificationInstallAt(ctx context.Context, notificat
 	s.SetPatchNotificationInstallAtFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetPatchNotificationInstallAtFunc(ctx, notificationUUID, installAt)
-}
-
-func (s *DataStore) ResetPatchNotification(ctx context.Context, notificationUUID string) error {
-	s.mu.Lock()
-	s.ResetPatchNotificationFuncInvoked = true
-	s.mu.Unlock()
-	return s.ResetPatchNotificationFunc(ctx, notificationUUID)
 }
 
 func (s *DataStore) ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -548,6 +548,14 @@ type SetPatchNotificationAppsQueuedFunc func(ctx context.Context, notificationUU
 
 type ListPatchNotificationAppsFunc func(ctx context.Context, notificationUUID string) ([]fleet.PatchNotificationAppDetail, error)
 
+type DeletePatchNotificationAppsFunc func(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
+
+type SetPatchNotificationInstallAtFunc func(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
+
+type ResetPatchNotificationFunc func(ctx context.Context, notificationUUID string) error
+
+type ListPatchNotificationsDueFunc func(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error)
+
 type ListSoftwareForVulnDetectionFunc func(ctx context.Context, filter fleet.VulnSoftwareFilter) ([]fleet.Software, error)
 
 type ListSoftwareForVulnDetectionByOSVersionFunc func(ctx context.Context, osVer fleet.OSVersion) ([]fleet.Software, error)
@@ -3132,6 +3140,18 @@ type DataStore struct {
 
 	ListPatchNotificationAppsFunc        ListPatchNotificationAppsFunc
 	ListPatchNotificationAppsFuncInvoked bool
+
+	DeletePatchNotificationAppsFunc        DeletePatchNotificationAppsFunc
+	DeletePatchNotificationAppsFuncInvoked bool
+
+	SetPatchNotificationInstallAtFunc        SetPatchNotificationInstallAtFunc
+	SetPatchNotificationInstallAtFuncInvoked bool
+
+	ResetPatchNotificationFunc        ResetPatchNotificationFunc
+	ResetPatchNotificationFuncInvoked bool
+
+	ListPatchNotificationsDueFunc        ListPatchNotificationsDueFunc
+	ListPatchNotificationsDueFuncInvoked bool
 
 	ListSoftwareForVulnDetectionFunc        ListSoftwareForVulnDetectionFunc
 	ListSoftwareForVulnDetectionFuncInvoked bool
@@ -7665,6 +7685,34 @@ func (s *DataStore) ListPatchNotificationApps(ctx context.Context, notificationU
 	s.ListPatchNotificationAppsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListPatchNotificationAppsFunc(ctx, notificationUUID)
+}
+
+func (s *DataStore) DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error {
+	s.mu.Lock()
+	s.DeletePatchNotificationAppsFuncInvoked = true
+	s.mu.Unlock()
+	return s.DeletePatchNotificationAppsFunc(ctx, notificationUUID, softwareTitleIDs)
+}
+
+func (s *DataStore) SetPatchNotificationInstallAt(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error) {
+	s.mu.Lock()
+	s.SetPatchNotificationInstallAtFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetPatchNotificationInstallAtFunc(ctx, notificationUUID, installAt)
+}
+
+func (s *DataStore) ResetPatchNotification(ctx context.Context, notificationUUID string) error {
+	s.mu.Lock()
+	s.ResetPatchNotificationFuncInvoked = true
+	s.mu.Unlock()
+	return s.ResetPatchNotificationFunc(ctx, notificationUUID)
+}
+
+func (s *DataStore) ListPatchNotificationsDue(ctx context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
+	s.mu.Lock()
+	s.ListPatchNotificationsDueFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListPatchNotificationsDueFunc(ctx, cutoff, limit)
 }
 
 func (s *DataStore) ListSoftwareForVulnDetection(ctx context.Context, filter fleet.VulnSoftwareFilter) ([]fleet.Software, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -548,6 +548,10 @@ type SetPatchNotificationAppsQueuedFunc func(ctx context.Context, notificationUU
 
 type ListPatchNotificationAppsFunc func(ctx context.Context, notificationUUID string) ([]fleet.PatchNotificationAppDetail, error)
 
+type ListPatchNotificationAppsForNotificationsFunc func(ctx context.Context, notificationUUIDs []string) (map[string][]fleet.PatchNotificationAppDetail, error)
+
+type ListHostSoftwareVersionsForTitlesFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error)
+
 type DeletePatchNotificationAppsFunc func(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
 
 type SetPatchNotificationInstallAtFunc func(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
@@ -1683,6 +1687,8 @@ type ListPendingSoftwareInstallsFunc func(ctx context.Context, hostID uint) ([]s
 type ListReadyToExecuteSoftwareInstallsFunc func(ctx context.Context, hostID uint) ([]string, error)
 
 type GetHostLastInstallDataFunc func(ctx context.Context, hostID uint, installerID uint) (*fleet.HostLastInstallData, error)
+
+type ListHostLastTitleInstallDataFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error)
 
 type MatchOrCreateSoftwareInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error)
 
@@ -3140,6 +3146,12 @@ type DataStore struct {
 
 	ListPatchNotificationAppsFunc        ListPatchNotificationAppsFunc
 	ListPatchNotificationAppsFuncInvoked bool
+
+	ListPatchNotificationAppsForNotificationsFunc        ListPatchNotificationAppsForNotificationsFunc
+	ListPatchNotificationAppsForNotificationsFuncInvoked bool
+
+	ListHostSoftwareVersionsForTitlesFunc        ListHostSoftwareVersionsForTitlesFunc
+	ListHostSoftwareVersionsForTitlesFuncInvoked bool
 
 	DeletePatchNotificationAppsFunc        DeletePatchNotificationAppsFunc
 	DeletePatchNotificationAppsFuncInvoked bool
@@ -4844,6 +4856,9 @@ type DataStore struct {
 
 	GetHostLastInstallDataFunc        GetHostLastInstallDataFunc
 	GetHostLastInstallDataFuncInvoked bool
+
+	ListHostLastTitleInstallDataFunc        ListHostLastTitleInstallDataFunc
+	ListHostLastTitleInstallDataFuncInvoked bool
 
 	MatchOrCreateSoftwareInstallerFunc        MatchOrCreateSoftwareInstallerFunc
 	MatchOrCreateSoftwareInstallerFuncInvoked bool
@@ -7685,6 +7700,20 @@ func (s *DataStore) ListPatchNotificationApps(ctx context.Context, notificationU
 	s.ListPatchNotificationAppsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListPatchNotificationAppsFunc(ctx, notificationUUID)
+}
+
+func (s *DataStore) ListPatchNotificationAppsForNotifications(ctx context.Context, notificationUUIDs []string) (map[string][]fleet.PatchNotificationAppDetail, error) {
+	s.mu.Lock()
+	s.ListPatchNotificationAppsForNotificationsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListPatchNotificationAppsForNotificationsFunc(ctx, notificationUUIDs)
+}
+
+func (s *DataStore) ListHostSoftwareVersionsForTitles(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+	s.mu.Lock()
+	s.ListHostSoftwareVersionsForTitlesFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListHostSoftwareVersionsForTitlesFunc(ctx, hostIDs, softwareTitleIDs)
 }
 
 func (s *DataStore) DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error {
@@ -11661,6 +11690,13 @@ func (s *DataStore) GetHostLastInstallData(ctx context.Context, hostID uint, ins
 	s.GetHostLastInstallDataFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetHostLastInstallDataFunc(ctx, hostID, installerID)
+}
+
+func (s *DataStore) ListHostLastTitleInstallData(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+	s.mu.Lock()
+	s.ListHostLastTitleInstallDataFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListHostLastTitleInstallDataFunc(ctx, hostIDs, softwareTitleIDs)
 }
 
 func (s *DataStore) MatchOrCreateSoftwareInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -550,8 +550,6 @@ type ListPatchNotificationAppsFunc func(ctx context.Context, notificationUUID st
 
 type ListPatchNotificationAppsForNotificationsFunc func(ctx context.Context, notificationUUIDs []string) (map[string][]fleet.PatchNotificationAppDetail, error)
 
-type ListSoftwareTitleVersionsForHostsFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error)
-
 type DeletePatchNotificationAppsFunc func(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error
 
 type SetPatchNotificationInstallAtFunc func(ctx context.Context, notificationUUID string, installAt time.Time) (time.Time, error)
@@ -1689,6 +1687,8 @@ type ListReadyToExecuteSoftwareInstallsFunc func(ctx context.Context, hostID uin
 type GetHostLastInstallDataFunc func(ctx context.Context, hostID uint, installerID uint) (*fleet.HostLastInstallData, error)
 
 type ListLastTitleInstallDataForHostsFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error)
+
+type ListSoftwareTitleVersionsForHostsFunc func(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error)
 
 type MatchOrCreateSoftwareInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error)
 
@@ -3149,9 +3149,6 @@ type DataStore struct {
 
 	ListPatchNotificationAppsForNotificationsFunc        ListPatchNotificationAppsForNotificationsFunc
 	ListPatchNotificationAppsForNotificationsFuncInvoked bool
-
-	ListSoftwareTitleVersionsForHostsFunc        ListSoftwareTitleVersionsForHostsFunc
-	ListSoftwareTitleVersionsForHostsFuncInvoked bool
 
 	DeletePatchNotificationAppsFunc        DeletePatchNotificationAppsFunc
 	DeletePatchNotificationAppsFuncInvoked bool
@@ -4859,6 +4856,9 @@ type DataStore struct {
 
 	ListLastTitleInstallDataForHostsFunc        ListLastTitleInstallDataForHostsFunc
 	ListLastTitleInstallDataForHostsFuncInvoked bool
+
+	ListSoftwareTitleVersionsForHostsFunc        ListSoftwareTitleVersionsForHostsFunc
+	ListSoftwareTitleVersionsForHostsFuncInvoked bool
 
 	MatchOrCreateSoftwareInstallerFunc        MatchOrCreateSoftwareInstallerFunc
 	MatchOrCreateSoftwareInstallerFuncInvoked bool
@@ -7707,13 +7707,6 @@ func (s *DataStore) ListPatchNotificationAppsForNotifications(ctx context.Contex
 	s.ListPatchNotificationAppsForNotificationsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListPatchNotificationAppsForNotificationsFunc(ctx, notificationUUIDs)
-}
-
-func (s *DataStore) ListSoftwareTitleVersionsForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
-	s.mu.Lock()
-	s.ListSoftwareTitleVersionsForHostsFuncInvoked = true
-	s.mu.Unlock()
-	return s.ListSoftwareTitleVersionsForHostsFunc(ctx, hostIDs, softwareTitleIDs)
 }
 
 func (s *DataStore) DeletePatchNotificationApps(ctx context.Context, notificationUUID string, softwareTitleIDs []uint) error {
@@ -11697,6 +11690,13 @@ func (s *DataStore) ListLastTitleInstallDataForHosts(ctx context.Context, hostID
 	s.ListLastTitleInstallDataForHostsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListLastTitleInstallDataForHostsFunc(ctx, hostIDs, softwareTitleIDs)
+}
+
+func (s *DataStore) ListSoftwareTitleVersionsForHosts(ctx context.Context, hostIDs []uint, softwareTitleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+	s.mu.Lock()
+	s.ListSoftwareTitleVersionsForHostsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListSoftwareTitleVersionsForHostsFunc(ctx, hostIDs, softwareTitleIDs)
 }
 
 func (s *DataStore) MatchOrCreateSoftwareInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error) {

--- a/server/notifications/internal/mysql/end_user_notifications.go
+++ b/server/notifications/internal/mysql/end_user_notifications.go
@@ -330,7 +330,7 @@ func (ds *Datastore) DelayEndUserNotification(ctx context.Context, notificationU
 	// Terminal notifications are excluded so a delay can't revive a notification
 	// that is already over.
 	//
-	// The lifetime is pushed out because a notification on a countdown can be re-dispatched for longer
+	// The lifetime is pushed out because a notification waiting on a deadline can be re-dispatched for longer
 	// than the lifetime it was created with.
 	const updateStmt = `
 UPDATE notifications_end_user

--- a/server/notifications/internal/mysql/end_user_notifications.go
+++ b/server/notifications/internal/mysql/end_user_notifications.go
@@ -329,22 +329,17 @@ func (ds *Datastore) DelayEndUserNotification(ctx context.Context, notificationU
 	//
 	// Terminal notifications are excluded so a delay can't revive a notification
 	// that is already over.
-	//
-	// The lifetime is pushed out because a notification waiting on a deadline can be re-dispatched for longer
-	// than the lifetime it was created with.
 	const updateStmt = `
 UPDATE notifications_end_user
 SET status = ?, next_attempt_at = ?, last_reason = ?, displayed_at = NULL,
-	payload = COALESCE(?, payload),
-	expires_at = GREATEST(expires_at, NOW(6) + INTERVAL ? SECOND)
+	payload = COALESCE(?, payload)
 WHERE uuid = ?
 	AND status NOT IN (?, ?, ?)
 	AND expires_at > NOW(6)
 `
 
 	if _, err := ds.primary.ExecContext(ctx, updateStmt,
-		api.EndUserNotificationPending, nextAttemptAt, api.EndUserNotificationReasonDelayed, payload,
-		int(api.EndUserNotificationMaxLifetime.Seconds()), notificationUUID,
+		api.EndUserNotificationPending, nextAttemptAt, api.EndUserNotificationReasonDelayed, payload, notificationUUID,
 		api.EndUserNotificationExpired, api.EndUserNotificationFailed, api.EndUserNotificationActed,
 	); err != nil {
 		return ctxerr.Wrap(ctx, err, "delay end user notification")

--- a/server/notifications/internal/mysql/end_user_notifications.go
+++ b/server/notifications/internal/mysql/end_user_notifications.go
@@ -329,17 +329,22 @@ func (ds *Datastore) DelayEndUserNotification(ctx context.Context, notificationU
 	//
 	// Terminal notifications are excluded so a delay can't revive a notification
 	// that is already over.
+	//
+	// The lifetime is pushed out because a notification on a countdown can be re-dispatched for longer
+	// than the lifetime it was created with.
 	const updateStmt = `
 UPDATE notifications_end_user
 SET status = ?, next_attempt_at = ?, last_reason = ?, displayed_at = NULL,
-	payload = COALESCE(?, payload)
+	payload = COALESCE(?, payload),
+	expires_at = GREATEST(expires_at, NOW(6) + INTERVAL ? SECOND)
 WHERE uuid = ?
 	AND status NOT IN (?, ?, ?)
 	AND expires_at > NOW(6)
 `
 
 	if _, err := ds.primary.ExecContext(ctx, updateStmt,
-		api.EndUserNotificationPending, nextAttemptAt, api.EndUserNotificationReasonDelayed, payload, notificationUUID,
+		api.EndUserNotificationPending, nextAttemptAt, api.EndUserNotificationReasonDelayed, payload,
+		int(api.EndUserNotificationMaxLifetime.Seconds()), notificationUUID,
 		api.EndUserNotificationExpired, api.EndUserNotificationFailed, api.EndUserNotificationActed,
 	); err != nil {
 		return ctxerr.Wrap(ctx, err, "delay end user notification")

--- a/server/service/integration_end_user_notifications_test.go
+++ b/server/service/integration_end_user_notifications_test.go
@@ -78,8 +78,8 @@ func getTestInstallAt(t *testing.T, ds *mysql.Datastore, notificationUUID string
 }
 
 // setTestInstallAt moves a deadline, so a test can stand in for the hour passing.
-// installAt is SQL rather than a value, since the rest of the countdown reads the
-// database clock.
+// installAt is SQL rather than a value, since the rest of the deadline handling reads
+// the database clock.
 func setTestInstallAt(t *testing.T, ds *mysql.Datastore, notificationUUID string, installAt string) {
 	t.Helper()
 	mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -384,9 +384,9 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			[]byte(`{"action": "verify"}`), http.StatusOK)
 	})
 
-	// The countdown pass sends the reminder whatever the end user pressed, so the
+	// RemindAndInstallDuePatches sends the reminder whatever the end user pressed, so the
 	// button only closes the toast and the deadline it was pressed against stays put.
-	t.Run("POST delay leaves the countdown alone and the reminder still arrives", func(t *testing.T) {
+	t.Run("POST delay leaves the deadline alone and the reminder still arrives", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-delay-registered")
 		notificationUUID := newRenderableTestNotification(t, s.ds, host.ID, `{"reminder": false}`)
 		dispatch(t)
@@ -394,7 +394,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NotNil(t, dispatched.ExecutionID)
 		_, token := fetchScript(t, host, *dispatched.ExecutionID)
 
-		// exit 0 is what marks it displayed, which is what starts the countdown
+		// exit 0 is what marks it displayed, which is what sets the deadline
 		postScriptResult(host, *dispatched.ExecutionID, 0)
 		displayed := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, displayed.DisplayedAt)
@@ -417,7 +417,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) + INTERVAL 4 MINUTE")
 		shortened := getTestInstallAt(t, s.ds, notificationUUID)
 		require.NotNil(t, shortened)
-		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
 
 		reminded := getTestNotification(t, s.ds, notificationUUID)
 		require.Equal(t, notifications_api.EndUserNotificationPending, reminded.Status)
@@ -429,7 +429,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.JSONEq(t, `{"reminder": true}`, string(reminded.Payload))
 
 		// a second pass finds it pending, which is how it knows the reminder went out
-		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
 		require.Equal(t, notifications_api.EndUserNotificationPending, getTestNotification(t, s.ds, notificationUUID).Status)
 
 		dispatch(t)
@@ -784,7 +784,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.False(t, result.OverridePreInstallQuery)
 	})
 
-	// TestPatchNotificationCountdowns covers which branch the pass takes. This
+	// TestRemindAndInstallDuePatches covers which branch the pass takes. This
 	// covers the ending the pass is there for: the deadline is stored on display,
 	// and once it passes the install is queued with no app open gate.
 	t.Run("the deadline closes and updates the app", func(t *testing.T) {
@@ -820,7 +820,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			PolicyID: &policy.ID, SoftwareTitleID: titleID, SoftwareInstallerID: &installerID,
 		}))
 
-		// the toast on screen is what starts the countdown
+		// the toast on screen is what sets the deadline
 		dispatch(t)
 		dispatched := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, dispatched.ExecutionID)
@@ -835,7 +835,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		// stand in for the hour passing
 		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) - INTERVAL 1 MINUTE")
 
-		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
 
 		acted := getTestNotification(t, s.ds, notificationUUID)
 		require.Equal(t, notifications_api.EndUserNotificationActed, acted.Status,
@@ -863,7 +863,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.Empty(t, queued.PreInstallCondition)
 
 		// a second pass finds nothing to do, since the notification is acted
-		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 			return sqlx.SelectContext(ctx, q, &queuedInstalls, `
 				SELECT ua.execution_id, siua.policy_id

--- a/server/service/integration_end_user_notifications_test.go
+++ b/server/service/integration_end_user_notifications_test.go
@@ -255,10 +255,8 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 	})
 
 	t.Run("GET returns the view the notification's kind builds", func(t *testing.T) {
-		// The view carries the org's own logos, so give the org one of each. Each
-		// mode-aware field has a deprecated twin that Fleet rejects the config for
-		// disagreeing with, so both move together, and whatever another test left
-		// behind is put back afterwards.
+		// each mode-aware logo field has a deprecated twin, and the config is rejected when the two
+		// disagree, so both move together and are restored afterwards
 		setOrgLogos := func(light, dark string) {
 			s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
 				"org_info": {
@@ -613,10 +611,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NotContains(t, resp.ScriptContents, token)
 	})
 
-	// TestPatchNotificationUpdateNow covers which installs get queued. This covers
-	// what the unified queue does with those installs: an install keeps its policy
-	// but not the app open query the policy would otherwise add, both while the
-	// install is upcoming and once the install is activated.
+	// the install keeps its policy but not the app open query, both while upcoming and once activated
 	t.Run("update now queues an install that runs with the app open", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-update-now")
 		team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "update-now-team"})
@@ -709,9 +704,6 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.False(t, result.OverridePreInstallQuery)
 	})
 
-	// TestRemindAndInstallDuePatches covers which branch the pass takes. This
-	// covers the ending the pass is there for: the deadline is stored on display,
-	// and once it passes the install is queued with no app open gate.
 	// First notification, delay, reminder, then the install at install_at. A second host is included
 	// so each pass handles a batch of two with separate install_at values.
 	t.Run("a displayed notification is reminded and then installed at install_at", func(t *testing.T) {
@@ -720,6 +712,8 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NoError(t, err)
 		require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 
+		// a real installer and policy, so the install queued at install_at is a real one with an app
+		// open query it has to ignore
 		installerID, _, err := s.ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 			InstallScript: "echo", Filename: "deadline.pkg", StorageID: uuid.NewString(),
 			Title: "Deadline App", Version: "2.0.0", Source: "apps", Platform: "darwin",
@@ -769,7 +763,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			return queued
 		}
 
-		// install_at comes from displayed_at, so it is null until the script result arrives.
+		// install_at comes from displayed_at, so it is null until the script result arrives
 		dispatch(t)
 		dispatched := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, dispatched.ExecutionID)
@@ -781,19 +775,21 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NotNil(t, otherDispatched.ExecutionID)
 		postScriptResult(otherHost, *otherDispatched.ExecutionID, 0)
 
+		// exit 0 records displayed_at, and install_at follows it an hour out
 		displayed := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, displayed.DisplayedAt)
 		deadline := getTestInstallAt(t, s.ds, notificationUUID)
 		require.NotNil(t, deadline)
 		require.WithinDuration(t, displayed.DisplayedAt.Add(time.Hour), *deadline, time.Minute)
 
+		// the second host gets its own install_at from its own displayed_at
 		otherDisplayed := getTestNotification(t, s.ds, otherUUID)
 		require.NotNil(t, otherDisplayed.DisplayedAt)
 		otherDeadline := getTestInstallAt(t, s.ds, otherUUID)
 		require.NotNil(t, otherDeadline)
 		require.WithinDuration(t, otherDisplayed.DisplayedAt.Add(time.Hour), *otherDeadline, time.Minute)
 
-		// the delay action does not move install_at
+		// the end user closes the toast, which leaves the install_at just set above alone
 		s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s/actions", token, notificationUUID),
 			[]byte(`{"action": "delay"}`), http.StatusOK)
 
@@ -805,7 +801,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NotNil(t, stillDue)
 		require.WithinDuration(t, *deadline, *stillDue, time.Second, "the delay action does not move install_at")
 
-		// into the reminder window. The other host stays an hour out and must not be re-dispatched.
+		// stand in for the hour running down. The other host keeps its hour and must be left alone.
 		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) + INTERVAL 4 MINUTE")
 		shortened := getTestInstallAt(t, s.ds, notificationUUID)
 		require.NotNil(t, shortened)
@@ -829,6 +825,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
 		require.Equal(t, notifications_api.EndUserNotificationPending, getTestNotification(t, s.ds, notificationUUID).Status)
 
+		// the reminder goes out on the next dispatch, rendering the 5 minute copy
 		dispatch(t)
 		redispatched := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, redispatched.ExecutionID)
@@ -850,11 +847,12 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		afterReminder := getTestInstallAt(t, s.ds, notificationUUID)
 		require.NotNil(t, afterReminder)
 		require.False(t, afterReminder.Before(reminderDisplayed.DisplayedAt.Add(5*time.Minute)),
-			"the apps must not be queued less than five minutes after the reminder reached the screen")
-		require.True(t, afterReminder.After(*shortened), "the deadline moved out by the reminder's display latency")
+			"install_at is never less than 5 minutes after the reminder's displayed_at")
+		require.True(t, afterReminder.After(*shortened), "install_at moved out to follow the reminder's displayed_at")
 		require.WithinDuration(t, reminderDisplayed.DisplayedAt.Add(5*time.Minute), *afterReminder, time.Second)
 
-		// one pass, two notifications: this one installs, the other only reminds
+		// one pass over both: the first is past install_at and installs, the second has just reached
+		// its reminder window
 		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) - INTERVAL 1 MINUTE")
 		setTestInstallAt(t, s.ds, otherUUID, "NOW(6) + INTERVAL 4 MINUTE")
 		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))

--- a/server/service/integration_end_user_notifications_test.go
+++ b/server/service/integration_end_user_notifications_test.go
@@ -446,12 +446,17 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			{ID: "update_now", Label: "Update now"},
 		}, view.Actions, "the reminder swaps Remind for Hide")
 
-		// the reminder's own display reports the deadline already stored rather than
-		// pushing it out another hour
+		// The reminder's display counts from the screen, not from when it was queued, so the end user
+		// always gets the whole five minutes. It is not pushed out by another hour either.
 		postScriptResult(host, *redispatched.ExecutionID, 0)
+		reminderDisplayed := getTestNotification(t, s.ds, notificationUUID)
+		require.NotNil(t, reminderDisplayed.DisplayedAt)
 		afterReminder := getTestInstallAt(t, s.ds, notificationUUID)
 		require.NotNil(t, afterReminder)
-		require.WithinDuration(t, *shortened, *afterReminder, time.Second)
+		require.False(t, afterReminder.Before(reminderDisplayed.DisplayedAt.Add(5*time.Minute)),
+			"the apps must not be queued less than five minutes after the reminder reached the screen")
+		require.True(t, afterReminder.After(*shortened), "the deadline moved out by the reminder's display latency")
+		require.WithinDuration(t, reminderDisplayed.DisplayedAt.Add(5*time.Minute), *afterReminder, time.Second)
 	})
 
 	t.Run("POST delay with no kind registered is a no-op", func(t *testing.T) {
@@ -829,11 +834,6 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 
 		// stand in for the hour passing
 		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) - INTERVAL 1 MINUTE")
-
-		// createOrbitEnrolledHost backdates seen_time a minute, which is exactly the online window
-		// for a host with no distributed_interval, so say plainly that this host is online. An
-		// offline one restarts its countdown instead of installing.
-		require.NoError(t, s.ds.MarkHostsSeen(ctx, []uint{host.ID}, time.Now()))
 
 		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
 

--- a/server/service/integration_end_user_notifications_test.go
+++ b/server/service/integration_end_user_notifications_test.go
@@ -179,7 +179,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.Equal(t, []string{*dispatched.ExecutionID}, orbitResp.Notifications.PendingScriptExecutionIDs)
 	})
 
-	t.Run("exit 0 records displayed_at", func(t *testing.T) {
+	t.Run("a notify script that exits 0 marks the notification displayed", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-exit0")
 		notificationUUID := newTestNotification(t, s.ds, host.ID, "patch", `{"title": "hello"}`)
 		dispatch(t)
@@ -195,7 +195,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.EqualValues(t, 0, *got.LastExitCode)
 	})
 
-	t.Run("exit 41 schedules a retry", func(t *testing.T) {
+	t.Run("a notify script that exits 41 on a locked screen schedules a retry", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-exit41")
 		notificationUUID := newTestNotification(t, s.ds, host.ID, "patch", `{"title": "hello"}`)
 		dispatch(t)
@@ -212,7 +212,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NotNil(t, got.NextAttemptAt)
 	})
 
-	t.Run("exit 2 is a terminal failure", func(t *testing.T) {
+	t.Run("a notify script that exits 2 fails the notification with no retry", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-exit2")
 		notificationUUID := newTestNotification(t, s.ds, host.ID, "patch", `{"title": "hello"}`)
 		dispatch(t)
@@ -372,7 +372,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 
 	// TODO: verify is currently a stub (see apply_action.go), so this only
 	// confirms the action is accepted, not that it records anything.
-	t.Run("POST verify is accepted", func(t *testing.T) {
+	t.Run("a device posting the verify action gets a 200", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-verify")
 		notificationUUID := newRenderableTestNotification(t, s.ds, host.ID, `{"reminder": false}`)
 		dispatch(t)
@@ -384,82 +384,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			[]byte(`{"action": "verify"}`), http.StatusOK)
 	})
 
-	// RemindAndInstallDuePatches sends the reminder whatever the end user pressed, so the
-	// button only closes the toast and the deadline it was pressed against stays put.
-	t.Run("POST delay leaves the deadline alone and the reminder still arrives", func(t *testing.T) {
-		host := newNotifiableHost(t, "notif-delay-registered")
-		notificationUUID := newRenderableTestNotification(t, s.ds, host.ID, `{"reminder": false}`)
-		dispatch(t)
-		dispatched := getTestNotification(t, s.ds, notificationUUID)
-		require.NotNil(t, dispatched.ExecutionID)
-		_, token := fetchScript(t, host, *dispatched.ExecutionID)
-
-		// exit 0 is what marks it displayed, which is what sets the deadline
-		postScriptResult(host, *dispatched.ExecutionID, 0)
-		displayed := getTestNotification(t, s.ds, notificationUUID)
-		require.NotNil(t, displayed.DisplayedAt)
-		deadline := getTestInstallAt(t, s.ds, notificationUUID)
-		require.NotNil(t, deadline)
-		require.WithinDuration(t, displayed.DisplayedAt.Add(time.Hour), *deadline, time.Minute)
-
-		s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s/actions", token, notificationUUID),
-			[]byte(`{"action": "delay"}`), http.StatusOK)
-
-		delayed := getTestNotification(t, s.ds, notificationUUID)
-		require.Equal(t, notifications_api.EndUserNotificationDispatched, delayed.Status)
-		require.NotNil(t, delayed.DisplayedAt, "the toast the end user closed still counts as displayed")
-		require.JSONEq(t, `{"reminder": false}`, string(delayed.Payload))
-		stillDue := getTestInstallAt(t, s.ds, notificationUUID)
-		require.NotNil(t, stillDue)
-		require.WithinDuration(t, *deadline, *stillDue, time.Second, "pressing the button cannot buy more time")
-
-		// stand in for the hour running down to the reminder's lead time
-		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) + INTERVAL 4 MINUTE")
-		shortened := getTestInstallAt(t, s.ds, notificationUUID)
-		require.NotNil(t, shortened)
-		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
-
-		reminded := getTestNotification(t, s.ds, notificationUUID)
-		require.Equal(t, notifications_api.EndUserNotificationPending, reminded.Status)
-		require.Nil(t, reminded.DisplayedAt, "the next send records its own display")
-		require.NotNil(t, reminded.LastReason)
-		require.Equal(t, notifications_api.EndUserNotificationReasonDelayed, *reminded.LastReason)
-		require.NotNil(t, reminded.ExecutionID, "keeps its execution_id so a late result can still find it")
-		require.Equal(t, *dispatched.ExecutionID, *reminded.ExecutionID)
-		require.JSONEq(t, `{"reminder": true}`, string(reminded.Payload))
-
-		// a second pass finds it pending, which is how it knows the reminder went out
-		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
-		require.Equal(t, notifications_api.EndUserNotificationPending, getTestNotification(t, s.ds, notificationUUID).Status)
-
-		dispatch(t)
-		redispatched := getTestNotification(t, s.ds, notificationUUID)
-		require.NotNil(t, redispatched.ExecutionID)
-		_, reminderToken := fetchScript(t, host, *redispatched.ExecutionID)
-
-		var view notifications_api.NotificationView
-		s.DoJSONWithoutAuth("GET", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s", reminderToken, notificationUUID),
-			nil, http.StatusOK, &view)
-		require.Contains(t, view.Description, "**5 minutes**")
-		require.Equal(t, []notifications_api.NotificationAction{
-			{ID: "dismiss", Label: "Hide"},
-			{ID: "update_now", Label: "Update now"},
-		}, view.Actions, "the reminder swaps Remind for Hide")
-
-		// The reminder's display counts from the screen, not from when it was queued, so the end user
-		// always gets the whole five minutes. It is not pushed out by another hour either.
-		postScriptResult(host, *redispatched.ExecutionID, 0)
-		reminderDisplayed := getTestNotification(t, s.ds, notificationUUID)
-		require.NotNil(t, reminderDisplayed.DisplayedAt)
-		afterReminder := getTestInstallAt(t, s.ds, notificationUUID)
-		require.NotNil(t, afterReminder)
-		require.False(t, afterReminder.Before(reminderDisplayed.DisplayedAt.Add(5*time.Minute)),
-			"the apps must not be queued less than five minutes after the reminder reached the screen")
-		require.True(t, afterReminder.After(*shortened), "the deadline moved out by the reminder's display latency")
-		require.WithinDuration(t, reminderDisplayed.DisplayedAt.Add(5*time.Minute), *afterReminder, time.Second)
-	})
-
-	t.Run("POST delay with no kind registered is a no-op", func(t *testing.T) {
+	t.Run("a delay action on a notification with no registered kind changes nothing", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-delay-unregistered")
 		notificationUUID := newTestNotification(t, s.ds, host.ID, "some_unregistered_kind", `{"title": "hello"}`)
 		dispatch(t)
@@ -787,7 +712,9 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 	// TestRemindAndInstallDuePatches covers which branch the pass takes. This
 	// covers the ending the pass is there for: the deadline is stored on display,
 	// and once it passes the install is queued with no app open gate.
-	t.Run("the deadline closes and updates the app", func(t *testing.T) {
+	// First notification, delay, reminder, then the install at install_at. A second host is included
+	// so each pass handles a batch of two with separate install_at values.
+	t.Run("a displayed notification is reminded and then installed at install_at", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-deadline")
 		team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "deadline-team"})
 		require.NoError(t, err)
@@ -814,63 +741,146 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		})
 		require.NoError(t, err)
 
-		notificationUUID := newTestNotification(t, s.ds, host.ID, "patch", `{"reminder": false}`)
+		notificationUUID := newTestNotification(t, s.ds, host.ID, fleet.PatchNotificationKind, `{"reminder": false}`)
 		require.NoError(t, s.ds.NewPatchNotification(ctx, notificationUUID))
 		require.NoError(t, s.ds.AddPatchNotificationApp(ctx, notificationUUID, fleet.PatchNotificationApp{
 			PolicyID: &policy.ID, SoftwareTitleID: titleID, SoftwareInstallerID: &installerID,
 		}))
 
-		// the toast on screen is what sets the deadline
+		otherHost := newNotifiableHost(t, "notif-deadline-other")
+		otherUUID := newRenderableTestNotification(t, s.ds, otherHost.ID, `{"reminder": false}`)
+
+		queuedInstalls := func(hostID uint) []struct {
+			ExecutionID string `db:"execution_id"`
+			PolicyID    *uint  `db:"policy_id"`
+		} {
+			t.Helper()
+			var queued []struct {
+				ExecutionID string `db:"execution_id"`
+				PolicyID    *uint  `db:"policy_id"`
+			}
+			mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+				return sqlx.SelectContext(ctx, q, &queued, `
+					SELECT ua.execution_id, siua.policy_id
+					FROM upcoming_activities ua
+						JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
+					WHERE ua.host_id = ?`, hostID)
+			})
+			return queued
+		}
+
+		// install_at comes from displayed_at, so it is null until the script result arrives.
 		dispatch(t)
 		dispatched := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, dispatched.ExecutionID)
+		require.Nil(t, getTestInstallAt(t, s.ds, notificationUUID), "install_at is null until the notification is displayed")
+		_, token := fetchScript(t, host, *dispatched.ExecutionID)
 		postScriptResult(host, *dispatched.ExecutionID, 0)
+
+		otherDispatched := getTestNotification(t, s.ds, otherUUID)
+		require.NotNil(t, otherDispatched.ExecutionID)
+		postScriptResult(otherHost, *otherDispatched.ExecutionID, 0)
 
 		displayed := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, displayed.DisplayedAt)
-		installAt := getTestInstallAt(t, s.ds, notificationUUID)
-		require.NotNil(t, installAt, "the display sets the deadline")
-		require.WithinDuration(t, displayed.DisplayedAt.Add(time.Hour), *installAt, time.Minute)
+		deadline := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, deadline)
+		require.WithinDuration(t, displayed.DisplayedAt.Add(time.Hour), *deadline, time.Minute)
 
-		// stand in for the hour passing
+		otherDisplayed := getTestNotification(t, s.ds, otherUUID)
+		require.NotNil(t, otherDisplayed.DisplayedAt)
+		otherDeadline := getTestInstallAt(t, s.ds, otherUUID)
+		require.NotNil(t, otherDeadline)
+		require.WithinDuration(t, otherDisplayed.DisplayedAt.Add(time.Hour), *otherDeadline, time.Minute)
+
+		// the delay action does not move install_at
+		s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s/actions", token, notificationUUID),
+			[]byte(`{"action": "delay"}`), http.StatusOK)
+
+		delayed := getTestNotification(t, s.ds, notificationUUID)
+		require.Equal(t, notifications_api.EndUserNotificationDispatched, delayed.Status)
+		require.NotNil(t, delayed.DisplayedAt, "the delay action leaves displayed_at set")
+		require.JSONEq(t, `{"reminder": false}`, string(delayed.Payload))
+		stillDue := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, stillDue)
+		require.WithinDuration(t, *deadline, *stillDue, time.Second, "the delay action does not move install_at")
+
+		// into the reminder window. The other host stays an hour out and must not be re-dispatched.
+		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) + INTERVAL 4 MINUTE")
+		shortened := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, shortened)
+		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
+
+		reminded := getTestNotification(t, s.ds, notificationUUID)
+		require.Equal(t, notifications_api.EndUserNotificationPending, reminded.Status)
+		require.Nil(t, reminded.DisplayedAt, "the re-dispatch clears displayed_at so the reminder records its own")
+		require.NotNil(t, reminded.LastReason)
+		require.Equal(t, notifications_api.EndUserNotificationReasonDelayed, *reminded.LastReason)
+		require.NotNil(t, reminded.ExecutionID, "execution_id is kept so a late script result still resolves the notification")
+		require.Equal(t, *dispatched.ExecutionID, *reminded.ExecutionID)
+		require.JSONEq(t, `{"reminder": true}`, string(reminded.Payload))
+
+		untouched := getTestNotification(t, s.ds, otherUUID)
+		require.Equal(t, notifications_api.EndUserNotificationDispatched, untouched.Status,
+			"the other host's install_at is outside the reminder window")
+		require.JSONEq(t, `{"reminder": false}`, string(untouched.Payload))
+
+		// pending is the guard against a second reminder
+		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
+		require.Equal(t, notifications_api.EndUserNotificationPending, getTestNotification(t, s.ds, notificationUUID).Status)
+
+		dispatch(t)
+		redispatched := getTestNotification(t, s.ds, notificationUUID)
+		require.NotNil(t, redispatched.ExecutionID)
+		_, reminderToken := fetchScript(t, host, *redispatched.ExecutionID)
+
+		var view notifications_api.NotificationView
+		s.DoJSONWithoutAuth("GET", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s", reminderToken, notificationUUID),
+			nil, http.StatusOK, &view)
+		require.Contains(t, view.Description, "**5 minutes**")
+		require.Equal(t, []notifications_api.NotificationAction{
+			{ID: "dismiss", Label: "Hide"},
+			{ID: "update_now", Label: "Update now"},
+		}, view.Actions, "the reminder swaps Remind for Hide")
+
+		// a late reminder moves install_at out rather than losing part of its 5 minutes
+		postScriptResult(host, *redispatched.ExecutionID, 0)
+		reminderDisplayed := getTestNotification(t, s.ds, notificationUUID)
+		require.NotNil(t, reminderDisplayed.DisplayedAt)
+		afterReminder := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, afterReminder)
+		require.False(t, afterReminder.Before(reminderDisplayed.DisplayedAt.Add(5*time.Minute)),
+			"the apps must not be queued less than five minutes after the reminder reached the screen")
+		require.True(t, afterReminder.After(*shortened), "the deadline moved out by the reminder's display latency")
+		require.WithinDuration(t, reminderDisplayed.DisplayedAt.Add(5*time.Minute), *afterReminder, time.Second)
+
+		// one pass, two notifications: this one installs, the other only reminds
 		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) - INTERVAL 1 MINUTE")
-
+		setTestInstallAt(t, s.ds, otherUUID, "NOW(6) + INTERVAL 4 MINUTE")
 		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
 
 		acted := getTestNotification(t, s.ds, notificationUUID)
 		require.Equal(t, notifications_api.EndUserNotificationActed, acted.Status,
-			"the notification is taken before the installs go out, so Update now can't queue them twice")
+			"the notification is acted before the install requests are queued, so update_now cannot queue them again")
 
-		var queuedInstalls []struct {
-			ExecutionID string `db:"execution_id"`
-			PolicyID    *uint  `db:"policy_id"`
-		}
-		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			return sqlx.SelectContext(ctx, q, &queuedInstalls, `
-				SELECT ua.execution_id, siua.policy_id
-				FROM upcoming_activities ua
-					JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
-				WHERE ua.host_id = ?`, host.ID)
-		})
-		require.Len(t, queuedInstalls, 1, "the notification's one app gets one install")
-		require.NotNil(t, queuedInstalls[0].PolicyID, "the install keeps its policy so it shows in Automation runs")
-		require.Equal(t, policy.ID, *queuedInstalls[0].PolicyID)
+		otherReminded := getTestNotification(t, s.ds, otherUUID)
+		require.Equal(t, notifications_api.EndUserNotificationPending, otherReminded.Status)
+		require.JSONEq(t, `{"reminder": true}`, string(otherReminded.Payload))
+		require.Empty(t, queuedInstalls(otherHost.ID), "the other host is re-dispatched, not installed")
 
-		// no app open gate, so the app closes and updates
-		queued, err := s.ds.GetSoftwareInstallDetails(ctx, queuedInstalls[0].ExecutionID)
+		installs := queuedInstalls(host.ID)
+		require.Len(t, installs, 1, "the notification's one software title gets one install request")
+		require.NotNil(t, installs[0].PolicyID, "the install request keeps its policy id")
+		require.Equal(t, policy.ID, *installs[0].PolicyID)
+
+		// no override_pre_install_query, so the app open query never runs
+		queued, err := s.ds.GetSoftwareInstallDetails(ctx, installs[0].ExecutionID)
 		require.NoError(t, err)
 		require.False(t, queued.OverridePreInstallQuery)
 		require.Empty(t, queued.PreInstallCondition)
 
-		// a second pass finds nothing to do, since the notification is acted
+		// acted is the guard against a second install request
 		require.NoError(t, s.patchNotificationKind.RemindAndInstallDuePatches(ctx))
-		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			return sqlx.SelectContext(ctx, q, &queuedInstalls, `
-				SELECT ua.execution_id, siua.policy_id
-				FROM upcoming_activities ua
-					JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
-				WHERE ua.host_id = ?`, host.ID)
-		})
-		require.Len(t, queuedInstalls, 1)
+		require.Len(t, queuedInstalls(host.ID), 1)
 	})
 }

--- a/server/service/integration_end_user_notifications_test.go
+++ b/server/service/integration_end_user_notifications_test.go
@@ -67,6 +67,28 @@ func newRenderableTestNotification(t *testing.T, ds *mysql.Datastore, hostID uin
 	return notificationUUID
 }
 
+func getTestInstallAt(t *testing.T, ds *mysql.Datastore, notificationUUID string) *time.Time {
+	t.Helper()
+	var installAt *time.Time
+	mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &installAt,
+			`SELECT install_at FROM patch_notifications WHERE notification_uuid = ?`, notificationUUID)
+	})
+	return installAt
+}
+
+// setTestInstallAt moves a deadline, so a test can stand in for the hour passing.
+// installAt is SQL rather than a value, since the rest of the countdown reads the
+// database clock.
+func setTestInstallAt(t *testing.T, ds *mysql.Datastore, notificationUUID string, installAt string) {
+	t.Helper()
+	mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(context.Background(),
+			`UPDATE patch_notifications SET install_at = `+installAt+` WHERE notification_uuid = ?`, notificationUUID)
+		return err
+	})
+}
+
 // getTestNotification reads a notification row directly, for asserting on
 // state the bounded context's own HTTP API doesn't expose (e.g. status,
 // execution_id).
@@ -225,7 +247,7 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		// and nothing else has happened since, so it is the newest one globally
 		var globalFeed listActivitiesResponse
 		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &globalFeed,
-			"order_key", "a.id", "order_direction", "desc", "per_page", "1")
+			"order_key", "id", "order_direction", "desc", "per_page", "1")
 		require.Len(t, globalFeed.Activities, 1)
 		require.Equal(t, "notified_end_user_before_patching", globalFeed.Activities[0].Type)
 		require.NotNil(t, globalFeed.Activities[0].Details)
@@ -362,7 +384,9 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			[]byte(`{"action": "verify"}`), http.StatusOK)
 	})
 
-	t.Run("POST delay with a registered kind delays it", func(t *testing.T) {
+	// The countdown pass sends the reminder whatever the end user pressed, so the
+	// button only closes the toast and the deadline it was pressed against stays put.
+	t.Run("POST delay leaves the countdown alone and the reminder still arrives", func(t *testing.T) {
 		host := newNotifiableHost(t, "notif-delay-registered")
 		notificationUUID := newRenderableTestNotification(t, s.ds, host.ID, `{"reminder": false}`)
 		dispatch(t)
@@ -370,29 +394,43 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NotNil(t, dispatched.ExecutionID)
 		_, token := fetchScript(t, host, *dispatched.ExecutionID)
 
-		// exit 0 is what marks it displayed, which is the point the patch kind
-		// counts its next attempt from
+		// exit 0 is what marks it displayed, which is what starts the countdown
 		postScriptResult(host, *dispatched.ExecutionID, 0)
 		displayed := getTestNotification(t, s.ds, notificationUUID)
 		require.NotNil(t, displayed.DisplayedAt)
+		deadline := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, deadline)
+		require.WithinDuration(t, displayed.DisplayedAt.Add(time.Hour), *deadline, time.Minute)
 
 		s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s/actions", token, notificationUUID),
 			[]byte(`{"action": "delay"}`), http.StatusOK)
 
-		got := getTestNotification(t, s.ds, notificationUUID)
-		require.Equal(t, notifications_api.EndUserNotificationPending, got.Status)
-		require.NotNil(t, got.ExecutionID, "keeps its execution_id so a late result can still find it")
-		require.Equal(t, *dispatched.ExecutionID, *got.ExecutionID)
-		require.NotNil(t, got.LastReason)
-		require.Equal(t, notifications_api.EndUserNotificationReasonDelayed, *got.LastReason)
-		require.Nil(t, got.DisplayedAt, "the next send records its own display")
+		delayed := getTestNotification(t, s.ds, notificationUUID)
+		require.Equal(t, notifications_api.EndUserNotificationDispatched, delayed.Status)
+		require.NotNil(t, delayed.DisplayedAt, "the toast the end user closed still counts as displayed")
+		require.JSONEq(t, `{"reminder": false}`, string(delayed.Payload))
+		stillDue := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, stillDue)
+		require.WithinDuration(t, *deadline, *stillDue, time.Second, "pressing the button cannot buy more time")
 
-		// the patch kind rejoins the hour-then-five-minutes schedule rather than
-		// starting a fresh wait
-		require.NotNil(t, got.NextAttemptAt)
-		require.WithinDuration(t, displayed.DisplayedAt.Add(55*time.Minute), *got.NextAttemptAt, time.Minute)
+		// stand in for the hour running down to the reminder's lead time
+		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) + INTERVAL 4 MINUTE")
+		shortened := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, shortened)
+		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
 
-		require.JSONEq(t, `{"reminder": true}`, string(got.Payload))
+		reminded := getTestNotification(t, s.ds, notificationUUID)
+		require.Equal(t, notifications_api.EndUserNotificationPending, reminded.Status)
+		require.Nil(t, reminded.DisplayedAt, "the next send records its own display")
+		require.NotNil(t, reminded.LastReason)
+		require.Equal(t, notifications_api.EndUserNotificationReasonDelayed, *reminded.LastReason)
+		require.NotNil(t, reminded.ExecutionID, "keeps its execution_id so a late result can still find it")
+		require.Equal(t, *dispatched.ExecutionID, *reminded.ExecutionID)
+		require.JSONEq(t, `{"reminder": true}`, string(reminded.Payload))
+
+		// a second pass finds it pending, which is how it knows the reminder went out
+		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+		require.Equal(t, notifications_api.EndUserNotificationPending, getTestNotification(t, s.ds, notificationUUID).Status)
 
 		dispatch(t)
 		redispatched := getTestNotification(t, s.ds, notificationUUID)
@@ -408,21 +446,12 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 			{ID: "update_now", Label: "Update now"},
 		}, view.Actions, "the reminder swaps Remind for Hide")
 
-		// one that was delayed without ever being displayed has no mark to count
-		// from, so it waits a full interval
-		neverShown := newRenderableTestNotification(t, s.ds, host.ID, `{"reminder": false}`)
-		dispatch(t)
-		neverShownDispatched := getTestNotification(t, s.ds, neverShown)
-		require.NotNil(t, neverShownDispatched.ExecutionID)
-		_, neverShownToken := fetchScript(t, host, *neverShownDispatched.ExecutionID)
-
-		s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/notifications/%s/actions", neverShownToken, neverShown),
-			[]byte(`{"action": "delay"}`), http.StatusOK)
-
-		got = getTestNotification(t, s.ds, neverShown)
-		require.NotNil(t, got.NextAttemptAt)
-		require.WithinDuration(t, time.Now().UTC().Add(notifications_api.EndUserNotificationDelayInterval), *got.NextAttemptAt, time.Minute)
-		require.JSONEq(t, `{"reminder": false}`, string(got.Payload))
+		// the reminder's own display reports the deadline already stored rather than
+		// pushing it out another hour
+		postScriptResult(host, *redispatched.ExecutionID, 0)
+		afterReminder := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, afterReminder)
+		require.WithinDuration(t, *shortened, *afterReminder, time.Second)
 	})
 
 	t.Run("POST delay with no kind registered is a no-op", func(t *testing.T) {
@@ -748,5 +777,100 @@ func (s *integrationTestSuite) TestEndUserNotifications() {
 		require.NoError(t, err)
 		require.True(t, result.NotifyBeforePatching)
 		require.False(t, result.OverridePreInstallQuery)
+	})
+
+	// TestPatchNotificationCountdowns covers which branch the pass takes. This
+	// covers the ending the pass is there for: the deadline is stored on display,
+	// and once it passes the install is queued with no app open gate.
+	t.Run("the deadline closes and updates the app", func(t *testing.T) {
+		host := newNotifiableHost(t, "notif-deadline")
+		team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "deadline-team"})
+		require.NoError(t, err)
+		require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
+
+		installerID, _, err := s.ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript: "echo", Filename: "deadline.pkg", StorageID: uuid.NewString(),
+			Title: "Deadline App", Version: "2.0.0", Source: "apps", Platform: "darwin",
+			UserID: s.users["admin1@example.com"].ID,
+			TeamID: &team.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{},
+			BundleIdentifier: "com.example.deadline",
+			AppOpenQuery:     "SELECT 1 FROM processes WHERE name = 'app'",
+		})
+		require.NoError(t, err)
+
+		var titleID uint
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &titleID,
+				`SELECT title_id FROM software_installers WHERE id = ?`, installerID)
+		})
+
+		policy, err := s.ds.NewTeamPolicy(ctx, team.ID, nil, fleet.PolicyPayload{
+			Name: "Deadline App up to date", Query: "SELECT 1;",
+		})
+		require.NoError(t, err)
+
+		notificationUUID := newTestNotification(t, s.ds, host.ID, "patch", `{"reminder": false}`)
+		require.NoError(t, s.ds.NewPatchNotification(ctx, notificationUUID))
+		require.NoError(t, s.ds.AddPatchNotificationApp(ctx, notificationUUID, fleet.PatchNotificationApp{
+			PolicyID: &policy.ID, SoftwareTitleID: titleID, SoftwareInstallerID: &installerID,
+		}))
+
+		// the toast on screen is what starts the countdown
+		dispatch(t)
+		dispatched := getTestNotification(t, s.ds, notificationUUID)
+		require.NotNil(t, dispatched.ExecutionID)
+		postScriptResult(host, *dispatched.ExecutionID, 0)
+
+		displayed := getTestNotification(t, s.ds, notificationUUID)
+		require.NotNil(t, displayed.DisplayedAt)
+		installAt := getTestInstallAt(t, s.ds, notificationUUID)
+		require.NotNil(t, installAt, "the display sets the deadline")
+		require.WithinDuration(t, displayed.DisplayedAt.Add(time.Hour), *installAt, time.Minute)
+
+		// stand in for the hour passing
+		setTestInstallAt(t, s.ds, notificationUUID, "NOW(6) - INTERVAL 1 MINUTE")
+
+		// createOrbitEnrolledHost backdates seen_time a minute, which is exactly the online window
+		// for a host with no distributed_interval, so say plainly that this host is online. An
+		// offline one restarts its countdown instead of installing.
+		require.NoError(t, s.ds.MarkHostsSeen(ctx, []uint{host.ID}, time.Now()))
+
+		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+
+		acted := getTestNotification(t, s.ds, notificationUUID)
+		require.Equal(t, notifications_api.EndUserNotificationActed, acted.Status,
+			"the notification is taken before the installs go out, so Update now can't queue them twice")
+
+		var queuedInstalls []struct {
+			ExecutionID string `db:"execution_id"`
+			PolicyID    *uint  `db:"policy_id"`
+		}
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &queuedInstalls, `
+				SELECT ua.execution_id, siua.policy_id
+				FROM upcoming_activities ua
+					JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
+				WHERE ua.host_id = ?`, host.ID)
+		})
+		require.Len(t, queuedInstalls, 1, "the notification's one app gets one install")
+		require.NotNil(t, queuedInstalls[0].PolicyID, "the install keeps its policy so it shows in Automation runs")
+		require.Equal(t, policy.ID, *queuedInstalls[0].PolicyID)
+
+		// no app open gate, so the app closes and updates
+		queued, err := s.ds.GetSoftwareInstallDetails(ctx, queuedInstalls[0].ExecutionID)
+		require.NoError(t, err)
+		require.False(t, queued.OverridePreInstallQuery)
+		require.Empty(t, queued.PreInstallCondition)
+
+		// a second pass finds nothing to do, since the notification is acted
+		require.NoError(t, s.patchNotificationKind.RunPatchNotificationCountdowns(ctx))
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &queuedInstalls, `
+				SELECT ua.execution_id, siua.policy_id
+				FROM upcoming_activities ua
+					JOIN software_install_upcoming_activities siua ON siua.upcoming_activity_id = ua.id
+				WHERE ua.host_id = ?`, host.ID)
+		})
+		require.Len(t, queuedInstalls, 1)
 	})
 }

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server"
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -25,8 +25,8 @@ const (
 	patchNotificationFirstNoticeBefore = time.Hour
 	patchNotificationReminderBefore    = 5 * time.Minute
 
-	// how many countdowns one cron pass reads
-	patchNotificationCountdownBatchSize = 500
+	// how many due patch notifications one cron pass reads
+	duePatchNotificationBatchSize = 500
 )
 
 // Which of the two notices the notification is for. In the payload because that
@@ -67,7 +67,7 @@ type patchNotificationKind struct {
 
 type PatchNotificationKind interface {
 	notifications_api.NotificationKind
-	RunPatchNotificationCountdowns(ctx context.Context) error
+	RemindAndInstallDuePatches(ctx context.Context) error
 }
 
 func NewPatchNotificationKind(
@@ -245,47 +245,46 @@ func (k *patchNotificationKind) OnVerify(ctx context.Context, notification *noti
 }
 
 func (k *patchNotificationKind) OnDelay(ctx context.Context, notification *notifications_api.EndUserNotification) (*notifications_api.NotificationView, error) {
-	// The countdown pass sends the reminder whatever the end user pressed, so the button only has to
-	// close the toast, which the page does over the bridge. Leaving the row alone is also what stops
-	// the button buying more time.
+	// RemindAndInstallDuePatches sends the reminder whatever the end user pressed, so the button only
+	// has to close the toast, which the page does over the bridge. Leaving the row alone is also what
+	// stops the button buying more time.
 	return nil, nil
 }
 
-func (k *patchNotificationKind) RunPatchNotificationCountdowns(ctx context.Context) error {
+func (k *patchNotificationKind) RemindAndInstallDuePatches(ctx context.Context) error {
 	now := time.Now().UTC()
 
-	countdowns, err := k.ds.ListPatchNotificationsDue(ctx, now.Add(patchNotificationReminderBefore), patchNotificationCountdownBatchSize)
+	duePatches, err := k.ds.ListPatchNotificationsDue(ctx, now.Add(patchNotificationReminderBefore), duePatchNotificationBatchSize)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list patch notifications due")
 	}
-	if len(countdowns) == 0 {
+	if len(duePatches) == 0 {
 		return nil
 	}
 
-	notificationUUIDs := make([]string, 0, len(countdowns))
-	hostIDs := make([]uint, 0, len(countdowns))
-	for _, countdown := range countdowns {
-		notificationUUIDs = append(notificationUUIDs, countdown.NotificationUUID)
-		hostIDs = append(hostIDs, countdown.HostID)
+	notificationUUIDs := make([]string, 0, len(duePatches))
+	hostIDs := make([]uint, 0, len(duePatches))
+	for _, duePatch := range duePatches {
+		notificationUUIDs = append(notificationUUIDs, duePatch.NotificationUUID)
+		hostIDs = append(hostIDs, duePatch.HostID)
 	}
 
-	// The apps, the inventory and the install history of every countdown in the batch, read up front so
-	// the loop below does writes and installs rather than a handful of reads per countdown.
+	// The apps, the inventory and the install history of every due patch in the batch, read up front so
+	// the loop below does writes and installs rather than a handful of reads per notification.
 	appsByNotification, err := k.ds.ListPatchNotificationAppsForNotifications(ctx, notificationUUIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list patch notification apps for the batch")
 	}
 
+	// The same title comes up once per host notified about it, so the IN list is deduplicated. The due
+	// patches are walked rather than the map, which would put the list in a different order every pass.
 	var softwareTitleIDs []uint
-	for _, apps := range appsByNotification {
-		for _, app := range apps {
+	for _, duePatch := range duePatches {
+		for _, app := range appsByNotification[duePatch.NotificationUUID] {
 			softwareTitleIDs = append(softwareTitleIDs, app.SoftwareTitleID)
 		}
 	}
-	// The same title comes up once per host notified about it, and sorting before compacting keeps the
-	// IN list short and in the same order every pass.
-	slices.Sort(softwareTitleIDs)
-	softwareTitleIDs = slices.Compact(softwareTitleIDs)
+	softwareTitleIDs = server.RemoveDuplicatesFromSlice(softwareTitleIDs)
 
 	versions, err := k.ds.ListHostSoftwareVersionsForTitles(ctx, hostIDs, softwareTitleIDs)
 	if err != nil {
@@ -302,145 +301,135 @@ func (k *patchNotificationKind) RunPatchNotificationCountdowns(ctx context.Conte
 		return ctxerr.Wrap(ctx, err, "list host last title install data for the batch")
 	}
 
-	// One host's countdown failing must not hold up the rest of the batch.
+	// One notification failing must not hold up the rest of the batch.
 	var errs []error
-	for _, countdown := range countdowns {
-		// The batch reaches no further ahead than the reminder's lead time, so a deadline still to come
-		// means this pass is the reminder rather than the patch.
-		var sendReminder bool
-		if countdown.InstallAt.After(now) {
-			sendReminder = true
-		}
-
-		if sendReminder {
-			// These three checks are what keep the reminder to one send: the re-dispatch leaves the row
-			// pending, and the display after that leaves the reminder flag in the payload.
-			if countdown.Status != notifications_api.EndUserNotificationDispatched || countdown.DisplayedAt == nil {
-				continue
-			}
-			var alreadyReminder bool
-			alreadyReminder, err = patchNotificationIsReminder(countdown.Payload)
-			if err != nil {
-				errs = append(errs, ctxerr.Wrapf(ctx, err, "read patch notification payload: notification_uuid=%s", countdown.NotificationUUID))
-				continue
-			}
-			if alreadyReminder {
-				continue
-			}
-		} else if countdown.DisplayedAt == nil {
-			// The end user never saw the notice this deadline belongs to, so the countdown starts over and
-			// they get a fresh hour whenever their host next reaches the screen. A host that went offline and
-			// a reminder still on its way both land here, and both want the same thing.
-			err = k.ds.ResetPatchNotification(ctx, countdown.NotificationUUID)
-			if err != nil {
-				errs = append(errs, ctxerr.Wrapf(ctx, err,
-					"clear the deadline of a patch notification the end user has not seen: notification_uuid=%s", countdown.NotificationUUID))
-				continue
-			}
-			err = k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationFirstNoticePayload)
-			if err != nil {
-				errs = append(errs, ctxerr.Wrapf(ctx, err,
-					"restart a patch notification the end user has not seen: notification_uuid=%s", countdown.NotificationUUID))
-			}
-			continue
-		}
-
-		// An app whose installer is gone stays listed, because there is nothing left to install with.
-		apps := appsByNotification[countdown.NotificationUUID]
-		var alreadyUpdatedTitleIDs []uint
-		remaining := make([]fleet.PatchNotificationAppDetail, 0, len(apps))
-		for _, app := range apps {
-			if app.SoftwareInstallerID == nil {
-				remaining = append(remaining, app)
-				continue
-			}
-
-			appKey := fleet.HostSoftwareTitleKey{HostID: countdown.HostID, SoftwareTitleID: app.SoftwareTitleID}
-
-			// Version strings of Fleet-maintained apps cannot be ordered, and the version Fleet installs
-			// is whichever installer is active rather than the highest string, so the only thing inventory
-			// can say is whether the host already carries exactly what this installer would put down. A
-			// host can carry more than one copy of a title, and the app is only dropped when every copy is
-			// on that version.
-			installed := installedVersions[appKey]
-			upToDate := len(installed) > 0
-			for _, installedVersion := range installed {
-				if installedVersion != app.InstallerVersion {
-					upToDate = false
-					break
-				}
-			}
-			if upToDate {
-				alreadyUpdatedTitleIDs = append(alreadyUpdatedTitleIDs, app.SoftwareTitleID)
-				continue
-			}
-
-			// A self-service or admin install patches the app just as much as this notification would, and
-			// inventory can be an hour behind the install, so an install Fleet finished since the
-			// notification was created counts too. Read by title, so an install that went through an
-			// installer replaced during the countdown still counts.
-			var installedByFleet bool
-			for _, install := range installsByTitle[appKey] {
-				if install.Status != nil && *install.Status == fleet.SoftwareInstalled && install.UpdatedAt.After(countdown.CreatedAt) {
-					installedByFleet = true
-					break
-				}
-			}
-			if installedByFleet {
-				alreadyUpdatedTitleIDs = append(alreadyUpdatedTitleIDs, app.SoftwareTitleID)
-				continue
-			}
-			remaining = append(remaining, app)
-		}
-
-		// Render builds the toast from this table, so the rows have to go for the reminder to stop naming
-		// apps the end user already updated.
-		if len(alreadyUpdatedTitleIDs) > 0 {
-			err = k.ds.DeletePatchNotificationApps(ctx, countdown.NotificationUUID, alreadyUpdatedTitleIDs)
-			if err != nil {
-				errs = append(errs, ctxerr.Wrapf(ctx, err,
-					"delete patch notification apps that no longer need updating: notification_uuid=%s", countdown.NotificationUUID))
-				continue
-			}
-		}
-
-		if sendReminder {
-			// Nothing is left to warn about, and the notification would now render nothing, so close it.
-			if len(remaining) == 0 {
-				_, err = k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID)
-				if err != nil {
-					errs = append(errs, ctxerr.Wrapf(ctx, err,
-						"act on a patch notification with nothing left to update: notification_uuid=%s", countdown.NotificationUUID))
-				}
-				continue
-			}
-			err = k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationReminderPayload)
-			if err != nil {
-				errs = append(errs, ctxerr.Wrapf(ctx, err, "send patch notification reminder: notification_uuid=%s", countdown.NotificationUUID))
-			}
-			continue
-		}
-
-		// Acted first, so an Update now arriving at the same moment cannot queue the same installs twice.
-		var acted bool
-		acted, err = k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID)
+	for _, duePatch := range duePatches {
+		err = k.remindOrInstallDuePatch(ctx, duePatch, appsByNotification[duePatch.NotificationUUID], installedVersions, installsByTitle, now)
 		if err != nil {
-			errs = append(errs, ctxerr.Wrapf(ctx, err, "act on patch notification: notification_uuid=%s", countdown.NotificationUUID))
-			continue
-		}
-		if !acted || len(remaining) == 0 {
-			continue
-		}
-
-		// One InsertSoftwareInstallRequest per app left, so this call is what the pass costs to write.
-		// Stays acted on failure: there is no second press to finish the rest here, and the patch policy
-		// opens a new notification for whatever is left unpatched.
-		_, err = k.queuePatchNotificationInstalls(ctx, countdown.NotificationUUID, countdown.HostID, remaining, installsByTitle)
-		if err != nil {
-			errs = append(errs, ctxerr.Wrapf(ctx, err, "queue patch notification installs at the deadline: notification_uuid=%s", countdown.NotificationUUID))
+			errs = append(errs, ctxerr.Wrapf(ctx, err, "notification_uuid=%s", duePatch.NotificationUUID))
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (k *patchNotificationKind) remindOrInstallDuePatch(
+	ctx context.Context,
+	duePatch fleet.PatchNotificationDue,
+	apps []fleet.PatchNotificationAppDetail,
+	installedVersions map[fleet.HostSoftwareTitleKey][]string,
+	installsByTitle map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData,
+	now time.Time,
+) error {
+	// decide whether to send a reminder notification or force the app installs
+	var shouldSendReminder bool
+	if duePatch.InstallAt.After(now) {
+		shouldSendReminder = true
+	}
+
+	if shouldSendReminder {
+		// no reminder for a notice that is queued or not yet on screen
+		if duePatch.DisplayedAt == nil || duePatch.Status != notifications_api.EndUserNotificationDispatched {
+			return nil
+		}
+		notificationIsReminder, err := patchNotificationIsReminder(duePatch.Payload)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "read patch notification payload")
+		}
+		// the reminder already went out
+		if notificationIsReminder {
+			return nil
+		}
+	} else if duePatch.DisplayedAt == nil {
+		// the end user never saw this notice, so the deadline starts over from the next display
+		err := k.ds.ResetPatchNotification(ctx, duePatch.NotificationUUID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "clear the deadline of a patch notification the end user has not seen")
+		}
+		err = k.notificationSvc.DelayNotification(ctx, duePatch.NotificationUUID, now, patchNotificationFirstNoticePayload)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "restart a patch notification the end user has not seen")
+		}
+		return nil
+	}
+
+	// leave out the apps updated since the notification was created, so the reminder stops naming them and nothing is queued for them
+	var alreadyUpdatedTitleIDs []uint
+	remaining := make([]fleet.PatchNotificationAppDetail, 0, len(apps))
+	for _, app := range apps {
+		if app.SoftwareInstallerID == nil {
+			remaining = append(remaining, app)
+			continue
+		}
+
+		appKey := fleet.HostSoftwareTitleKey{HostID: duePatch.HostID, SoftwareTitleID: app.SoftwareTitleID}
+
+		installed := installedVersions[appKey]
+		upToDate := len(installed) > 0
+		for _, installedVersion := range installed {
+			if installedVersion != app.InstallerVersion {
+				upToDate = false
+				break
+			}
+		}
+		if upToDate {
+			alreadyUpdatedTitleIDs = append(alreadyUpdatedTitleIDs, app.SoftwareTitleID)
+			continue
+		}
+
+		var installedByFleet bool
+		for _, install := range installsByTitle[appKey] {
+			if install.Status != nil && *install.Status == fleet.SoftwareInstalled && install.UpdatedAt.After(duePatch.CreatedAt) {
+				installedByFleet = true
+				break
+			}
+		}
+		if installedByFleet {
+			alreadyUpdatedTitleIDs = append(alreadyUpdatedTitleIDs, app.SoftwareTitleID)
+			continue
+		}
+		remaining = append(remaining, app)
+	}
+
+	// Render builds the toast from these rows, so updated apps stop being named
+	if len(alreadyUpdatedTitleIDs) > 0 {
+		err := k.ds.DeletePatchNotificationApps(ctx, duePatch.NotificationUUID, alreadyUpdatedTitleIDs)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "delete patch notification apps that no longer need updating")
+		}
+	}
+
+	if shouldSendReminder {
+		// nothing left to update, so the notification closes instead of reminding
+		if len(remaining) == 0 {
+			_, err := k.notificationSvc.ActOnNotification(ctx, duePatch.NotificationUUID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "act on a patch notification with nothing left to update")
+			}
+		} else {
+			// re-send the notification with the reminder payload, so the end user gets the 5 minute notice
+			err := k.notificationSvc.DelayNotification(ctx, duePatch.NotificationUUID, now, patchNotificationReminderPayload)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "send patch notification reminder")
+			}
+		}
+		return nil
+	}
+
+	// set the notification's status to acted before queueing, so a simultaneous Update now press cannot queue the same installs
+	actedInThisPass, err := k.notificationSvc.ActOnNotification(ctx, duePatch.NotificationUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "act on patch notification")
+	}
+	// nothing is left to install
+	if !actedInThisPass || len(remaining) == 0 {
+		return nil
+	}
+
+	_, err = k.queuePatchNotificationInstalls(ctx, duePatch.NotificationUUID, duePatch.HostID, remaining, installsByTitle)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "queue patch notification installs at the deadline")
+	}
+	return nil
 }
 
 func (k *patchNotificationKind) OnAction(ctx context.Context, notification *notifications_api.EndUserNotification, actionID string) (*notifications_api.NotificationView, error) {
@@ -467,11 +456,11 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 	}
 
 	// Mark the notification acted first, so two presses at once can't both queue installs.
-	acted, err := k.notificationSvc.ActOnNotification(ctx, notification.UUID)
+	actedInThisRequest, err := k.notificationSvc.ActOnNotification(ctx, notification.UUID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "act on patch notification")
 	}
-	if !acted {
+	if !actedInThisRequest {
 		return k.renderView(ctx, notification, true)
 	}
 
@@ -495,10 +484,10 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 		return nil, ctxerr.Wrapf(ctx, err, "list host last title install data: host_id=%d", notification.HostID)
 	}
 
-	canPutBack, queueErr := k.queuePatchNotificationInstalls(ctx, notification.UUID, notification.HostID, apps, installsByTitle)
+	installsRecorded, queueErr := k.queuePatchNotificationInstalls(ctx, notification.UUID, notification.HostID, apps, installsByTitle)
 	if queueErr != nil {
-		// Back to the status it had, so the next press finishes the rest.
-		if canPutBack {
+		// hand the notification back only when what went out was recorded, so the next press finishes the rest
+		if installsRecorded {
 			k.putPatchNotificationBack(ctx, notification)
 		}
 		return nil, queueErr
@@ -508,8 +497,7 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 }
 
 func (k *patchNotificationKind) putPatchNotificationBack(ctx context.Context, notification *notifications_api.EndUserNotification) {
-	err := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil,
-		[]string{notifications_api.EndUserNotificationActed})
+	err := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil, []string{notifications_api.EndUserNotificationActed})
 	if err != nil {
 		k.logger.ErrorContext(ctx, "failed to put the patch notification back",
 			"notification_uuid", notification.UUID, "err", err)
@@ -522,8 +510,8 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 	hostID uint,
 	apps []fleet.PatchNotificationAppDetail,
 	installsByTitle map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData,
-) (canPutBack bool, err error) {
-	// An attempt that fails part way still records what it queued, so the next one finishes the rest.
+) (installsRecorded bool, err error) {
+	// record what was queued even when the loop breaks, so the next attempt finishes the rest
 	var queuedTitleIDs []uint
 	var queueErr error
 	for _, app := range apps {
@@ -536,8 +524,8 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 		if app.InstallQueued {
 			continue
 		}
-		// An install of the app already on its way, however it was requested, must not be queued a
-		// second time.
+
+		// leave out an app whose install is already on its way, whoever requested it
 		var installPending bool
 		for _, install := range installsByTitle[fleet.HostSoftwareTitleKey{HostID: hostID, SoftwareTitleID: app.SoftwareTitleID}] {
 			if install.Status != nil && *install.Status == fleet.SoftwareInstallPending {
@@ -549,21 +537,19 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 			continue
 		}
 
-		// OverridePreInstallQuery stays false, which leaves the agent no app open gate to run, so the
-		// app closes and updates.
-		if _, err := k.ds.InsertSoftwareInstallRequest(ctx, hostID, *app.SoftwareInstallerID,
-			fleet.HostSoftwareInstallOptions{PolicyID: app.PolicyID},
-		); err != nil {
-			queueErr = ctxerr.Wrapf(ctx, err, "insert software install request: host_id=%d, software_installer_id=%d",
-				hostID, *app.SoftwareInstallerID)
+		// OverridePreInstallQuery stays false, so the app open check does not stop the install
+		_, insertErr := k.ds.InsertSoftwareInstallRequest(ctx, hostID, *app.SoftwareInstallerID, fleet.HostSoftwareInstallOptions{PolicyID: app.PolicyID})
+		if insertErr != nil {
+			queueErr = ctxerr.Wrapf(ctx, insertErr, "insert software install request: host_id=%d, software_installer_id=%d", hostID, *app.SoftwareInstallerID)
 			break
 		}
 
 		queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
 	}
 
-	// Once this write fails the installs have gone out unrecorded, so a second attempt would repeat them.
-	if err := k.ds.SetPatchNotificationAppsQueued(ctx, notificationUUID, queuedTitleIDs); err != nil {
+	// the installs are already out, so a failure here leaves them unrecorded and a second attempt would repeat them
+	err = k.ds.SetPatchNotificationAppsQueued(ctx, notificationUUID, queuedTitleIDs)
+	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "set patch notification apps queued")
 	}
 	return true, queueErr

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
@@ -257,156 +258,189 @@ func (k *patchNotificationKind) RunPatchNotificationCountdowns(ctx context.Conte
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list patch notifications due")
 	}
+	if len(countdowns) == 0 {
+		return nil
+	}
+
+	notificationUUIDs := make([]string, 0, len(countdowns))
+	hostIDs := make([]uint, 0, len(countdowns))
+	for _, countdown := range countdowns {
+		notificationUUIDs = append(notificationUUIDs, countdown.NotificationUUID)
+		hostIDs = append(hostIDs, countdown.HostID)
+	}
+
+	// The apps, the inventory and the install history of every countdown in the batch, read up front so
+	// the loop below does writes and installs rather than a handful of reads per countdown.
+	appsByNotification, err := k.ds.ListPatchNotificationAppsForNotifications(ctx, notificationUUIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list patch notification apps for the batch")
+	}
+
+	var softwareTitleIDs []uint
+	for _, apps := range appsByNotification {
+		for _, app := range apps {
+			softwareTitleIDs = append(softwareTitleIDs, app.SoftwareTitleID)
+		}
+	}
+	// The same title comes up once per host notified about it, and sorting before compacting keeps the
+	// IN list short and in the same order every pass.
+	slices.Sort(softwareTitleIDs)
+	softwareTitleIDs = slices.Compact(softwareTitleIDs)
+
+	versions, err := k.ds.ListHostSoftwareVersionsForTitles(ctx, hostIDs, softwareTitleIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list host software versions for the batch")
+	}
+	installedVersions := make(map[fleet.HostSoftwareTitleKey][]string, len(versions))
+	for _, version := range versions {
+		key := fleet.HostSoftwareTitleKey{HostID: version.HostID, SoftwareTitleID: version.SoftwareTitleID}
+		installedVersions[key] = append(installedVersions[key], version.Version)
+	}
+
+	installsByTitle, err := k.ds.ListHostLastTitleInstallData(ctx, hostIDs, softwareTitleIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list host last title install data for the batch")
+	}
 
 	// One host's countdown failing must not hold up the rest of the batch.
 	var errs []error
 	for _, countdown := range countdowns {
+		// The batch reaches no further ahead than the reminder's lead time, so a deadline still to come
+		// means this pass is the reminder rather than the patch.
+		var sendReminder bool
 		if countdown.InstallAt.After(now) {
-			if err := k.remindBeforePatching(ctx, countdown, now); err != nil {
-				errs = append(errs, ctxerr.Wrapf(ctx, err, "remind before patching: notification_uuid=%s", countdown.NotificationUUID))
+			sendReminder = true
+		}
+
+		if sendReminder {
+			// These three checks are what keep the reminder to one send: the re-dispatch leaves the row
+			// pending, and the display after that leaves the reminder flag in the payload.
+			if countdown.Status != notifications_api.EndUserNotificationDispatched || countdown.DisplayedAt == nil {
+				continue
+			}
+			var alreadyReminder bool
+			alreadyReminder, err = patchNotificationIsReminder(countdown.Payload)
+			if err != nil {
+				errs = append(errs, ctxerr.Wrapf(ctx, err, "read patch notification payload: notification_uuid=%s", countdown.NotificationUUID))
+				continue
+			}
+			if alreadyReminder {
+				continue
+			}
+		} else if countdown.DisplayedAt == nil {
+			// The end user never saw the notice this deadline belongs to, so the countdown starts over and
+			// they get a fresh hour whenever their host next reaches the screen. A host that went offline and
+			// a reminder still on its way both land here, and both want the same thing.
+			err = k.ds.ResetPatchNotification(ctx, countdown.NotificationUUID)
+			if err != nil {
+				errs = append(errs, ctxerr.Wrapf(ctx, err,
+					"clear the deadline of a patch notification the end user has not seen: notification_uuid=%s", countdown.NotificationUUID))
+				continue
+			}
+			err = k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationFirstNoticePayload)
+			if err != nil {
+				errs = append(errs, ctxerr.Wrapf(ctx, err,
+					"restart a patch notification the end user has not seen: notification_uuid=%s", countdown.NotificationUUID))
 			}
 			continue
 		}
-		if err := k.patchAtDeadline(ctx, countdown, now); err != nil {
-			errs = append(errs, ctxerr.Wrapf(ctx, err, "patch at deadline: notification_uuid=%s", countdown.NotificationUUID))
+
+		// An app whose installer is gone stays listed, because there is nothing left to install with.
+		apps := appsByNotification[countdown.NotificationUUID]
+		var alreadyUpdatedTitleIDs []uint
+		remaining := make([]fleet.PatchNotificationAppDetail, 0, len(apps))
+		for _, app := range apps {
+			if app.SoftwareInstallerID == nil {
+				remaining = append(remaining, app)
+				continue
+			}
+
+			appKey := fleet.HostSoftwareTitleKey{HostID: countdown.HostID, SoftwareTitleID: app.SoftwareTitleID}
+
+			// Version strings of Fleet-maintained apps cannot be ordered, and the version Fleet installs
+			// is whichever installer is active rather than the highest string, so the only thing inventory
+			// can say is whether the host already carries exactly what this installer would put down. A
+			// host can carry more than one copy of a title, and the app is only dropped when every copy is
+			// on that version.
+			installed := installedVersions[appKey]
+			upToDate := len(installed) > 0
+			for _, installedVersion := range installed {
+				if installedVersion != app.InstallerVersion {
+					upToDate = false
+					break
+				}
+			}
+			if upToDate {
+				alreadyUpdatedTitleIDs = append(alreadyUpdatedTitleIDs, app.SoftwareTitleID)
+				continue
+			}
+
+			// A self-service or admin install patches the app just as much as this notification would, and
+			// inventory can be an hour behind the install, so an install Fleet finished since the
+			// notification was created counts too. Read by title, so an install that went through an
+			// installer replaced during the countdown still counts.
+			var installedByFleet bool
+			for _, install := range installsByTitle[appKey] {
+				if install.Status != nil && *install.Status == fleet.SoftwareInstalled && install.UpdatedAt.After(countdown.CreatedAt) {
+					installedByFleet = true
+					break
+				}
+			}
+			if installedByFleet {
+				alreadyUpdatedTitleIDs = append(alreadyUpdatedTitleIDs, app.SoftwareTitleID)
+				continue
+			}
+			remaining = append(remaining, app)
+		}
+
+		// Render builds the toast from this table, so the rows have to go for the reminder to stop naming
+		// apps the end user already updated.
+		if len(alreadyUpdatedTitleIDs) > 0 {
+			err = k.ds.DeletePatchNotificationApps(ctx, countdown.NotificationUUID, alreadyUpdatedTitleIDs)
+			if err != nil {
+				errs = append(errs, ctxerr.Wrapf(ctx, err,
+					"delete patch notification apps that no longer need updating: notification_uuid=%s", countdown.NotificationUUID))
+				continue
+			}
+		}
+
+		if sendReminder {
+			// Nothing is left to warn about, and the notification would now render nothing, so close it.
+			if len(remaining) == 0 {
+				_, err = k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID)
+				if err != nil {
+					errs = append(errs, ctxerr.Wrapf(ctx, err,
+						"act on a patch notification with nothing left to update: notification_uuid=%s", countdown.NotificationUUID))
+				}
+				continue
+			}
+			err = k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationReminderPayload)
+			if err != nil {
+				errs = append(errs, ctxerr.Wrapf(ctx, err, "send patch notification reminder: notification_uuid=%s", countdown.NotificationUUID))
+			}
+			continue
+		}
+
+		// Acted first, so an Update now arriving at the same moment cannot queue the same installs twice.
+		var acted bool
+		acted, err = k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID)
+		if err != nil {
+			errs = append(errs, ctxerr.Wrapf(ctx, err, "act on patch notification: notification_uuid=%s", countdown.NotificationUUID))
+			continue
+		}
+		if !acted || len(remaining) == 0 {
+			continue
+		}
+
+		// One InsertSoftwareInstallRequest per app left, so this call is what the pass costs to write.
+		// Stays acted on failure: there is no second press to finish the rest here, and the patch policy
+		// opens a new notification for whatever is left unpatched.
+		_, err = k.queuePatchNotificationInstalls(ctx, countdown.NotificationUUID, countdown.HostID, remaining, installsByTitle)
+		if err != nil {
+			errs = append(errs, ctxerr.Wrapf(ctx, err, "queue patch notification installs at the deadline: notification_uuid=%s", countdown.NotificationUUID))
 		}
 	}
 	return errors.Join(errs...)
-}
-
-func (k *patchNotificationKind) remindBeforePatching(ctx context.Context, countdown fleet.PatchNotificationDue, now time.Time) error {
-	// These three checks are what keep the reminder to one send: the re-dispatch leaves the row
-	// pending, and the display after that leaves the reminder flag in the payload.
-	if countdown.Status != notifications_api.EndUserNotificationDispatched || countdown.DisplayedAt == nil {
-		return nil
-	}
-	reminder, err := patchNotificationIsReminder(countdown.Payload)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "read patch notification payload")
-	}
-	if reminder {
-		return nil
-	}
-
-	remaining, err := k.dropAppsAlreadyUpdated(ctx, countdown)
-	if err != nil {
-		return err
-	}
-
-	// Nothing is left to warn about, and the notification would now render nothing, so close it.
-	if remaining == 0 {
-		if _, err := k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID); err != nil {
-			return ctxerr.Wrap(ctx, err, "act on a patch notification with nothing left to update")
-		}
-		return nil
-	}
-
-	if err := k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationReminderPayload); err != nil {
-		return ctxerr.Wrap(ctx, err, "send patch notification reminder")
-	}
-	return nil
-}
-
-func (k *patchNotificationKind) patchAtDeadline(ctx context.Context, countdown fleet.PatchNotificationDue, now time.Time) error {
-	// The end user never saw the notice this deadline belongs to, so the countdown starts over and
-	// they get a fresh hour whenever their host next reaches the screen. A host that went offline and
-	// a reminder still on its way both land here, and both want the same thing.
-	if countdown.DisplayedAt == nil {
-		if err := k.ds.ResetPatchNotification(ctx, countdown.NotificationUUID); err != nil {
-			return ctxerr.Wrap(ctx, err, "clear the deadline of an offline host's patch notification")
-		}
-		if err := k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationFirstNoticePayload); err != nil {
-			return ctxerr.Wrap(ctx, err, "restart an offline host's patch notification")
-		}
-		return nil
-	}
-
-	remaining, err := k.dropAppsAlreadyUpdated(ctx, countdown)
-	if err != nil {
-		return err
-	}
-
-	// Acted first, so an Update now arriving at the same moment cannot queue the same installs twice.
-	acted, err := k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "act on patch notification")
-	}
-	if !acted || remaining == 0 {
-		return nil
-	}
-
-	// Stays acted on failure: there is no second press to finish the rest here, and the patch policy
-	// opens a new notification for whatever is left unpatched.
-	if _, err := k.queuePatchNotificationInstalls(ctx, countdown.NotificationUUID, countdown.HostID); err != nil {
-		return ctxerr.Wrap(ctx, err, "queue patch notification installs at the deadline")
-	}
-	return nil
-}
-
-func (k *patchNotificationKind) dropAppsAlreadyUpdated(ctx context.Context, countdown fleet.PatchNotificationDue) (remaining int, err error) {
-	apps, err := k.ds.ListPatchNotificationApps(ctx, countdown.NotificationUUID)
-	if err != nil {
-		return 0, ctxerr.Wrap(ctx, err, "list patch notification apps")
-	}
-	if len(apps) == 0 {
-		return 0, nil
-	}
-
-	// Inventory refreshes after any Fleet install and on refetch, so within the hour it is the freshest
-	// record of what the host actually has.
-	installed, err := k.ds.ListSoftwareByHostIDShort(ctx, countdown.HostID)
-	if err != nil {
-		return 0, ctxerr.Wrapf(ctx, err, "list software on host: host_id=%d", countdown.HostID)
-	}
-	installedVersionByBundleIdentifier := make(map[string]string, len(installed))
-	for _, software := range installed {
-		if software.BundleIdentifier != "" {
-			installedVersionByBundleIdentifier[software.BundleIdentifier] = software.Version
-		}
-	}
-
-	// An app whose installer is gone stays listed, because there is no version to compare it against.
-	var dropped []uint
-	for _, app := range apps {
-		if app.SoftwareInstallerID == nil {
-			continue
-		}
-		installer, err := k.ds.GetSoftwareInstallerMetadataByID(ctx, *app.SoftwareInstallerID)
-		if err != nil {
-			if fleet.IsNotFound(err) {
-				continue
-			}
-			return 0, ctxerr.Wrapf(ctx, err, "get software installer metadata: software_installer_id=%d", *app.SoftwareInstallerID)
-		}
-
-		// FMA version strings are not reliably semver and CompareVersions treats an invalid one as lower,
-		// which would force an install, so both sides are normalized first. An app with no inventory row
-		// normalizes to an empty version and stays listed.
-		installedVersion := toValidSemVer(installedVersionByBundleIdentifier[installer.BundleIdentifier])
-		if installedVersion != "" && fleet.CompareVersions(toValidSemVer(installer.Version), installedVersion) != 1 {
-			dropped = append(dropped, app.SoftwareTitleID)
-			continue
-		}
-
-		// A My device self-service update lands before inventory catches up, so a Fleet install that
-		// succeeded since the notification was created counts too.
-		lastInstall, err := k.ds.GetHostLastInstallData(ctx, countdown.HostID, *app.SoftwareInstallerID)
-		if err != nil {
-			return 0, ctxerr.Wrapf(ctx, err, "get host last install data: host_id=%d, software_installer_id=%d",
-				countdown.HostID, *app.SoftwareInstallerID)
-		}
-		if lastInstall != nil && lastInstall.Status != nil &&
-			*lastInstall.Status == fleet.SoftwareInstalled && lastInstall.UpdatedAt.After(countdown.CreatedAt) {
-			dropped = append(dropped, app.SoftwareTitleID)
-		}
-	}
-
-	// Render builds the toast from this table, so the rows have to go for the reminder to stop naming
-	// apps the end user already updated.
-	if err := k.ds.DeletePatchNotificationApps(ctx, countdown.NotificationUUID, dropped); err != nil {
-		return 0, ctxerr.Wrap(ctx, err, "delete patch notification apps that no longer need updating")
-	}
-	return len(apps) - len(dropped), nil
 }
 
 func (k *patchNotificationKind) OnAction(ctx context.Context, notification *notifications_api.EndUserNotification, actionID string) (*notifications_api.NotificationView, error) {
@@ -441,16 +475,31 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 		return k.renderView(ctx, notification, true)
 	}
 
-	canPutBack, queueErr := k.queuePatchNotificationInstalls(ctx, notification.UUID, notification.HostID)
+	// The deadline pass has the install history from the verify it just did. Update now has done no
+	// such read, so it makes the same one: without it the pending check in the queue below cannot tell
+	// "no install" from "not looked up".
+	apps, err := k.ds.ListPatchNotificationApps(ctx, notification.UUID)
+	if err != nil {
+		// Nothing was queued, so undo the act above and let the next press try.
+		k.putPatchNotificationBack(ctx, notification)
+		return nil, ctxerr.Wrap(ctx, err, "list patch notification apps")
+	}
+
+	softwareTitleIDs := make([]uint, 0, len(apps))
+	for _, app := range apps {
+		softwareTitleIDs = append(softwareTitleIDs, app.SoftwareTitleID)
+	}
+	installsByTitle, err := k.ds.ListHostLastTitleInstallData(ctx, []uint{notification.HostID}, softwareTitleIDs)
+	if err != nil {
+		k.putPatchNotificationBack(ctx, notification)
+		return nil, ctxerr.Wrapf(ctx, err, "list host last title install data: host_id=%d", notification.HostID)
+	}
+
+	canPutBack, queueErr := k.queuePatchNotificationInstalls(ctx, notification.UUID, notification.HostID, apps, installsByTitle)
 	if queueErr != nil {
 		// Back to the status it had, so the next press finishes the rest.
 		if canPutBack {
-			setStatusErr := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil,
-				[]string{notifications_api.EndUserNotificationActed})
-			if setStatusErr != nil {
-				k.logger.ErrorContext(ctx, "failed to put the patch notification back",
-					"notification_uuid", notification.UUID, "err", setStatusErr)
-			}
+			k.putPatchNotificationBack(ctx, notification)
 		}
 		return nil, queueErr
 	}
@@ -458,12 +507,22 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 	return k.renderView(ctx, notification, true)
 }
 
-func (k *patchNotificationKind) queuePatchNotificationInstalls(ctx context.Context, notificationUUID string, hostID uint) (canPutBack bool, err error) {
-	apps, err := k.ds.ListPatchNotificationApps(ctx, notificationUUID)
+func (k *patchNotificationKind) putPatchNotificationBack(ctx context.Context, notification *notifications_api.EndUserNotification) {
+	err := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil,
+		[]string{notifications_api.EndUserNotificationActed})
 	if err != nil {
-		return true, ctxerr.Wrap(ctx, err, "list patch notification apps")
+		k.logger.ErrorContext(ctx, "failed to put the patch notification back",
+			"notification_uuid", notification.UUID, "err", err)
 	}
+}
 
+func (k *patchNotificationKind) queuePatchNotificationInstalls(
+	ctx context.Context,
+	notificationUUID string,
+	hostID uint,
+	apps []fleet.PatchNotificationAppDetail,
+	installsByTitle map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData,
+) (canPutBack bool, err error) {
 	// An attempt that fails part way still records what it queued, so the next one finishes the rest.
 	var queuedTitleIDs []uint
 	var queueErr error
@@ -477,15 +536,16 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(ctx context.Conte
 		if app.InstallQueued {
 			continue
 		}
-
-		// check if this install is already queued
-		lastInstall, err := k.ds.GetHostLastInstallData(ctx, hostID, *app.SoftwareInstallerID)
-		if err != nil {
-			queueErr = ctxerr.Wrapf(ctx, err, "get host last install data: host_id=%d, software_installer_id=%d",
-				hostID, *app.SoftwareInstallerID)
-			break
+		// An install of the app already on its way, however it was requested, must not be queued a
+		// second time.
+		var installPending bool
+		for _, install := range installsByTitle[fleet.HostSoftwareTitleKey{HostID: hostID, SoftwareTitleID: app.SoftwareTitleID}] {
+			if install.Status != nil && *install.Status == fleet.SoftwareInstallPending {
+				installPending = true
+				break
+			}
 		}
-		if lastInstall != nil && lastInstall.Status != nil && *lastInstall.Status == fleet.SoftwareInstallPending {
+		if installPending {
 			continue
 		}
 

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -404,13 +404,17 @@ func (k *patchNotificationKind) remindOrInstallDuePatch(
 		return nil
 	}
 
-	// set the notification's status to acted before queueing, so a simultaneous Update now press cannot queue the same installs
+	// Moving the status to acted is what claims the queueing, so an Update now press and this pass
+	// cannot both send the same installs.
+	isStatusActed := duePatch.Status == notifications_api.EndUserNotificationActed
 	actedInThisPass, err := k.notificationSvc.ActOnNotification(ctx, duePatch.NotificationUUID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "act on patch notification")
 	}
-	// nothing is left to install
-	if !actedInThisPass || len(remaining) == 0 {
+	// Not claiming the queueing has two causes. Acted at read time is an earlier pass that stopped
+	// part way, which this one finishes. Acted only now is an Update now press, which queues the
+	// installs instead. Or verify dropped every app.
+	if (!actedInThisPass && !isStatusActed) || len(remaining) == 0 {
 		return nil
 	}
 
@@ -500,16 +504,19 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 	apps []fleet.PatchNotificationAppDetail,
 	installsByTitle map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData,
 ) (installsRecorded bool, err error) {
-	// record what was queued even when the loop breaks, so the next attempt finishes the rest
+	// install_queued records that an app has been dealt with, whether that meant queueing an install
+	// or deciding not to. An app left unmarked is one this pass could not queue, which is what tells
+	// a later pass the notification was acted on with installs still to go out.
 	var queuedTitleIDs []uint
-	var queueErr error
+	var queueErrs []error
 	for _, app := range apps {
 		if app.SoftwareInstallerID == nil {
 			k.logger.InfoContext(ctx, "skipping patch notification install for software with no installer",
 				"notification_uuid", notificationUUID, "software_title_id", app.SoftwareTitleID)
+			queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
 			continue
 		}
-		// queued by an earlier attempt that failed before it finished
+		// this app was dealt with by an earlier attempt
 		if app.InstallQueued {
 			continue
 		}
@@ -523,14 +530,18 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 			}
 		}
 		if installPending {
+			queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
 			continue
 		}
 
 		// OverridePreInstallQuery stays false, so the app open check does not stop the install
 		_, insertErr := k.ds.InsertSoftwareInstallRequest(ctx, hostID, *app.SoftwareInstallerID, fleet.HostSoftwareInstallOptions{PolicyID: app.PolicyID})
 		if insertErr != nil {
-			queueErr = ctxerr.Wrapf(ctx, insertErr, "insert software install request: host_id=%d, software_installer_id=%d", hostID, *app.SoftwareInstallerID)
-			break
+			// One app Fleet cannot queue must not hold up the rest. This app stays unmarked below,
+			// which is what brings the notification back to be finished.
+			queueErrs = append(queueErrs, ctxerr.Wrapf(ctx, insertErr,
+				"insert software install request: host_id=%d, software_installer_id=%d", hostID, *app.SoftwareInstallerID))
+			continue
 		}
 
 		queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
@@ -541,7 +552,7 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "set patch notification apps queued")
 	}
-	return true, queueErr
+	return true, errors.Join(queueErrs...)
 }
 
 func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *notifications_api.EndUserNotification, outcome notifications_api.NotificationOutcome) error {

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -286,7 +286,7 @@ func (k *patchNotificationKind) RemindAndInstallDuePatches(ctx context.Context) 
 	}
 	softwareTitleIDs = server.RemoveDuplicatesFromSlice(softwareTitleIDs)
 
-	versions, err := k.ds.ListHostSoftwareVersionsForTitles(ctx, hostIDs, softwareTitleIDs)
+	versions, err := k.ds.ListSoftwareTitleVersionsForHosts(ctx, hostIDs, softwareTitleIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list host software versions for the batch")
 	}
@@ -296,7 +296,7 @@ func (k *patchNotificationKind) RemindAndInstallDuePatches(ctx context.Context) 
 		installedVersions[key] = append(installedVersions[key], version.Version)
 	}
 
-	installsByTitle, err := k.ds.ListHostLastTitleInstallData(ctx, hostIDs, softwareTitleIDs)
+	installsByTitle, err := k.ds.ListLastTitleInstallDataForHosts(ctx, hostIDs, softwareTitleIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "list host last title install data for the batch")
 	}
@@ -478,7 +478,7 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 	for _, app := range apps {
 		softwareTitleIDs = append(softwareTitleIDs, app.SoftwareTitleID)
 	}
-	installsByTitle, err := k.ds.ListHostLastTitleInstallData(ctx, []uint{notification.HostID}, softwareTitleIDs)
+	installsByTitle, err := k.ds.ListLastTitleInstallDataForHosts(ctx, []uint{notification.HostID}, softwareTitleIDs)
 	if err != nil {
 		k.putPatchNotificationBack(ctx, notification)
 		return nil, ctxerr.Wrapf(ctx, err, "list host last title install data: host_id=%d", notification.HostID)

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
@@ -521,14 +522,11 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(
 			continue
 		}
 
-		// leave out an app whose install is already on its way, whoever requested it
-		var installPending bool
-		for _, install := range installsByTitle[fleet.HostSoftwareTitleKey{HostID: hostID, SoftwareTitleID: app.SoftwareTitleID}] {
-			if install.Status != nil && *install.Status == fleet.SoftwareInstallPending {
-				installPending = true
-				break
-			}
-		}
+		// an install carrying override_pre_install_query would skip while the app is open, so it needs to be queued again
+		titleKey := fleet.HostSoftwareTitleKey{HostID: hostID, SoftwareTitleID: app.SoftwareTitleID}
+		installPending := slices.ContainsFunc(installsByTitle[titleKey], func(install *fleet.HostLastInstallData) bool {
+			return install.Status != nil && *install.Status == fleet.SoftwareInstallPending && !install.OverridePreInstallQuery
+		})
 		if installPending {
 			queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
 			continue

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -22,6 +23,9 @@ const (
 const (
 	patchNotificationFirstNoticeBefore = time.Hour
 	patchNotificationReminderBefore    = 5 * time.Minute
+
+	// how many countdowns one cron pass reads
+	patchNotificationCountdownBatchSize = 500
 )
 
 // Which of the two notices the notification is for. In the payload because that
@@ -60,12 +64,19 @@ type patchNotificationKind struct {
 	logger          *slog.Logger
 }
 
+// The patch kind plus the countdown pass its cron job calls, so cmd/fleet can register the kind and
+// schedule the pass from one value.
+type PatchNotificationKind interface {
+	notifications_api.NotificationKind
+	RunPatchNotificationCountdowns(ctx context.Context) error
+}
+
 func NewPatchNotificationKind(
 	ds fleet.Datastore,
 	activities patchNotificationActivityWriter,
 	notificationSvc patchNotificationService,
 	logger *slog.Logger,
-) notifications_api.NotificationKind {
+) PatchNotificationKind {
 	return &patchNotificationKind{
 		ds:              ds,
 		activities:      activities,
@@ -231,28 +242,170 @@ func (k *patchNotificationKind) OnVerify(ctx context.Context, notification *noti
 	return nil
 }
 
-// TODO: should there be a grace period where we install no matter what?
+// The countdown pass sends the reminder whatever the end user pressed, so the button only has to close
+// the toast, which the page does over the bridge. Leaving the row alone is also what stops the button
+// buying more time.
 func (k *patchNotificationKind) OnDelay(ctx context.Context, notification *notifications_api.EndUserNotification) (*notifications_api.NotificationView, error) {
-	untilReminder := patchNotificationFirstNoticeBefore - patchNotificationReminderBefore
+	return nil, nil
+}
 
+func (k *patchNotificationKind) RunPatchNotificationCountdowns(ctx context.Context) error {
 	now := time.Now().UTC()
-	nextAttemptAt := now.Add(notifications_api.EndUserNotificationDelayInterval)
-	payload := patchNotificationFirstNoticePayload
-	if notification.DisplayedAt != nil {
-		if fromDisplay := notification.DisplayedAt.Add(untilReminder); fromDisplay.After(now) {
-			nextAttemptAt = fromDisplay
-			payload = patchNotificationReminderPayload
+
+	countdowns, err := k.ds.ListPatchNotificationsDue(ctx, now.Add(patchNotificationReminderBefore), patchNotificationCountdownBatchSize)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list patch notifications due")
+	}
+
+	// One host's countdown failing must not hold up the rest of the batch.
+	var errs []error
+	for _, countdown := range countdowns {
+		if countdown.InstallAt.After(now) {
+			if err := k.remindBeforePatching(ctx, countdown, now); err != nil {
+				errs = append(errs, ctxerr.Wrapf(ctx, err, "remind before patching: notification_uuid=%s", countdown.NotificationUUID))
+			}
+			continue
+		}
+		if err := k.patchAtDeadline(ctx, countdown, now); err != nil {
+			errs = append(errs, ctxerr.Wrapf(ctx, err, "patch at deadline: notification_uuid=%s", countdown.NotificationUUID))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// The reminder goes out once: the re-dispatch leaves the notification pending, and the display after
+// that leaves the reminder flag in the payload, so a second pass fails one of the three checks below.
+func (k *patchNotificationKind) remindBeforePatching(ctx context.Context, countdown fleet.PatchNotificationDue, now time.Time) error {
+	if countdown.Status != notifications_api.EndUserNotificationDispatched || countdown.DisplayedAt == nil {
+		return nil
+	}
+	reminder, err := patchNotificationIsReminder(countdown.Payload)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "read patch notification payload")
+	}
+	if reminder {
+		return nil
+	}
+
+	remaining, err := k.verifyPatchNotificationApps(ctx, countdown)
+	if err != nil {
+		return err
+	}
+
+	// Verify deleted every app, so the notification has to close rather than render nothing.
+	if remaining == 0 {
+		if _, err := k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "act on a patch notification with nothing left to update")
+		}
+		return nil
+	}
+
+	if err := k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationReminderPayload); err != nil {
+		return ctxerr.Wrap(ctx, err, "send patch notification reminder")
+	}
+	return nil
+}
+
+func (k *patchNotificationKind) patchAtDeadline(ctx context.Context, countdown fleet.PatchNotificationDue, now time.Time) error {
+	// An offline host never saw the countdown run out, so it starts over with a fresh hour on the
+	// same notification rather than being patched on sight.
+	if !countdown.HostOnline {
+		if err := k.ds.ResetPatchNotification(ctx, countdown.NotificationUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "clear the deadline of an offline host's patch notification")
+		}
+		if err := k.notificationSvc.DelayNotification(ctx, countdown.NotificationUUID, now, patchNotificationFirstNoticePayload); err != nil {
+			return ctxerr.Wrap(ctx, err, "restart an offline host's patch notification")
+		}
+		return nil
+	}
+
+	remaining, err := k.verifyPatchNotificationApps(ctx, countdown)
+	if err != nil {
+		return err
+	}
+
+	// Acted first, so an Update now arriving at the same moment cannot queue the same installs twice.
+	acted, err := k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "act on patch notification")
+	}
+	if !acted || remaining == 0 {
+		return nil
+	}
+
+	// Stays acted on failure: there is no second press to finish the rest here, and the patch policy
+	// opens a new notification for whatever is left unpatched.
+	if _, err := k.queuePatchNotificationInstalls(ctx, countdown.NotificationUUID, countdown.HostID); err != nil {
+		return ctxerr.Wrap(ctx, err, "queue patch notification installs at the deadline")
+	}
+	return nil
+}
+
+// Inventory is read rather than the policy result: policy_membership.updated_at only moves on a state
+// change and policies re-run on the host's distributed interval, so within the hour the policy answer
+// is usually staler than inventory, which refreshes after any Fleet install and on refetch.
+func (k *patchNotificationKind) verifyPatchNotificationApps(ctx context.Context, countdown fleet.PatchNotificationDue) (int, error) {
+	apps, err := k.ds.ListPatchNotificationApps(ctx, countdown.NotificationUUID)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "list patch notification apps")
+	}
+	if len(apps) == 0 {
+		return 0, nil
+	}
+
+	installed, err := k.ds.ListSoftwareByHostIDShort(ctx, countdown.HostID)
+	if err != nil {
+		return 0, ctxerr.Wrapf(ctx, err, "list software on host: host_id=%d", countdown.HostID)
+	}
+	installedVersionByBundleIdentifier := make(map[string]string, len(installed))
+	for _, software := range installed {
+		if software.BundleIdentifier != "" {
+			installedVersionByBundleIdentifier[software.BundleIdentifier] = software.Version
 		}
 	}
 
-	if err := k.notificationSvc.DelayNotification(ctx, notification.UUID, nextAttemptAt, payload); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "delay patch notification")
+	// An app whose installer is gone stays listed, because there is no version to compare it against.
+	var dropped []uint
+	for _, app := range apps {
+		if app.SoftwareInstallerID == nil {
+			continue
+		}
+		installer, err := k.ds.GetSoftwareInstallerMetadataByID(ctx, *app.SoftwareInstallerID)
+		if err != nil {
+			if fleet.IsNotFound(err) {
+				continue
+			}
+			return 0, ctxerr.Wrapf(ctx, err, "get software installer metadata: software_installer_id=%d", *app.SoftwareInstallerID)
+		}
+
+		// FMA version strings are not reliably semver and CompareVersions treats an invalid one as lower,
+		// which would force an install, so both sides are normalized first. An app with no inventory row
+		// normalizes to an empty version and stays listed.
+		installedVersion := toValidSemVer(installedVersionByBundleIdentifier[installer.BundleIdentifier])
+		if installedVersion != "" && fleet.CompareVersions(toValidSemVer(installer.Version), installedVersion) != 1 {
+			dropped = append(dropped, app.SoftwareTitleID)
+			continue
+		}
+
+		// A My device self-service update lands before inventory catches up, so a Fleet install that
+		// succeeded since the notification was created counts too.
+		lastInstall, err := k.ds.GetHostLastInstallData(ctx, countdown.HostID, *app.SoftwareInstallerID)
+		if err != nil {
+			return 0, ctxerr.Wrapf(ctx, err, "get host last install data: host_id=%d, software_installer_id=%d",
+				countdown.HostID, *app.SoftwareInstallerID)
+		}
+		if lastInstall != nil && lastInstall.Status != nil &&
+			*lastInstall.Status == fleet.SoftwareInstalled && lastInstall.UpdatedAt.After(countdown.CreatedAt) {
+			dropped = append(dropped, app.SoftwareTitleID)
+		}
 	}
 
-	// The delay wrote the payload the view's copy comes from, so carry it over
-	// instead of reading the row again.
-	notification.Payload = payload
-	return k.renderView(ctx, notification, false)
+	// Render builds the toast from this table, so an in-memory filter would leave the reminder naming
+	// an app the end user already updated.
+	if err := k.ds.DeletePatchNotificationApps(ctx, countdown.NotificationUUID, dropped); err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "delete patch notification apps that no longer need updating")
+	}
+	return len(apps) - len(dropped), nil
 }
 
 func (k *patchNotificationKind) OnAction(ctx context.Context, notification *notifications_api.EndUserNotification, actionID string) (*notifications_api.NotificationView, error) {
@@ -287,71 +440,73 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 		return k.renderView(ctx, notification, true)
 	}
 
-	apps, err := k.ds.ListPatchNotificationApps(ctx, notification.UUID)
-	if err != nil {
-		// Nothing was queued, so undo the act above and let the next press try.
-		setStatusErr := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil,
-			[]string{notifications_api.EndUserNotificationActed})
-		if setStatusErr != nil {
-			k.logger.ErrorContext(ctx, "failed to put the patch notification back",
-				"notification_uuid", notification.UUID, "err", setStatusErr)
+	canPutBack, queueErr := k.queuePatchNotificationInstalls(ctx, notification.UUID, notification.HostID)
+	if queueErr != nil {
+		// Back to the status it had, so the next press finishes the rest.
+		if canPutBack {
+			setStatusErr := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil,
+				[]string{notifications_api.EndUserNotificationActed})
+			if setStatusErr != nil {
+				k.logger.ErrorContext(ctx, "failed to put the patch notification back",
+					"notification_uuid", notification.UUID, "err", setStatusErr)
+			}
 		}
-		return nil, ctxerr.Wrap(ctx, err, "list patch notification apps")
+		return nil, queueErr
 	}
 
-	// A press that fails part way goes back to the status it had, so the next press finishes the rest.
+	return k.renderView(ctx, notification, true)
+}
+
+// The bool reports whether the notification can be put back to the status it had: false once installs
+// have gone out without being recorded, because a second attempt would then install them again.
+func (k *patchNotificationKind) queuePatchNotificationInstalls(ctx context.Context, notificationUUID string, hostID uint) (bool, error) {
+	apps, err := k.ds.ListPatchNotificationApps(ctx, notificationUUID)
+	if err != nil {
+		return true, ctxerr.Wrap(ctx, err, "list patch notification apps")
+	}
+
+	// An attempt that fails part way still records what it queued, so the next one finishes the rest.
 	var queuedTitleIDs []uint
 	var queueErr error
 	for _, app := range apps {
 		if app.SoftwareInstallerID == nil {
 			k.logger.InfoContext(ctx, "skipping patch notification install for software with no installer",
-				"notification_uuid", notification.UUID, "software_title_id", app.SoftwareTitleID)
+				"notification_uuid", notificationUUID, "software_title_id", app.SoftwareTitleID)
 			continue
 		}
-		// queued by an earlier press that failed before it finished
+		// queued by an earlier attempt that failed before it finished
 		if app.InstallQueued {
 			continue
 		}
 
 		// check if this install is already queued
-		lastInstall, err := k.ds.GetHostLastInstallData(ctx, notification.HostID, *app.SoftwareInstallerID)
+		lastInstall, err := k.ds.GetHostLastInstallData(ctx, hostID, *app.SoftwareInstallerID)
 		if err != nil {
 			queueErr = ctxerr.Wrapf(ctx, err, "get host last install data: host_id=%d, software_installer_id=%d",
-				notification.HostID, *app.SoftwareInstallerID)
+				hostID, *app.SoftwareInstallerID)
 			break
 		}
 		if lastInstall != nil && lastInstall.Status != nil && *lastInstall.Status == fleet.SoftwareInstallPending {
 			continue
 		}
 
-		if _, err := k.ds.InsertSoftwareInstallRequest(ctx, notification.HostID, *app.SoftwareInstallerID,
+		// OverridePreInstallQuery stays false, which leaves the agent no app open gate to run, so the
+		// app closes and updates.
+		if _, err := k.ds.InsertSoftwareInstallRequest(ctx, hostID, *app.SoftwareInstallerID,
 			fleet.HostSoftwareInstallOptions{PolicyID: app.PolicyID},
 		); err != nil {
 			queueErr = ctxerr.Wrapf(ctx, err, "insert software install request: host_id=%d, software_installer_id=%d",
-				notification.HostID, *app.SoftwareInstallerID)
+				hostID, *app.SoftwareInstallerID)
 			break
 		}
 
 		queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
 	}
 
-	// Stay acted if this write fails, because the installs went out and a second press would repeat them.
-	err = k.ds.SetPatchNotificationAppsQueued(ctx, notification.UUID, queuedTitleIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "set patch notification apps queued")
+	if err := k.ds.SetPatchNotificationAppsQueued(ctx, notificationUUID, queuedTitleIDs); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "set patch notification apps queued")
 	}
-	if queueErr != nil {
-		// back to the status it had, since a pending notification set to dispatched is never sent
-		setStatusErr := k.notificationSvc.SetNotificationStatus(ctx, notification.UUID, notification.Status, nil,
-			[]string{notifications_api.EndUserNotificationActed})
-		if setStatusErr != nil {
-			k.logger.ErrorContext(ctx, "failed to put the patch notification back",
-				"notification_uuid", notification.UUID, "err", setStatusErr)
-		}
-		return nil, queueErr
-	}
-
-	return k.renderView(ctx, notification, true)
+	return true, queueErr
 }
 
 func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *notifications_api.EndUserNotification, outcome notifications_api.NotificationOutcome) error {
@@ -383,8 +538,19 @@ func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *not
 	}
 
 	status := "failed"
+	var installAt *time.Time
 	if outcome.Displayed {
 		status = "success"
+
+		// Set-once means a reminder's display no-ops and returns the deadline already stored.
+		// notification.DisplayedAt can't stand in for the clock: RecordOutcome loaded that copy before
+		// the outcome write, so it is still nil.
+		deadline, err := k.ds.SetPatchNotificationInstallAt(ctx, notification.UUID,
+			time.Now().UTC().Add(patchNotificationFirstNoticeBefore))
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "set patch notification install at")
+		}
+		installAt = &deadline
 	}
 
 	reminder, err := patchNotificationIsReminder(notification.Payload)
@@ -403,6 +569,7 @@ func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *not
 		SoftwareTitles:        softwareTitles,
 		PolicyIDs:             policyIDs,
 		TimeBefore:            int(timeBefore.Seconds()),
+		InstallAt:             installAt,
 		Status:                status,
 		ScriptExecutionID:     outcome.ExecutionID,
 	}); err != nil {

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -320,35 +320,24 @@ func (k *patchNotificationKind) remindOrInstallDuePatch(
 	installsByTitle map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData,
 	now time.Time,
 ) error {
-	// decide whether to send a reminder notification or force the app installs
-	var shouldSendReminder bool
-	if duePatch.InstallAt.After(now) {
-		shouldSendReminder = true
+	// A re-dispatch clears displayed_at, so a null one means the reminder has been queued but not
+	// displayed yet.
+	if duePatch.DisplayedAt == nil {
+		return nil
 	}
 
-	if shouldSendReminder {
-		// no reminder for a notice that is queued or not yet on screen
-		if duePatch.DisplayedAt == nil || duePatch.Status != notifications_api.EndUserNotificationDispatched {
+	notificationIsReminder, err := patchNotificationIsReminder(duePatch.Payload)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "read patch notification payload")
+	}
+
+	// Which notice was displayed last decides what happens next.
+	if !notificationIsReminder {
+		if duePatch.Status != notifications_api.EndUserNotificationDispatched {
 			return nil
 		}
-		notificationIsReminder, err := patchNotificationIsReminder(duePatch.Payload)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "read patch notification payload")
-		}
-		// the reminder already went out
-		if notificationIsReminder {
-			return nil
-		}
-	} else if duePatch.DisplayedAt == nil {
-		// the end user never saw this notice, so the deadline starts over from the next display
-		err := k.ds.ResetPatchNotification(ctx, duePatch.NotificationUUID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "clear the deadline of a patch notification the end user has not seen")
-		}
-		err = k.notificationSvc.DelayNotification(ctx, duePatch.NotificationUUID, now, patchNotificationFirstNoticePayload)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "restart a patch notification the end user has not seen")
-		}
+	} else if now.Before(duePatch.InstallAt) {
+		// the reminder was displayed and its five minutes are not up
 		return nil
 	}
 
@@ -398,7 +387,7 @@ func (k *patchNotificationKind) remindOrInstallDuePatch(
 		}
 	}
 
-	if shouldSendReminder {
+	if !notificationIsReminder {
 		// nothing left to update, so the notification closes instead of reminding
 		if len(remaining) == 0 {
 			_, err := k.notificationSvc.ActOnNotification(ctx, duePatch.NotificationUUID)

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -64,8 +64,6 @@ type patchNotificationKind struct {
 	logger          *slog.Logger
 }
 
-// The patch kind plus the countdown pass its cron job calls, so cmd/fleet can register the kind and
-// schedule the pass from one value.
 type PatchNotificationKind interface {
 	notifications_api.NotificationKind
 	RunPatchNotificationCountdowns(ctx context.Context) error
@@ -127,19 +125,22 @@ func (svc *Service) createPatchNotificationForEndUser(ctx context.Context, host 
 		notificationUUID = created.UUID
 	}
 
-	// the app row goes first, because a notification listing no apps can't render
+	if awaiting == nil {
+		if err := svc.ds.NewPatchNotification(ctx, notificationUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "create patch notification record")
+		}
+	}
+
+	// The app row goes last because it is what stops a later skip starting over: once it exists,
+	// PatchNotificationExistsForApp returns true and this function returns early. Anything written
+	// after it that failed would stay missing for the life of the notification. A notification left
+	// with no apps is safe by comparison, since Render fails it and the policy opens a new one.
 	if err := svc.ds.AddPatchNotificationApp(ctx, notificationUUID, fleet.PatchNotificationApp{
 		PolicyID:            install.PolicyID,
 		SoftwareTitleID:     *install.SoftwareTitleID,
 		SoftwareInstallerID: install.SoftwareInstallerID,
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "add patch notification app")
-	}
-
-	if awaiting == nil {
-		if err := svc.ds.NewPatchNotification(ctx, notificationUUID); err != nil {
-			return ctxerr.Wrap(ctx, err, "create patch notification record")
-		}
 	}
 	return nil
 }
@@ -242,10 +243,10 @@ func (k *patchNotificationKind) OnVerify(ctx context.Context, notification *noti
 	return nil
 }
 
-// The countdown pass sends the reminder whatever the end user pressed, so the button only has to close
-// the toast, which the page does over the bridge. Leaving the row alone is also what stops the button
-// buying more time.
 func (k *patchNotificationKind) OnDelay(ctx context.Context, notification *notifications_api.EndUserNotification) (*notifications_api.NotificationView, error) {
+	// The countdown pass sends the reminder whatever the end user pressed, so the button only has to
+	// close the toast, which the page does over the bridge. Leaving the row alone is also what stops
+	// the button buying more time.
 	return nil, nil
 }
 
@@ -273,9 +274,9 @@ func (k *patchNotificationKind) RunPatchNotificationCountdowns(ctx context.Conte
 	return errors.Join(errs...)
 }
 
-// The reminder goes out once: the re-dispatch leaves the notification pending, and the display after
-// that leaves the reminder flag in the payload, so a second pass fails one of the three checks below.
 func (k *patchNotificationKind) remindBeforePatching(ctx context.Context, countdown fleet.PatchNotificationDue, now time.Time) error {
+	// These three checks are what keep the reminder to one send: the re-dispatch leaves the row
+	// pending, and the display after that leaves the reminder flag in the payload.
 	if countdown.Status != notifications_api.EndUserNotificationDispatched || countdown.DisplayedAt == nil {
 		return nil
 	}
@@ -287,12 +288,12 @@ func (k *patchNotificationKind) remindBeforePatching(ctx context.Context, countd
 		return nil
 	}
 
-	remaining, err := k.verifyPatchNotificationApps(ctx, countdown)
+	remaining, err := k.dropAppsAlreadyUpdated(ctx, countdown)
 	if err != nil {
 		return err
 	}
 
-	// Verify deleted every app, so the notification has to close rather than render nothing.
+	// Nothing is left to warn about, and the notification would now render nothing, so close it.
 	if remaining == 0 {
 		if _, err := k.notificationSvc.ActOnNotification(ctx, countdown.NotificationUUID); err != nil {
 			return ctxerr.Wrap(ctx, err, "act on a patch notification with nothing left to update")
@@ -307,9 +308,10 @@ func (k *patchNotificationKind) remindBeforePatching(ctx context.Context, countd
 }
 
 func (k *patchNotificationKind) patchAtDeadline(ctx context.Context, countdown fleet.PatchNotificationDue, now time.Time) error {
-	// An offline host never saw the countdown run out, so it starts over with a fresh hour on the
-	// same notification rather than being patched on sight.
-	if !countdown.HostOnline {
+	// The end user never saw the notice this deadline belongs to, so the countdown starts over and
+	// they get a fresh hour whenever their host next reaches the screen. A host that went offline and
+	// a reminder still on its way both land here, and both want the same thing.
+	if countdown.DisplayedAt == nil {
 		if err := k.ds.ResetPatchNotification(ctx, countdown.NotificationUUID); err != nil {
 			return ctxerr.Wrap(ctx, err, "clear the deadline of an offline host's patch notification")
 		}
@@ -319,7 +321,7 @@ func (k *patchNotificationKind) patchAtDeadline(ctx context.Context, countdown f
 		return nil
 	}
 
-	remaining, err := k.verifyPatchNotificationApps(ctx, countdown)
+	remaining, err := k.dropAppsAlreadyUpdated(ctx, countdown)
 	if err != nil {
 		return err
 	}
@@ -341,10 +343,7 @@ func (k *patchNotificationKind) patchAtDeadline(ctx context.Context, countdown f
 	return nil
 }
 
-// Inventory is read rather than the policy result: policy_membership.updated_at only moves on a state
-// change and policies re-run on the host's distributed interval, so within the hour the policy answer
-// is usually staler than inventory, which refreshes after any Fleet install and on refetch.
-func (k *patchNotificationKind) verifyPatchNotificationApps(ctx context.Context, countdown fleet.PatchNotificationDue) (int, error) {
+func (k *patchNotificationKind) dropAppsAlreadyUpdated(ctx context.Context, countdown fleet.PatchNotificationDue) (remaining int, err error) {
 	apps, err := k.ds.ListPatchNotificationApps(ctx, countdown.NotificationUUID)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "list patch notification apps")
@@ -353,6 +352,8 @@ func (k *patchNotificationKind) verifyPatchNotificationApps(ctx context.Context,
 		return 0, nil
 	}
 
+	// Inventory refreshes after any Fleet install and on refetch, so within the hour it is the freshest
+	// record of what the host actually has.
 	installed, err := k.ds.ListSoftwareByHostIDShort(ctx, countdown.HostID)
 	if err != nil {
 		return 0, ctxerr.Wrapf(ctx, err, "list software on host: host_id=%d", countdown.HostID)
@@ -400,8 +401,8 @@ func (k *patchNotificationKind) verifyPatchNotificationApps(ctx context.Context,
 		}
 	}
 
-	// Render builds the toast from this table, so an in-memory filter would leave the reminder naming
-	// an app the end user already updated.
+	// Render builds the toast from this table, so the rows have to go for the reminder to stop naming
+	// apps the end user already updated.
 	if err := k.ds.DeletePatchNotificationApps(ctx, countdown.NotificationUUID, dropped); err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "delete patch notification apps that no longer need updating")
 	}
@@ -457,9 +458,7 @@ func (k *patchNotificationKind) updateNow(ctx context.Context, notification *not
 	return k.renderView(ctx, notification, true)
 }
 
-// The bool reports whether the notification can be put back to the status it had: false once installs
-// have gone out without being recorded, because a second attempt would then install them again.
-func (k *patchNotificationKind) queuePatchNotificationInstalls(ctx context.Context, notificationUUID string, hostID uint) (bool, error) {
+func (k *patchNotificationKind) queuePatchNotificationInstalls(ctx context.Context, notificationUUID string, hostID uint) (canPutBack bool, err error) {
 	apps, err := k.ds.ListPatchNotificationApps(ctx, notificationUUID)
 	if err != nil {
 		return true, ctxerr.Wrap(ctx, err, "list patch notification apps")
@@ -503,6 +502,7 @@ func (k *patchNotificationKind) queuePatchNotificationInstalls(ctx context.Conte
 		queuedTitleIDs = append(queuedTitleIDs, app.SoftwareTitleID)
 	}
 
+	// Once this write fails the installs have gone out unrecorded, so a second attempt would repeat them.
 	if err := k.ds.SetPatchNotificationAppsQueued(ctx, notificationUUID, queuedTitleIDs); err != nil {
 		return false, ctxerr.Wrap(ctx, err, "set patch notification apps queued")
 	}
@@ -537,22 +537,6 @@ func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *not
 		}
 	}
 
-	status := "failed"
-	var installAt *time.Time
-	if outcome.Displayed {
-		status = "success"
-
-		// Set-once means a reminder's display no-ops and returns the deadline already stored.
-		// notification.DisplayedAt can't stand in for the clock: RecordOutcome loaded that copy before
-		// the outcome write, so it is still nil.
-		deadline, err := k.ds.SetPatchNotificationInstallAt(ctx, notification.UUID,
-			time.Now().UTC().Add(patchNotificationFirstNoticeBefore))
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "set patch notification install at")
-		}
-		installAt = &deadline
-	}
-
 	reminder, err := patchNotificationIsReminder(notification.Payload)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "read patch notification payload")
@@ -560,6 +544,21 @@ func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *not
 	timeBefore := patchNotificationFirstNoticeBefore
 	if reminder {
 		timeBefore = patchNotificationReminderBefore
+	}
+
+	status := "failed"
+	var installAt *time.Time
+	if outcome.Displayed {
+		status = "success"
+
+		// The deadline is counted from this notice reaching the screen, so the end user gets the whole
+		// lead time the toast promises however long the toast took to get there. notification.DisplayedAt
+		// is still nil here, since RecordOutcome loaded that copy before the outcome write.
+		deadline, err := k.ds.SetPatchNotificationInstallAt(ctx, notification.UUID, time.Now().UTC().Add(timeBefore))
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "set patch notification install at")
+		}
+		installAt = &deadline
 	}
 
 	if err := k.activities.NewActivity(ctx, nil, fleet.ActivityTypeNotifiedEndUserBeforePatching{

--- a/server/service/notification_kind_patch.go
+++ b/server/service/notification_kind_patch.go
@@ -378,7 +378,7 @@ func (k *patchNotificationKind) remindOrInstallDuePatch(
 
 		var installedByFleet bool
 		for _, install := range installsByTitle[appKey] {
-			if install.Status != nil && *install.Status == fleet.SoftwareInstalled && install.UpdatedAt.After(duePatch.CreatedAt) {
+			if install.Status != nil && *install.Status == fleet.SoftwareInstalled && install.UpdatedAt.After(app.CreatedAt) {
 				installedByFleet = true
 				break
 			}
@@ -596,10 +596,12 @@ func (k *patchNotificationKind) OnOutcome(ctx context.Context, notification *not
 	var installAt *time.Time
 	if outcome.Displayed {
 		status = "success"
-
-		// The deadline is counted from this notice reaching the screen, so the end user gets the whole
-		// lead time the toast promises however long the toast took to get there. notification.DisplayedAt
-		// is still nil here, since RecordOutcome loaded that copy before the outcome write.
+	}
+	// install_at follows displayed_at, which the notifications context only records while the
+	// notification is still dispatched. A result from a superseded script arriving after a delay or
+	// an update_now must not move install_at. notification.DisplayedAt is nil either way here, since
+	// RecordOutcome loaded that copy before the outcome write.
+	if outcome.Displayed && notification.Status == notifications_api.EndUserNotificationDispatched {
 		deadline, err := k.ds.SetPatchNotificationInstallAt(ctx, notification.UUID, time.Now().UTC().Add(timeBefore))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "set patch notification install at")

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -35,6 +35,8 @@ type stubNotificationService struct {
 	actInvoked   bool
 	setStatus    string
 	failedReason string
+	delayInvoked bool
+	delayPayload json.RawMessage
 }
 
 func (s *stubNotificationService) ActOnNotification(_ context.Context, _ string) (bool, error) {
@@ -50,7 +52,9 @@ func (s *stubNotificationService) SetNotificationStatus(_ context.Context, _ str
 	return nil
 }
 
-func (s *stubNotificationService) DelayNotification(_ context.Context, _ string, _ time.Time, _ json.RawMessage) error {
+func (s *stubNotificationService) DelayNotification(_ context.Context, _ string, _ time.Time, payload json.RawMessage) error {
+	s.delayInvoked = true
+	s.delayPayload = payload
 	return nil
 }
 
@@ -575,6 +579,257 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 
 			assert.Equal(t, c.wantTitles, activity.SoftwareTitles)
 			assert.Equal(t, c.wantPolicyIDs, activity.PolicyIDs)
+		})
+	}
+}
+
+func TestPatchNotificationCountdowns(t *testing.T) {
+	const (
+		hostID           = uint(1)
+		oneTitleID       = uint(10)
+		twoTitleID       = uint(11)
+		oneInstallerID   = uint(20)
+		twoInstallerID   = uint(21)
+		policyID         = uint(30)
+		oneBundle        = "com.example.one"
+		twoBundle        = "com.example.two"
+		installerVersion = "2.0.0"
+	)
+
+	// Both apps are a version behind what their installer would put on the host.
+	behind := map[string]string{oneBundle: "1.0.0", twoBundle: "1.0.0"}
+
+	displayedAt := time.Now().UTC().Add(-55 * time.Minute)
+
+	cases := []struct {
+		name string
+		// how far the deadline is from now, negative once it has passed
+		untilDeadline time.Duration
+		status        string
+		displayed     bool
+		reminder      bool
+		hostOnline    bool
+		// software inventory by bundle identifier
+		installedVersions map[string]string
+		// GetHostLastInstallData for the first app
+		lastInstalled *time.Time
+		// ActOnNotification: an Update now got there first
+		alreadyActed bool
+
+		wantReminder bool
+		wantInstalls []uint
+		// the pass tried to take the notification, whether or not it got it
+		wantActed       bool
+		wantReset       bool
+		wantAppsDropped []uint
+	}{
+		{
+			name:              "a notification inside the reminder window is reminded once",
+			untilDeadline:     4 * time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			hostOnline:        true,
+			installedVersions: behind,
+			wantReminder:      true,
+		},
+		{
+			// the re-dispatch left it pending, which is how a second pass knows the
+			// reminder already went out
+			name:              "a notification whose reminder is queued is left alone",
+			untilDeadline:     time.Minute,
+			status:            notifications_api.EndUserNotificationPending,
+			displayed:         false,
+			hostOnline:        true,
+			installedVersions: behind,
+		},
+		{
+			// the reminder payload is how a second pass knows the reminder was displayed
+			name:              "a notification whose reminder is on screen is left alone",
+			untilDeadline:     time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			reminder:          true,
+			hostOnline:        true,
+			installedVersions: behind,
+		},
+		{
+			name:              "an app updated during the hour is dropped from the reminder",
+			untilDeadline:     4 * time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			hostOnline:        true,
+			installedVersions: map[string]string{oneBundle: installerVersion, twoBundle: "1.0.0"},
+			wantReminder:      true,
+			wantAppsDropped:   []uint{oneTitleID},
+		},
+		{
+			name:              "every app updated during the hour means no reminder and nothing to install",
+			untilDeadline:     4 * time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			hostOnline:        true,
+			installedVersions: map[string]string{oneBundle: installerVersion, twoBundle: "9.0.0"},
+			wantActed:         true,
+			wantAppsDropped:   []uint{oneTitleID, twoTitleID},
+		},
+		{
+			name:              "the deadline closes and updates every app still behind",
+			untilDeadline:     -time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			reminder:          true,
+			hostOnline:        true,
+			installedVersions: behind,
+			wantActed:         true,
+			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
+		},
+		{
+			// a My device self-service update lands before inventory catches up
+			name:              "an app Fleet installed since the notification was created is not installed again",
+			untilDeadline:     -time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			reminder:          true,
+			hostOnline:        true,
+			installedVersions: behind,
+			lastInstalled:     new(time.Now().UTC()),
+			wantActed:         true,
+			wantInstalls:      []uint{twoInstallerID},
+			wantAppsDropped:   []uint{oneTitleID},
+		},
+		{
+			name:              "an Update now that got there first stops the deadline installing the same apps again",
+			untilDeadline:     -time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			reminder:          true,
+			hostOnline:        true,
+			installedVersions: behind,
+			alreadyActed:      true,
+			wantActed:         true,
+		},
+		{
+			// the end user never saw the countdown run out, so it starts over
+			name:              "an offline host at the deadline is notified again instead of patched",
+			untilDeadline:     -time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			reminder:          true,
+			installedVersions: behind,
+			wantReset:         true,
+			wantReminder:      true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			notificationSvc := &stubNotificationService{acts: !c.alreadyActed}
+			kind := &patchNotificationKind{
+				ds: ds, notificationSvc: notificationSvc, logger: slog.New(slog.DiscardHandler),
+			}
+
+			payload := patchNotificationFirstNoticePayload
+			if c.reminder {
+				payload = patchNotificationReminderPayload
+			}
+			var displayed *time.Time
+			if c.displayed {
+				displayed = &displayedAt
+			}
+			var gotCutoff time.Time
+			ds.ListPatchNotificationsDueFunc = func(_ context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
+				gotCutoff = cutoff
+				assert.Equal(t, patchNotificationCountdownBatchSize, limit)
+				return []fleet.PatchNotificationDue{{
+					NotificationUUID: "notification-uuid",
+					HostID:           hostID,
+					Status:           c.status,
+					Payload:          payload,
+					DisplayedAt:      displayed,
+					CreatedAt:        displayedAt.Add(-time.Minute),
+					InstallAt:        time.Now().UTC().Add(c.untilDeadline),
+					HostOnline:       c.hostOnline,
+				}}, nil
+			}
+
+			// the apps the pass drops stop being listed, the same as deleting their rows does
+			dropped := make(map[uint]struct{})
+			ds.ListPatchNotificationAppsFunc = func(_ context.Context, _ string) ([]fleet.PatchNotificationAppDetail, error) {
+				all := []fleet.PatchNotificationAppDetail{
+					{SoftwareTitleID: oneTitleID, SoftwareInstallerID: new(oneInstallerID), PolicyID: new(policyID)},
+					{SoftwareTitleID: twoTitleID, SoftwareInstallerID: new(twoInstallerID), PolicyID: new(policyID)},
+				}
+				listed := make([]fleet.PatchNotificationAppDetail, 0, len(all))
+				for _, app := range all {
+					if _, gone := dropped[app.SoftwareTitleID]; !gone {
+						listed = append(listed, app)
+					}
+				}
+				return listed, nil
+			}
+			var gotDropped []uint
+			ds.DeletePatchNotificationAppsFunc = func(_ context.Context, _ string, softwareTitleIDs []uint) error {
+				for _, titleID := range softwareTitleIDs {
+					dropped[titleID] = struct{}{}
+				}
+				gotDropped = append(gotDropped, softwareTitleIDs...)
+				return nil
+			}
+
+			ds.ListSoftwareByHostIDShortFunc = func(_ context.Context, _ uint) ([]fleet.Software, error) {
+				return []fleet.Software{
+					{BundleIdentifier: oneBundle, Version: c.installedVersions[oneBundle]},
+					{BundleIdentifier: twoBundle, Version: c.installedVersions[twoBundle]},
+				}, nil
+			}
+			ds.GetSoftwareInstallerMetadataByIDFunc = func(_ context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+				bundle := oneBundle
+				if id == twoInstallerID {
+					bundle = twoBundle
+				}
+				return &fleet.SoftwareInstaller{Version: installerVersion, BundleIdentifier: bundle}, nil
+			}
+			ds.GetHostLastInstallDataFunc = func(_ context.Context, _ uint, installerID uint) (*fleet.HostLastInstallData, error) {
+				if c.lastInstalled == nil || installerID != oneInstallerID {
+					return nil, nil
+				}
+				return &fleet.HostLastInstallData{Status: new(fleet.SoftwareInstalled), UpdatedAt: *c.lastInstalled}, nil
+			}
+
+			var installs []uint
+			ds.InsertSoftwareInstallRequestFunc = func(_ context.Context, gotHostID uint, installerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
+				assert.Equal(t, hostID, gotHostID)
+				assert.False(t, opts.OverridePreInstallQuery, "the deadline forces the install, so the app being open must not stop it")
+				require.NotNil(t, opts.PolicyID)
+				assert.Equal(t, policyID, *opts.PolicyID)
+				installs = append(installs, installerID)
+				return "", nil
+			}
+			ds.SetPatchNotificationAppsQueuedFunc = func(_ context.Context, _ string, _ []uint) error { return nil }
+			ds.ResetPatchNotificationFunc = func(_ context.Context, _ string) error { return nil }
+
+			require.NoError(t, kind.RunPatchNotificationCountdowns(context.Background()))
+
+			assert.WithinDuration(t, time.Now().UTC().Add(patchNotificationReminderBefore), gotCutoff, time.Minute,
+				"the pass reads the countdowns that reach their deadline within the reminder's lead time")
+
+			assert.ElementsMatch(t, c.wantInstalls, installs)
+			assert.ElementsMatch(t, c.wantAppsDropped, gotDropped)
+			assert.Equal(t, c.wantActed, notificationSvc.actInvoked)
+			assert.Equal(t, c.wantReset, ds.ResetPatchNotificationFuncInvoked)
+
+			if !c.wantReminder {
+				assert.False(t, notificationSvc.delayInvoked)
+				return
+			}
+			require.True(t, notificationSvc.delayInvoked)
+			// the offline restart begins a new hour, so it goes back to the first notice
+			wantPayload := patchNotificationReminderPayload
+			if c.wantReset {
+				wantPayload = patchNotificationFirstNoticePayload
+			}
+			assert.JSONEq(t, string(wantPayload), string(notificationSvc.delayPayload))
 		})
 	}
 }

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -111,12 +111,13 @@ func TestCreatePatchNotificationForEndUser(t *testing.T) {
 			wantAppOn: "",
 		},
 		{
-			// the app is recorded first, so the notification still renders
-			name:          "a failure recording the patch notification still leaves the app listed",
+			// Leaving the app unlisted is what lets the next skip start over, since
+			// PatchNotificationExistsForApp is what makes this function return early.
+			name:          "a failure recording the patch notification leaves the app unlisted so it can be retried",
 			newPatchFails: true,
 			wantErr:       true,
 			wantCreated:   true,
-			wantAppOn:     createdUUID,
+			wantAppOn:     "",
 		},
 	}
 
@@ -608,7 +609,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 		status        string
 		displayed     bool
 		reminder      bool
-		hostOnline    bool
 		// software inventory by bundle identifier
 		installedVersions map[string]string
 		// GetHostLastInstallData for the first app
@@ -628,7 +628,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			untilDeadline:     4 * time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
-			hostOnline:        true,
 			installedVersions: behind,
 			wantReminder:      true,
 		},
@@ -639,7 +638,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			untilDeadline:     time.Minute,
 			status:            notifications_api.EndUserNotificationPending,
 			displayed:         false,
-			hostOnline:        true,
 			installedVersions: behind,
 		},
 		{
@@ -649,7 +647,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
-			hostOnline:        true,
 			installedVersions: behind,
 		},
 		{
@@ -657,7 +654,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			untilDeadline:     4 * time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
-			hostOnline:        true,
 			installedVersions: map[string]string{oneBundle: installerVersion, twoBundle: "1.0.0"},
 			wantReminder:      true,
 			wantAppsDropped:   []uint{oneTitleID},
@@ -667,7 +663,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			untilDeadline:     4 * time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
-			hostOnline:        true,
 			installedVersions: map[string]string{oneBundle: installerVersion, twoBundle: "9.0.0"},
 			wantActed:         true,
 			wantAppsDropped:   []uint{oneTitleID, twoTitleID},
@@ -678,7 +673,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
-			hostOnline:        true,
 			installedVersions: behind,
 			wantActed:         true,
 			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
@@ -690,7 +684,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
-			hostOnline:        true,
 			installedVersions: behind,
 			lastInstalled:     new(time.Now().UTC()),
 			wantActed:         true,
@@ -703,17 +696,16 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
-			hostOnline:        true,
 			installedVersions: behind,
 			alreadyActed:      true,
 			wantActed:         true,
 		},
 		{
-			// the end user never saw the countdown run out, so it starts over
-			name:              "an offline host at the deadline is notified again instead of patched",
+			// An offline host and a reminder still on its way both leave displayed_at unset, and
+			// neither end user has seen the warning, so the countdown starts over for both.
+			name:              "a deadline the end user never saw notifies again instead of patching",
 			untilDeadline:     -time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
-			displayed:         true,
 			reminder:          true,
 			installedVersions: behind,
 			wantReset:         true,
@@ -749,7 +741,6 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 					DisplayedAt:      displayed,
 					CreatedAt:        displayedAt.Add(-time.Minute),
 					InstallAt:        time.Now().UTC().Add(c.untilDeadline),
-					HostOnline:       c.hostOnline,
 				}}, nil
 			}
 

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -80,7 +80,7 @@ func TestCreatePatchNotificationForEndUser(t *testing.T) {
 		// NotificationAwaitingDisplay: this host has a notification the end user
 		// has not seen yet
 		awaiting bool
-		// host_software_installs.software_title_id
+		// the skipped install carries no software title, so there is no app to name
 		noTitle bool
 		// NewPatchNotification: the patch_notifications row can't be written
 		newPatchFails bool
@@ -90,7 +90,7 @@ func TestCreatePatchNotificationForEndUser(t *testing.T) {
 		wantAppOn   string // "" means no app was recorded
 	}{
 		{
-			name:        "the host has no patch notification",
+			name:        "a host with no patch notification gets a new one listing the app",
 			wantCreated: true,
 			wantAppOn:   createdUUID,
 		},
@@ -101,12 +101,12 @@ func TestCreatePatchNotificationForEndUser(t *testing.T) {
 			wantAppOn:   awaitingUUID,
 		},
 		{
-			name:      "the app is already listed on a pending or dispatched notification",
+			name:      "an app already listed on a pending or dispatched notification is not listed twice",
 			exists:    true,
 			wantAppOn: "",
 		},
 		{
-			name:      "the install has no software title to record",
+			name:      "an install with no software title records no notification",
 			noTitle:   true,
 			wantAppOn: "",
 		},
@@ -484,7 +484,7 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 		wantPolicyIDs  []uint
 	}{
 		{
-			name:           "the first notice, displayed, names every app and policy",
+			name:           "a displayed first notice records an activity naming every app and policy",
 			outcome:        notifications_api.NotificationOutcome{Displayed: true, ExitCode: 0, ExecutionID: "exec-1"},
 			apps:           twoAppsTwoPolicies,
 			wantStatus:     "success",
@@ -493,7 +493,7 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			wantPolicyIDs:  []uint{30, 31},
 		},
 		{
-			name:           "the reminder, displayed, uses the reminder's time before",
+			name:           "a displayed reminder records five minutes as its time before",
 			reminder:       true,
 			outcome:        notifications_api.NotificationOutcome{Displayed: true, ExitCode: 0, ExecutionID: "exec-2"},
 			apps:           twoAppsTwoPolicies,
@@ -503,7 +503,7 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			wantPolicyIDs:  []uint{30, 31},
 		},
 		{
-			name:           "a first failure is recorded",
+			name:           "a screen locked failure is recorded the first time it happens",
 			outcome:        notifications_api.NotificationOutcome{Displayed: false, ExitCode: 41, ExecutionID: "exec-3"},
 			apps:           twoAppsTwoPolicies,
 			wantStatus:     "failed",
@@ -590,8 +590,8 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			assert.Equal(t, c.wantStatus, activity.Status)
 			assert.Equal(t, c.wantTimeBefore, activity.TimeBefore)
 
-			// Only a display sets a deadline, and it is counted from this notice's own lead time so a
-			// reminder does not push it out by another hour.
+			// Only a displayed outcome sets install_at, and it is set from the lead time of the
+			// notification that was displayed, so a reminder sets it 5 minutes out, not an hour.
 			if c.wantStatus != "success" {
 				assert.False(t, ds.SetPatchNotificationInstallAtFuncInvoked)
 				assert.Nil(t, activity.InstallAt)
@@ -629,7 +629,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		name string
 		// how far the deadline is from now, negative once it has passed
 		untilDeadline time.Duration
-		status        string
 		displayed     bool
 		reminder      bool
 		// software inventory by software title id
@@ -647,35 +646,8 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		wantAppsDropped []uint
 	}{
 		{
-			name:              "a notification inside the reminder window is reminded once",
-			untilDeadline:     4 * time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
-			displayed:         true,
-			installedVersions: behind,
-			wantReminder:      true,
-		},
-		{
-			// the re-dispatch left it pending, which is how a second pass knows the
-			// reminder already went out
-			name:              "a notification whose reminder is queued is left alone",
-			untilDeadline:     time.Minute,
-			status:            notifications_api.EndUserNotificationPending,
-			displayed:         false,
-			installedVersions: behind,
-		},
-		{
-			// the reminder payload is how a second pass knows the reminder was displayed
-			name:              "a notification whose reminder is on screen is left alone",
-			untilDeadline:     time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
-			displayed:         true,
-			reminder:          true,
-			installedVersions: behind,
-		},
-		{
 			name:              "an app updated during the hour is dropped from the reminder",
 			untilDeadline:     4 * time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			installedVersions: map[uint]string{oneTitleID: installerVersion, twoTitleID: "1.0.0"},
 			wantReminder:      true,
@@ -684,7 +656,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		{
 			name:              "every app updated during the hour means no reminder and nothing to install",
 			untilDeadline:     4 * time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			installedVersions: map[uint]string{oneTitleID: installerVersion, twoTitleID: installerVersion},
 			wantActed:         true,
@@ -695,7 +666,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			// what the installer would put down is treated as still needing the update.
 			name:              "an app the host is on a different version of is still updated at the deadline",
 			untilDeadline:     -time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
 			installedVersions: map[uint]string{oneTitleID: "9.0.0", twoTitleID: "1.0.0"},
@@ -703,20 +673,9 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
 		},
 		{
-			name:              "the deadline closes and updates every app still behind",
-			untilDeadline:     -time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
-			displayed:         true,
-			reminder:          true,
-			installedVersions: behind,
-			wantActed:         true,
-			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
-		},
-		{
 			// a My device self-service update lands before inventory catches up
 			name:              "an app Fleet installed since the notification was created is not installed again",
 			untilDeadline:     -time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
 			installedVersions: behind,
@@ -728,7 +687,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		{
 			name:              "an Update now that got there first stops the deadline installing the same apps again",
 			untilDeadline:     -time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
 			reminder:          true,
 			installedVersions: behind,
@@ -736,11 +694,9 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantActed:         true,
 		},
 		{
-			// An offline host and a reminder still on its way both leave displayed_at unset, and
-			// neither end user has seen the warning, so the deadline starts over for both.
-			name:              "a deadline the end user never saw notifies again instead of patching",
+			// an offline host and a reminder that was never displayed both leave displayed_at null
+			name:              "a notification past install_at with no displayed_at is re-dispatched instead of installed",
 			untilDeadline:     -time.Minute,
-			status:            notifications_api.EndUserNotificationDispatched,
 			reminder:          true,
 			installedVersions: behind,
 			wantReset:         true,
@@ -771,7 +727,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				return []fleet.PatchNotificationDue{{
 					NotificationUUID: "notification-uuid",
 					HostID:           hostID,
-					Status:           c.status,
+					Status:           notifications_api.EndUserNotificationDispatched,
 					Payload:          payload,
 					DisplayedAt:      displayed,
 					CreatedAt:        displayedAt.Add(-time.Minute),
@@ -779,10 +735,11 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				}}, nil
 			}
 
-			// the apps the pass drops stop being listed, the same as deleting their rows does
+			// dropped software titles stop being returned, as deleting their rows would do
 			dropped := make(map[uint]struct{})
+			var appReads int
 			ds.ListPatchNotificationAppsForNotificationsFunc = func(_ context.Context, uuids []string) (map[string][]fleet.PatchNotificationAppDetail, error) {
-				require.Len(t, uuids, 1, "the batch's apps are read in one statement")
+				appReads++
 				all := []fleet.PatchNotificationAppDetail{
 					{SoftwareTitleID: oneTitleID, SoftwareInstallerID: new(oneInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion},
 					{SoftwareTitleID: twoTitleID, SoftwareInstallerID: new(twoInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion},
@@ -804,8 +761,9 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				return nil
 			}
 
+			var versionReads int
 			ds.ListHostSoftwareVersionsForTitlesFunc = func(_ context.Context, hostIDs []uint, titleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
-				require.Len(t, hostIDs, 1, "the batch's inventory is read in one statement")
+				versionReads++
 				versions := make([]fleet.HostSoftwareTitleVersion, 0, len(titleIDs))
 				for _, titleID := range titleIDs {
 					if installed, ok := c.installedVersions[titleID]; ok {
@@ -816,8 +774,9 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				}
 				return versions, nil
 			}
+			var installDataReads int
 			ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
-				require.Len(t, hostIDs, 1, "the batch's install history is read in one statement")
+				installDataReads++
 				if c.lastInstalled == nil {
 					return nil, nil
 				}
@@ -843,7 +802,12 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			require.NoError(t, kind.RemindAndInstallDuePatches(context.Background()))
 
 			assert.WithinDuration(t, time.Now().UTC().Add(patchNotificationReminderBefore), gotCutoff, time.Minute,
-				"the pass reads the notifications that reach their deadline within the reminder's lead time")
+				"the cutoff is install_at plus the reminder lead time")
+
+			// one read each per batch, not one per notification
+			assert.Equal(t, 1, appReads)
+			assert.Equal(t, 1, versionReads)
+			assert.Equal(t, 1, installDataReads)
 
 			assert.ElementsMatch(t, c.wantInstalls, installs)
 			assert.ElementsMatch(t, c.wantAppsDropped, gotDropped)
@@ -855,7 +819,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				return
 			}
 			require.True(t, notificationSvc.delayInvoked)
-			// the offline restart begins a new hour, so it goes back to the first notice
+			// a reset re-sends the first notification, not the reminder
 			wantPayload := patchNotificationReminderPayload
 			if c.wantReset {
 				wantPayload = patchNotificationFirstNoticePayload

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -272,11 +272,16 @@ func TestPatchNotificationUpdateNow(t *testing.T) {
 			kind := &patchNotificationKind{
 				ds: ds, notificationSvc: notificationSvc, logger: slog.New(slog.DiscardHandler),
 			}
-			ds.GetHostLastInstallDataFunc = func(_ context.Context, _ uint, _ uint) (*fleet.HostLastInstallData, error) {
+			ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, _ []uint, titleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 				if !c.alreadyPending {
 					return nil, nil
 				}
-				return &fleet.HostLastInstallData{Status: new(fleet.SoftwareInstallPending)}, nil
+				pending := make(map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, len(titleIDs))
+				for _, id := range titleIDs {
+					pending[fleet.HostSoftwareTitleKey{HostID: hostID, SoftwareTitleID: id}] =
+						[]*fleet.HostLastInstallData{{Status: new(fleet.SoftwareInstallPending)}}
+				}
+				return pending, nil
 			}
 			ds.SetPatchNotificationAppsQueuedFunc = func(_ context.Context, _ string, _ []uint) error { return nil }
 			ds.ListPatchNotificationAppsFunc = func(_ context.Context, _ string) ([]fleet.PatchNotificationAppDetail, error) {
@@ -383,12 +388,13 @@ func TestPatchNotificationUpdateNowResumesAfterFailure(t *testing.T) {
 
 	// the first app's install finishes between the two presses, so it is no
 	// longer pending by the time the second press runs
-	ds.GetHostLastInstallDataFunc = func(_ context.Context, _ uint, installerID uint) (*fleet.HostLastInstallData, error) {
-		_, firstAppQueued := queued[firstTitleID]
-		if installerID == firstInstaller && firstAppQueued {
-			return &fleet.HostLastInstallData{Status: new(fleet.SoftwareInstalled)}, nil
+	ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+		if _, firstAppQueued := queued[firstTitleID]; !firstAppQueued {
+			return nil, nil
 		}
-		return nil, nil
+		return map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData{
+			{HostID: hostIDs[0], SoftwareTitleID: firstTitleID}: {{Status: new(fleet.SoftwareInstalled)}},
+		}, nil
 	}
 
 	var installed []uint
@@ -547,6 +553,13 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			ds.HostLiteByIDFunc = func(_ context.Context, _ uint) (*fleet.HostLite, error) {
 				return &fleet.HostLite{ID: hostID, ComputerName: "Test Host"}, nil
 			}
+			// the deadline the display lands on, which the activity reports back
+			var gotLeadTime time.Duration
+			deadline := time.Now().UTC().Add(time.Hour)
+			ds.SetPatchNotificationInstallAtFunc = func(_ context.Context, _ string, installAt time.Time) (time.Time, error) {
+				gotLeadTime = time.Until(installAt).Round(time.Minute)
+				return deadline, nil
+			}
 
 			writer := &capturingActivityWriter{}
 			kind := &patchNotificationKind{ds: ds, activities: writer, logger: slog.New(slog.DiscardHandler)}
@@ -576,6 +589,18 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			assert.Equal(t, notification.UUID, activity.PatchNotificationUUID)
 			assert.Equal(t, c.wantStatus, activity.Status)
 			assert.Equal(t, c.wantTimeBefore, activity.TimeBefore)
+
+			// Only a display sets a deadline, and it is counted from this notice's own lead time so a
+			// reminder does not push it out by another hour.
+			if c.wantStatus != "success" {
+				assert.False(t, ds.SetPatchNotificationInstallAtFuncInvoked)
+				assert.Nil(t, activity.InstallAt)
+			} else {
+				assert.True(t, ds.SetPatchNotificationInstallAtFuncInvoked)
+				assert.Equal(t, time.Duration(c.wantTimeBefore)*time.Second, gotLeadTime)
+				require.NotNil(t, activity.InstallAt)
+				assert.Equal(t, deadline, *activity.InstallAt)
+			}
 			assert.Equal(t, c.outcome.ExecutionID, activity.ScriptExecutionID)
 
 			assert.Equal(t, c.wantTitles, activity.SoftwareTitles)
@@ -592,13 +617,11 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 		oneInstallerID   = uint(20)
 		twoInstallerID   = uint(21)
 		policyID         = uint(30)
-		oneBundle        = "com.example.one"
-		twoBundle        = "com.example.two"
 		installerVersion = "2.0.0"
 	)
 
 	// Both apps are a version behind what their installer would put on the host.
-	behind := map[string]string{oneBundle: "1.0.0", twoBundle: "1.0.0"}
+	behind := map[uint]string{oneTitleID: "1.0.0", twoTitleID: "1.0.0"}
 
 	displayedAt := time.Now().UTC().Add(-55 * time.Minute)
 
@@ -609,9 +632,9 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 		status        string
 		displayed     bool
 		reminder      bool
-		// software inventory by bundle identifier
-		installedVersions map[string]string
-		// GetHostLastInstallData for the first app
+		// software inventory by software title id
+		installedVersions map[uint]string
+		// when Fleet last finished installing the first app, if it did
 		lastInstalled *time.Time
 		// ActOnNotification: an Update now got there first
 		alreadyActed bool
@@ -654,7 +677,7 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			untilDeadline:     4 * time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
-			installedVersions: map[string]string{oneBundle: installerVersion, twoBundle: "1.0.0"},
+			installedVersions: map[uint]string{oneTitleID: installerVersion, twoTitleID: "1.0.0"},
 			wantReminder:      true,
 			wantAppsDropped:   []uint{oneTitleID},
 		},
@@ -663,9 +686,21 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			untilDeadline:     4 * time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
 			displayed:         true,
-			installedVersions: map[string]string{oneBundle: installerVersion, twoBundle: "9.0.0"},
+			installedVersions: map[uint]string{oneTitleID: installerVersion, twoTitleID: installerVersion},
 			wantActed:         true,
 			wantAppsDropped:   []uint{oneTitleID, twoTitleID},
+		},
+		{
+			// Version strings are not compared, only matched, so a host carrying something other than
+			// what the installer would put down is treated as still needing the update.
+			name:              "an app the host is on a different version of is still updated at the deadline",
+			untilDeadline:     -time.Minute,
+			status:            notifications_api.EndUserNotificationDispatched,
+			displayed:         true,
+			reminder:          true,
+			installedVersions: map[uint]string{oneTitleID: "9.0.0", twoTitleID: "1.0.0"},
+			wantActed:         true,
+			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
 		},
 		{
 			name:              "the deadline closes and updates every app still behind",
@@ -746,10 +781,11 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 
 			// the apps the pass drops stop being listed, the same as deleting their rows does
 			dropped := make(map[uint]struct{})
-			ds.ListPatchNotificationAppsFunc = func(_ context.Context, _ string) ([]fleet.PatchNotificationAppDetail, error) {
+			ds.ListPatchNotificationAppsForNotificationsFunc = func(_ context.Context, uuids []string) (map[string][]fleet.PatchNotificationAppDetail, error) {
+				require.Len(t, uuids, 1, "the batch's apps are read in one statement")
 				all := []fleet.PatchNotificationAppDetail{
-					{SoftwareTitleID: oneTitleID, SoftwareInstallerID: new(oneInstallerID), PolicyID: new(policyID)},
-					{SoftwareTitleID: twoTitleID, SoftwareInstallerID: new(twoInstallerID), PolicyID: new(policyID)},
+					{SoftwareTitleID: oneTitleID, SoftwareInstallerID: new(oneInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion},
+					{SoftwareTitleID: twoTitleID, SoftwareInstallerID: new(twoInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion},
 				}
 				listed := make([]fleet.PatchNotificationAppDetail, 0, len(all))
 				for _, app := range all {
@@ -757,7 +793,7 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 						listed = append(listed, app)
 					}
 				}
-				return listed, nil
+				return map[string][]fleet.PatchNotificationAppDetail{uuids[0]: listed}, nil
 			}
 			var gotDropped []uint
 			ds.DeletePatchNotificationAppsFunc = func(_ context.Context, _ string, softwareTitleIDs []uint) error {
@@ -768,24 +804,28 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 				return nil
 			}
 
-			ds.ListSoftwareByHostIDShortFunc = func(_ context.Context, _ uint) ([]fleet.Software, error) {
-				return []fleet.Software{
-					{BundleIdentifier: oneBundle, Version: c.installedVersions[oneBundle]},
-					{BundleIdentifier: twoBundle, Version: c.installedVersions[twoBundle]},
-				}, nil
-			}
-			ds.GetSoftwareInstallerMetadataByIDFunc = func(_ context.Context, id uint) (*fleet.SoftwareInstaller, error) {
-				bundle := oneBundle
-				if id == twoInstallerID {
-					bundle = twoBundle
+			ds.ListHostSoftwareVersionsForTitlesFunc = func(_ context.Context, hostIDs []uint, titleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+				require.Len(t, hostIDs, 1, "the batch's inventory is read in one statement")
+				versions := make([]fleet.HostSoftwareTitleVersion, 0, len(titleIDs))
+				for _, titleID := range titleIDs {
+					if installed, ok := c.installedVersions[titleID]; ok {
+						versions = append(versions, fleet.HostSoftwareTitleVersion{
+							HostID: hostID, SoftwareTitleID: titleID, Version: installed,
+						})
+					}
 				}
-				return &fleet.SoftwareInstaller{Version: installerVersion, BundleIdentifier: bundle}, nil
+				return versions, nil
 			}
-			ds.GetHostLastInstallDataFunc = func(_ context.Context, _ uint, installerID uint) (*fleet.HostLastInstallData, error) {
-				if c.lastInstalled == nil || installerID != oneInstallerID {
+			ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+				require.Len(t, hostIDs, 1, "the batch's install history is read in one statement")
+				if c.lastInstalled == nil {
 					return nil, nil
 				}
-				return &fleet.HostLastInstallData{Status: new(fleet.SoftwareInstalled), UpdatedAt: *c.lastInstalled}, nil
+				return map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData{
+					{HostID: hostID, SoftwareTitleID: oneTitleID}: {{
+						Status: new(fleet.SoftwareInstalled), UpdatedAt: *c.lastInstalled,
+					}},
+				}, nil
 			}
 
 			var installs []uint

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -636,8 +636,12 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		installedVersions map[uint]string
 		// when Fleet last finished installing the first app, if it did
 		lastInstalled *time.Time
+		// the first app's install request fails, which must not stop the second being queued
+		firstInstallFails bool
 		// ActOnNotification: an Update now got there first
 		alreadyActed bool
+		// the notification is already acted, which an earlier pass stopping part way through leaves behind
+		statusActed bool
 
 		wantReminder bool
 		wantInstalls []uint
@@ -707,6 +711,31 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantReminder:      true,
 		},
 		{
+			// one installer Fleet cannot queue must not take the rest of the host's apps with it
+			name:              "an app whose install request fails does not stop the others being queued",
+			untilDeadline:     -time.Minute,
+			displayed:         true,
+			reminder:          true,
+			installedVersions: behind,
+			firstInstallFails: true,
+			wantActed:         true,
+			wantInstalls:      []uint{twoInstallerID},
+		},
+		{
+			// if an earlier pass set the status to acted and then stopped before queueing, the apps
+			// are still unhandled. ActOnNotification returns false against that status, and
+			// isStatusActed is what lets this pass carry on and queue them.
+			name:              "an acted notification with an app still unhandled has its installs queued",
+			untilDeadline:     -time.Minute,
+			displayed:         true,
+			reminder:          true,
+			statusActed:       true,
+			alreadyActed:      true,
+			installedVersions: behind,
+			wantActed:         true,
+			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
+		},
+		{
 			name:              "an Update now that got there first stops the deadline installing the same apps again",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
@@ -741,6 +770,10 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			if c.displayed {
 				displayed = &displayedAt
 			}
+			status := notifications_api.EndUserNotificationDispatched
+			if c.statusActed {
+				status = notifications_api.EndUserNotificationActed
+			}
 			var gotCutoff time.Time
 			ds.ListPatchNotificationsDueFunc = func(_ context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
 				gotCutoff = cutoff
@@ -748,7 +781,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				return []fleet.PatchNotificationDue{{
 					NotificationUUID: "notification-uuid",
 					HostID:           hostID,
-					Status:           notifications_api.EndUserNotificationDispatched,
+					Status:           status,
 					Payload:          payload,
 					DisplayedAt:      displayed,
 					InstallAt:        time.Now().UTC().Add(c.untilDeadline),
@@ -813,12 +846,25 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				require.False(t, opts.OverridePreInstallQuery, "the deadline forces the install, so the app being open must not stop it")
 				require.NotNil(t, opts.PolicyID)
 				require.Equal(t, policyID, *opts.PolicyID)
+				if c.firstInstallFails && installerID == oneInstallerID {
+					return "", errors.New("insert failed")
+				}
 				installs = append(installs, installerID)
 				return "", nil
 			}
-			ds.SetPatchNotificationAppsQueuedFunc = func(_ context.Context, _ string, _ []uint) error { return nil }
+			var markedQueued []uint
+			ds.SetPatchNotificationAppsQueuedFunc = func(_ context.Context, _ string, softwareTitleIDs []uint) error {
+				markedQueued = append(markedQueued, softwareTitleIDs...)
+				return nil
+			}
 
-			require.NoError(t, kind.RemindAndInstallDuePatches(context.Background()))
+			passErr := kind.RemindAndInstallDuePatches(context.Background())
+			if c.firstInstallFails {
+				require.Error(t, passErr)
+				require.NotContains(t, markedQueued, oneTitleID, "the app that failed stays unmarked so a later pass retries it")
+			} else {
+				require.NoError(t, passErr)
+			}
 
 			require.WithinDuration(t, time.Now().UTC().Add(patchNotificationReminderBefore), gotCutoff, time.Minute,
 				"the cutoff is install_at plus the reminder lead time")

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -643,7 +643,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		wantInstalls []uint
 		// the pass tried to take the notification, whether or not it got it
 		wantActed       bool
-		wantReset       bool
 		wantAppsDropped []uint
 	}{
 		{
@@ -698,6 +697,16 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
 		},
 		{
+			// A pass that misses the reminder window leaves the first notice on screen with the
+			// deadline already gone. The apps must not close without the 5 minute warning, so the
+			// reminder is sent late rather than skipped.
+			name:              "a deadline reached with the first notice still displayed sends the reminder",
+			untilDeadline:     -time.Minute,
+			displayed:         true,
+			installedVersions: behind,
+			wantReminder:      true,
+		},
+		{
 			name:              "an Update now that got there first stops the deadline installing the same apps again",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
@@ -707,13 +716,12 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantActed:         true,
 		},
 		{
-			// an offline host and a reminder that was never displayed both leave displayed_at null
-			name:              "a notification past install_at with no displayed_at is re-dispatched instead of installed",
+			// an offline host and a reminder still on its way both leave displayed_at null, and
+			// neither has been seen, so the pass waits for the reminder to reach the screen
+			name:              "a notification past install_at with no displayed_at does nothing",
 			untilDeadline:     -time.Minute,
 			reminder:          true,
 			installedVersions: behind,
-			wantReset:         true,
-			wantReminder:      true,
 		},
 	}
 
@@ -809,7 +817,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				return "", nil
 			}
 			ds.SetPatchNotificationAppsQueuedFunc = func(_ context.Context, _ string, _ []uint) error { return nil }
-			ds.ResetPatchNotificationFunc = func(_ context.Context, _ string) error { return nil }
 
 			require.NoError(t, kind.RemindAndInstallDuePatches(context.Background()))
 
@@ -824,19 +831,13 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			require.ElementsMatch(t, c.wantInstalls, installs)
 			require.ElementsMatch(t, c.wantAppsDropped, gotDropped)
 			require.Equal(t, c.wantActed, notificationSvc.actInvoked)
-			require.Equal(t, c.wantReset, ds.ResetPatchNotificationFuncInvoked)
 
 			if !c.wantReminder {
 				require.False(t, notificationSvc.delayInvoked)
 				return
 			}
 			require.True(t, notificationSvc.delayInvoked)
-			// a reset re-sends the first notification, not the reminder
-			wantPayload := patchNotificationReminderPayload
-			if c.wantReset {
-				wantPayload = patchNotificationFirstNoticePayload
-			}
-			require.JSONEq(t, string(wantPayload), string(notificationSvc.delayPayload))
+			require.JSONEq(t, string(patchNotificationReminderPayload), string(notificationSvc.delayPayload))
 		})
 	}
 }

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	notifications_api "github.com/fleetdm/fleet/v4/server/notifications/api"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -137,9 +136,9 @@ func TestCreatePatchNotificationForEndUser(t *testing.T) {
 				return &notifications_api.EndUserNotification{UUID: awaitingUUID}, nil
 			}
 			notificationsSvc.CreateNotificationFunc = func(_ context.Context, notification *notifications_api.EndUserNotification) (*notifications_api.EndUserNotification, error) {
-				assert.Equal(t, hostID, notification.HostID)
-				assert.Equal(t, fleet.PatchNotificationKind, notification.Kind)
-				assert.JSONEq(t, `{"reminder":false}`, string(notification.Payload))
+				require.Equal(t, hostID, notification.HostID)
+				require.Equal(t, fleet.PatchNotificationKind, notification.Kind)
+				require.JSONEq(t, `{"reminder":false}`, string(notification.Payload))
 				require.NotNil(t, notification.ExpiresAt, "a notification with no expiry never gives up")
 				return &notifications_api.EndUserNotification{UUID: createdUUID}, nil
 			}
@@ -176,16 +175,16 @@ func TestCreatePatchNotificationForEndUser(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, c.wantCreated, notificationsSvc.CreateNotificationFuncInvoked)
-			assert.Equal(t, c.wantCreated, ds.NewPatchNotificationFuncInvoked)
-			assert.Equal(t, c.wantAppOn, addedTo)
+			require.Equal(t, c.wantCreated, notificationsSvc.CreateNotificationFuncInvoked)
+			require.Equal(t, c.wantCreated, ds.NewPatchNotificationFuncInvoked)
+			require.Equal(t, c.wantAppOn, addedTo)
 
 			if c.wantAppOn != "" {
-				assert.Equal(t, titleID, addedApp.SoftwareTitleID)
+				require.Equal(t, titleID, addedApp.SoftwareTitleID)
 				require.NotNil(t, addedApp.SoftwareInstallerID)
-				assert.Equal(t, installerID, *addedApp.SoftwareInstallerID)
+				require.Equal(t, installerID, *addedApp.SoftwareInstallerID)
 				require.NotNil(t, addedApp.PolicyID)
-				assert.Equal(t, policyID, *addedApp.PolicyID)
+				require.Equal(t, policyID, *addedApp.PolicyID)
 			}
 		})
 	}
@@ -298,8 +297,8 @@ func TestPatchNotificationUpdateNow(t *testing.T) {
 
 			var installs []fleet.HostSoftwareInstallOptions
 			ds.InsertSoftwareInstallRequestFunc = func(_ context.Context, gotHostID uint, gotInstallerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
-				assert.Equal(t, hostID, gotHostID)
-				assert.Equal(t, installerID, gotInstallerID)
+				require.Equal(t, hostID, gotHostID)
+				require.Equal(t, installerID, gotInstallerID)
 				if c.installFails {
 					return "", errors.New("insert failed")
 				}
@@ -320,30 +319,30 @@ func TestPatchNotificationUpdateNow(t *testing.T) {
 			})
 			if c.wantErr {
 				require.Error(t, err)
-				assert.Equal(t, c.status, notificationSvc.setStatus,
+				require.Equal(t, c.status, notificationSvc.setStatus,
 					"the notification goes back to the status it had so the next press can finish queueing")
 				return
 			}
-			assert.Empty(t, notificationSvc.setStatus)
+			require.Empty(t, notificationSvc.setStatus)
 			require.NoError(t, err)
 
 			require.Len(t, installs, c.wantInstalls)
 			for _, opts := range installs {
-				assert.False(t, opts.OverridePreInstallQuery, "the end user asked for this, so the app being open must not stop it")
+				require.False(t, opts.OverridePreInstallQuery, "the end user asked for this, so the app being open must not stop it")
 				require.NotNil(t, opts.PolicyID, "the install keeps its policy so it shows in Automation runs")
-				assert.Equal(t, policyID, *opts.PolicyID)
+				require.Equal(t, policyID, *opts.PolicyID)
 			}
-			assert.Equal(t, c.wantActionTry, notificationSvc.actInvoked)
+			require.Equal(t, c.wantActionTry, notificationSvc.actInvoked)
 
 			if !c.wantActionTry {
-				assert.Nil(t, view, "nothing changed, so the notification renders as it was")
+				require.Nil(t, view, "nothing changed, so the notification renders as it was")
 				return
 			}
 
 			// the returned view is what the end user sees without a second request
 			require.NotNil(t, view)
 			require.Len(t, view.Items, 1)
-			assert.Equal(t, "Installing...", view.Items[0].Status)
+			require.Equal(t, "Installing...", view.Items[0].Status)
 			require.Equal(t, []notifications_api.NotificationAction{
 				{ID: patchNotificationActionDismiss, Label: "Hide"},
 			}, view.Actions, "the apps are already installing, so only Hide is offered")
@@ -421,7 +420,7 @@ func TestPatchNotificationUpdateNowResumesAfterFailure(t *testing.T) {
 	_, err := kind.updateNow(context.Background(), notification)
 	require.Error(t, err)
 	require.Equal(t, []uint{firstInstaller}, installed)
-	assert.Equal(t, notifications_api.EndUserNotificationDispatched, notificationSvc.setStatus)
+	require.Equal(t, notifications_api.EndUserNotificationDispatched, notificationSvc.setStatus)
 
 	// the end user presses again, and this time the second app's install works
 	secondInstallerFails = false
@@ -430,8 +429,8 @@ func TestPatchNotificationUpdateNowResumesAfterFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []uint{firstInstaller, secondInstaller}, installed,
 		"the first app is not queued a second time")
-	assert.True(t, notificationSvc.actInvoked)
-	assert.Empty(t, notificationSvc.setStatus)
+	require.True(t, notificationSvc.actInvoked)
+	require.Empty(t, notificationSvc.setStatus)
 }
 
 // A notification whose apps are gone, after an admin deletes the title, fails rather than retrying.
@@ -451,8 +450,8 @@ func TestPatchNotificationRenderWithNoApps(t *testing.T) {
 		Payload: patchNotificationFirstNoticePayload,
 	})
 	require.Error(t, err)
-	assert.Nil(t, view)
-	assert.Equal(t, notifications_api.EndUserNotificationReasonNothingToShow, notificationSvc.failedReason)
+	require.Nil(t, view)
+	require.Equal(t, notifications_api.EndUserNotificationReasonNothingToShow, notificationSvc.failedReason)
 }
 
 // What the activity OnOutcome records: which apps and policies it names, which
@@ -570,13 +569,14 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			}
 			notification := &notifications_api.EndUserNotification{
 				UUID: "notification-uuid", HostID: hostID, Payload: payload, LastExitCode: c.lastExitCode,
+				Status: notifications_api.EndUserNotificationDispatched,
 			}
 
 			err := kind.OnOutcome(context.Background(), notification, c.outcome)
 			require.NoError(t, err)
 
 			if c.wantNoActivity {
-				assert.False(t, writer.invoked)
+				require.False(t, writer.invoked)
 				return
 			}
 
@@ -584,27 +584,27 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 			activity, ok := writer.activity.(fleet.ActivityTypeNotifiedEndUserBeforePatching)
 			require.True(t, ok)
 
-			assert.Equal(t, hostID, activity.HostID)
-			assert.Equal(t, "Test Host", activity.HostDisplayName)
-			assert.Equal(t, notification.UUID, activity.PatchNotificationUUID)
-			assert.Equal(t, c.wantStatus, activity.Status)
-			assert.Equal(t, c.wantTimeBefore, activity.TimeBefore)
+			require.Equal(t, hostID, activity.HostID)
+			require.Equal(t, "Test Host", activity.HostDisplayName)
+			require.Equal(t, notification.UUID, activity.PatchNotificationUUID)
+			require.Equal(t, c.wantStatus, activity.Status)
+			require.Equal(t, c.wantTimeBefore, activity.TimeBefore)
 
 			// Only a displayed outcome sets install_at, and it is set from the lead time of the
 			// notification that was displayed, so a reminder sets it 5 minutes out, not an hour.
 			if c.wantStatus != "success" {
-				assert.False(t, ds.SetPatchNotificationInstallAtFuncInvoked)
-				assert.Nil(t, activity.InstallAt)
+				require.False(t, ds.SetPatchNotificationInstallAtFuncInvoked)
+				require.Nil(t, activity.InstallAt)
 			} else {
-				assert.True(t, ds.SetPatchNotificationInstallAtFuncInvoked)
-				assert.Equal(t, time.Duration(c.wantTimeBefore)*time.Second, gotLeadTime)
+				require.True(t, ds.SetPatchNotificationInstallAtFuncInvoked)
+				require.Equal(t, time.Duration(c.wantTimeBefore)*time.Second, gotLeadTime)
 				require.NotNil(t, activity.InstallAt)
-				assert.Equal(t, deadline, *activity.InstallAt)
+				require.Equal(t, deadline, *activity.InstallAt)
 			}
-			assert.Equal(t, c.outcome.ExecutionID, activity.ScriptExecutionID)
+			require.Equal(t, c.outcome.ExecutionID, activity.ScriptExecutionID)
 
-			assert.Equal(t, c.wantTitles, activity.SoftwareTitles)
-			assert.Equal(t, c.wantPolicyIDs, activity.PolicyIDs)
+			require.Equal(t, c.wantTitles, activity.SoftwareTitles)
+			require.Equal(t, c.wantPolicyIDs, activity.PolicyIDs)
 		})
 	}
 }
@@ -624,6 +624,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 	behind := map[uint]string{oneTitleID: "1.0.0", twoTitleID: "1.0.0"}
 
 	displayedAt := time.Now().UTC().Add(-55 * time.Minute)
+	appAddedAt := time.Now().UTC().Add(-50 * time.Minute)
 
 	cases := []struct {
 		name string
@@ -674,15 +675,27 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		},
 		{
 			// a My device self-service update lands before inventory catches up
-			name:              "an app Fleet installed since the notification was created is not installed again",
+			name:              "an app Fleet installed since it was added to the notification is not installed again",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
 			reminder:          true,
 			installedVersions: behind,
-			lastInstalled:     new(time.Now().UTC()),
+			lastInstalled:     new(appAddedAt.Add(time.Minute)),
 			wantActed:         true,
 			wantInstalls:      []uint{twoInstallerID},
 			wantAppsDropped:   []uint{oneTitleID},
+		},
+		{
+			// the app was added because its policy failed after that install, so the install is no
+			// evidence that it is up to date
+			name:              "an app Fleet installed before it was added to the notification is still installed",
+			untilDeadline:     -time.Minute,
+			displayed:         true,
+			reminder:          true,
+			installedVersions: behind,
+			lastInstalled:     new(appAddedAt.Add(-time.Minute)),
+			wantActed:         true,
+			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
 		},
 		{
 			name:              "an Update now that got there first stops the deadline installing the same apps again",
@@ -723,14 +736,13 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			var gotCutoff time.Time
 			ds.ListPatchNotificationsDueFunc = func(_ context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
 				gotCutoff = cutoff
-				assert.Equal(t, duePatchNotificationBatchSize, limit)
+				require.Equal(t, duePatchNotificationBatchSize, limit)
 				return []fleet.PatchNotificationDue{{
 					NotificationUUID: "notification-uuid",
 					HostID:           hostID,
 					Status:           notifications_api.EndUserNotificationDispatched,
 					Payload:          payload,
 					DisplayedAt:      displayed,
-					CreatedAt:        displayedAt.Add(-time.Minute),
 					InstallAt:        time.Now().UTC().Add(c.untilDeadline),
 				}}, nil
 			}
@@ -741,8 +753,8 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			ds.ListPatchNotificationAppsForNotificationsFunc = func(_ context.Context, uuids []string) (map[string][]fleet.PatchNotificationAppDetail, error) {
 				appReads++
 				all := []fleet.PatchNotificationAppDetail{
-					{SoftwareTitleID: oneTitleID, SoftwareInstallerID: new(oneInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion},
-					{SoftwareTitleID: twoTitleID, SoftwareInstallerID: new(twoInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion},
+					{SoftwareTitleID: oneTitleID, SoftwareInstallerID: new(oneInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion, CreatedAt: appAddedAt},
+					{SoftwareTitleID: twoTitleID, SoftwareInstallerID: new(twoInstallerID), PolicyID: new(policyID), InstallerVersion: installerVersion, CreatedAt: appAddedAt},
 				}
 				listed := make([]fleet.PatchNotificationAppDetail, 0, len(all))
 				for _, app := range all {
@@ -789,10 +801,10 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 
 			var installs []uint
 			ds.InsertSoftwareInstallRequestFunc = func(_ context.Context, gotHostID uint, installerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
-				assert.Equal(t, hostID, gotHostID)
-				assert.False(t, opts.OverridePreInstallQuery, "the deadline forces the install, so the app being open must not stop it")
+				require.Equal(t, hostID, gotHostID)
+				require.False(t, opts.OverridePreInstallQuery, "the deadline forces the install, so the app being open must not stop it")
 				require.NotNil(t, opts.PolicyID)
-				assert.Equal(t, policyID, *opts.PolicyID)
+				require.Equal(t, policyID, *opts.PolicyID)
 				installs = append(installs, installerID)
 				return "", nil
 			}
@@ -801,21 +813,21 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 
 			require.NoError(t, kind.RemindAndInstallDuePatches(context.Background()))
 
-			assert.WithinDuration(t, time.Now().UTC().Add(patchNotificationReminderBefore), gotCutoff, time.Minute,
+			require.WithinDuration(t, time.Now().UTC().Add(patchNotificationReminderBefore), gotCutoff, time.Minute,
 				"the cutoff is install_at plus the reminder lead time")
 
 			// one read each per batch, not one per notification
-			assert.Equal(t, 1, appReads)
-			assert.Equal(t, 1, versionReads)
-			assert.Equal(t, 1, installDataReads)
+			require.Equal(t, 1, appReads)
+			require.Equal(t, 1, versionReads)
+			require.Equal(t, 1, installDataReads)
 
-			assert.ElementsMatch(t, c.wantInstalls, installs)
-			assert.ElementsMatch(t, c.wantAppsDropped, gotDropped)
-			assert.Equal(t, c.wantActed, notificationSvc.actInvoked)
-			assert.Equal(t, c.wantReset, ds.ResetPatchNotificationFuncInvoked)
+			require.ElementsMatch(t, c.wantInstalls, installs)
+			require.ElementsMatch(t, c.wantAppsDropped, gotDropped)
+			require.Equal(t, c.wantActed, notificationSvc.actInvoked)
+			require.Equal(t, c.wantReset, ds.ResetPatchNotificationFuncInvoked)
 
 			if !c.wantReminder {
-				assert.False(t, notificationSvc.delayInvoked)
+				require.False(t, notificationSvc.delayInvoked)
 				return
 			}
 			require.True(t, notificationSvc.delayInvoked)
@@ -824,7 +836,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			if c.wantReset {
 				wantPayload = patchNotificationFirstNoticePayload
 			}
-			assert.JSONEq(t, string(wantPayload), string(notificationSvc.delayPayload))
+			require.JSONEq(t, string(wantPayload), string(notificationSvc.delayPayload))
 		})
 	}
 }

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -271,7 +271,7 @@ func TestPatchNotificationUpdateNow(t *testing.T) {
 			kind := &patchNotificationKind{
 				ds: ds, notificationSvc: notificationSvc, logger: slog.New(slog.DiscardHandler),
 			}
-			ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, _ []uint, titleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+			ds.ListLastTitleInstallDataForHostsFunc = func(_ context.Context, _ []uint, titleIDs []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 				if !c.alreadyPending {
 					return nil, nil
 				}
@@ -387,7 +387,7 @@ func TestPatchNotificationUpdateNowResumesAfterFailure(t *testing.T) {
 
 	// the first app's install finishes between the two presses, so it is no
 	// longer pending by the time the second press runs
-	ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+	ds.ListLastTitleInstallDataForHostsFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 		if _, firstAppQueued := queued[firstTitleID]; !firstAppQueued {
 			return nil, nil
 		}
@@ -774,7 +774,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			}
 
 			var versionReads int
-			ds.ListHostSoftwareVersionsForTitlesFunc = func(_ context.Context, hostIDs []uint, titleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
+			ds.ListSoftwareTitleVersionsForHostsFunc = func(_ context.Context, hostIDs []uint, titleIDs []uint) ([]fleet.HostSoftwareTitleVersion, error) {
 				versionReads++
 				versions := make([]fleet.HostSoftwareTitleVersion, 0, len(titleIDs))
 				for _, titleID := range titleIDs {
@@ -787,7 +787,7 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 				return versions, nil
 			}
 			var installDataReads int
-			ds.ListHostLastTitleInstallDataFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
+			ds.ListLastTitleInstallDataForHostsFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 				installDataReads++
 				if c.lastInstalled == nil {
 					return nil, nil

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -609,7 +609,7 @@ func TestPatchNotificationOnOutcome(t *testing.T) {
 	}
 }
 
-func TestPatchNotificationCountdowns(t *testing.T) {
+func TestRemindAndInstallDuePatches(t *testing.T) {
 	const (
 		hostID           = uint(1)
 		oneTitleID       = uint(10)
@@ -737,7 +737,7 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 		},
 		{
 			// An offline host and a reminder still on its way both leave displayed_at unset, and
-			// neither end user has seen the warning, so the countdown starts over for both.
+			// neither end user has seen the warning, so the deadline starts over for both.
 			name:              "a deadline the end user never saw notifies again instead of patching",
 			untilDeadline:     -time.Minute,
 			status:            notifications_api.EndUserNotificationDispatched,
@@ -767,7 +767,7 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			var gotCutoff time.Time
 			ds.ListPatchNotificationsDueFunc = func(_ context.Context, cutoff time.Time, limit int) ([]fleet.PatchNotificationDue, error) {
 				gotCutoff = cutoff
-				assert.Equal(t, patchNotificationCountdownBatchSize, limit)
+				assert.Equal(t, duePatchNotificationBatchSize, limit)
 				return []fleet.PatchNotificationDue{{
 					NotificationUUID: "notification-uuid",
 					HostID:           hostID,
@@ -840,10 +840,10 @@ func TestPatchNotificationCountdowns(t *testing.T) {
 			ds.SetPatchNotificationAppsQueuedFunc = func(_ context.Context, _ string, _ []uint) error { return nil }
 			ds.ResetPatchNotificationFunc = func(_ context.Context, _ string) error { return nil }
 
-			require.NoError(t, kind.RunPatchNotificationCountdowns(context.Background()))
+			require.NoError(t, kind.RemindAndInstallDuePatches(context.Background()))
 
 			assert.WithinDuration(t, time.Now().UTC().Add(patchNotificationReminderBefore), gotCutoff, time.Minute,
-				"the pass reads the countdowns that reach their deadline within the reminder's lead time")
+				"the pass reads the notifications that reach their deadline within the reminder's lead time")
 
 			assert.ElementsMatch(t, c.wantInstalls, installs)
 			assert.ElementsMatch(t, c.wantAppsDropped, gotDropped)

--- a/server/service/notification_kind_patch_test.go
+++ b/server/service/notification_kind_patch_test.go
@@ -638,6 +638,10 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 		lastInstalled *time.Time
 		// the first app's install request fails, which must not stop the second being queued
 		firstInstallFails bool
+		// an install for the first app is already on the host's queue
+		pendingInstall bool
+		// that pending install runs the app open query, so it skips while the app is open
+		pendingInstallSkipsWhenOpen bool
 		// ActOnNotification: an Update now got there first
 		alreadyActed bool
 		// the notification is already acted, which an earlier pass stopping part way through leaves behind
@@ -677,7 +681,8 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
 		},
 		{
-			// a My device self-service update lands before inventory catches up
+			// Fleet's own install record catches a My device self-service update before the host's
+			// software inventory has refreshed to show it
 			name:              "an app Fleet installed since it was added to the notification is not installed again",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
@@ -689,8 +694,8 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantAppsDropped:   []uint{oneTitleID},
 		},
 		{
-			// the app was added because its policy failed after that install, so the install is no
-			// evidence that it is up to date
+			// the app was added after Fleet's install finished, because its policy failed anyway, so
+			// that install is no evidence the app is up to date
 			name:              "an app Fleet installed before it was added to the notification is still installed",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
@@ -701,9 +706,9 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantInstalls:      []uint{oneInstallerID, twoInstallerID},
 		},
 		{
-			// A pass that misses the reminder window leaves the first notice on screen with the
-			// deadline already gone. The apps must not close without the 5 minute warning, so the
-			// reminder is sent late rather than skipped.
+			// a pass that misses the reminder window leaves the first notice as the last one
+			// displayed with install_at already past, and the reminder is sent late rather than
+			// skipped so the apps never close without their 5 minute warning
 			name:              "a deadline reached with the first notice still displayed sends the reminder",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
@@ -711,7 +716,6 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			wantReminder:      true,
 		},
 		{
-			// one installer Fleet cannot queue must not take the rest of the host's apps with it
 			name:              "an app whose install request fails does not stop the others being queued",
 			untilDeadline:     -time.Minute,
 			displayed:         true,
@@ -720,6 +724,29 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			firstInstallFails: true,
 			wantActed:         true,
 			wantInstalls:      []uint{twoInstallerID},
+		},
+		{
+			name:              "an app with an install already pending is not queued again",
+			untilDeadline:     -time.Minute,
+			displayed:         true,
+			reminder:          true,
+			installedVersions: behind,
+			pendingInstall:    true,
+			wantActed:         true,
+			wantInstalls:      []uint{twoInstallerID},
+		},
+		{
+			// The policy queues its installs with the app open query attached, so a pending one of
+			// those skips for the same reason the deadline exists.
+			name:                        "an app whose pending install skips while the app is open is queued anyway",
+			untilDeadline:               -time.Minute,
+			displayed:                   true,
+			reminder:                    true,
+			installedVersions:           behind,
+			pendingInstall:              true,
+			pendingInstallSkipsWhenOpen: true,
+			wantActed:                   true,
+			wantInstalls:                []uint{oneInstallerID, twoInstallerID},
 		},
 		{
 			// if an earlier pass set the status to acted and then stopped before queueing, the apps
@@ -830,13 +857,23 @@ func TestRemindAndInstallDuePatches(t *testing.T) {
 			var installDataReads int
 			ds.ListLastTitleInstallDataForHostsFunc = func(_ context.Context, hostIDs []uint, _ []uint) (map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData, error) {
 				installDataReads++
-				if c.lastInstalled == nil {
+				firstAppInstalls := make([]*fleet.HostLastInstallData, 0, 2)
+				if c.lastInstalled != nil {
+					firstAppInstalls = append(firstAppInstalls, &fleet.HostLastInstallData{
+						Status: new(fleet.SoftwareInstalled), UpdatedAt: *c.lastInstalled,
+					})
+				}
+				if c.pendingInstall {
+					firstAppInstalls = append(firstAppInstalls, &fleet.HostLastInstallData{
+						Status:                  new(fleet.SoftwareInstallPending),
+						OverridePreInstallQuery: c.pendingInstallSkipsWhenOpen,
+					})
+				}
+				if len(firstAppInstalls) == 0 {
 					return nil, nil
 				}
 				return map[fleet.HostSoftwareTitleKey][]*fleet.HostLastInstallData{
-					{HostID: hostID, SoftwareTitleID: oneTitleID}: {{
-						Status: new(fleet.SoftwareInstalled), UpdatedAt: *c.lastInstalled,
-					}},
+					{HostID: hostID, SoftwareTitleID: oneTitleID}: firstAppInstalls,
 				}, nil
 			}
 

--- a/server/service/test_types.go
+++ b/server/service/test_types.go
@@ -108,7 +108,7 @@ type TestServerOpts struct {
 	NotificationsSvc notifications_api.Service
 
 	// PatchNotificationKind is populated alongside NotificationsSvc, so tests can
-	// run the countdown pass directly instead of going through the cron.
+	// run RemindAndInstallDuePatches directly instead of going through the cron.
 	PatchNotificationKind PatchNotificationKind
 
 	// NotificationsMock is populated automatically when a test service is built,

--- a/server/service/test_types.go
+++ b/server/service/test_types.go
@@ -107,6 +107,10 @@ type TestServerOpts struct {
 	// dispatch notifications directly instead of going through the cron.
 	NotificationsSvc notifications_api.Service
 
+	// PatchNotificationKind is populated alongside NotificationsSvc, so tests can
+	// run the countdown pass directly instead of going through the cron.
+	PatchNotificationKind PatchNotificationKind
+
 	// NotificationsMock is populated automatically when a test service is built,
 	// and is what the service uses unless DBConns replaced it with NotificationsSvc.
 	NotificationsMock *fleet_mock.MockNotificationsService

--- a/server/service/testing_client_test.go
+++ b/server/service/testing_client_test.go
@@ -100,7 +100,8 @@ type withServer struct {
 
 	fleetSvc fleet.Service
 
-	notificationsSvc notifications_api.Service
+	notificationsSvc      notifications_api.Service
+	patchNotificationKind PatchNotificationKind
 }
 
 func (ts *withServer) SetupSuite(dbName string) {
@@ -127,6 +128,7 @@ func (ts *withServer) SetupSuite(dbName string) {
 	ts.cachedAdminToken = ts.token
 	ts.redisPool = redisPool
 	ts.notificationsSvc = opts.NotificationsSvc
+	ts.patchNotificationKind = opts.PatchNotificationKind
 }
 
 func (ts *withServer) TearDownSuite() {

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -544,10 +544,12 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 			logger,
 		)
 		svc.SetNotificationsService(notificationsSvc)
-		notificationsSvc.RegisterKind(NewPatchNotificationKind(ds, svc, notificationsSvc, logger))
+		patchNotificationKind := NewPatchNotificationKind(ds, svc, notificationsSvc, logger)
+		notificationsSvc.RegisterKind(patchNotificationKind)
 		notificationsAuthMiddleware := DeviceAuthMiddleware(svc, logger, notifications.NewHostContext)
 		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, notificationsRoutesFn(notificationsAuthMiddleware))
 		opts[0].NotificationsSvc = notificationsSvc
+		opts[0].PatchNotificationKind = patchNotificationKind
 	} else {
 		_, notificationsRoutesFn := notifications_bootstrap.New(
 			&common_mysql.DBConnections{},


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50913 

# Notes

- (claude) This diverges from the subtask in three linked ways: the install is gated on the *reminder* having been displayed rather than on `install_at` alone, so `install_at` moves to the reminder's display time plus five minutes via `GREATEST` instead of being set once from the first notice, and there is no offline reset — a host that hasn't seen the reminder waits for it rather than restarting the hour.
- This PR modifies a migration that's on the feature branch but hasn't merged to main yet. If you checked out the `20260831184623_CreatePatchNotifications.go` migration you will need to fix it manually (delete table and run the create table query from the migration). 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


## AI

**AI:** Claude Code (claude-opus-5[1m])


## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
- [ ] Ensured the migration can be retried if it was partially applied after a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic reminders for patch notifications approaching their installation deadline.
  - Patch installations are now queued automatically when the deadline is reached.
  - Added support for tracking installation deadlines and displaying relevant patch and installer details.
  - Improved patch verification using installed software versions and previous installation activity.
- **Bug Fixes**
  - Improved handling of retries, concurrent updates, and partially completed installation queues.
  - Notifications now reset or update appropriately when software changes or installation activity is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->