### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aldente/darwin.json
+++ b/ee/maintained-apps/outputs/aldente/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.38.1",
+      "version": "1.39.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.apphousekitchen.aldente-pro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apphousekitchen.aldente-pro' AND version_compare(bundle_short_version, '1.38.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apphousekitchen.aldente-pro' AND version_compare(bundle_short_version, '1.39.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.apphousekitchen.aldente-pro' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://apphousekitchen.com/aldente/AlDente1.38.1.dmg",
+      "installer_url": "https://apphousekitchen.com/aldente/AlDente1.39.1.dmg",
       "install_script_ref": "cb72fdf2",
       "uninstall_script_ref": "c2d64a5f",
-      "sha256": "1ac545c21bb001d0efaa135add62a881b8320cffac3ce9e86911176bf30498d2",
+      "sha256": "4c579115d13576452a8a9d20bf852ea6429321cbaf9c29d72d7260e1ec779ccf",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/batfi/darwin.json
+++ b/ee/maintained-apps/outputs/batfi/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.1.1",
+      "version": "4.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'software.micropixels.BatFi';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'software.micropixels.BatFi' AND version_compare(bundle_short_version, '3.1.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'software.micropixels.BatFi' AND version_compare(bundle_short_version, '4.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'software.micropixels.BatFi' AND a.bundle_executable != '');"
       },
       "installer_url": "https://files.micropixels.software/batfi/BatFi-latest.zip",

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.3.89",
+      "version": "4.3.104",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.89') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.104') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.automattic.beeper.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.89-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.104-arm64-mac.zip",
       "install_script_ref": "403ed251",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "f6968462decc167e62c9469cbca84ec1ead7b57cedc1c766b7fbc7febd692c4e",
+      "sha256": "ef228b69962689d7e25bf87d991597383781c746d8bda2b9b8fa8c62cb97388c",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.800",
+      "version": "6.802",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.800') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.802') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.hegenberg.BetterTouchTool' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.800-2026090806.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.802-2026090902.zip",
       "install_script_ref": "17a00450",
       "uninstall_script_ref": "aef4d4fc",
-      "sha256": "a3d3ecc849ece6a7d1ea58a708d3b77b6d7873175a0308a0e08fda168fe7abbc",
+      "sha256": "1c611722506ea14a26fe7e1cbced4bde433682dd5c82bcc9d84b890c7c10ad26",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/camunda-modeler/darwin.json
+++ b/ee/maintained-apps/outputs/camunda-modeler/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.50.1",
+      "version": "5.51.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.camunda.CamundaModeler';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.camunda.CamundaModeler' AND version_compare(bundle_short_version, '5.50.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.camunda.CamundaModeler' AND version_compare(bundle_short_version, '5.51.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.camunda.CamundaModeler' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.camunda.cloud/release/camunda-modeler/5.50.1/camunda-modeler-5.50.1-mac-arm64.dmg",
+      "installer_url": "https://downloads.camunda.cloud/release/camunda-modeler/5.51.0/camunda-modeler-5.51.0-mac-arm64.dmg",
       "install_script_ref": "ae9ea988",
       "uninstall_script_ref": "68ff5179",
-      "sha256": "aa6c69b1b5f562b1119da065cf65090c0af8de0eaab3f4f57f2cc3612d72a679",
+      "sha256": "cec0d06c934ddf387a5ab98f48aadb8fd20f0658df776e632824de18aba31326",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cherry-studio/darwin.json
+++ b/ee/maintained-apps/outputs/cherry-studio/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.0.13",
+      "version": "2.0.14",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.kangfenmao.CherryStudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.kangfenmao.CherryStudio' AND version_compare(bundle_short_version, '2.0.13') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.kangfenmao.CherryStudio' AND version_compare(bundle_short_version, '2.0.14') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.kangfenmao.CherryStudio' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.13/Cherry-Studio-2.0.13-mac-arm64.dmg",
+      "installer_url": "https://github.com/CherryHQ/cherry-studio/releases/download/v2.0.14/Cherry-Studio-2.0.14-mac-arm64.dmg",
       "install_script_ref": "31529318",
       "uninstall_script_ref": "4e2b7fe0",
-      "sha256": "a9d1486875ddb188524e51915f5f1f7e30a5a9915000580b88aca529f2d8f09b",
+      "sha256": "955690c2362557ddda21d66491661910be0d58aec5712945bb5b6c6ad51304b3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/coconutbattery/darwin.json
+++ b/ee/maintained-apps/outputs/coconutbattery/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.3.4",
+      "version": "4.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu' AND version_compare(bundle_short_version, '4.3.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu' AND version_compare(bundle_short_version, '4.4.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.coconut-flavour.coconutBattery-Menu' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://www.coconut-flavour.com/downloads/coconutBattery_434_224.zip",
+      "installer_url": "https://www.coconut-flavour.com/downloads/coconutBattery_440_265.zip",
       "install_script_ref": "f4ca6863",
       "uninstall_script_ref": "4bf3cb18",
