### PR TITLE
show MDM is not turned on for config status modal

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,11 +43,8 @@ const config: StorybookConfig = {
     return config;
   },
   stories: [
-    "../frontend/components/**/*.stories.mdx",
     "../frontend/components/**/*.stories.@(js|jsx|ts|tsx)",
-    "../frontend/pages/SoftwarePage/components/**/*.stories.@(js|jsx|ts|tsx)",
-    "../frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/**/*.stories.@(js|jsx|ts|tsx)",
-    "../frontend/pages/admin/IntegrationsPage/**/*.stories.@(js|jsx|ts|tsx)",
+    "../frontend/pages/**/*.stories.@(js|jsx|ts|tsx)",
   ],
   addons: [
     "@storybook/addon-links",

--- a/changes/52794-fix-config-profile-status-modal
+++ b/changes/52794-fix-config-profile-status-modal
@@ -1,0 +1,1 @@
+- Fixed an issue clicking the info icon on a configuration profile for a platform that no longer has MDM enabled showed a generic error.

--- a/frontend/components/DataError/DataError.tsx
+++ b/frontend/components/DataError/DataError.tsx
@@ -9,6 +9,8 @@ import { Padding } from "styles/var/padding";
 const baseClass = "data-error";
 
 interface IDataErrorProps {
+  /** The title text displayed instead of the generic "Something's gone wrong" if set */
+  title?: string;
   /** the description text displayed under the header */
   description?: string;
   /** Excludes the link that asks user to create an issue. Defaults to `false` */
@@ -31,9 +33,11 @@ interface IDataErrorProps {
   selfCenter?: boolean;
 }
 
+const DEFAULT_TITLE = "Something's gone wrong";
 const DEFAULT_DESCRIPTION = "Refresh the page or log in again.";
 
 const DataError = ({
+  title = DEFAULT_TITLE,
   description = DEFAULT_DESCRIPTION,
   excludeIssueLink = false,
   children,
@@ -79,9 +83,7 @@ const DataError = ({
           }`}
         >
           <Graphic name="data-error" />
-          <div className={`${baseClass}__header`}>
-            Something&apos;s gone wrong.
-          </div>
+          <div className={`${baseClass}__header`}>{title}</div>
           {children || (
             <>
               <div className={`${baseClass}__description`}>
@@ -114,7 +116,7 @@ const DataError = ({
         <div className={`${baseClass}__content`}>
           <span className={`${baseClass}__header`}>
             <Icon name="error" />
-            Something&apos;s gone wrong.
+            {title}
           </span>
 
           <>

--- a/frontend/components/DataError/DataError.tsx
+++ b/frontend/components/DataError/DataError.tsx
@@ -33,7 +33,7 @@ interface IDataErrorProps {
   selfCenter?: boolean;
 }
 
-const DEFAULT_TITLE = "Something's gone wrong";
+const DEFAULT_TITLE = "Something's gone wrong.";
 const DEFAULT_DESCRIPTION = "Refresh the page or log in again.";
 
 const DataError = ({

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -1,6 +1,6 @@
-import { IConfigServerSettings } from "./config";
+import { IConfigServerSettings, IMdmConfig } from "./config";
 import { HostAndroidCertStatus, IHostDevice, IHostMdmData } from "./host";
-import { isAppleDevice } from "./platform";
+import { isAndroid, isAppleDevice, isWindows } from "./platform";
 
 export interface IMdmApple {
   common_name: string;
@@ -167,6 +167,45 @@ export type ProfilePlatform =
   | "ipados"
   | "linux"
   | "android";
+
+export const isMDMConfiguredForPlatform = (
+  platform: ProfilePlatform,
+  mdmConfig: IMdmConfig | undefined
+) => {
+  if (!mdmConfig) {
+    return false;
+  }
+
+  if (isWindows(platform)) {
+    return mdmConfig.windows_enabled_and_configured;
+  }
+
+  if (isAppleDevice(platform)) {
+    return mdmConfig.enabled_and_configured;
+  }
+
+  if (isAndroid(platform)) {
+    return mdmConfig.android_enabled_and_configured;
+  }
+
+  // Other platform types does not have MDM.
+  return false;
+};
+
+export const platformToMDMLabel = (platform: ProfilePlatform) => {
+  switch (platform) {
+    case "android":
+      return "Android";
+    case "darwin":
+    case "ios":
+    case "ipados":
+      return "Apple";
+    case "windows":
+      return "Windows";
+    default:
+      return "Unknown";
+  }
+};
 
 export interface IProfileLabel {
   name: string;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -168,6 +168,9 @@ export type ProfilePlatform =
   | "linux"
   | "android";
 
+// Checks if MDM is configured for a given platform.
+// It will return false for platforms that do not have MDM as a concept.
+// It will return false on a missing config.
 export const isMDMConfiguredForPlatform = (
   platform: ProfilePlatform,
   mdmConfig: IMdmConfig | undefined
@@ -188,7 +191,7 @@ export const isMDMConfiguredForPlatform = (
     return mdmConfig.android_enabled_and_configured;
   }
 
-  // Other platform types does not have MDM.
+  // Other platform types do not have MDM.
   return false;
 };
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -389,6 +389,7 @@ const ConfigurationProfiles = ({
           teamId={currentTeamId}
           name={selectedProfile.current.name}
           uuid={selectedProfile.current.profile_uuid}
+          platform={selectedProfile.current.platform}
           onClickResend={(hostCount) => {
             selectedStatusHostCount.current = hostCount;
             setShowConfigProfileStatusModal(false);

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.stories.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { AppContext } from "context/app";
@@ -33,8 +34,8 @@ const meta: Meta<typeof ConfigProfileStatusModal> = {
     name: "Storybook Profile",
     teamId: 0,
     uuid: "apple-profile",
-    onClickResend: undefined,
-    onExit: undefined,
+    onClickResend: () => {},
+    onExit: () => {},
     platform: "darwin",
   },
   argTypes: {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.stories.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.stories.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import { AppContext } from "context/app";
+import createMockConfig from "__mocks__/configMock";
+import { IMdmConfig } from "interfaces/config";
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryClientProviderProps,
+} from "react-query";
+import configProfileAPI from "services/entities/config_profiles";
+import ConfigProfileStatusModal from "./ConfigProfileStatusModal";
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+type CustomQueryClientProviderProps = React.PropsWithChildren<QueryClientProviderProps>;
+const CustomQueryClientProvider: React.FC<CustomQueryClientProviderProps> = QueryClientProvider;
+
+// Storybook has no backend — short-circuit the network call react-query fires on mount
+configProfileAPI.getConfigProfileStatus = () =>
+  Promise.resolve({
+    verified: 0,
+    verifying: 2,
+    pending: 1,
+    failed: 3,
+  });
+
+const meta: Meta<typeof ConfigProfileStatusModal> = {
+  component: ConfigProfileStatusModal,
+  title: "Pages/ConfigurationProfiles/Components/ConfigProfileStatusModal",
+  args: {
+    name: "Storybook Profile",
+    teamId: 0,
+    uuid: "apple-profile",
+    onClickResend: undefined,
+    onExit: undefined,
+    platform: "darwin",
+  },
+  argTypes: {
+    onClickResend: { control: false },
+    onExit: { control: false },
+    teamId: { control: false },
+    uuid: { control: false },
+  },
+  decorators: [
+    (Story) => {
+      const appContextValue = {
+        isPremiumTier: true,
+        config: createMockConfig({
+          mdm: {
+            enabled_and_configured: true,
+          } as IMdmConfig,
+        }),
+        setConfig: () => {
+          // Mock function for stories
+        },
+      };
+      return (
+        <CustomQueryClientProvider client={queryClient}>
+          <AppContext.Provider value={appContextValue as any}>
+            <Story />
+          </AppContext.Provider>
+        </CustomQueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfigProfileStatusModal>;
+
+export const Default: Story = {};
+
+export const MDMTurnedOff: Story = {
+  args: {
+    platform: "windows",
+  },
+};

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.tests.tsx
@@ -1,17 +1,30 @@
 import React from "react";
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { noop } from "lodash";
 
 import { createCustomRenderer } from "test/test-utils";
 import mockServer from "test/mock-server";
 import { defaultConfigProfileStatusHandler } from "test/handlers/config-profiles";
+import { IMdmConfig } from "interfaces/config";
+import { platformToMDMLabel, ProfilePlatform } from "interfaces/mdm";
 
 import ConfigProfileStatusModal from "./ConfigProfileStatusModal";
 
 describe("ConfigProfileStatusModal", () => {
-  const render = createCustomRenderer({
-    withBackendMock: true,
-  });
+  const render = (ui: React.ReactElement, mdmOverride?: Partial<IMdmConfig>) =>
+    createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          config: {
+            mdm: {
+              enabled_and_configured: true,
+              ...mdmOverride,
+            },
+          },
+        },
+      },
+    })(ui);
 
   it("renders the correct number of hosts for each status", async () => {
     mockServer.use(defaultConfigProfileStatusHandler);
@@ -20,6 +33,7 @@ describe("ConfigProfileStatusModal", () => {
         name="Test profile"
         uuid="123-abc"
         teamId={0}
+        platform="darwin"
         onClickResend={noop}
         onExit={noop}
       />
@@ -54,6 +68,7 @@ describe("ConfigProfileStatusModal", () => {
         name="Test profile"
         uuid="123-abc"
         teamId={0}
+        platform="darwin"
         onClickResend={noop}
         onExit={noop}
       />
@@ -68,4 +83,41 @@ describe("ConfigProfileStatusModal", () => {
     const resendButton = screen.getByRole("button", { name: "Resend" });
     expect(resendButton).toBeVisible();
   });
+
+  it.each([
+    "darwin",
+    "ios",
+    "ipados",
+    "windows",
+    "android",
+  ] as ProfilePlatform[])(
+    "shows MDM turned off for %s with correct label and links",
+    async (platform) => {
+      render(
+        <ConfigProfileStatusModal
+          name="Test profile"
+          uuid="123-abc"
+          teamId={0}
+          platform={platform}
+          onClickResend={noop}
+          onExit={noop}
+        />,
+        { enabled_and_configured: false }
+      );
+
+      const mdmLabel = platformToMDMLabel(platform);
+
+      await waitFor(() =>
+        screen.getByText(`${mdmLabel} mdm isn't turned on`, { exact: false })
+      );
+
+      const learnMoreLink = await screen.findByRole("link", {
+        name: "Learn more",
+      });
+      expect(learnMoreLink).toHaveAttribute(
+        "href",
+        expect.stringMatching(new RegExp(mdmLabel, "i"))
+      );
+    }
+  );
 });

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusModal/ConfigProfileStatusModal.tsx
@@ -1,13 +1,23 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useQuery } from "react-query";
 
 import configProfileAPI from "services/entities/config_profiles";
