### PR TITLE
Fleet UI: Tooltip cleanups (default position, balance-cap workaround)

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -130,6 +130,9 @@ Anti-pattern:
 <span className={`${baseClass}__row-name`}>{item.name}</span>
 ```
 
+## Tooltips
+Arrowless `TooltipWrapper` is `bottom-start` with left-aligned bubble text. Only override `position` or `text-align` when the anchor uses `showArrow` (pointed callout).
+
 ## Interfaces & Types
 - Interface files live in `frontend/interfaces/` with `I` prefix: `IHost`, `IUser`, `IPack`
 - Legacy pattern: some files export both PropTypes (default export) and TypeScript interfaces (named export)

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -127,7 +127,9 @@ and mouseout from the element. If a boolean, sets delay to the default below. If
   /** If `true`, evenly distributes characters across lines and shrinks the
    * tooltip to hug the balanced text so there's no widow word or trailing
    * whitespace on the right. Adds a one-time layout measurement per content
-   * change. */
+   * change. Note: CSS `text-wrap: balance` only balances up to ~6 lines
+   * (browser cap) and falls back to normal wrapping beyond that — long
+   * tooltip strings may need manual `<br />` breaks to stay under the cap. */
   textBalanced?: boolean;
 }
 

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTableConfig.tsx
@@ -175,10 +175,7 @@ const generateTableHeaders = (
       Header: (cellProps: ITableHeaderProps) => (
         <HeaderCell
           value={
-            <TooltipWrapper
-              tipContent="Hosts with any version installed."
-              position="bottom"
-            >
+            <TooltipWrapper tipContent="Hosts with any version installed.">
               Hosts
             </TooltipWrapper>
           }

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/components/ServerAuthenticationSection/ServerAuthenticationSection.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/components/ServerAuthenticationSection/ServerAuthenticationSection.tsx
@@ -36,8 +36,19 @@ const ServerAuthenticationSection = ({
             parseTarget
             error={formErrors.ssoUserURL}
             tooltip={
-              !disableChildren &&
-              "Update this URL if you want your Fleet users (admins, maintainers, observers) to login via SSO using a URL that's different than the base URL of your Fleet instance. If not configured, login via SSO will use the base URL of the Fleet instance."
+              !disableChildren && (
+                // Manual break: too long for `text-wrap: balance` (~6-line cap).
+                <>
+                  Update this URL if you want your Fleet users (admins,
+                  maintainers, observers) to login via SSO using a URL
+                  that&apos;s different than the base URL of your Fleet
+                  instance.
+                  <br />
+                  <br />
+                  If not configured, login via SSO will use the base URL of the
+                  Fleet instance.
+                </>
+              )
             }
           />
         )}

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -216,6 +216,7 @@ $max-width: 2560px;
   z-index: 100;
   line-height: 1.375;
   white-space: initial;
+  text-align: left;
 
   // Hyphenated words will still break at hyphens first
   //  while non-hyphenated strings will break only when necessary


### PR DESCRIPTION
## Issue
Closes #46052

## Description
- Bug fix (root cause): SSO user URL tooltip orphaned the trailing word "instance." on its own line. String is ~245 chars against a 280px tooltip max-width — roughly 7 wrapped lines. Chrome's `text-wrap: balance` silently falls back to normal wrapping past its ~6-line cap, so no widow avoidance applies. Split the copy into two JSX segments with a `<br /><br />` between sentences so each segment stays under the cap and balance applies.
- UX: Software library "Hosts" column header tooltip explicitly passed `position="bottom"`, centering it under the anchor and breaking the left-aligned convention. Dropped the override so it uses the `bottom-start` default.
- Docs: added a note on `TooltipWrapper`'s `textBalanced` prop calling out the browser balance cap and pointing at manual `<br />` breaks as the workaround for long strings.

## Screenrecording
- SSO user URL tooltip after has no hanging word
-  Software library "Hosts" tooltip uis aligned bottom-start


<img width="431" height="320" alt="Screenshot 2026-09-09 at 11 54 07 PM" src="https://github.com/user-attachments/assets/c6784c4f-8bd1-42a2-b1e6-43fc35367c55" />
<img width="297" height="181" alt="Screenshot 2026-09-09 at 11 47 01 PM" src="https://github.com/user-attachments/assets/c34be5af-b032-4198-ba9c-50c13291d327" />

- some align left fixes after grepping through table headers
- 
<img width="436" height="183" alt="Screenshot 2026-09-10 at 12 04 46 AM" src="https://github.com/user-attachments/assets/5d0fb730-d20e-418c-a0ea-e5c54ba0b3ea" />
<img width="332" height="230" alt="Screenshot 2026-09-10 at 12 04 34 AM" src="https://github.com/user-attachments/assets/91145837-5482-4e83-8585-91076f99a31a" />


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip readability with clearer line breaks and consistent left-aligned text.
  * Tooltips for disabled controls are no longer displayed.
  * Updated the Hosts tooltip to use the standard default placement.

* **Documentation**
  * Expanded guidance for balancing tooltip text and using manual line breaks for longer messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->