### PR TITLE
Add timeout to maintained_apps_auto_update and cleanup_unused_software_installers jobs

### DIFF
--- a/changes/49620-cron-job-timeouts
+++ b/changes/49620-cron-job-timeouts
@@ -1,0 +1,1 @@
+- Added timeouts to the `maintained_apps_auto_update` and `cleanup_unused_software_installers` cron jobs.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1338,6 +1338,7 @@ func newCleanupsAndAggregationSchedule(
 		defaultInterval               = 1 * time.Hour
 		expiredHostsCleanupMaxRunTime = 10 * time.Minute
 		expiredHostsCleanupBatchSize  = 5000
+		installerCleanupMaxRunTime    = 10 * time.Minute
 	)
 	s := schedule.New(
 		ctx, name, instanceID, defaultInterval, ds, ds,
@@ -1539,10 +1540,7 @@ func newCleanupsAndAggregationSchedule(
 			return ds.CleanupExpiredLiveQueries(ctx, appConfig.ActivityExpirySettings.ActivityExpiryWindow)
 		}),
 		schedule.WithJob("cleanup_unused_software_installers", func(ctx context.Context) error {
-			// remove only those unused created more than a minute ago to avoid a
-			// race where we delete those created after the mysql query to get those
-			// in use.
-			return ds.CleanupUnusedSoftwareInstallers(ctx, softwareInstallStore, time.Now().Add(-time.Minute))
+			return cleanupUnusedSoftwareInstallersCronJob(ctx, ds, softwareInstallStore, installerCleanupMaxRunTime)
 		}),
 		schedule.WithJob("cleanup_unused_software_title_icons", func(ctx context.Context) error {
 			return ds.CleanupUnusedSoftwareTitleIcons(ctx, softwareTitleIconStore, time.Now().Add(-time.Minute))
@@ -1652,6 +1650,20 @@ func cleanupExpiredHostsCronJob(ctx context.Context, svc fleet.Service, logger *
 			return nil
 		}
 	}
+}
+
+func cleanupUnusedSoftwareInstallersCronJob(ctx context.Context, ds fleet.Datastore, softwareInstallStore fleet.SoftwareInstallerStore, maxRunTime time.Duration) error {
+	// Jobs in this schedule run one after another under a leader lock that keeps being extended while
+	// a job runs, so an S3 call with no deadline here blocks every job after it until a restart. The
+	// budget goes on the context rather than the wall clock because interrupting an S3 list or delete
+	// mid-call is safe.
+	workCtx, cancel := context.WithTimeout(ctx, maxRunTime)
+	defer cancel()
+
+	// remove only those unused created more than a minute ago to avoid a
+	// race where we delete those created after the mysql query to get those
+	// in use.
+	return ds.CleanupUnusedSoftwareInstallers(workCtx, softwareInstallStore, time.Now().Add(-time.Minute))
 }
 
 // buildChartScopeResolver returns a per-dataset scope resolver for the chart

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2457,6 +2457,7 @@ func newMaintainedAppsAutoUpdateSchedule(
 		name            = string(fleet.CronMaintainedAppsAutoUpdate)
 		defaultInterval = 1 * time.Hour
 		priorJobDiff    = -(defaultInterval - 30*time.Second)
+		maxRunTime      = 55 * time.Minute
 	)
 
 	logger = logger.With("cron", name)
@@ -2466,7 +2467,10 @@ func newMaintainedAppsAutoUpdateSchedule(
 		// ensures it runs a few seconds after Fleet is started
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("maintained_apps_auto_update", func(ctx context.Context) error {
-			return eeservice.AutoUpdateFleetMaintainedApps(ctx, ds, softwareInstallStore, logger)
+			workCtx, cancel := context.WithTimeout(ctx, maxRunTime)
+			defer cancel()
+
+			return eeservice.AutoUpdateFleetMaintainedApps(workCtx, ds, softwareInstallStore, logger)
 		}),
 	)
 

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -138,6 +138,26 @@ func TestMigrateABMTokenDuringDEPCronJob(t *testing.T) {
 	require.Empty(t, hosts)
 }
 
+func TestCleanupUnusedSoftwareInstallersCronJob(t *testing.T) {
+	ds := new(mock.Store)
+
+	const budget = time.Minute
+	var deadline time.Time
+	var hasDeadline bool
+	ds.CleanupUnusedSoftwareInstallersFunc = func(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore, removeCreatedBefore time.Time) error {
+		deadline, hasDeadline = ctx.Deadline()
+		return nil
+	}
+
+	// The schedule hands each job a context with no deadline, so the budget has to come from the job.
+	err := cleanupUnusedSoftwareInstallersCronJob(context.Background(), ds, nil, budget)
+	require.NoError(t, err)
+	require.True(t, ds.CleanupUnusedSoftwareInstallersFuncInvoked)
+	require.True(t, hasDeadline, "the S3 calls must inherit the job time budget")
+	require.Positive(t, time.Until(deadline))
+	require.LessOrEqual(t, time.Until(deadline), budget)
+}
+
 func TestCleanupStaleOSVVulnerabilities(t *testing.T) {
 	ctx := t.Context()
 	logger := slog.New(slog.DiscardHandler)

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -61,7 +61,9 @@ func AutoUpdateFleetMaintainedApps(ctx context.Context, ds fleet.Datastore, soft
 				"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug, "err", err)
 		}
 	}
