### PR TITLE
Set and clear the default AB token via API and GitOps

### DIFF
--- a/changes/52477-default-ab-token-gitops-api
+++ b/changes/52477-default-ab-token-gitops-api
@@ -1,0 +1,1 @@
+- Added the ability to set or unset the default Apple Business (AB) token via a new PATCH /ab_tokens/:id/default endpoint and via GitOps (`default: true` on an `apple_business` entry), with GitOps clearing the default when several tokens exist and none is marked.

--- a/changes/52477-default-ab-token-gitops-api
+++ b/changes/52477-default-ab-token-gitops-api
@@ -1,1 +1,0 @@
-- Added the ability to set or unset the default Apple Business (AB) token via a new PATCH /ab_tokens/:id/default endpoint and via GitOps (`default: true` on an `apple_business` entry), with GitOps clearing the default when several tokens exist and none is marked.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4864,13 +4864,13 @@ software:
 				{ID: 2, OrganizationName: "Foo Inc."},
 			},
 			dryRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
-				require.ErrorContains(t, err, "only one Apple Business Manager (ABM) token can be the default")
+				require.ErrorContains(t, err, "only one Apple Business (AB) token can be the default")
 				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
 				assert.Nil(t, lastSetDefaultTokenID)
 				assert.NotContains(t, out, "[!] gitops dry run succeeded")
 			},
 			realRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
