### PR TITLE
Docs: allow extensions_autoload flag in command_line_flags

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -55,6 +55,8 @@ Setting `command_line_flags` to an empty value (`{}` or `null`) is not the same 
 - If `command_line_flags` isn't present in your agent options, Fleet leaves each host's osquery flags as they are. Flags that shipped with the fleetd installer, or were set locally on the host, are preserved.
 - If `command_line_flags` is set to `{}` or `null`, Fleet clears all local osquery flags on your hosts. On each host, fleetd empties the `osquery.flags` file and restarts osquery without those flags.
 
+The `host_identifier` and `database_path` flags can't be set in `command_line_flags` because fleetd manages them. The `extensions_autoload` flag can be set, but not together with the [`extensions`](#extensions) key, because fleetd uses that flag to load the extensions it manages.
+
 To see a description for all available settings, first [enroll your host](https://fleetdm.com/guides/enroll-hosts) to Fleet. Then, open your **Terminal** app and run `sudo orbit shell` to open an interactive osquery shell. Then run the following osquery query:
 
 ```


### PR DESCRIPTION
**Related issue:** #47244

Documentation for the change in #47244 that allows setting the `extensions_autoload` flag in agent options `command_line_flags`. Documents which flags remain blocked (`host_identifier`, `database_path`) and that `extensions_autoload` can't be combined with the `extensions` key.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`. (Added in the code PR; docs-only change here.)

## Testing

- [x] QA'd all new/changed functionality manually

## AI

**AI:** Claude Code (claude-fable-5-1)
