### PR TITLE
Docs: Document `reset_policy` activity

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -130,6 +130,31 @@ This activity contains the following fields:
 }
 ```
 
+## reset_policy
+
+Generated when resetting a policy's results, either for all hosts or for a single host.
+
+This activity contains the following fields:
+- "policy_id": the ID of the reset policy.
+- "policy_name": the name of the reset policy.
+- "fleet_id": the ID of the fleet the policy belongs to. Use -1 for global policies, 0 for "no fleet" policies.
+- "fleet_name": the name of the fleet the policy belongs to. null for global policies and "no fleet" policies.
+- "host_id": the ID of the host whose result was reset. Only present when the reset was scoped to a single host.
+
+#### Example
+
+```json
+{
+	"policy_id": 123,
+	"policy_name": "foo",
+	"team_id": 1,
+	"team_name": "Workstations",
+	"fleet_id": 1,
+	"fleet_name": "Workstations",
+	"host_id": 42
+}
+```
+
 ## applied_spec_policy
 
 Generated when applying policy specs.

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -140,6 +140,7 @@ This activity contains the following fields:
 - "fleet_id": the ID of the fleet the policy belongs to. Use -1 for global policies, 0 for "no fleet" policies.
 - "fleet_name": the name of the fleet the policy belongs to. null for global policies and "no fleet" policies.
 - "host_id": the ID of the host whose result was reset. Only present when the reset was scoped to a single host.
+- "host_display_name": the display name of the host whose result was reset. Only present when the reset was scoped to a single host.
 
 #### Example
 
@@ -151,7 +152,8 @@ This activity contains the following fields:
 	"team_name": "Workstations",
 	"fleet_id": 1,
 	"fleet_name": "Workstations",
-	"host_id": 42
+	"host_id": 42,
+	"host_display_name": "Anna's MacBook Pro"
 }
 ```
 


### PR DESCRIPTION
**Related issue:** #51053

Follow-up to https://github.com/fleetdm/fleet/pull/52828#discussion_r3972774047: the `reset_policy` activity (emitted by `POST /api/v1/fleet/policies/:policy_id/reset`) was never added to `audit-logs.md`. This adds it alongside the other policy activities, including the optional `host_id` field that #52828 adds for single-host resets.

## Global activity

<img width="655" height="535" alt="Screenshot 2026-09-10 at 11 22 10 AM" src="https://github.com/user-attachments/assets/81c8de02-5574-406b-80b1-c67500b4aff5" />

## Host activity

<img width="655" height="535" alt="Screenshot 2026-09-10 at 11 28 57 AM" src="https://github.com/user-attachments/assets/e830a784-a430-4903-a96d-abd8b98e662e" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documentation-only change; no changes file needed.

## Testing

- [x] Verified the new entry matches the `ActivityTypeResetPolicy` struct fields in `server/fleet/activities.go` (as of #52828).
