### PR TITLE
Restore type-to-search in policy automation software/script pickers

### DIFF
--- a/changes/48606-policy-automations-searchable-dropdowns
+++ b/changes/48606-policy-automations-searchable-dropdowns
@@ -1,0 +1,1 @@
+* Fixed policy automations UI so the software, script, and configuration profile dropdowns allow typing to search again.

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
@@ -8,6 +8,7 @@ import {
   createMockSoftwarePackage,
   createMockAppStoreApp,
 } from "__mocks__/softwareMock";
+import { createMockScript } from "__mocks__/scriptMock";
 
 import { IPolicy } from "interfaces/policy";
 import { ISoftwareTitle } from "interfaces/software";
@@ -608,5 +609,58 @@ describe("PolicyAutomationsFields — Resend configuration profile row", () => {
         "Please select a configuration profile to resend."
       )
     ).toBeInTheDocument();
+  });
+});
+
+describe("PolicyAutomationsFields — type-to-search pickers", () => {
+  beforeEach(() => {
+    setSoftwareTitles([singlePackageTitle, multiPackageTitle, vppTitle]);
+    mockedUseScripts.mockReturnValue(({
+      data: {
+        count: 2,
+        scripts: [
+          createMockScript({ id: 1, name: "Rotate keys" }),
+          createMockScript({ id: 2, name: "Clear cache" }),
+        ],
+        meta: { has_next_results: false, has_previous_results: false },
+      },
+    } as unknown) as ReturnType<typeof useScripts>);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("filters software titles as the user types", async () => {
+    const { user } = renderWithHandle({
+      install_software: { name: "Single App", software_title_id: 10 },
+    });
+
+    await user.type(
+      screen.getByRole("combobox", { name: /Select software/i }),
+      "Multi"
+    );
+
+    const options = Array.from(
+      document.querySelectorAll(".react-select__option")
+    ).map((o) => o.textContent);
+    expect(options).toHaveLength(1);
+    expect(options[0]).toContain("Multi App");
+  });
+
+  it("filters scripts as the user types", async () => {
+    const { user } = renderWithHandle({
+      run_script: { id: 1, name: "Rotate keys" },
+    });
+
+    await user.type(
+      screen.getByRole("combobox", { name: /Select script/i }),
+      "Clear"
+    );
+
+    const options = Array.from(
+      document.querySelectorAll(".react-select__option")
+    ).map((o) => o.textContent);
+    expect(options).toEqual(["Clear cache"]);
   });
 });

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -514,6 +514,7 @@ const PolicyAutomationsFields = forwardRef<
               <div className={`${baseClass}__software-pickers`}>
                 <DropdownWrapper
                   name="software-title"
+                  isSearchable
                   className={`${baseClass}__row-picker`}
                   isDisabled={gitOpsModeEnabled}
                   value={
@@ -564,6 +565,7 @@ const PolicyAutomationsFields = forwardRef<
           picker: runScript ? (
             <DropdownWrapper
               name="script"
+              isSearchable
               className={`${baseClass}__row-picker`}
               isDisabled={gitOpsModeEnabled}
               value={
@@ -594,6 +596,7 @@ const PolicyAutomationsFields = forwardRef<
           picker: resendConfigProfile ? (
             <DropdownWrapper
               name="profile"
+              isSearchable
               className={`${baseClass}__row-picker`}
               isDisabled={gitOpsModeEnabled}
               value={


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48606

Restores the search functionality in software/script pickers for policy automations.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/edd7bda5-0d72-474b-a01f-efcd2faeaa23



## AI

**AI:** Claude Code (claude-fable-5-1)

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored type-to-search functionality in policy automation dropdowns for software, scripts, and configuration profiles.
  * Users can now quickly filter available options by typing in the relevant picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->