-      "sha256": "7eb936629795e2577a44494a04899abedfbdae5630fcc5d06ca9868a390bfffb",
+      "sha256": "ac7bb9a5f02af6f1b7f3107ae3fb62268ec41e8d853a3df5ecee58bf0a51db4d",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.19.13",
+      "version": "3.19.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.19.13') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.19.19') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.cursor.com/production/dd066f332fcea7382764400fde902f61920648d5/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/6496ea8a068aebfcd21990e70ff522e9abf10c8c/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "1ae48b55",
       "uninstall_script_ref": "03b9aece",
-      "sha256": "e870dfefc6feb19f283e69cdcf2af17fcb542afdcb9968bc9a1a7a1beeaf9e11",
+      "sha256": "cd329fcbc5c1fa2fc66ddc911beebbc9d594e3ff8677f50ccd4757abda0a7c67",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dayflow/darwin.json
+++ b/ee/maintained-apps/outputs/dayflow/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.4.0",
+      "version": "2.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.4.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.4.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'teleportlabs.com.Dayflow' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.4.0/Dayflow.dmg",
+      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.4.2/Dayflow.dmg",
       "install_script_ref": "9ec4db9b",
       "uninstall_script_ref": "8672edfc",
-      "sha256": "16183ec026b3f790a2b5d33d6b88ece27780c40acad9fc4fa6c0643751aaff60",
+      "sha256": "c4a24d47530a61587e8b8be0987ee683e586c5e82a81cd5e857da0f4cdd7f87d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dngrep/windows.json
+++ b/ee/maintained-apps/outputs/dngrep/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.0.49.0",
+      "version": "5.0.57.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'dnGrep %' AND publisher = 'dnGrep Community Contributors';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'dnGrep %' AND publisher = 'dnGrep Community Contributors' AND version_compare(version, '5.0.49.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'dnGrep %' AND publisher = 'dnGrep Community Contributors' AND version_compare(version, '5.0.57.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'dngrep.exe');"
       },
-      "installer_url": "https://github.com/dnGrep/dnGrep/releases/download/v5.0.49.0/dnGREP.5.0.49.x64.msi",
+      "installer_url": "https://github.com/dnGrep/dnGrep/releases/download/v5.0.57.0/dnGREP.5.0.57.x64.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "63930700",
-      "sha256": "a8d3bca28307d538fd4201650abd23a13549584406a28c2f997efe69d5ebed38",
+      "sha256": "b302f4f1d3faee251b3565aefb380d05246e5cf6721e1eaaad6dfa12376d2bd5",
       "default_categories": [
         "Utilities"
       ],

--- a/ee/maintained-apps/outputs/eclipse-ide/darwin.json
+++ b/ee/maintained-apps/outputs/eclipse-ide/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.40",
+      "version": "4.41",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers' AND version_compare(bundle_short_version, '4.40') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'epp.package.committers' AND version_compare(bundle_short_version, '4.41') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'epp.package.committers' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2026-06/R/eclipse-committers-2026-06-R-macosx-cocoa-aarch64.dmg&r=1",
+      "installer_url": "https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2026-09/R/eclipse-committers-2026-09-R-macosx-cocoa-aarch64.dmg&r=1",
       "install_script_ref": "6b90e6bc",
       "uninstall_script_ref": "93dd264d",
-      "sha256": "069e2418aa5faffd443516b0c147ad9f6453d6b4fc70e5209bd01b3673e48b53",
+      "sha256": "940fa9fe7feee5d3cbb3aff3904944d81a5fadbefc48d069881f7e5073e5ebd1",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/farrago/darwin.json
+++ b/ee/maintained-apps/outputs/farrago/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.1.5",
+      "version": "2.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.rogueamoeba.farrago';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rogueamoeba.farrago' AND version_compare(bundle_short_version, '2.1.5') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rogueamoeba.farrago' AND version_compare(bundle_short_version, '2.2.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.rogueamoeba.farrago' AND a.bundle_executable != '');"
       },
       "installer_url": "https://cdn.rogueamoeba.com/farrago/download/Farrago.zip",

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "156.0b4",
+      "version": "156.0b5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15626.9.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15626.9.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/156.0b4/mac/en-US/Firefox%20156.0b4.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/156.0b5/mac/en-US/Firefox%20156.0b5.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "353ea19d90ff7097402611a010b87bad0665fad0c6ae6690c4c906c0e3647da3",
+      "sha256": "a94b259db492bcd98105d029ce0a2c51227e0af11fc531f9366e83a3410bd11f",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "157.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.9.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15726.9.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.mozilla.nightly' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-08-21-54-17-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-09-08-38-22-mozilla-central/firefox-157.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "2de5209d14f4713e23f72fd8556ac64c007f8502c1330de67323ae98b1318ca1",
+      "sha256": "631cd167e03099373431d1ff7c85dc39951be0b0a0b3bd69b0f3884b15bf3178",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.190.0",
+      "version": "1.191.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.190.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.191.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.grammarly.ProjectLlama' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.190.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.191.0.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "586a57a6deac4cc0dfa3d9639780ff1cc640824ac3a69bddd6a5c4e9feaa960e",
+      "sha256": "ef565aa404552e2af642574e452dc301736c7acc611af0ff0d308948f6ec4ca0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.543.2",
+      "version": "7.543.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.543.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.543.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.granola.app' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.543.2/Granola-7.543.2-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.543.3/Granola-7.543.3-mac-universal.dmg",
       "install_script_ref": "08a593fa",
       "uninstall_script_ref": "903a1d58",