-	return nil
+
+	// The loop check above never sees a budget that ran out during the last app, so report that here.
+	return ctxerr.Wrap(ctx, ctx.Err(), "auto-updating fleet-maintained apps")
 }
 
 func autoUpdateOneFleetMaintainedApp(

--- a/ee/server/service/maintained_apps_auto_update.go
+++ b/ee/server/service/maintained_apps_auto_update.go
@@ -48,7 +48,15 @@ func AutoUpdateFleetMaintainedApps(ctx context.Context, ds fleet.Datastore, soft
 	manifests := map[string]*manifestEntry{}
 
 	for _, c := range candidates {
-		if err := autoUpdateOneFleetMaintainedApp(ctx, ds, softwareInstallStore, client, logger, c, manifests); err != nil {
+		// Each app can take up to InstallerTimeout to download, so a run over many apps can outlast the
+		// budget the caller gave it. Stop here rather than working through the rest; the next run resumes.
+		err = ctx.Err()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "auto-updating fleet-maintained apps")
+		}
+
+		err = autoUpdateOneFleetMaintainedApp(ctx, ds, softwareInstallStore, client, logger, c, manifests)
+		if err != nil {
 			logger.ErrorContext(ctx, "auto-updating fleet-maintained app",
 				"title_id", c.TitleID, "team_id", teamIDForLog(c.TeamID), "slug", c.Slug, "err", err)
 		}

--- a/ee/server/service/maintained_apps_auto_update_test.go
+++ b/ee/server/service/maintained_apps_auto_update_test.go
@@ -158,3 +158,29 @@ func TestAutoUpdateFleetMaintainedAppsContinuesPastError(t *testing.T) {
 	require.True(t, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
 	require.Equal(t, uint(2), flippedTitle)
 }
+
+func TestAutoUpdateFleetMaintainedAppsReportsCancelDuringLastApp(t *testing.T) {
+	ds := new(mock.Store)
+	teamID := uint(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ds.ListFleetMaintainedAppActiveInstallersFunc = func(ctx context.Context) ([]fleet.FMAAutoUpdateCandidate, error) {
+		return []fleet.FMAAutoUpdateCandidate{
+			{TeamID: &teamID, TitleID: 1, InstallerID: 9, Slug: "only/darwin"},
+		}, nil
+	}
+	// The budget runs out while the last app is in flight, so no later pass through the loop sees it.
+	ds.GetPinnedVersionFunc = func(ctx context.Context, tmID *uint, titleID uint) (*string, error) {
+		cancel()
+		return nil, sql.ErrNoRows
+	}
+	// Already on the newest cached version, so the app itself is a no-op and only the budget is left to report.
+	ds.GetFleetMaintainedVersionsByTitleIDFunc = func(ctx context.Context, tmID *uint, titleID uint) ([]fleet.FleetMaintainedVersion, error) {
+		return []fleet.FleetMaintainedVersion{{ID: 9, Version: "1.0"}}, nil
+	}
+
+	err := AutoUpdateFleetMaintainedApps(ctx, ds, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, ds.SetFleetMaintainedAppActiveInstallerFuncInvoked)
+}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29188,6 +29188,71 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCron() {
 	require.False(t, canceled)
 }
 
+func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCronTimeBudget() {
+	t := s.T()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Four Fleet-maintained apps behind a CDN that is slow but reachable, so each installer download eats into the run.
+	const downloadDelay = 400 * time.Millisecond
+	slugs := []string{"cloudflare-warp/windows", "zoom/windows", "1password/windows", "notion/windows"}
+	states := make(map[string]*fmaTestState, len(slugs))
+	for i, slug := range slugs {
+		states["/"+slug+".json"] = &fmaTestState{
+			version:        "1.0",
+			installerBytes: []byte(fmt.Sprintf("v1-%d", i)),
+			installerPath:  fmt.Sprintf("/fma-%d.msi", i),
+			installerDelay: downloadDelay,
+		}
+	}
+	startFMAServers(t, s.ds, states)
+
+	activeVersions := func(teamID uint) []string {
+		var versions []string
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &versions,
+				`SELECT version FROM software_installers WHERE global_or_team_id = ? AND is_active = 1 ORDER BY title_id`, teamID)
+		})
+		return versions
+	}
+
+	var teamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{
+		TeamPayload: fleet.TeamPayload{Name: new("team_" + t.Name())},
+	}, http.StatusOK, &teamResp)
+	team := *teamResp.Team
+
+	software := make([]*fleet.SoftwareInstallerPayload, 0, len(slugs))
+	for _, slug := range slugs {
+		software = append(software, &fleet.SoftwareInstallerPayload{Slug: new(slug)})
+	}
+	var batchResp batchSetSoftwareInstallersResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/batch",
+		batchSetSoftwareInstallersRequest{Software: software, TeamName: team.Name},
+		http.StatusAccepted, &batchResp, "team_name", team.Name, "team_id", fmt.Sprint(team.ID))
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, batchResp.RequestUUID)
+	require.Equal(t, []string{"1.0", "1.0", "1.0", "1.0"}, activeVersions(team.ID))
+
+	// Every app publishes a new version at once, so each app in the run needs its own slow download.
+	for i, slug := range slugs {
+		state := states["/"+slug+".json"]
+		state.version = "2.0"
+		state.installerBytes = []byte(fmt.Sprintf("v2-%d", i))
+		state.ComputeSHA(state.installerBytes)
+	}
+
+	// A run whose budget covers about one download must give up when the budget is gone instead of walking the whole list.
+	budgetedCtx, cancel := context.WithTimeout(ctx, downloadDelay+downloadDelay/2)
+	defer cancel()
+	err := eeservice.AutoUpdateFleetMaintainedApps(budgetedCtx, s.ds, s.softwareInstallStore, logger)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, activeVersions(team.ID), "1.0", "the run stopped early, so at least one app stays on the old version")
+
+	// The cancellation wedges nothing: the next run, with room to finish, advances every app.
+	require.NoError(t, eeservice.AutoUpdateFleetMaintainedApps(ctx, s.ds, s.softwareInstallStore, logger))
+	require.Equal(t, []string{"2.0", "2.0", "2.0", "2.0"}, activeVersions(team.ID))
+}
+
 func (s *integrationEnterpriseTestSuite) TestFMAVersionRollback() {
 	t := s.T()
 	ctx := context.Background()

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29218,7 +29218,7 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCronTimeBudget() {
 
 	var teamResp teamResponse
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{
-		TeamPayload: fleet.TeamPayload{Name: new("team_" + t.Name())},
+		Name: new("team_" + t.Name()),
 	}, http.StatusOK, &teamResp)
 	team := *teamResp.Team
 
@@ -29235,10 +29235,14 @@ func (s *integrationEnterpriseTestSuite) TestFMAAutoUpdateCronTimeBudget() {
 
 	// Every app publishes a new version at once, so each app in the run needs its own slow download.
 	for i, slug := range slugs {
-		state := states["/"+slug+".json"]
-		state.version = "2.0"
-		state.installerBytes = []byte(fmt.Sprintf("v2-%d", i))
+		state := &fmaTestState{
+			version:        "2.0",
+			installerBytes: []byte(fmt.Sprintf("v2-%d", i)),
+			installerPath:  fmt.Sprintf("/fma-%d.msi", i),
+			installerDelay: downloadDelay,
+		}
 		state.ComputeSHA(state.installerBytes)
+		states["/"+slug+".json"] = state
 	}
 
 	// A run whose budget covers about one download must give up when the budget is gone instead of walking the whole list.

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -1450,6 +1450,8 @@ type fmaTestState struct {
 	// placeholder when empty; set it to vary the script across builds (a real FMA
 	// script embeds the versioned installer filename, so a rebuild changes it).
 	installScript string
+	// installerDelay holds each installer download for this long, standing in for a slow but reachable CDN.
+	installerDelay time.Duration
 }
 
 func (s *fmaTestState) ComputeSHA(b []byte) {
@@ -1482,6 +1484,13 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 
 		for _, state := range states {
 			if state.installerPath == r.URL.Path {
+				if state.installerDelay > 0 {
+					select {
+					case <-time.After(state.installerDelay):
+					case <-r.Context().Done():
+						return
+					}
+				}
 				_, _ = w.Write(state.installerBytes)
 				return
 			}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** 
Resolves #49619
Resolves #49620 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
  - Checked that jobs cancel with `context deadline exceeded` and that there is no regression when not hitting the deadline.

## AI

**AI:** Claude code Opus 5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added execution time limits to maintained app auto-updates and unused installer cleanup jobs.
  - Auto-update runs now stop and report an error when canceled or when their time limit expires, preventing excessively long operations.
  - Interrupted updates can resume safely during a later run.
  - Cleanup operations now honor their configured time limit and stop when the deadline is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->