### PR TITLE
Fix guide heading styles

### DIFF
--- a/articles/enable-okta-verify-on-macOS-with-configuration-profile.md
+++ b/articles/enable-okta-verify-on-macOS-with-configuration-profile.md
@@ -12,7 +12,7 @@ By following these steps, you can automate the deployment of Okta Verify across 
 
 ## Step-by-step instructions
 
-### **Step 1: Install Okta Verify on your hosts**
+### Step 1: Install Okta Verify on your hosts
 
 Okta Verify can be installed:
 
@@ -21,7 +21,7 @@ Okta Verify can be installed:
 
 After installing Okta Verify on the host, the device will be registered in Okta.
 
-### **Step 2: Issue a SCEP certificate for management attestation**
+### Step 2: Issue a SCEP certificate for management attestation
 
 The next step to ensure Okta detects the device as managed is to issue a SCEP certificate.
 
@@ -116,7 +116,7 @@ The next step to ensure Okta detects the device as managed is to issue a SCEP ce
 SELECT * FROM certificates where common_name like '%managementAttestation%';
 ```
 
-### **Step 3: Configure device management in Okta**
+### Step 3: Configure device management in Okta
 
 With Okta Verify installed and an attestation certificate in place, all left is to configure Okta and the device for device management, useful links from the Okta documentation are:
 


### PR DESCRIPTION
Bolding the headings creates inconsistent font styles.

With bold in markdown (**):

<img width="403" height="147" alt="Screenshot 2026-09-09 at 5 34 35 PM" src="https://github.com/user-attachments/assets/6cfa3167-5e87-4296-adc0-88fdcda89d4d" />

Without:

<img width="349" height="280" alt="Screenshot 2026-09-09 at 5 34 57 PM" src="https://github.com/user-attachments/assets/53c8cd5f-8243-4e2d-b148-2319145b0ba8" />