-import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  LEARN_MORE_ABOUT_BASE_LINK,
+} from "utilities/constants";
 
 import Modal from "components/Modal";
 import Spinner from "components/Spinner";
 import DataError from "components/DataError";
 import Button from "components/buttons/Button";
+import { AppContext } from "context/app";
+import CustomLink from "components/CustomLink";
+import {
+  isMDMConfiguredForPlatform,
+  platformToMDMLabel,
+  ProfilePlatform,
+} from "interfaces/mdm";
 import ConfigProfileStatusTable from "../ConfigProfileStatusTable";
 
 const baseClass = "config-profile-status-modal";
@@ -16,6 +26,7 @@ interface IConfigProfileStatusModalProps {
   name: string;
   uuid: string;
   teamId: number;
+  platform: ProfilePlatform;
   onClickResend: (hostCount: number) => void;
   onExit: () => void;
 }
@@ -24,18 +35,56 @@ const ConfigProfileStatusModal = ({
   name,
   uuid,
   teamId,
+  platform,
   onClickResend,
   onExit,
 }: IConfigProfileStatusModalProps) => {
+  const { config } = useContext(AppContext);
+  const isMDMEnabled = isMDMConfiguredForPlatform(platform, config?.mdm);
   const { data, isLoading, isError } = useQuery(
     ["config-profile-status", uuid],
     () => configProfileAPI.getConfigProfileStatus(uuid),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: isMDMEnabled,
     }
   );
 
   const renderContent = () => {
+    if (!isMDMEnabled) {
+      const mdmLabel = platformToMDMLabel(platform);
+      let learnMoreUrl: string | undefined;
+      // eslint-disable-next-line default-case
+      switch (mdmLabel) {
+        case "Apple":
+          learnMoreUrl = `${LEARN_MORE_ABOUT_BASE_LINK}/turn-on-apple-mdm`;
+          break;
+        case "Windows":
+          learnMoreUrl = `${LEARN_MORE_ABOUT_BASE_LINK}/setup-windows-mdm`;
+          break;
+        case "Android":
+          learnMoreUrl = `${LEARN_MORE_ABOUT_BASE_LINK}/how-to-connect-android-enterprise`;
+          break;
+      }
+      return (
+        <DataError
+          verticalPaddingSize="pad-medium"
+          excludeIssueLink
+          title={`${mdmLabel} MDM isn't turned on.`}
+        >
+          <span>
+            Turn on {mdmLabel} MDM to manage this configuration profile.
+            {learnMoreUrl ? (
+              <>
+                {" "}
+                <CustomLink text="Learn more" newTab url={learnMoreUrl} />{" "}
+              </>
+            ) : null}
+          </span>
+        </DataError>
+      );
+    }
+
     if (isLoading) {
       return <Spinner />;
     }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52794

I also added it as a storybook story.

<img width="675" height="342" alt="image" src="https://github.com/user-attachments/assets/4581341e-37d7-4dff-aaf8-38a54ab67eb9" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed configuration profile status details when mobile device management (MDM) is disabled for the profile’s platform.
  - The status modal now displays a platform-specific explanation and relevant “Learn more” link instead of a generic error.
  - Prevented unnecessary status loading when MDM is unavailable for the selected platform.
  - Added platform-specific handling for Apple, Windows, and Android configuration profiles.

- **Improvements**
  - Error messages can now display more specific, contextual titles where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->