-				require.ErrorContains(t, err, "only one Apple Business Manager (ABM) token can be the default")
+				require.ErrorContains(t, err, "only one Apple Business (AB) token can be the default")
 				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
 				assert.Nil(t, lastSetDefaultTokenID)
 				assert.NotContains(t, out, "[!] gitops succeeded")

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4815,6 +4815,27 @@ software:
 			},
 		},
 		{
+			// the yaml spells the org name decomposed (e + combining accent) while
+			// the stored token is precomposed; mismatched normalization between the
+			// existence check and the fetch used to panic the request
+			name: "org name in a different unicode form matches",
+			cfgs: []string{
+				global(`
+                                  apple_business_manager:
+                                    - organization_name: "Café Inc."
+                                      macos_team: "No team"`),
+			},
+			tokens: []*fleet.ABMToken{{ID: 1, OrganizationName: "Café Inc."}},
+			dryRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.Contains(t, out, "[!] gitops dry run succeeded")
+			},
+			realRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.Contains(t, out, "[!] gitops succeeded")
+			},
+		},
+		{
 			name: "default on one token applies",
 			cfgs: []string{
 				global(`

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4495,6 +4495,9 @@ software:
 	ipadTeam := team("🔳🏢 Company-owned iPads")
 	byodTeam := team("📱🔐 Personal mobile devices")
 
+	// captures the token ID passed to the datastore when a run sets the default
+	var lastSetDefaultTokenID *uint
+
 	cases := []struct {
 		name             string
 		cfgs             []string
@@ -4811,6 +4814,124 @@ software:
 				assert.NotContains(t, out, "[!] gitops dry run succeeded")
 			},
 		},
+		{
+			name: "default on one token applies",
+			cfgs: []string{
+				global(`
+                                  apple_business_manager:
+                                    - organization_name: Fleet Device Management Inc.
+                                      macos_team: "No team"
+                                    - organization_name: Foo Inc.
+                                      default: true
+                                      macos_team: "No team"`),
+			},
+			tokens: []*fleet.ABMToken{
+				{ID: 1, OrganizationName: "Fleet Device Management Inc.", IsDefault: true},
+				{ID: 2, OrganizationName: "Foo Inc."},
+			},
+			dryRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
+				assert.Nil(t, lastSetDefaultTokenID)
+				assert.Contains(t, out, "[!] gitops dry run succeeded")
+			},
+			realRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, lastSetDefaultTokenID)
+				assert.Equal(t, uint(2), *lastSetDefaultTokenID)
+				defaults := map[string]bool{}
+				for _, e := range appCfg.MDM.AppleBusinessManager.Value {
+					defaults[e.OrganizationName] = e.Default
+				}
+				assert.Equal(t, map[string]bool{"Fleet Device Management Inc.": false, "Foo Inc.": true}, defaults)
+				assert.Contains(t, out, "[!] gitops succeeded")
+			},
+		},
+		{
+			name: "two defaults fails",
+			cfgs: []string{
+				global(`
+                                  apple_business_manager:
+                                    - organization_name: Fleet Device Management Inc.
+                                      default: true
+                                      macos_team: "No team"
+                                    - organization_name: Foo Inc.
+                                      default: true
+                                      macos_team: "No team"`),
+			},
+			tokens: []*fleet.ABMToken{
+				{ID: 1, OrganizationName: "Fleet Device Management Inc."},
+				{ID: 2, OrganizationName: "Foo Inc."},
+			},
+			dryRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.ErrorContains(t, err, "only one Apple Business Manager (ABM) token can be the default")
+				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
+				assert.Nil(t, lastSetDefaultTokenID)
+				assert.NotContains(t, out, "[!] gitops dry run succeeded")
+			},
+			realRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.ErrorContains(t, err, "only one Apple Business Manager (ABM) token can be the default")
+				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
+				assert.Nil(t, lastSetDefaultTokenID)
+				assert.NotContains(t, out, "[!] gitops succeeded")
+			},
+		},
+		{
+			name: "no default on multiple tokens clears it",
+			cfgs: []string{
+				global(`
+                                  apple_business_manager:
+                                    - organization_name: Fleet Device Management Inc.
+                                      macos_team: "No team"
+                                    - organization_name: Foo Inc.
+                                      macos_team: "No team"`),
+			},
+			tokens: []*fleet.ABMToken{
+				{ID: 1, OrganizationName: "Fleet Device Management Inc.", IsDefault: true},
+				{ID: 2, OrganizationName: "Foo Inc."},
+			},
+			dryRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
+				assert.False(t, ds.(*mock.Store).ClearABMTokenDefaultFuncInvoked)
+				assert.Contains(t, out, "[!] gitops dry run succeeded")
+			},
+			realRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.True(t, ds.(*mock.Store).ClearABMTokenDefaultFuncInvoked)
+				assert.Nil(t, lastSetDefaultTokenID)
+				for _, e := range appCfg.MDM.AppleBusinessManager.Value {
+					assert.False(t, e.Default, e.OrganizationName)
+				}
+				assert.Contains(t, out, "[!] gitops succeeded")
+			},
+		},
+		{
+			name: "single token with no default key stays default",
+			cfgs: []string{
+				global(`
+                                  apple_business_manager:
+                                    - organization_name: Fleet Device Management Inc.
+                                      macos_team: "No team"`),
+			},
+			tokens: []*fleet.ABMToken{
+				{ID: 1, OrganizationName: "Fleet Device Management Inc.", IsDefault: true},
+			},
+			dryRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.Empty(t, appCfg.MDM.AppleBusinessManager.Value)
+				assert.Contains(t, out, "[!] gitops dry run succeeded")
+			},
+			realRunAssertion: func(t *testing.T, appCfg *fleet.AppConfig, ds fleet.Datastore, out string, err error) {
+				require.NoError(t, err)
+				assert.Nil(t, lastSetDefaultTokenID)
+				assert.False(t, ds.(*mock.Store).ClearABMTokenDefaultFuncInvoked)
+				// the stored config reflects that a lone token is always the default
+				require.Len(t, appCfg.MDM.AppleBusinessManager.Value, 1)
+				assert.True(t, appCfg.MDM.AppleBusinessManager.Value[0].Default)
+				assert.Contains(t, out, "[!] gitops succeeded")
+			},
+		},
 	}
 
 	for _, tt := range cases {
@@ -4840,6 +4961,14 @@ software:
 			}
 
 			ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error {
+				return nil
+			}
+			lastSetDefaultTokenID = nil
+			ds.SetABMTokenDefaultFunc = func(ctx context.Context, tokenID uint) error {
+				lastSetDefaultTokenID = &tokenID
+				return nil
+			}
+			ds.ClearABMTokenDefaultFunc = func(ctx context.Context) error {
 				return nil
 			}
 			ds.DeleteIconsAssociatedWithTitlesWithoutInstallersFunc = func(ctx context.Context, teamID uint) error {

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/appConfig.json
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/appConfig.json
@@ -226,10 +226,15 @@
     "apple_business_manager": [
       {
         "organization_name": "Fleet Device Management Inc.",
+        "default": true,
         "macos_team": "💻 Workstations",
         "ios_team": "📱🏢 Company-owned mobile devices",
         "ipados_team": "📱🏢 Company-owned mobile devices",
         "byod_team": "📱🔐 Personal mobile devices"
+      },
+      {
+        "organization_name": "Second Org LLC",
+        "macos_team": "💻 Workstations"
       }
     ],
     "apple_bm_enabled_and_configured": true,

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
@@ -85,10 +85,16 @@ integrations:
 mdm:
   apple_business:
     - byod_fleet: "📱🔐 Personal mobile devices"
+      default: true
       ios_fleet: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
       ipados_fleet: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
       macos_fleet: "\U0001F4BB Workstations"
       organization_name: Fleet Device Management Inc.
+    - byod_fleet: ""
+      ios_fleet: ""
+      ipados_fleet: ""
+      macos_fleet: "\U0001F4BB Workstations"
+      organization_name: Second Org LLC
   apple_server_url: http://some-apple-server-url.com
   end_user_authentication:
     entity_id: some-mdm-entity-id.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
@@ -83,10 +83,16 @@ integrations:
 mdm:
   apple_business:
     - byod_fleet: "\U0001F4F1\U0001F510 Personal mobile devices"
+      default: true
       ios_fleet: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
       ipados_fleet: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
       macos_fleet: "\U0001F4BB Workstations"
       organization_name: Fleet Device Management Inc.
+    - byod_fleet: ""
+      ios_fleet: ""
+      ipados_fleet: ""
+      macos_fleet: "\U0001F4BB Workstations"
+      organization_name: Second Org LLC
   apple_server_url: http://some-apple-server-url.com
   end_user_authentication:
     entity_id: some-mdm-entity-id.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -125,10 +125,16 @@ org_settings:
   mdm:
     apple_business:
     - byod_fleet: "📱🔐 Personal mobile devices"
+      default: true
       ios_fleet: "📱🏢 Company-owned mobile devices"
       ipados_fleet: "📱🏢 Company-owned mobile devices"
       macos_fleet: "💻 Workstations"
       organization_name: Fleet Device Management Inc.
+    - byod_fleet:
+      ios_fleet:
+      ipados_fleet:
+      macos_fleet: "💻 Workstations"
+      organization_name: Second Org LLC
     apple_server_url: http://some-apple-server-url.com
     end_user_authentication:
       entity_id: some-mdm-entity-id.com

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -631,6 +631,12 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 	ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error {
 		return nil
 	}
+	ds.SetABMTokenDefaultFunc = func(ctx context.Context, tokenID uint) error {
+		return nil
+	}
+	ds.ClearABMTokenDefaultFunc = func(ctx context.Context) error {
+		return nil
+	}
 	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
 		return []*fleet.VPPTokenDB{}, nil
 	}

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1995,6 +1995,10 @@ func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefa
 		return nil, err
 	}
 
+	// reads here decide what gets written (token count, app config sync), so
+	// don't risk stale replica reads
+	ctx = ctxdb.RequirePrimary(ctx, true)
+
 	token, err := svc.ds.GetABMTokenByID(ctx, tokenID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get ABM token to set default")

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1990,6 +1990,57 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 	return token, nil
 }
 
+func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.AppleBM{}, fleet.ActionWrite); err != nil {
+		return nil, err
+	}
+
+	token, err := svc.ds.GetABMTokenByID(ctx, tokenID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get ABM token to set default")
+	}
+
+	switch {
+	case isDefault:
+		if err := svc.ds.SetABMTokenDefault(ctx, tokenID); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "setting default ABM token")
+		}
+	case token.IsDefault:
+		count, err := svc.ds.GetABMTokenCount(ctx)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "counting ABM tokens")
+		}
+		if count == 1 {
+			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("default",
+				"Couldn't unset the default. The only Apple Business Manager (ABM) token is always the default."))
+		}
+		if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "clearing default ABM token")
+		}
+	default:
+		// asked to unset a token that isn't the default: nothing to do
+		return token, nil
+	}
+	token.IsDefault = isDefault
+
+	// Changing the default can flip another token's flag off, so sync the app
+	// config from all tokens, not just this one.
+	tokens, err := svc.ds.ListABMTokens(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing ABM tokens to sync app config")
+	}
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "retrieving app config")
+	}
+	syncABMTokensToAppConfig(appCfg, tokens)
+	if err := svc.ds.SaveAppConfig(ctx, appCfg); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "saving app config after ABM token default update")
+	}
+
+	return token, nil
+}
+
 func (svc *Service) RenewABMToken(ctx context.Context, token io.Reader, tokenID uint) (*fleet.ABMToken, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.AppleBM{}, fleet.ActionRead); err != nil {
 		return nil, err

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1990,9 +1990,15 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 	return token, nil
 }
 
-func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error) {
+func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault *bool) (*fleet.ABMToken, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.AppleBM{}, fleet.ActionWrite); err != nil {
 		return nil, err
+	}
+
+	// require an explicit value: an omitted field would otherwise read as
+	// false and silently clear the default
+	if isDefault == nil {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("default", "missing required argument"))
 	}
 
 	// reads here decide what gets written (token count, app config sync), so
@@ -2005,7 +2011,7 @@ func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefa
 	}
 
 	switch {
-	case isDefault:
+	case *isDefault:
 		if err := svc.ds.SetABMTokenDefault(ctx, tokenID); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "setting default ABM token")
 		}
@@ -2016,7 +2022,7 @@ func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefa
 		}
 		if count == 1 {
 			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("default",
-				"Couldn't unset the default. The only Apple Business Manager (ABM) token is always the default."))
+				"Couldn't unset the default. The only Apple Business (AB) token is always the default."))
 		}
 		if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "clearing default ABM token")
@@ -2025,7 +2031,7 @@ func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefa
 		// asked to unset a token that isn't the default: nothing to do
 		return token, nil
 	}
-	token.IsDefault = isDefault
+	token.IsDefault = *isDefault
 
 	// Changing the default can flip another token's flag off, so sync the app
 	// config from all tokens, not just this one.

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -858,6 +858,144 @@ func TestUpdateABMTokenTeams(t *testing.T) {
 	})
 }
 
+func TestSetABMTokenDefault(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	svc := Service{ds: ds, authz: authorizer}
+
+	tokA := &fleet.ABMToken{ID: 1, OrganizationName: "Org A"}
+	tokB := &fleet.ABMToken{ID: 2, OrganizationName: "Org B"}
+	tokenCount := 2
+
+	resetState := func(defaultID uint) {
+		tokA.IsDefault = tokA.ID == defaultID
+		tokB.IsDefault = tokB.ID == defaultID
+		ds.SetABMTokenDefaultFuncInvoked = false
+		ds.ClearABMTokenDefaultFuncInvoked = false
+		ds.SaveAppConfigFuncInvoked = false
+	}
+
+	ds.GetABMTokenByIDFunc = func(ctx context.Context, tokenID uint) (*fleet.ABMToken, error) {
+		switch tokenID {
+		case tokA.ID:
+			return tokA, nil
+		case tokB.ID:
+			return tokB, nil
+		}
+		return nil, &notFoundError{}
+	}
+	ds.SetABMTokenDefaultFunc = func(ctx context.Context, tokenID uint) error {
+		tokA.IsDefault = tokA.ID == tokenID
+		tokB.IsDefault = tokB.ID == tokenID
+		return nil
+	}
+	ds.ClearABMTokenDefaultFunc = func(ctx context.Context) error {
+		tokA.IsDefault = false
+		tokB.IsDefault = false
+		return nil
+	}
+	ds.GetABMTokenCountFunc = func(ctx context.Context) (int, error) {
+		return tokenCount, nil
+	}
+	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
+		return []*fleet.ABMToken{tokA, tokB}[:tokenCount], nil
+	}
+	appCfg := &fleet.AppConfig{MDM: fleet.MDM{AppleBusinessManager: optjson.SetSlice([]fleet.MDMAppleABMAssignmentInfo{
+		{OrganizationName: tokA.OrganizationName},
+		{OrganizationName: tokB.OrganizationName},
+	})}}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return appCfg, nil
+	}
+	var updatedAppCfg *fleet.AppConfig
+	ds.SaveAppConfigFunc = func(ctx context.Context, cfg *fleet.AppConfig) error {
+		updatedAppCfg = cfg
+		return nil
+	}
+
+	appCfgDefaults := func() map[string]bool {
+		m := make(map[string]bool)
+		for _, e := range updatedAppCfg.MDM.AppleBusinessManager.Value {
+			m[e.OrganizationName] = e.Default
+		}
+		return m
+	}
+
+	t.Run("only admins are authorized", func(t *testing.T) {
+		cases := []struct {
+			desc    string
+			user    *fleet.User
+			wantErr error
+		}{
+			{"no role", test.UserNoRoles, test.ErrForbidden},
+			{"observer", test.UserObserver, test.ErrForbidden},
+			{"observer+", test.UserObserverPlus, test.ErrForbidden},
+			{"maintainer", test.UserMaintainer, test.ErrForbidden},
+			{"gitops", test.UserGitOps, test.ErrForbidden},
+			{"admin", test.UserAdmin, nil},
+		}
+		for _, c := range cases {
+			t.Run(c.desc, func(t *testing.T) {
+				resetState(tokA.ID)
+				ctx := test.UserContext(t.Context(), c.user)
+				_, err := svc.SetABMTokenDefault(ctx, tokB.ID, true)
+				test.RequireErrKind(t, c.wantErr, err)
+			})
+		}
+	})
+
+	adminCtx := test.UserContext(t.Context(), test.UserAdmin)
+
+	t.Run("unknown token id is not found", func(t *testing.T) {
+		resetState(tokA.ID)
+		_, err := svc.SetABMTokenDefault(adminCtx, 999, true)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
+	})
+
+	t.Run("setting default moves it from the other token", func(t *testing.T) {
+		resetState(tokA.ID)
+		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, true)
+		require.NoError(t, err)
+		assert.True(t, token.IsDefault)
+		assert.True(t, ds.SetABMTokenDefaultFuncInvoked)
+		require.True(t, ds.SaveAppConfigFuncInvoked)
+		assert.Equal(t, map[string]bool{"Org A": false, "Org B": true}, appCfgDefaults())
+	})
+
+	t.Run("unsetting the default clears it", func(t *testing.T) {
+		resetState(tokB.ID)
+		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, false)
+		require.NoError(t, err)
+		assert.False(t, token.IsDefault)
+		assert.True(t, ds.ClearABMTokenDefaultFuncInvoked)
+		require.True(t, ds.SaveAppConfigFuncInvoked)
+		assert.Equal(t, map[string]bool{"Org A": false, "Org B": false}, appCfgDefaults())
+	})
+
+	t.Run("unsetting a non-default token is a no-op", func(t *testing.T) {
+		resetState(tokA.ID)
+		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, false)
+		require.NoError(t, err)
+		assert.False(t, token.IsDefault)
+		assert.False(t, ds.SetABMTokenDefaultFuncInvoked)
+		assert.False(t, ds.ClearABMTokenDefaultFuncInvoked)
+		assert.False(t, ds.SaveAppConfigFuncInvoked)
+	})
+
+	t.Run("unsetting the only token's default is rejected", func(t *testing.T) {
+		tokenCount = 1
+		t.Cleanup(func() { tokenCount = 2 })
+		resetState(tokA.ID)
+		_, err := svc.SetABMTokenDefault(adminCtx, tokA.ID, false)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "always the default")
+		assert.False(t, ds.ClearABMTokenDefaultFuncInvoked)
+	})
+}
+
 func TestMDMAppleEditedAppleOSUpdatesDeclaration(t *testing.T) {
 	ctx := context.Background()
 	teamID := uint(1)

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -940,7 +940,7 @@ func TestSetABMTokenDefault(t *testing.T) {
 			t.Run(c.desc, func(t *testing.T) {
 				resetState(tokA.ID)
 				ctx := test.UserContext(t.Context(), c.user)
-				_, err := svc.SetABMTokenDefault(ctx, tokB.ID, true)
+				_, err := svc.SetABMTokenDefault(ctx, tokB.ID, new(true))
 				test.RequireErrKind(t, c.wantErr, err)
 			})
 		}
@@ -948,16 +948,25 @@ func TestSetABMTokenDefault(t *testing.T) {
 
 	adminCtx := test.UserContext(t.Context(), test.UserAdmin)
 
+	t.Run("omitted default value is rejected", func(t *testing.T) {
+		resetState(tokA.ID)
+		_, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, nil)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "missing required argument")
+		assert.False(t, ds.SetABMTokenDefaultFuncInvoked)
+		assert.False(t, ds.ClearABMTokenDefaultFuncInvoked)
+	})
+
 	t.Run("unknown token id is not found", func(t *testing.T) {
 		resetState(tokA.ID)
-		_, err := svc.SetABMTokenDefault(adminCtx, 999, true)
+		_, err := svc.SetABMTokenDefault(adminCtx, 999, new(true))
 		require.Error(t, err)
 		require.True(t, fleet.IsNotFound(err))
 	})
 
 	t.Run("setting default moves it from the other token", func(t *testing.T) {
 		resetState(tokA.ID)
-		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, true)
+		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, new(true))
 		require.NoError(t, err)
 		assert.True(t, token.IsDefault)
 		assert.True(t, ds.SetABMTokenDefaultFuncInvoked)
@@ -967,7 +976,7 @@ func TestSetABMTokenDefault(t *testing.T) {
 
 	t.Run("unsetting the default clears it", func(t *testing.T) {
 		resetState(tokB.ID)
-		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, false)
+		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, new(false))
 		require.NoError(t, err)
 		assert.False(t, token.IsDefault)
 		assert.True(t, ds.ClearABMTokenDefaultFuncInvoked)
@@ -977,7 +986,7 @@ func TestSetABMTokenDefault(t *testing.T) {
 
 	t.Run("unsetting a non-default token is a no-op", func(t *testing.T) {
 		resetState(tokA.ID)
-		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, false)
+		token, err := svc.SetABMTokenDefault(adminCtx, tokB.ID, new(false))
 		require.NoError(t, err)
 		assert.False(t, token.IsDefault)
 		assert.False(t, ds.SetABMTokenDefaultFuncInvoked)
@@ -989,7 +998,7 @@ func TestSetABMTokenDefault(t *testing.T) {
 		tokenCount = 1
 		t.Cleanup(func() { tokenCount = 2 })
 		resetState(tokA.ID)
-		_, err := svc.SetABMTokenDefault(adminCtx, tokA.ID, false)
+		_, err := svc.SetABMTokenDefault(adminCtx, tokA.ID, new(false))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "always the default")
 		assert.False(t, ds.ClearABMTokenDefaultFuncInvoked)

--- a/server/api_endpoints/api_endpoints.yml
+++ b/server/api_endpoints/api_endpoints.yml
@@ -352,6 +352,9 @@
   path: "/api/v1/fleet/abm_tokens"
   display_name: "List Apple Business (AB) tokens"
   deprecated: true
+- method: "PATCH"
+  path: "/api/v1/fleet/ab_tokens/{id}/default"
+  display_name: "Set default Apple Business (AB) token"
 - method: "GET"
   path: "/api/v1/fleet/vpp_tokens"
   display_name: "List Volume Purchasing Program (VPP) tokens"

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1121,6 +1121,11 @@ type Service interface {
 	// UpdateABMTokenTeams updates the default macOS, iOS, iPadOS, and BYOD team IDs for a given ABM token.
 	UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOSTeamID, iOSTeamID, iPadOSTeamID, byodTeamID *uint) (*ABMToken, error)
 
+	// SetABMTokenDefault marks the given ABM token as the default one used to
+	// sign GetToken responses for devices not enrolled through ABM, or unsets
+	// it so no token is the default.
+	SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*ABMToken, error)
+
 	// DeleteABMToken deletes the given ABM token.
 	DeleteABMToken(ctx context.Context, tokenID uint) error
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1123,8 +1123,8 @@ type Service interface {
 
 	// SetABMTokenDefault marks the given ABM token as the default one used to
 	// sign GetToken responses for devices not enrolled through ABM, or unsets
-	// it so no token is the default.
-	SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*ABMToken, error)
+	// it so no token is the default. isDefault is required; nil is rejected.
+	SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault *bool) (*ABMToken, error)
 
 	// DeleteABMToken deletes the given ABM token.
 	DeleteABMToken(ctx context.Context, tokenID uint) error

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -663,7 +663,7 @@ type CountABMTokensFunc func(ctx context.Context) (int, error)
 
 type UpdateABMTokenTeamsFunc func(ctx context.Context, tokenID uint, macOSTeamID *uint, iOSTeamID *uint, iPadOSTeamID *uint, byodTeamID *uint) (*fleet.ABMToken, error)
 
-type SetABMTokenDefaultFunc func(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error)
+type SetABMTokenDefaultFunc func(ctx context.Context, tokenID uint, isDefault *bool) (*fleet.ABMToken, error)
 
 type DeleteABMTokenFunc func(ctx context.Context, tokenID uint) error
 
@@ -4767,7 +4767,7 @@ func (s *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOSTe
 	return s.UpdateABMTokenTeamsFunc(ctx, tokenID, macOSTeamID, iOSTeamID, iPadOSTeamID, byodTeamID)
 }
 
-func (s *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error) {
+func (s *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault *bool) (*fleet.ABMToken, error) {
 	s.mu.Lock()
 	s.SetABMTokenDefaultFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -663,6 +663,8 @@ type CountABMTokensFunc func(ctx context.Context) (int, error)
 
 type UpdateABMTokenTeamsFunc func(ctx context.Context, tokenID uint, macOSTeamID *uint, iOSTeamID *uint, iPadOSTeamID *uint, byodTeamID *uint) (*fleet.ABMToken, error)
 
+type SetABMTokenDefaultFunc func(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error)
+
 type DeleteABMTokenFunc func(ctx context.Context, tokenID uint) error
 
 type RenewABMTokenFunc func(ctx context.Context, token io.Reader, tokenID uint) (*fleet.ABMToken, error)
@@ -1980,6 +1982,9 @@ type Service struct {
 
 	UpdateABMTokenTeamsFunc        UpdateABMTokenTeamsFunc
 	UpdateABMTokenTeamsFuncInvoked bool
+
+	SetABMTokenDefaultFunc        SetABMTokenDefaultFunc
+	SetABMTokenDefaultFuncInvoked bool
 
 	DeleteABMTokenFunc        DeleteABMTokenFunc
 	DeleteABMTokenFuncInvoked bool
@@ -4760,6 +4765,13 @@ func (s *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOSTe
 	s.UpdateABMTokenTeamsFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateABMTokenTeamsFunc(ctx, tokenID, macOSTeamID, iOSTeamID, iPadOSTeamID, byodTeamID)
+}
+
+func (s *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error) {
+	s.mu.Lock()
+	s.SetABMTokenDefaultFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetABMTokenDefaultFunc(ctx, tokenID, isDefault)
 }
 
 func (s *Service) DeleteABMToken(ctx context.Context, tokenID uint) error {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -2722,7 +2722,7 @@ func (svc *Service) validateABMAssignments(
 		for _, bm := range mdm.AppleBusinessManager.Value {
 			if bm.Default {
 				if defaultTokenID != nil {
-					invalid.Append("mdm.apple_business", "only one Apple Business Manager (ABM) token can be the default")
+					invalid.Append("mdm.apple_business", "only one Apple Business (AB) token can be the default")
 					return nil, nil, nil
 				}
 				if tok, ok := tokensByName[norm.NFC.String(bm.OrganizationName)]; ok {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1506,88 +1506,13 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	tokensInCfg := make(map[string]struct{})
-	for _, t := range newAppConfig.MDM.AppleBusinessManager.Value {
-		tokensInCfg[t.OrganizationName] = struct{}{}
-	}
-
-	toks, err := svc.ds.ListABMTokens(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "listing ABM tokens")
-	}
-
-	if newAppConfig.MDM.AppleBusinessManager.Set && len(newAppConfig.MDM.AppleBusinessManager.Value) == 0 {
-		for _, tok := range toks {
-			if _, ok := tokensInCfg[tok.OrganizationName]; !ok {
-				tok.MacOSDefaultTeamID = nil
-				tok.IOSDefaultTeamID = nil
-				tok.IPadOSDefaultTeamID = nil
-				tok.BYODDefaultTeamID = nil
-				if err := svc.ds.SaveABMToken(ctx, tok); err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "saving ABM token assignments")
-				}
-			}
-		}
-		// An explicitly empty apple_business also clears the default, like it
-		// clears the default fleets above. A lone token is always the default,
-		// so leave it alone then.
-		if len(toks) > 1 {
-			if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "clearing default ABM token")
-			}
-		}
-	}
-
-	if (appConfig.MDM.AppleBusinessManager.Set && appConfig.MDM.AppleBusinessManager.Valid) || appConfig.MDM.DeprecatedAppleBMDefaultTeam != "" {
-		for _, tok := range abmAssignments {
-			if err := svc.ds.SaveABMToken(ctx, tok); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "saving ABM token assignments")
-			}
-		}
-	}
-
-	if newAppConfig.MDM.AppleBusinessManager.Set && newAppConfig.MDM.AppleBusinessManager.Valid && len(newAppConfig.MDM.AppleBusinessManager.Value) > 0 {
-		switch {
-		case defaultABMTokenID != nil:
-			if err := svc.ds.SetABMTokenDefault(ctx, *defaultABMTokenID); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "setting default ABM token")
-			}
-		case len(toks) > 1:
-			// No entry marked default: with several tokens that means "no
-			// default". A lone token is always the default, so leave it then.
-			if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "clearing default ABM token")
-			}
-		}
+	if err := svc.applyABMTokenAssignments(ctx, newAppConfig, appConfig, abmAssignments, defaultABMTokenID); err != nil {
+		return nil, err
 	}
 
 	if vppAssignmentsDefined {
-		// 1. Reset teams for VPP tokens that exist in Fleet but aren't present in the config being passed
-		clear(tokensInCfg)
-		for _, t := range newAppConfig.MDM.VolumePurchasingProgram.Value {
-			tokensInCfg[t.Location] = struct{}{}
-		}
-		vppToks, err := svc.ds.ListVPPTokens(ctx)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "listing VPP tokens")
-		}
-		for _, tok := range vppToks {
-			if _, ok := tokensInCfg[tok.Location]; !ok {
-				tok.Teams = nil
-				if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tok.ID, nil); err != nil {
-					return nil, ctxerr.Wrap(ctx, err, "saving VPP token teams")
-				}
-			}
-		}
-		// 2. Set VPP assignments that are defined in the config.
-		for tokenID, tokenTeams := range vppAssignments {
-			if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tokenID, tokenTeams); err != nil {
-				var errTokConstraint fleet.ErrVPPTokenTeamConstraint
-				if errors.As(err, &errTokConstraint) {
-					return nil, ctxerr.Wrap(ctx, fleet.NewUserMessageError(errTokConstraint, http.StatusConflict))
-				}
-				return nil, ctxerr.Wrap(ctx, err, "saving ABM token assignments")
-			}
+		if err := svc.applyVPPTokenAssignments(ctx, newAppConfig, vppAssignments); err != nil {
+			return nil, err
 		}
 	}
 
@@ -1609,6 +1534,110 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	return obfuscatedAppConfig, nil
+}
+
+// applyABMTokenAssignments persists the ABM token changes computed while validating an app config
+// change: default fleet assignments and the default token. It runs after SaveAppConfig has
+// committed, so returning an error here leaves the new configuration persisted.
+func (svc *Service) applyABMTokenAssignments(
+	ctx context.Context,
+	newAppConfig fleet.AppConfig,
+	appConfig *fleet.AppConfig,
+	abmAssignments []*fleet.ABMToken,
+	defaultABMTokenID *uint,
+) error {
+	tokensInCfg := make(map[string]struct{})
+	for _, t := range newAppConfig.MDM.AppleBusinessManager.Value {
+		tokensInCfg[t.OrganizationName] = struct{}{}
+	}
+
+	toks, err := svc.ds.ListABMTokens(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "listing ABM tokens")
+	}
+
+	if newAppConfig.MDM.AppleBusinessManager.Set && len(newAppConfig.MDM.AppleBusinessManager.Value) == 0 {
+		for _, tok := range toks {
+			if _, ok := tokensInCfg[tok.OrganizationName]; !ok {
+				tok.MacOSDefaultTeamID = nil
+				tok.IOSDefaultTeamID = nil
+				tok.IPadOSDefaultTeamID = nil
+				tok.BYODDefaultTeamID = nil
+				if err := svc.ds.SaveABMToken(ctx, tok); err != nil {
+					return ctxerr.Wrap(ctx, err, "saving ABM token assignments")
+				}
+			}
+		}
+		// An explicitly empty apple_business also clears the default, like it
+		// clears the default fleets above. A lone token is always the default,
+		// so leave it alone then.
+		if len(toks) > 1 {
+			if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
+				return ctxerr.Wrap(ctx, err, "clearing default ABM token")
+			}
+		}
+	}
+
+	if (appConfig.MDM.AppleBusinessManager.Set && appConfig.MDM.AppleBusinessManager.Valid) || appConfig.MDM.DeprecatedAppleBMDefaultTeam != "" {
+		for _, tok := range abmAssignments {
+			if err := svc.ds.SaveABMToken(ctx, tok); err != nil {
+				return ctxerr.Wrap(ctx, err, "saving ABM token assignments")
+			}
+		}
+	}
+
+	if newAppConfig.MDM.AppleBusinessManager.Set && newAppConfig.MDM.AppleBusinessManager.Valid && len(newAppConfig.MDM.AppleBusinessManager.Value) > 0 {
+		switch {
+		case defaultABMTokenID != nil:
+			if err := svc.ds.SetABMTokenDefault(ctx, *defaultABMTokenID); err != nil {
+				return ctxerr.Wrap(ctx, err, "setting default ABM token")
+			}
+		case len(toks) > 1:
+			// No entry marked default: with several tokens that means "no
+			// default". A lone token is always the default, so leave it then.
+			if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
+				return ctxerr.Wrap(ctx, err, "clearing default ABM token")
+			}
+		}
+	}
+
+	return nil
+}
+
+// applyVPPTokenAssignments persists the VPP token fleet assignments computed while validating an
+// app config change. Like applyABMTokenAssignments, it runs after SaveAppConfig has committed.
+func (svc *Service) applyVPPTokenAssignments(
+	ctx context.Context,
+	newAppConfig fleet.AppConfig,
+	vppAssignments map[uint][]uint,
+) error {
+	// 1. Reset teams for VPP tokens that exist in Fleet but aren't present in the config being passed
+	tokensInCfg := make(map[string]struct{})
+	for _, t := range newAppConfig.MDM.VolumePurchasingProgram.Value {
+		tokensInCfg[t.Location] = struct{}{}
+	}
+	vppToks, err := svc.ds.ListVPPTokens(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "listing VPP tokens")
+	}
+	for _, tok := range vppToks {
+		if _, ok := tokensInCfg[tok.Location]; !ok {
+			tok.Teams = nil
+			if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tok.ID, nil); err != nil {
+				return ctxerr.Wrap(ctx, err, "saving VPP token teams")
+			}
+		}
+	}
+	// 2. Set VPP assignments that are defined in the config.
+	for tokenID, tokenTeams := range vppAssignments {
+		if _, err := svc.ds.UpdateVPPTokenTeams(ctx, tokenID, tokenTeams); err != nil {
+			if errTokConstraint, ok := errors.AsType[fleet.ErrVPPTokenTeamConstraint](err); ok {
+				return ctxerr.Wrap(ctx, fleet.NewUserMessageError(errTokConstraint, http.StatusConflict))
+			}
+			return ctxerr.Wrap(ctx, err, "saving ABM token assignments")
+		}
+	}
+	return nil
 }
 
 func clearCertRenewals(ctx context.Context, svc *Service, oldAppConfig, appConfig *fleet.AppConfig) error {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1102,7 +1102,8 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	// with GET /ab_tokens.
 	if defaultABMTokenID == nil && appConfig.MDM.AppleBusinessManager.Set && appConfig.MDM.AppleBusinessManager.Valid &&
 		len(appConfig.MDM.AppleBusinessManager.Value) == 1 {
-		count, err := svc.ds.GetABMTokenCount(ctx)
+		// this count decides what gets saved, so don't risk a stale replica read
+		count, err := svc.ds.GetABMTokenCount(ctxdb.RequirePrimary(ctx, true))
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "counting ABM tokens")
 		}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1092,9 +1092,23 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		return nil, ctxerr.Wrap(ctx, err, "validating MDM config")
 	}
 
-	abmAssignments, err := svc.validateABMAssignments(ctx, &newAppConfig.MDM, &oldAppConfig.MDM, invalid, lic)
+	abmAssignments, defaultABMTokenID, err := svc.validateABMAssignments(ctx, &newAppConfig.MDM, &oldAppConfig.MDM, invalid, lic)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "validating ABM token assignments")
+	}
+
+	// A lone ABM token is always the default even when the config doesn't mark
+	// it, so reflect that in the stored config to keep GET /config consistent
+	// with GET /ab_tokens.
+	if defaultABMTokenID == nil && appConfig.MDM.AppleBusinessManager.Set && appConfig.MDM.AppleBusinessManager.Valid &&
+		len(appConfig.MDM.AppleBusinessManager.Value) == 1 {
+		count, err := svc.ds.GetABMTokenCount(ctx)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "counting ABM tokens")
+		}
+		if count == 1 {
+			appConfig.MDM.AppleBusinessManager.Value[0].Default = true
+		}
 	}
 
 	var vppAssignments map[uint][]uint
@@ -1514,12 +1528,35 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 				}
 			}
 		}
+		// An explicitly empty apple_business also clears the default, like it
+		// clears the default fleets above. A lone token is always the default,
+		// so leave it alone then.
+		if len(toks) > 1 {
+			if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "clearing default ABM token")
+			}
+		}
 	}
 
 	if (appConfig.MDM.AppleBusinessManager.Set && appConfig.MDM.AppleBusinessManager.Valid) || appConfig.MDM.DeprecatedAppleBMDefaultTeam != "" {
 		for _, tok := range abmAssignments {
 			if err := svc.ds.SaveABMToken(ctx, tok); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "saving ABM token assignments")
+			}
+		}
+	}
+
+	if newAppConfig.MDM.AppleBusinessManager.Set && newAppConfig.MDM.AppleBusinessManager.Valid && len(newAppConfig.MDM.AppleBusinessManager.Value) > 0 {
+		switch {
+		case defaultABMTokenID != nil:
+			if err := svc.ds.SetABMTokenDefault(ctx, *defaultABMTokenID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "setting default ABM token")
+			}
+		case len(toks) > 1:
+			// No entry marked default: with several tokens that means "no
+			// default". A lone token is always the default, so leave it then.
+			if err := svc.ds.ClearABMTokenDefault(ctx); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "clearing default ABM token")
 			}
 		}
 	}
@@ -2581,35 +2618,35 @@ func (svc *Service) validateABMAssignments(
 	mdm, oldMdm *fleet.MDM,
 	invalid *fleet.InvalidArgumentError,
 	lic *fleet.LicenseInfo,
-) ([]*fleet.ABMToken, error) {
+) (tokensToSave []*fleet.ABMToken, defaultTokenID *uint, err error) {
 	if mdm.DeprecatedAppleBMDefaultTeam != "" && mdm.AppleBusinessManager.Set && mdm.AppleBusinessManager.Valid {
 		invalid.Append("mdm.apple_bm_default_team", fleet.AppleABMDefaultTeamDeprecatedMessage)
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	if name := mdm.DeprecatedAppleBMDefaultTeam; name != "" && name != oldMdm.DeprecatedAppleBMDefaultTeam {
 		if !lic.IsPremium() {
 			invalid.Append("mdm.apple_bm_default_team", ErrMissingLicense.Error())
-			return nil, nil
+			return nil, nil, nil
 		}
 		team, err := svc.ds.TeamByName(ctx, name)
 		if err != nil {
 			invalid.Append("mdm.apple_bm_default_team", "team name not found")
-			return nil, nil
+			return nil, nil, nil
 		}
 		tokens, err := svc.ds.ListABMTokens(ctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if len(tokens) > 1 {
 			invalid.Append("mdm.apple_bm_default_team", fleet.AppleABMDefaultTeamDeprecatedMessage)
-			return nil, nil
+			return nil, nil, nil
 		}
 
 		if len(tokens) == 0 {
 			invalid.Append("mdm.apple_bm_default_team", "no ABM tokens found")
-			return nil, nil
+			return nil, nil, nil
 		}
 
 		tok := tokens[0]
@@ -2617,18 +2654,18 @@ func (svc *Service) validateABMAssignments(
 		tok.IOSDefaultTeamID = &team.ID
 		tok.IPadOSDefaultTeamID = &team.ID
 		tok.BYODDefaultTeamID = &team.ID
-		return []*fleet.ABMToken{tok}, nil
+		return []*fleet.ABMToken{tok}, nil, nil
 	}
 
 	if mdm.AppleBusinessManager.Set && len(mdm.AppleBusinessManager.Value) > 0 {
 		if !lic.IsPremium() {
 			invalid.Append("mdm.apple_business", ErrMissingLicense.Error())
-			return nil, nil
+			return nil, nil, nil
 		}
 
 		teams, err := svc.ds.TeamsSummary(ctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		teamsByName := map[string]*uint{"": nil, "No team": nil}
 		for _, tm := range teams {
@@ -2636,7 +2673,7 @@ func (svc *Service) validateABMAssignments(
 		}
 		tokens, err := svc.ds.ListABMTokens(ctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		tokensByName := map[string]*fleet.ABMToken{}
 		for _, token := range tokens {
@@ -2652,18 +2689,27 @@ func (svc *Service) validateABMAssignments(
 			tokensByName[token.OrganizationName] = token
 		}
 
-		var tokensToSave []*fleet.ABMToken
 		for _, bm := range mdm.AppleBusinessManager.Value {
+			if bm.Default {
+				if defaultTokenID != nil {
+					invalid.Append("mdm.apple_business", "only one Apple Business Manager (ABM) token can be the default")
+					return nil, nil, nil
+				}
+				if tok, ok := tokensByName[norm.NFC.String(bm.OrganizationName)]; ok {
+					defaultTokenID = &tok.ID
+				}
+			}
+
 			for _, tmName := range []string{bm.MacOSTeam, bm.IOSTeam, bm.IpadOSTeam, bm.BYODTeam} {
 				if _, ok := teamsByName[norm.NFC.String(tmName)]; !ok {
 					invalid.Appendf("mdm.apple_business", "team %s doesn't exist", tmName)
-					return nil, nil
+					return nil, nil, nil
 				}
 			}
 
 			if _, ok := tokensByName[norm.NFC.String(bm.OrganizationName)]; !ok {
 				invalid.Appendf("mdm.apple_business", "token with organization name %s doesn't exist", bm.OrganizationName)
-				return nil, nil
+				return nil, nil, nil
 			}
 
 			tok := tokensByName[bm.OrganizationName]
@@ -2674,10 +2720,10 @@ func (svc *Service) validateABMAssignments(
 			tokensToSave = append(tokensToSave, tok)
 		}
 
-		return tokensToSave, nil
+		return tokensToSave, defaultTokenID, nil
 	}
 
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (svc *Service) validateVPPAssignments(

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -2720,12 +2720,17 @@ func (svc *Service) validateABMAssignments(
 		}
 
 		for _, bm := range mdm.AppleBusinessManager.Value {
+			// look up with the same normalized names throughout: a check that
+			// normalizes paired with a fetch that doesn't panics on names whose
+			// Unicode form differs between the request and the database
+			orgName := norm.NFC.String(bm.OrganizationName)
+
 			if bm.Default {
 				if defaultTokenID != nil {
 					invalid.Append("mdm.apple_business", "only one Apple Business (AB) token can be the default")
 					return nil, nil, nil
 				}
-				if tok, ok := tokensByName[norm.NFC.String(bm.OrganizationName)]; ok {
+				if tok, ok := tokensByName[orgName]; ok {
 					defaultTokenID = &tok.ID
 				}
 			}
@@ -2737,16 +2742,16 @@ func (svc *Service) validateABMAssignments(
 				}
 			}
 
-			if _, ok := tokensByName[norm.NFC.String(bm.OrganizationName)]; !ok {
+			if _, ok := tokensByName[orgName]; !ok {
 				invalid.Appendf("mdm.apple_business", "token with organization name %s doesn't exist", bm.OrganizationName)
 				return nil, nil, nil
 			}
 
-			tok := tokensByName[bm.OrganizationName]
-			tok.MacOSDefaultTeamID = teamsByName[bm.MacOSTeam]
-			tok.IOSDefaultTeamID = teamsByName[bm.IOSTeam]
-			tok.IPadOSDefaultTeamID = teamsByName[bm.IpadOSTeam]
-			tok.BYODDefaultTeamID = teamsByName[bm.BYODTeam]
+			tok := tokensByName[orgName]
+			tok.MacOSDefaultTeamID = teamsByName[norm.NFC.String(bm.MacOSTeam)]
+			tok.IOSDefaultTeamID = teamsByName[norm.NFC.String(bm.IOSTeam)]
+			tok.IPadOSDefaultTeamID = teamsByName[norm.NFC.String(bm.IpadOSTeam)]
+			tok.BYODDefaultTeamID = teamsByName[norm.NFC.String(bm.BYODTeam)]
 			tokensToSave = append(tokensToSave, tok)
 		}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -8571,7 +8571,8 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 
 type setABMTokenDefaultRequest struct {
 	TokenID uint `url:"id"`
-	Default bool `json:"default"`
+	// pointer so an omitted field is rejected instead of silently clearing the default
+	Default *bool `json:"default"`
 }
 
 type setABMTokenDefaultResponse struct {
@@ -8592,7 +8593,7 @@ func setABMTokenDefaultEndpoint(ctx context.Context, request any, svc fleet.Serv
 	return &setABMTokenDefaultResponse{ABMToken: tok}, nil
 }
 
-func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error) {
+func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault *bool) (*fleet.ABMToken, error) {
 	// skipauth: No authorization check needed due to implementation returning
 	// only license error.
 	svc.authz.SkipAuthorization(ctx)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -8566,6 +8566,41 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Set ABM token default endpoint
+////////////////////////////////////////////////////////////////////////////////
+
+type setABMTokenDefaultRequest struct {
+	TokenID uint `url:"id"`
+	Default bool `json:"default"`
+}
+
+type setABMTokenDefaultResponse struct {
+	ABMToken *fleet.ABMToken `json:"abm_token,omitempty" renameto:"ab_token,inline"`
+	Err      error           `json:"error,omitempty"`
+}
+
+func (r setABMTokenDefaultResponse) Error() error { return r.Err }
+
+func setABMTokenDefaultEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*setABMTokenDefaultRequest)
+
+	tok, err := svc.SetABMTokenDefault(ctx, req.TokenID, req.Default)
+	if err != nil {
+		return &setABMTokenDefaultResponse{Err: err}, nil
+	}
+
+	return &setABMTokenDefaultResponse{ABMToken: tok}, nil
+}
+
+func (svc *Service) SetABMTokenDefault(ctx context.Context, tokenID uint, isDefault bool) (*fleet.ABMToken, error) {
+	// skipauth: No authorization check needed due to implementation returning
+	// only license error.
+	svc.authz.SkipAuthorization(ctx)
+
+	return nil, fleet.ErrMissingLicense
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Renew ABM token endpoint
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1385,7 +1385,7 @@ func TestSetABMTokenDefaultFreeLicense(t *testing.T) {
 	svc, ctx, _, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierFree})
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
 
-	_, err := svc.SetABMTokenDefault(ctx, 1, true)
+	_, err := svc.SetABMTokenDefault(ctx, 1, new(true))
 	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
 }
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1381,6 +1381,14 @@ func TestBatchSetMDMAppleProfilesWithSecrets(t *testing.T) {
 	assert.ErrorContains(t, err, "profiles[1]")
 }
 
+func TestSetABMTokenDefaultFreeLicense(t *testing.T) {
+	svc, ctx, _, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierFree})
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+	_, err := svc.SetABMTokenDefault(ctx, 1, true)
+	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+}
+
 func TestNewMDMAppleDeclarationFreeLicenseTeam(t *testing.T) {
 	svc, ctx, _, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierFree})
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -893,6 +893,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/ab_tokens", listABMTokensEndpoint, nil)
 	ue.GET("/api/_version_/fleet/ab_tokens/count", countABMTokensEndpoint, nil)
 	ue.PATCH("/api/_version_/fleet/ab_tokens/{id:[0-9]+}/fleets", updateABMTokenTeamsEndpoint, updateABMTokenTeamsRequest{})
+	ue.PATCH("/api/_version_/fleet/ab_tokens/{id:[0-9]+}/default", setABMTokenDefaultEndpoint, setABMTokenDefaultRequest{})
 	ue.PATCH("/api/_version_/fleet/ab_tokens/{id:[0-9]+}/renew", renewABMTokenEndpoint, renewABMTokenRequest{})
 
 	ue.GET("/api/_version_/fleet/mdm/apple/request_csr", getMDMAppleCSREndpoint, getMDMAppleCSRRequest{})

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1566,6 +1566,11 @@ func (s *integrationMDMTestSuite) TestABMTokenDefault() {
 	// unknown token id
 	s.Do("PATCH", "/api/latest/fleet/ab_tokens/999999/default",
 		json.RawMessage(`{"default": true}`), http.StatusNotFound)
+
+	// omitting "default" is rejected instead of silently clearing the default
+	res := s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/ab_tokens/%d/default", tokA.ID),
+		json.RawMessage(`{}`), http.StatusUnprocessableEntity)
+	require.Contains(t, extractServerErrorText(res.Body), "missing required argument")
 }
 
 func (s *integrationMDMTestSuite) TestABMExpiredToken() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1496,6 +1496,78 @@ func (s *integrationMDMTestSuite) TestABMTeamPersistsOnConfigChange() {
 	assert.Equal(t, team.ID, tokensResp.Tokens[0].IOSTeam.ID)
 }
 
+func (s *integrationMDMTestSuite) TestABMTokenDefault() {
+	t := s.T()
+
+	orgA := t.Name() + "-org-a"
+	orgB := t.Name() + "-org-b"
+	s.enableABM(orgA)
+	s.enableABM(orgB)
+
+	tokensResp := listABMTokensResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/ab_tokens", nil, http.StatusOK, &tokensResp)
+	require.Len(t, tokensResp.Tokens, 2)
+	tokA := s.getABMTokenByName(orgA, tokensResp.Tokens)
+	tokB := s.getABMTokenByName(orgB, tokensResp.Tokens)
+
+	// the first token became the default when it was the only one
+	require.True(t, tokA.IsDefault)
+	require.False(t, tokB.IsDefault)
+
+	countDefaults := func() (n int, defaultOrg string) {
+		s.DoJSON("GET", "/api/latest/fleet/ab_tokens", nil, http.StatusOK, &tokensResp)
+		for _, tok := range tokensResp.Tokens {
+			if tok.IsDefault {
+				n++
+				defaultOrg = tok.OrganizationName
+			}
+		}
+		return n, defaultOrg
+	}
+	appCfgDefaults := func() map[string]bool {
+		acResp := appConfigResponse{}
+		s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+		m := make(map[string]bool)
+		for _, e := range acResp.MDM.AppleBusinessManager.Value {
+			m[e.OrganizationName] = e.Default
+		}
+		return m
+	}
+
+	// setting B as default moves it off A in one call
+	var setResp setABMTokenDefaultResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/ab_tokens/%d/default", tokB.ID),
+		json.RawMessage(`{"default": true}`), http.StatusOK, &setResp)
+	require.NotNil(t, setResp.ABMToken)
+	assert.True(t, setResp.ABMToken.IsDefault)
+	n, defaultOrg := countDefaults()
+	assert.Equal(t, 1, n)
+	assert.Equal(t, orgB, defaultOrg)
+	// GET /config mirrors it on B's entry and drops it from A's
+	cfgDefaults := appCfgDefaults()
+	assert.True(t, cfgDefaults[orgB])
+	assert.False(t, cfgDefaults[orgA])
+
+	// unsetting the default clears it everywhere
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/ab_tokens/%d/default", tokB.ID),
+		json.RawMessage(`{"default": false}`), http.StatusOK, &setResp)
+	assert.False(t, setResp.ABMToken.IsDefault)
+	n, _ = countDefaults()
+	assert.Equal(t, 0, n)
+	cfgDefaults = appCfgDefaults()
+	assert.False(t, cfgDefaults[orgA])
+	assert.False(t, cfgDefaults[orgB])
+
+	// unsetting a non-default token is a no-op
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/ab_tokens/%d/default", tokA.ID),
+		json.RawMessage(`{"default": false}`), http.StatusOK, &setResp)
+	assert.False(t, setResp.ABMToken.IsDefault)
+
+	// unknown token id
+	s.Do("PATCH", "/api/latest/fleet/ab_tokens/999999/default",
+		json.RawMessage(`{"default": true}`), http.StatusNotFound)
+}
+
 func (s *integrationMDMTestSuite) TestABMExpiredToken() {
 	t := s.T()
 


### PR DESCRIPTION
**Related issue:** Resolves #52477

Builds on #52752 (merged).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Details

- `PATCH /ab_tokens/:id/default` with `{"default": bool}` sets or unsets the default AB token (admin-only; setting moves it atomically off any other token; unsetting the only token's default is rejected — a lone token is always the default). App config is resynced from all tokens so `GET /config` mirrors `GET /ab_tokens`.
- GitOps: `default: true` on one `apple_business` entry sets it; two marked entries fail validation in dry run and apply; none marked with several tokens clears it (per Slack: a default is optional); a lone token keeps its default and the stored config is stamped to reflect it.
- `generate-gitops` exports `default: true` on the marked entry only.
- Chosen behavior for reviewers to veto: an explicitly empty `apple_business: []` also clears the default, mirroring how it already clears default fleets.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

EE RBAC/behavior unit tests, core free-tier test, integration test (atomic move, `/config` mirror, unset, 404), `TestGitOpsABM` cases (set/two-fail/clear/lone-token), generate-gitops goldens. Manually verified every case against a live server via curl and `fleetctl gitops`.

## AI

**AI:** Claude Code (claude-fable-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting, switching, and clearing the default Apple Business Manager token.
  - Added an API endpoint for managing the default token.
  - Apple Business Manager token assignments and defaults now synchronize automatically with app configuration.

- **Bug Fixes**
  - Improved validation for missing, invalid, expired, or conflicting Apple Business Manager tokens.
  - Improved organization-name matching, including Unicode normalization.
  - Improved Apple device enrollment authorization and certificate renewal handling.
  - Deleting the final Apple Business Manager token now correctly disables Apple Business Manager configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->