-      "sha256": "72f5635dc2cf35c4f94c56a829dac39113ee81a750b521f4aa3fb17e977c16b0",
+      "sha256": "0f7b9f70b97556e1188e6cd95b5c01f1fa3e9effaef28e9b33cb303623471971",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/home-assistant/darwin.json
+++ b/ee/maintained-apps/outputs/home-assistant/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.9.0",
+      "version": "2026.9.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant' AND version_compare(bundle_short_version, '2026.9.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.robbie.HomeAssistant' AND version_compare(bundle_short_version, '2026.9.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.robbie.HomeAssistant' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/home-assistant/iOS/releases/download/release%2F2026.9.0%2F2026.2874/home-assistant-mac.zip",
+      "installer_url": "https://github.com/home-assistant/iOS/releases/download/release%2F2026.9.1%2F2026.2985/home-assistant-mac.zip",
       "install_script_ref": "3485600f",
       "uninstall_script_ref": "b46351a1",
-      "sha256": "760fca25e5801355bc29869a63b8441699ac07dd039f6955b397995c1508ab27",
+      "sha256": "63e44280b8f0b8b56ef0f8b7bf5f400e83f51d4e2300f78784a9926d466ee0bf",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hp-prime-virtual-calculator/windows.json
+++ b/ee/maintained-apps/outputs/hp-prime-virtual-calculator/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.4",
+      "version": "2.4.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'HP Prime Virtual Calculator';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'HP Prime Virtual Calculator' AND version_compare(version, '2.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'HP Prime Virtual Calculator' AND version_compare(version, '2.4.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'hp prime virtual calculator.exe');"
       },
-      "installer_url": "https://updates.moravia-consulting.com/HP_Prime_Virtual_Calculator_x64_2025_09_15.exe",
+      "installer_url": "https://updates.moravia-consulting.com/HP_Prime_Virtual_Calculator_x64_2026_09_09.exe",
       "install_script_ref": "198b4efd",
       "uninstall_script_ref": "489cd493",
-      "sha256": "de9a063ef839eea85e75d78c77a688d2bd9d373542514864a87db8dd4ba9ca58",
+      "sha256": "8653a27d099d78e4fcdd5504dbca46373381d3646391f3364116eada02fbb6a9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/darwin.json
+++ b/ee/maintained-apps/outputs/prisma-browser/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.8.5.83",
+      "version": "153.3.3.37",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '152.8.5.83') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '153.3.3.37') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.talon-sec.Work' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-152.8.5.83-2b4ba508.pkg",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-153.3.3.37-502f22a6.pkg",
       "install_script_ref": "827875fd",
       "uninstall_script_ref": "ff947f47",
-      "sha256": "93a82c7ade5c5dd972306f2c3ac7f72b7d8bf396c5e3bb497c63f21588b6589d",
+      "sha256": "2b52fcbc8db1e65f16763863db2cbd7fdcfabb18428c0376fe3a7aaf548e9fac",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/windows.json
+++ b/ee/maintained-apps/outputs/prisma-browser/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.8.5.83",
+      "version": "153.3.3.37",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '152.8.5.83') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Prisma Access Browser' AND publisher = 'Palo Alto Networks Inc' AND version_compare(version, '153.3.3.37') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'prisma browser.exe');"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_152_8_5_83-152.8.5.83-4c48f0a4.msi",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/win/packaged/x64/crx_signed_o4_stable_prisma_access_browser_installer_153_3_3_37-153.3.3.37-7eaba529.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "84194ed8",
-      "sha256": "6721c076a9211734d044ced038b3f1cc3fd7e3621d57529b10bbc7eb41e2643f",
+      "sha256": "9b6294a6eaa224c328abdfcd0a3c20dbce26397004b598aba61d9da2eecbe4cc",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/proton-mail/darwin.json
+++ b/ee/maintained-apps/outputs/proton-mail/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.13.4",
+      "version": "1.14.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop' AND version_compare(bundle_short_version, '1.13.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonmail.desktop' AND version_compare(bundle_short_version, '1.14.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'ch.protonmail.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://proton.me/download/mail/macos/1.13.4/ProtonMail-desktop.dmg",
+      "installer_url": "https://proton.me/download/mail/macos/1.14.0/ProtonMail-desktop.dmg",
       "install_script_ref": "1f588a8f",
       "uninstall_script_ref": "a5eb828a",
