### PR TITLE
Fix caret position in searchable dropdowns

### DIFF
--- a/changes/52935-dropdown-searchable-caret
+++ b/changes/52935-dropdown-searchable-caret
@@ -1,0 +1,1 @@
+* Fixed the text cursor appearing after the placeholder or selected value when focusing a searchable dropdown.

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -304,12 +304,19 @@ export const generateCustomDropdownStyles = (
       maxHeight: maxMenuHeight != null ? `${maxMenuHeight}px` : "none",
       ...(nowrapMenu && { width: "fit-content" }),
     }),
-    valueContainer: (provided) => ({
+    valueContainer: (provided, state) => ({
       ...provided,
       padding: 0,
-      display: "flex",
-      gap: PADDING["pad-small"],
-      flexWrap: "nowrap", // This ensures the value is on a single line and truncated
+      // Searchable dropdowns keep react-select's grid so the input overlays the
+      // placeholder/value and the caret sits at the left edge instead of after
+      // the text. Flex + nowrap keeps the non-searchable value on one line.
+      ...(state.selectProps.isSearchable
+        ? { display: "grid" }
+        : ({
+            display: "flex",
+            gap: PADDING["pad-small"],
+            flexWrap: "nowrap",
+          } as const)),
     }),
     option: (provided, state) => ({
       ...provided,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52935, Resolves #52796

Focusing a searchable dropdown puts the text cursor after the placeholder or selected value instead of at the left edge. react-select stacks the placeholder, value, and input in one grid cell, but DropdownWrapper overrides the value container to flex, laying the input out beside the text.
This restores the grid layout for searchable dropdowns only; non-searchable ones are unchanged.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

#### Before


https://github.com/user-attachments/assets/b3a7cf25-5327-4141-a9d0-80acfe67db99



#### After

https://github.com/user-attachments/assets/c33fba39-f6c2-4257-a15a-b119b39eca58



## AI

**AI:** Claude Code (claude-fable-5-1)

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the text cursor position in searchable dropdowns so it appears at the beginning of the input, before the placeholder or selected value.
  - Preserved single-line display and truncation behavior for non-searchable dropdown values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->