### PR TITLE
For R.C. - Fleet UI: Skipped-install cadence link + surface real failure on My device (#52420)

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -5,6 +5,7 @@ import { createMockHostSoftware } from "__mocks__/hostMock";
 import { createMockSoftwareInstallResult } from "__mocks__/softwareMock";
 import {
   getDefaultSoftwareInstallHandler,
+  getDeviceSoftwareInstallHandlerFailedWithPreInstall,
   getSoftwareInstallHandlerNoOutputs,
   getSoftwareInstallHandlerOnlyInstallOutput,
   getSoftwareInstallHandlerWithHash,
@@ -136,7 +137,7 @@ describe("SoftwareInstallDetailsModal", () => {
       expect(screen.getByText(/\d+.*ago/)).toBeInTheDocument();
     });
 
-    it("renders app-open skipped copy instead of generic failed-install copy", () => {
+    it("renders app-open skipped copy with a policy-automations link on the admin activity feed", () => {
       render(
         <StatusMessage
           softwareName="CoolApp"
@@ -149,16 +150,48 @@ describe("SoftwareInstallDetailsModal", () => {
       );
 
       expect(screen.getByText(/Fleet skipped install of/)).toBeInTheDocument();
-      expect(screen.getByText(/The app was open/)).toBeInTheDocument();
       expect(
         screen.getByText(
-          /It will update once the user closes it and policy runs again, or update via self service\./
+          /The app was open\. It will update once the user closes it and the/
         )
       ).toBeInTheDocument();
+      // "policy runs again" is the external CustomLink to the cadence docs.
+      const link = screen.getByRole("link", { name: /policy runs again/ });
+      expect(link).toHaveAttribute(
+        "href",
+        "https://fleetdm.com/learn-more-about/policy-automations"
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      // Self-service tail should be gone.
+      expect(
+        screen.queryByText(/update via self service/)
+      ).not.toBeInTheDocument();
       expect(screen.queryByText(/failed to install/)).not.toBeInTheDocument();
       // Grey "!" (error-outline), not the red failure icon.
       expect(screen.getByTestId("error-outline-icon")).toBeInTheDocument();
       expect(screen.queryByTestId("error-icon")).not.toBeInTheDocument();
+    });
+
+    it("renders skipped copy as plain text (no policy-automations link) on the My device page", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "failed_install",
+          })}
+          isMyDevicePage
+          skippedInstall
+        />
+      );
+
+      expect(
+        screen.getByText(
+          /It will update once the user closes it and the policy runs again\./
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /policy runs again/ })
+      ).not.toBeInTheDocument();
     });
 
     it("on host details page/install activity, renders installed message with timestamp", () => {
@@ -436,6 +469,35 @@ describe("SoftwareInstallDetailsModal", () => {
           name: /Details/i,
         })
       ).not.toBeInTheDocument();
+    });
+
+    // #52017: on the end-user My device page, clicking "Failed" opened the modal
+    // but showed "is installed" because the host inventory still reported an
+    // older version. The override is meant for the admin Host details page;
+    // My device (deviceAuthToken) must show the failure so the user can see
+    // Details + Retry.
+    it("on My device, does not override a failed install to 'is installed' even when the host reports an older installed version", async () => {
+      mockServer.use(getDeviceSoftwareInstallHandlerFailedWithPreInstall);
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
+
+      renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={baseDetails}
+          hostSoftware={createMockHostSoftware({
+            id: 99,
+            name: "CoolApp",
+          })}
+          deviceAuthToken="token123"
+          onCancel={noop}
+        />
+      );
+
+      expect(await screen.findByText(/failed to install/)).toBeInTheDocument();
+      expect(screen.queryByText(/is installed\./i)).not.toBeInTheDocument();
+      expect(
+        await screen.findByRole("button", { name: /Details/i })
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     });
   });
 

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -42,6 +42,9 @@ import TooltipTruncatedText from "components/TooltipTruncatedText";
 import {
   INSTALL_DETAILS_STATUS_ICONS,
   SKIPPED_INSTALL_DETAILS,
+  SKIPPED_INSTALL_DETAILS_LINK_TEXT,
+  SKIPPED_INSTALL_DETAILS_LINK_URL,
+  SKIPPED_INSTALL_DETAILS_PREFIX,
   SKIPPED_PRE_INSTALL_OUTPUT,
   getInstallDetailsStatusPredicate,
 } from "../constants";
