### PR TITLE
Allow `extensions_autoload` flag in `command_line_flags`

### DIFF
--- a/changes/47244-allow-extensions-autoload-flag
+++ b/changes/47244-allow-extensions-autoload-flag
@@ -1,0 +1,1 @@
+- Allowed setting the `extensions_autoload` flag in agent options `command_line_flags`. It's still rejected when the `extensions` key is also configured, because fleetd uses that flag to load the extensions it manages.

--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -106,11 +106,13 @@ func ValidateJSONAgentOptions(ctx context.Context, ds Datastore, rawJSON json.Ra
 		if flags.HostIdentifier != "" {
 			return fmt.Errorf(flagNotSupportedErr, "--host_identifier")
 		}
-		if flags.ExtensionsAutoload != "" {
-			return fmt.Errorf(flagNotSupportedErr, "--extensions_autoload")
-		}
 		if flags.DatabasePath != "" {
 			return fmt.Errorf(flagNotSupportedErr, "--database_path")
+		}
+		// fleetd passes its own --extensions_autoload (after --flagfile, so it wins)
+		// when the extensions option is set, which would silently ignore this one.
+		if flags.ExtensionsAutoload != "" && hasExtensions(opts.Extensions) {
+			return errors.New("The --extensions_autoload flag can't be used together with the extensions option. Please remove one of them.")
 		}
 	}
 
@@ -167,6 +169,16 @@ func ValidateJSONAgentOptions(ctx context.Context, ds Datastore, rawJSON json.Ra
 	}
 
 	return nil
+}
+
+// hasExtensions reports whether the extensions agent option declares at least
+// one extension. Malformed JSON is reported by validateJSONAgentOptionsExtensions.
+func hasExtensions(raw json.RawMessage) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	return len(m) > 0
 }
 
 func checkEmptyFields(prefix string, data json.RawMessage) error {

--- a/server/fleet/agent_options_test.go
+++ b/server/fleet/agent_options_test.go
@@ -142,6 +142,23 @@ func TestValidateAgentOptions(t *testing.T) {
 		{"setting a valid os-specific flag", `{"command_line_flags":{
 			"users_service_delay": 123
 		}}`, true, ``},
+		{"unsupported command-line flag host_identifier", `{"command_line_flags":{
+			"host_identifier": "instance"
+		}}`, true, `The --host_identifier flag isn't supported`},
+		{"unsupported command-line flag database_path", `{"command_line_flags":{
+			"database_path": "/tmp/osquery.db"
+		}}`, true, `The --database_path flag isn't supported`},
+		{"extensions_autoload flag without extensions", `{"command_line_flags":{
+			"extensions_autoload": "/etc/osquery/extensions.load"
+		}}`, true, ``},
+		{"extensions_autoload flag with empty extensions", `{
+			"command_line_flags": {"extensions_autoload": "/etc/osquery/extensions.load"},
+			"extensions": {}
+		}`, true, ``},
+		{"extensions_autoload flag with extensions", `{
+			"command_line_flags": {"extensions_autoload": "/etc/osquery/extensions.load"},
+			"extensions": {"hello_world": {"channel": "stable", "platform": "macos"}}
+		}`, true, `The --extensions_autoload flag can't be used together with the extensions option`},
 		{"setting a valid os-specific option", `{"config":{
 			"options": {
 				"users_service_delay": 123


### PR DESCRIPTION
Resolves #47244.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests.
- [X] QA'd all new/changed functionality manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent configurations can now use the `extensions_autoload` command-line flag when no extensions are configured.
  - The flag is also accepted when the extensions configuration is empty.

- **Bug Fixes**
  - Configurations combining `extensions_autoload` with managed extensions now receive a clear validation error.
  - Unsupported command-line flags continue to be rejected with specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->