-      "sha256": "e3211f353f3db0ea000218e3655698d7283a005b98a7ab4cfc0ae7157fb5599c",
+      "sha256": "343802be033408ce91364968d95b8c4596ffa13e726a25bb42ac89540afa847a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -1,13 +1,13 @@
 {
   "versions": [
     {
-      "version": "1.136.2",
+      "version": "1.137.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.136.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.137.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.microsoft.VSCode' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.136.2/darwin-universal/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.137.0/darwin-universal/stable",
       "install_script_ref": "58ade691",
       "uninstall_script_ref": "38d65803",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/wavebox/darwin.json
+++ b/ee/maintained-apps/outputs/wavebox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.2.193.2",
+      "version": "153.2.196.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox' AND version_compare(bundle_short_version, '152.2.193.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox' AND version_compare(bundle_short_version, '153.2.196.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.wavebox.wavebox' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download.wavebox.app/stable/macarm64/Wavebox_152.2.193.2.zip",
+      "installer_url": "https://download.wavebox.app/stable/macarm64/Wavebox_153.2.196.2.zip",
       "install_script_ref": "316254ed",
       "uninstall_script_ref": "ecfbed36",
-      "sha256": "dfea80029c6332e9f9307603d50e8d6d3a14e9c956b49a006ce1d4751737e5f5",
+      "sha256": "dd65ed9d04e975e01c69a64c513f0dfc42f426d106677673fb9c83a0cc66e153",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "78.5.0",
+      "version": "78.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '78.5.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '78.6.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.webcatalog.jordan' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-78.5.0-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-78.6.0-universal.dmg",
       "install_script_ref": "23e707d7",
       "uninstall_script_ref": "6ca374e8",
-      "sha256": "80b2ee871a811fb4522d4d8ac05678a25d9d219c05838755090b0285feeae067",
+      "sha256": "0e751dfd378265cef4690d6f0918bafc98274285da1da75e504246efe563c488",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/yubico-authenticator/windows.json
+++ b/ee/maintained-apps/outputs/yubico-authenticator/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.4.1",
+      "version": "7.4.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Yubico Authenticator' AND publisher = 'Yubico AB';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Yubico Authenticator' AND publisher = 'Yubico AB' AND version_compare(version, '7.4.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Yubico Authenticator' AND publisher = 'Yubico AB' AND version_compare(version, '7.4.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'yubico authenticator.exe');"
       },
-      "installer_url": "https://github.com/Yubico/yubioath-flutter/releases/download/7.4.1/yubico-authenticator-7.4.1-win64.msi",
+      "installer_url": "https://github.com/Yubico/yubioath-flutter/releases/download/7.4.2/yubico-authenticator-7.4.2-win64.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "da50bb65",
-      "sha256": "fd3a4beee31b07ce6acb67f8b9f46b75daf15b669bd034b7582171743e0436ad",
+      "sha256": "9f252a0f2ef06c11a580bb95952ec4ebdc6f1e4d533341aee920f790f5c327f4",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/zeplin/darwin.json
+++ b/ee/maintained-apps/outputs/zeplin/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "10.32.0",
+      "version": "10.33.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx' AND version_compare(bundle_short_version, '10.32.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.zeplin.osx' AND version_compare(bundle_short_version, '10.33.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.zeplin.osx' AND a.bundle_executable != '');"
       },
       "installer_url": "https://pkg.zeplin.io/macos/latest/zeplin-darwin-universal.zip",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated maintained app versions and installation details across macOS and Windows.
  - Refreshes include AlDente, BatFi, Beeper, BetterTouchTool, Camunda Modeler, Cherry Studio, CoconutBattery, Cursor, Dayflow, dnGrep, Eclipse IDE, Farrago, Firefox editions, Grammarly, Granola, Home Assistant, Prisma Access Browser, Proton Mail, Visual Studio Code, Wavebox, WebCatalog, Yubico Authenticator, Zeplin, and others.
  - Installers and verification data were updated where applicable, ensuring new releases are correctly detected and installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->