@@ -149,6 +152,22 @@ export const StatusMessage = ({
     : "";
 
   if (skippedInstall && status === "failed_install") {
+    // Admin-facing pages link "policy runs again" to cadence docs; the end-user
+    // "My device" flow shows plain text since the doc is admin-only.
+    const skippedDetails = isMyDevicePage ? (
+      SKIPPED_INSTALL_DETAILS
+    ) : (
+      <>
+        {SKIPPED_INSTALL_DETAILS_PREFIX}
+        <CustomLink
+          url={SKIPPED_INSTALL_DETAILS_LINK_URL}
+          text={SKIPPED_INSTALL_DETAILS_LINK_TEXT}
+          newTab
+        />
+        .
+      </>
+    );
+
     return (
       <IconStatusMessage
         className={`${baseClass}__status-message`}
@@ -158,7 +177,7 @@ export const StatusMessage = ({
           <span>
             Fleet skipped install of <b>{software_title}</b> ({software_package}
             ) on {formattedHost}
-            {displayTimeStamp}. {SKIPPED_INSTALL_DETAILS}
+            {displayTimeStamp}. {skippedDetails}
           </span>
         }
       />
@@ -377,17 +396,21 @@ export const SoftwareInstallDetailsModal = ({
   // True when host inventory reports at least one installed version for this app.
   const inventoryReportsInstalled = !!hostSoftware?.installed_versions?.length;
 
-  // This modal is opened in two contexts:
-  // - From Host -> Software: hostSoftware is defined (we trust inventory to override failures).
-  // - From the Activity feed: hostSoftware is undefined (we trust install result status).
+  // This modal is opened in three contexts:
+  // - Admin Host -> Software: hostSoftware defined, no deviceAuthToken.
+  // - End-user My device: hostSoftware defined, deviceAuthToken present.
+  // - Activity feed: hostSoftware undefined.
   const openedFromHostSoftwarePage = !!hostSoftware;
 
   // Used only for overriding failed_install/failed_uninstall -> "is installed."
-  // - From Host -> Software: override based on inventory.
-  // - From Activity feed: never override (always show the failure).
-  const canOverrideFailureWithInstalled = openedFromHostSoftwarePage
-    ? inventoryReportsInstalled
-    : false;
+  // - Admin Host -> Software: override based on inventory (4.82 #31663).
+  // - My device: never override — the end user just triggered Update and needs
+  //   to see the failure + Details + Retry (#52017).
+  // - Activity feed: never override (always show the failure).
+  const canOverrideFailureWithInstalled =
+    openedFromHostSoftwarePage && !deviceAuthToken
+      ? inventoryReportsInstalled
+      : false;
 
   // Treat failed_install / failed_uninstall with installed versions as installed
   const overrideFailedMessageWithInstalledMessage =

--- a/frontend/components/ActivityDetails/InstallDetails/constants.ts
+++ b/frontend/components/ActivityDetails/InstallDetails/constants.ts
@@ -22,8 +22,13 @@ export const INSTALL_DETAILS_STATUS_ICONS: Record<
   skipped_install: "error-outline",
 } as const;
 
-export const SKIPPED_INSTALL_DETAILS =
-  "The app was open. It will update once the user closes it and policy runs again, or update via self service.";
+export const SKIPPED_INSTALL_DETAILS_PREFIX =
+  "The app was open. It will update once the user closes it and the ";
+export const SKIPPED_INSTALL_DETAILS_LINK_TEXT = "policy runs again";
+export const SKIPPED_INSTALL_DETAILS_LINK_URL =
+  "https://fleetdm.com/learn-more-about/policy-automations";
+
+export const SKIPPED_INSTALL_DETAILS = `${SKIPPED_INSTALL_DETAILS_PREFIX}${SKIPPED_INSTALL_DETAILS_LINK_TEXT}.`;
 
 // A skip stores an empty pre-install query output, so there is nothing to echo back.
 export const SKIPPED_PRE_INSTALL_OUTPUT =

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -143,6 +143,23 @@ export const getSoftwareInstallHandlerWithHash = http.get(
   }
 );
 
+// Failed install on the end-user (device_user) path — mirrors the admin
+// getSoftwareInstallHandlerOnlyPreInstallOutput but on the token-scoped route.
+export const getDeviceSoftwareInstallHandlerFailedWithPreInstall = http.get(
+  baseUrl("/device/:token/software/install/:install_uuid/results"),
+  ({ params }) => {
+    return HttpResponse.json({
+      results: createMockSoftwareInstallResult({
+        install_uuid: params.install_uuid as string,
+        status: "failed_install",
+        output: "",
+        post_install_script_output: "",
+        pre_install_query_output: "Pre-install only",
+      }),
+    });
+  }
+);
+
 // ---- MDM Command Handlers ----
 
 /** This is used for testing command results of IPA custom packages */


### PR DESCRIPTION
## Issue
Closes #51820

## Description
- Previously merged into `main` with #52420
- This is for the 4.92.0 R.C.

## Screenrecording

### Activity skipped details modal - links out, removes "updates via self service"
https://github.com/user-attachments/assets/1bcc1de4-ec81-4372-a4d7-af43c5ecc840

### Policy run skipped details - removes "updates via self service"
https://github.com/user-attachments/assets/8c88a9f8-b5f8-4d4a-b510-4ca3f5c91aeb

## End user on fleet desktop can see the failure modal now as well


https://github.com/user-attachments/assets/d5ba6421-2bd2-46d1-a651-8c45c9d5193a


## Testing
- [x] QA'd all new/changed functionality manually