### PR TITLE
Fix enrolled hosts chart drill-down to exclude pending hosts

### DIFF
--- a/changes/48880-enrolled-hosts-drilldown
+++ b/changes/48880-enrolled-hosts-drilldown
@@ -1,0 +1,1 @@
+Fixed "Hosts enrolled" chart drill-down on the dashboard to exclude pending hosts from the filtered host list.

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -203,6 +203,7 @@ const HostsEnrolledCard = ({
     router.push(
       getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(labelId), {
         fleet_id: currentTeamId,
+        mdm_enrollment_status: "exclude_pending",
       })
     );
   };

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1677,6 +1677,12 @@ func filterHostsByMDM(sql string, opt fleet.HostListOptions, params []interface{
 			sql += ` AND hmdm.enrolled = 0 AND hmdm.installed_from_dep = 1`
 		case fleet.MDMEnrollStatusUnenrolled:
 			sql += ` AND hmdm.enrolled = 0 AND hmdm.installed_from_dep = 0`
+		case fleet.MDMEnrollStatusExcludePending:
+			// Exclude hosts with pending MDM enrollment but include all platforms
+			// (including those with no MDM data). Used by the dashboard "Hosts enrolled"
+			// chart drill-down so the list matches the chart counts.
+			sql += ` AND (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending')`
+			return sql, params
 		}
 	}
 	if opt.MDMNameFilter != nil || opt.MDMIDFilter != nil || opt.MDMEnrollmentStatusFilter != "" {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -1863,6 +1863,13 @@ func testHostsListMDM(t *testing.T, ds *Datastore) {
 		gotIDs = append(gotIDs, h.ID)
 	}
 	assert.ElementsMatch(t, []uint{hostIDs[0], hostIDs[1], hostIDs[2], hostIDs[10], hostIDs[11]}, gotIDs)
+
+	// exclude_pending: returns all hosts except the one pending MDM enrollment.
+	// This includes hosts with no MDM data and unenrolled hosts (unlike the other
+	// MDM filters which restrict to MDM-managed platforms only). Regression test
+	// for #48880 drill-down.
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{MDMEnrollmentStatusFilter: fleet.MDMEnrollStatusExcludePending}, 12)
+	assert.Equal(t, 12, len(hosts))
 }
 
 func testListHostsDEPFilters(t *testing.T, ds *Datastore) {

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -117,8 +117,9 @@ const (
 	MDMEnrollStatusAutomatic  = MDMEnrollStatus("automatic")
 	MDMEnrollStatusPending    = MDMEnrollStatus("pending")
 	MDMEnrollStatusUnenrolled = MDMEnrollStatus("unenrolled")
-	MDMEnrollStatusEnrolled   = MDMEnrollStatus("enrolled") // combination of "manual", "automatic" and "personal"
-	MDMEnrollStatusPersonal   = MDMEnrollStatus("personal")
+	MDMEnrollStatusEnrolled       = MDMEnrollStatus("enrolled")        // combination of "manual", "automatic" and "personal"
+	MDMEnrollStatusPersonal       = MDMEnrollStatus("personal")
+	MDMEnrollStatusExcludePending = MDMEnrollStatus("exclude_pending") // all hosts except pending MDM enrollment
 )
 
 // OSSettingsStatus defines the possible statuses of the host's OS settings, which is derived from the

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -393,7 +393,8 @@ func hostListOptionsFromRequest(r *http.Request) (fleet.HostListOptions, error) 
 	enrollmentStatus := r.URL.Query().Get("mdm_enrollment_status")
 	switch fleet.MDMEnrollStatus(enrollmentStatus) {
 	case fleet.MDMEnrollStatusManual, fleet.MDMEnrollStatusAutomatic, fleet.MDMEnrollStatusPersonal,
-		fleet.MDMEnrollStatusPending, fleet.MDMEnrollStatusUnenrolled, fleet.MDMEnrollStatusEnrolled:
+		fleet.MDMEnrollStatusPending, fleet.MDMEnrollStatusUnenrolled, fleet.MDMEnrollStatusEnrolled,
+		fleet.MDMEnrollStatusExcludePending:
 		hopt.MDMEnrollmentStatusFilter = fleet.MDMEnrollStatus(enrollmentStatus)
 	case "":
 		// No error when unset


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/48880 (follow-up to https://github.com/fleetdm/fleet/pull/51295)

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

---

## What

PR #51295 fixed the "Hosts enrolled" chart **counts** to exclude pending hosts, but clicking a platform bar in the chart still navigated to a host list that included pending hosts. This PR fixes the drill-down so the list matches the chart.

## Why

QA found that clicking a platform in the "Hosts enrolled" chart on the dashboard showed more hosts than the chart counted, because the drill-down URL had no filter to exclude pending MDM enrollments.

## Fix

**Backend** (3 files):
- `server/fleet/hosts.go`: Added new `MDMEnrollStatusExcludePending` constant (`"exclude_pending"`)
- `server/service/transport.go`: Accept `exclude_pending` as a valid `mdm_enrollment_status` query parameter
- `server/datastore/mysql/hosts.go` in `filterHostsByMDM()`: Added a case for `exclude_pending` that applies `AND (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending')` and returns early to **skip the platform restriction** (`h.platform IN (...)`) that the other MDM filters add. This is critical because the chart includes all platforms (including Linux hosts with no MDM data), and the platform restriction would wrongly exclude them.

**Frontend** (1 file):
- `frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx`: Added `mdm_enrollment_status: "exclude_pending"` to the query params in `navigateToPlatform()`, so the drill-down host list excludes pending hosts.

## Impact analysis

The new `exclude_pending` filter value is only used by the dashboard chart drill-down. Existing `mdm_enrollment_status` filter values (`manual`, `automatic`, `personal`, `pending`, `unenrolled`, `enrolled`) are unchanged. The `ManageHostsPage` already reads and preserves `mdm_enrollment_status` from URL params, so the new value flows through without additional frontend changes.

## Reproduction and screenshots

**Test setup:** 8 hosts total: 3 enrolled macOS, 2 pending macOS, 2 enrolled Windows, 1 Linux (no MDM).

### Screenshot 1: Dashboard "Hosts enrolled" chart (counts are correct)
Chart shows macOS=3 (not 5), Windows=2, Linux=1. Pending hosts excluded from chart. "Total hosts" card correctly shows 8 (includes pending).

<img width="1440" alt="Dashboard - Hosts enrolled chart shows correct counts excluding pending" src="https://github.com/user-attachments/assets/cc249f97-f9bd-4afc-95e0-d93336b7bdb0" />

### Screenshot 2: All hosts list without filter (old drill-down behavior)
Shows all 8 hosts including "New-MacBook-Pending" and "New-MacBook-Pending-2". This is what the drill-down showed before the fix.

<img width="1440" alt="All hosts list includes pending hosts - old behavior" src="https://github.com/user-attachments/assets/de89f1ad-2016-41b1-9cfa-92eb14d60f97" />

### Screenshot 3: Hosts list with `exclude_pending` filter (new behavior)
Shows 6 hosts. Both pending hosts are gone. Note the "MDM status: exclude_pen..." filter badge in the top-left. Linux host (Server-Ubuntu) is still present.

<img width="1440" alt="Hosts list with exclude_pending filter - pending hosts removed" src="https://github.com/user-attachments/assets/1a9358a2-13f1-41b6-af39-3e109430daf2" />

### Screenshot 4: Drill-down from clicking macOS in chart (fix working)
After clicking macOS in the "Hosts enrolled" chart: shows only 3 enrolled macOS hosts. URL contains `mdm_enrollment_status=exclude_pending`. The 2 pending macOS hosts are correctly excluded.

<img width="1440" alt="Drill-down from chart shows only enrolled macOS hosts" src="https://github.com/user-attachments/assets/b6432b79-2717-44dc-90ee-53ed77c98dbc" />

## Verification against bug requirements

| # | Bug requirement | Status | Evidence |
|---|---|---|---|
| 1 | Chart counts exclude pending hosts | Confirmed | Screenshot 1: macOS=3 (not 5) |
| 2 | Drill-down filtered list excludes pending hosts | Confirmed | Screenshot 4: 3 macOS hosts, no pending |
| 3 | "Total hosts" card still includes pending | Confirmed | Screenshot 1: Total=8 |
| 4 | Linux/no-MDM hosts still counted normally | Confirmed | Screenshot 1: Linux=1, Screenshot 3: Server-Ubuntu present |

## Testing performed

- `TestHosts/ListMDM`: Added `exclude_pending` assertion verifying 12 of 13 hosts returned (1 pending excluded), including hosts with no MDM data and across both darwin and windows platforms
- `TestHosts/GenerateStatusStatisticsPlatformBreakdownExcludesPending`: Existing regression test from PR #51295 still passes
- Go build clean, all existing `GenerateStatusStatistics*` and `ListMDM*` tests pass

## QA test plan

1. Set up a Fleet instance with MDM enabled and some hosts in "Pending" enrollment status
2. Go to the **Dashboard** page
3. Verify the "Hosts enrolled" chart per-platform counts exclude pending hosts
4. Click on a platform bar (e.g., macOS)
5. **Verify:** The resulting host list does NOT include pending hosts
6. **Verify:** The URL contains `mdm_enrollment_status=exclude_pending`
7. **Verify:** Linux/osquery-only hosts (no MDM) still appear in the list
8. **Verify:** The "Total hosts" card on the dashboard still includes pending hosts
9. **Verify:** When pending hosts exist, the "Total hosts" count will be higher than the sum of the per-platform counts in the "Hosts enrolled" chart (expected)