### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/superhuman/darwin.json
+++ b/ee/maintained-apps/outputs/superhuman/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1041.0.50",
+      "version": "1041.0.51",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.50') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.51') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.superhuman.mail' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.50-arm64-latest-mac.zip",
+      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.51-arm64-latest-mac.zip",
       "install_script_ref": "7e74bd96",
       "uninstall_script_ref": "1809183d",
-      "sha256": "dc89a86d6ddd0243ae7c7962ab4aa7ed7b44f03082a0ba0d0f0e979c6c07c10c",
+      "sha256": "2659a786b097adabb7fc7cce076b7cc94f47a7e4b2a80d6d53c979f1d508a0c6",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.18.1",
+      "version": "1.19.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.18.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.19.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'dev.zed.Zed' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.18.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.19.2/Zed-aarch64.dmg",
       "install_script_ref": "bdea8414",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "6c488fc69d538715cb5ba2a99d4a45897e84aca18211a30549291cb90e4b6546",
+      "sha256": "581212c4cac8003f52679cf24711f7176d51e8a9fae51001c9217627e406da14",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zotero/darwin.json
+++ b/ee/maintained-apps/outputs/zotero/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "10.0.1",
+      "version": "10.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero' AND version_compare(bundle_short_version, '10.0.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero' AND version_compare(bundle_short_version, '10.0.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.zotero.zotero' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download.zotero.org/client/release/10.0.1/Zotero-10.0.1.dmg",
+      "installer_url": "https://download.zotero.org/client/release/10.0.2/Zotero-10.0.2.dmg",
       "install_script_ref": "a22985ef",
       "uninstall_script_ref": "1b2e443c",
-      "sha256": "1b6e57cedb2dbcbe3f31c06069734d2201559da99a34c7f84167b6b4c7ee5aa8",
+      "sha256": "99c2f3d073090cc7ef2a43609c3a678eabdec132ef8c8c447acab9fcb204cdae",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the macOS app definitions for:
    - Superhuman to version 1041.0.51
    - Zed to version 1.19.2
    - Zotero to version 10.0.2
  - Installer links, version checks, and verification checksums now correspond to these releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->