### PR TITLE
Document Windows managed local account rotation

### DIFF
--- a/articles/secure-local-admin-passwords.md
+++ b/articles/secure-local-admin-passwords.md
@@ -4,6 +4,12 @@ Managing local administrator passwords is one of those things everyone knows mat
 
 The good news? With Fleet and 1Password Connect, you can automate the entire process. Think of it as setting up password rotation once and forgetting about it—except IT can still grab credentials when needed.
 
+> Fleet has a built-in managed local admin account for macOS and Windows hosts. It creates the account during setup, and you can
+> view and rotate its password from **Host details** > **Actions** > **Show managed account**. See the
+> [macOS setup experience guide](https://fleetdm.com/guides/setup-experience) and the
+> [Windows and Linux setup experience guide](https://fleetdm.com/guides/windows-linux-setup-experience). Use the approach below
+> if you need the passwords in your own vault, or on hosts the built-in account doesn't cover, such as Linux.
+
 ## What this solves
 
 **The problem:** Local admin accounts on macOS and Windows typically use passwords that never change. When someone leaves the team or a device is compromised, you're stuck manually resetting passwords across hundreds (or thousands) of machines.

--- a/articles/windows-linux-setup-experience.md
+++ b/articles/windows-linux-setup-experience.md
@@ -159,6 +159,21 @@ reported the password back.
 
 Go to **Host details** > **Actions** > **Show managed account**. The password is unique per host and is stored encrypted in Fleet.
 
+### Rotate the password
+
+Go to **Host details** > **Actions** > **Show managed account**, then press **Rotate password**. Fleet also rotates the password
+automatically about an hour after someone views it.
+
+Fleet asks the host to generate a new password, set it, and report it back, so a rotation finishes on the host's next check-in
+rather than immediately. Fleet keeps showing the current password until the new one arrives.
+
+If the host can't set the new password, the managed account modal says the rotation failed, and Fleet keeps showing the last
+password it received. The reason the host reported is on the failed rotation entry in **Host details** > **Activity**.
+
+Fleet does not try again on its own. The request is cleared and the automatic rotation timer is turned off, so nothing changes
+until someone presses **Rotate password** again. Fix the cause first: see Troubleshoot the managed local account below for the
+failures a host can report.
+
 ### Sign in as the managed account
 
 The account is hidden from the Windows sign-in screen and from **Settings** > **Accounts**, so it won't appear in the list of users.

--- a/articles/windows-linux-setup-experience.md
+++ b/articles/windows-linux-setup-experience.md
@@ -171,7 +171,7 @@ If the host can't set the new password, the managed account modal says the rotat
 password it received. The reason the host reported is on the failed rotation entry in **Host details** > **Activity**.
 
 Fleet does not try again on its own. The request is cleared and the automatic rotation timer is turned off, so nothing changes
-until someone presses **Rotate password** again. Fix the cause first: see Troubleshoot the managed local account below for the
+until someone presses **Rotate password** again. Fix the cause first: see [Troubleshoot the managed local account](#Troubleshoot the managed local account) for the
 failures a host can report.
 
 ### Sign in as the managed account

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3141,6 +3141,25 @@ This activity contains the following fields:
 }
 ```
 
+## failed_to_rotate_managed_local_account_password
+
+Generated when a host reports that it could not rotate its managed local account password. Attributed to Fleet, because the failure arrives from the device outside any user's request.
+
+This activity contains the following fields:
+- "host_id": ID of the host.
+- "host_display_name": Display name of the host.
+- "detail": The reason the host reported, if it sent one. Only Windows hosts report a reason today, so the field is omitted for macOS.
+
+#### Example
+
+```json
+{
+  "host_id": 123,
+  "host_display_name": "DESKTOP-ABC123",
+  "detail": "Resetting password for _fleetadmin failed: The password does not meet the password policy requirements."
+}
+```
+
 ## enabled_managed_local_account
 
 Generated when a user turns on create managed local account for a fleet (or unassigned hosts).

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7013,7 +7013,9 @@ Remotely clear the passcode on a host. Requires iOS/iPadOS host to have sent its
 
 _Available in Fleet Premium_
 
-Rotates the managed local account password for a host.
+Rotates the managed local account password for a macOS or Windows host.
+
+On macOS, Fleet generates the new password and sends it to the host in an MDM command. On Windows, Fleet asks fleetd to generate a new password, set it, and send it back, so the rotation completes on the host's next check-in.
 
 `POST /api/v1/fleet/hosts/:id/managed_account_password/rotate`
 
@@ -7035,7 +7037,7 @@ Rotates the managed local account password for a host.
 
 Retrieves the managed account password for an eligible macOS or Windows host.
 
-The host will only return a password if its managed account password status is "Verified".
+On macOS, a password is returned only while its managed account password status is "Verified". On Windows, a password is returned whenever one has been escrowed, including after a failed rotation, in which case it is the last password the host reported.
 
 `GET /api/v1/fleet/hosts/:id/managed_account_password`
 


### PR DESCRIPTION
**Related issue:** #43489 (docs for #52683)

Documents Windows managed local account password rotation, added in #52683. Targets `docs-v4.93.0`.

- `articles/windows-linux-setup-experience.md`: new "Rotate the password" section. Covers rotating from the UI, the automatic rotation after a view, that a rotation lands on the host's next check-in rather than immediately, and what happens when a rotation fails, including that Fleet keeps showing the last password the host reported and does not retry. Points at the existing troubleshooting section rather than repeating it.
- `docs/REST API/rest-api.md`: the rotate endpoint now says macOS or Windows and describes the two mechanisms. The get endpoint's "only if Verified" line was accurate for macOS only, so it now splits by platform.
- `articles/secure-local-admin-passwords.md`: adds a callout pointing at Fleet's built-in managed local account, per the feature guide item on #43489. That guide covers a roll-your-own LAPS setup and did not mention the built-in account for either platform. Note it has a named external author (@kc9wwh) and no CODEOWNERS coverage.

# Checklist for submitter

- [x] No changes file: docs only.

## Testing

- [x] QA'd all new/changed functionality manually: the documented behavior was verified against #52683 on an Autopilot-enrolled Windows 11 VM, covering manual rotation, automatic rotation after a view, a failed rotation that kept the previous password readable, and that a failed rotation is not retried automatically.
- [ ] Not tested: local rendering of fleetdm.com. The added markdown follows the style of the surrounding sections.

