### PR TITLE
Add articles: Chrome's seventh 2026 zero-day and macOS 27 dropping Intel Mac support

### DIFF
--- a/articles/chrome-153-seventh-zero-day-patch-verification.md
+++ b/articles/chrome-153-seventh-zero-day-patch-verification.md
@@ -1,0 +1,45 @@
+# Google shipped a fix for Chrome's seventh 2026 zero-day. Most fleets can't say which hosts got it.
+
+*CVE-2026-87491 is an actively exploited V8 flaw, patched in Chrome 153.0.8010.36. Here is how to confirm the fix reached every host instead of assuming auto-update did.*
+
+## Key takeaways
+
+- **This is Chrome's seventh zero-day of the year, and it's already being exploited.** CVE-2026-87491 is a V8 engine flaw Google says attackers are using in the wild, not a theoretical bug researchers found first.
+- **A patched build number and a patched fleet are two different claims.** Chrome 153.0.8010.36 fixes the flaw, but the fix only helps hosts that are running it.
+- **Auto-update answers "did Chrome download it," not "is Chrome running it."** A browser that's been asleep, or sitting on an unclosed "relaunch to update" prompt, can still be executing the vulnerable version in memory.
+- **Fleet's software inventory reports the exact Chrome build on every host.** Search it once and you get a straight answer: how many hosts are still below 153.0.8010.36, right now, broken out by macOS, Windows, and Linux.
+- **Seven zero-days in a year is a pattern, not a one-off.** A version check you run once answers today's question. A Fleet policy that checks Chrome's version on a schedule answers it every time Google ships the next one.
+
+<a purpose="cta-button" href="https://fleetdm.com/software-catalog">See software inventory in Fleet</a>
+
+Google patched CVE-2026-87491 in Chrome 153.0.8010.36, the seventh actively exploited zero-day fixed in Chrome so far this year. Unlike a routine patch, active exploitation means the fix isn't optional homework for later. It's a race between the attackers who already have a working exploit and however long it takes your fleet to actually run the new build.
+
+That race isn't won when Google ships the patch. It's won when every host on your network is running it.
+
+## Auto-update tells you what shipped, not what's running
+
+Chrome's auto-update mechanism downloads and stages a new version quietly in the background. The catch is that the fix doesn't take effect until the browser restarts. A laptop that's been asleep, or a browser tab someone's been ignoring the "relaunch to update" nudge on for a week, is still executing the vulnerable version in memory even though the installer says it's current.
+
+From IT's vantage point, that host looks fine. Auto-update ran, the download completed, and there's nothing in a standard device inventory to distinguish it from a host that relaunched. The only way to tell the difference is to check the version Chrome is running, not the version it downloaded.
+
+## Turning "probably patched" into a number
+
+Fleet's software inventory reports the exact Chrome build installed on every enrolled host, macOS, Windows, and Linux alike, the same way it reports every other piece of installed software. Search the inventory for Google Chrome and the result isn't a guess. It's a list: every host running it, broken out by the version each one reports, so "did CVE-2026-87491's fix land" becomes a count of how many hosts are still below 153.0.8010.36 instead of a hope that auto-update caught everyone.
+
+That inventory feeds Fleet's vulnerability matching automatically. Once a host's Chrome version is in the software table, it's cross-referenced against CVE data the same way every other installed package is, so a host still running a build affected by CVE-2026-87491 shows up as a flagged vulnerability tied to that specific machine, not a line in a release note someone has to remember to cross-check.
+
+## Seven zero-days in, checking once isn't the finish line
+
+CVE-2026-87491 is the seventh Chrome zero-day patched this year. Whatever number it lands on by December, another one is coming, and the version check that answers today's question won't answer the next one on its own. Saving that check as a Fleet policy, a minimum Chrome version compared against every host on a schedule, means the next actively exploited flaw doesn't start with someone remembering to go look. Because policies live in Git as YAML and deploy through the same GitOps workflow as everything else Fleet manages, bumping the minimum version when Chrome 154 ships is a reviewable pull request, not a task on a list nobody checks until the next incident.
+
+## See it live
+
+- **Get a demo** to see Chrome's version reported across your own fleet: [fleetdm.com/contact](https://fleetdm.com/contact)
+- **Explore the software catalog** Fleet already builds from every host: [fleetdm.com/software-catalog](https://fleetdm.com/software-catalog)
+
+<meta name="articleTitle" value="Google shipped a fix for Chrome's seventh 2026 zero-day. Most fleets can't say which hosts got it.">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="category" value="industry news">
+<meta name="publishedOn" value="2026-09-10">
+<meta name="description" value="CVE-2026-87491 is Chrome's seventh 2026 zero-day. See how to confirm the fix reached every host instead of trusting auto-update.">

--- a/articles/macos-27-drops-intel-mac-support-hardware-refresh.md
+++ b/articles/macos-27-drops-intel-mac-support-hardware-refresh.md
@@ -1,0 +1,47 @@
+# Every Intel Mac still in service loses macOS security updates the day macOS 27 ships
+
+*Apple confirmed macOS 27 Golden Gate, arriving September 14 alongside iOS 27 and iPadOS 27, runs only on Apple silicon. Here is how to find every Intel Mac in your fleet before that cutoff, instead of after.*
+
+## Key takeaways
+
+- **September 14 is a hard cutoff, not a recommendation.** macOS 27 Golden Gate installs only on Apple silicon. Any Intel Mac still in service stops receiving new macOS security updates the moment this release ships.
+- **"We don't have many Intel Macs left" is a guess until someone checks.** Trade-ins, remote hires, and BYOD devices routinely outlive the spreadsheet that was supposed to track them.
+- **Fleet already knows the chip in every Mac you manage.** Hardware inventory reports architecture, model, and OS version for every enrolled host, so the Intel Macs in your fleet are a query away, not a manual audit.
+- **A hardware refresh plan needs a real list, not an estimate.** Knowing exactly which hosts, and whose hosts, are affected turns "we should probably budget for some replacements" into a specific purchase order.
+- **The same inventory becomes an ongoing check.** A Fleet policy that fails on Intel architecture keeps the list current as new hosts enroll, so the gap doesn't quietly reopen after the initial cleanup.
+
+<a purpose="cta-button" href="https://fleetdm.com/software-catalog">See hardware inventory in Fleet</a>
+
+Apple confirmed that macOS 27 Golden Gate ships September 14 alongside iOS 27 and iPadOS 27, and that it runs only on Apple silicon. There's no Intel build this time. Every Mac still running an Intel chip on that date stops being eligible for macOS's newest security updates, full stop, regardless of how well it's held up otherwise.
+
+That's a real deadline for any team still running a mixed fleet, but the deadline isn't the hard part. The hard part is knowing which machines it applies to.
+
+## The gap between the inventory spreadsheet and the actual fleet
+
+Most IT teams believe they know roughly how many Intel Macs are left. Few can name them. A Mac bought four years ago for a departed employee and reassigned to someone else, a remote hire's personal device enrolled through BYOD, a lab machine nobody's opened a ticket about in a year, all of these can quietly outlast the asset spreadsheet that was supposed to track them.
+
+That gap is invisible right up until it isn't. An Intel Mac running past September 14 doesn't announce itself. It just stops getting the next patch, and stays that way until whoever's using it reports something going wrong, or until an attacker gets there first.
+
+## Turning "probably a handful" into a list with names on it
+
+Fleet already collects hardware and chip architecture from every enrolled Mac, the same way it collects installed software and OS version. Search that inventory for Intel-based hosts and the result isn't a guess: it's every Mac still on Intel silicon, along with who's using it, what team it's on, and what OS it's currently running, so a hardware refresh plan can start from a real list instead of a rounding error.
+
+That specificity is what makes the difference between "we should look into replacing a few Intel Macs" and a purchase order with a device count and a set of names attached. Finance and procurement can plan around a number. They can't plan around a hunch.
+
+## Making the check permanent, not a one-time cleanup
+
+Running that search once clears the current backlog. It doesn't stop a new Intel Mac from showing up later, whether through a device transfer, a reissued laptop from storage, or an acquisition bringing in a fleet nobody's audited yet. A Fleet policy that flags any host still running Intel architecture keeps that list current automatically, on a schedule, instead of depending on someone remembering to re-run the search every quarter.
+
+Because policies live in Git as YAML and deploy through the same GitOps workflow as everything else Fleet manages, updating that policy as the fleet changes is a reviewable pull request. The Intel Mac count stays visible on its own, not buried in a spreadsheet someone updates when they remember to.
+
+## See it live
+
+- **Get a demo** to see your own fleet's hardware and chip architecture broken out by host: [fleetdm.com/contact](https://fleetdm.com/contact)
+- **Explore the software catalog** Fleet already builds from every host: [fleetdm.com/software-catalog](https://fleetdm.com/software-catalog)
+
+<meta name="articleTitle" value="Every Intel Mac still in service loses macOS security updates the day macOS 27 ships">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="category" value="industry news">
+<meta name="publishedOn" value="2026-09-10">
+<meta name="description" value="macOS 27 runs only on Apple silicon. See how to find every Intel Mac in your fleet before security updates stop on September 14.">


### PR DESCRIPTION
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (N/A — content-only change, no user-visible product change.)

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters. (N/A — markdown content only.)
- [x] Timeouts are implemented and retries are limited to avoid infinite loops (N/A — markdown content only.)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes (N/A)

## Testing

- [x] Added/updated automated tests (N/A — markdown content only.)
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another) (N/A)

- [x] QA'd all new/changed functionality manually (Read through the rendered markdown for formatting, verified both description meta tags are under 150 characters, and checked the category value against `website/scripts/build-static-content.js`.)

## AI

**AI:** Claude Code (claude-sonnet-5)

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after. (N/A — content-only change; not rendered on the website until merged.)

## Notes for reviewer

This PR was supposed to be two separate draft PRs (one per approved pitch), but this automated session is restricted to a single designated branch (`allenhouchins/happy-cerf-rh0q1g`) with a hard rule against pushing to any other branch without explicit permission. Since GitHub only allows one open PR per branch, both approved pitches from today's digest thread ended up as two commits on this one PR instead. Flagging this so a human can split them into separate PRs if that's preferred.

### Article 1: Chrome's seventh 2026 zero-day (`chrome-153-seventh-zero-day-patch-verification.md`)

Drafted from an approved pitch in #_content-news-digest (Slack). Title candidates considered and why this one won:

- **Chosen:** "Google shipped a fix for Chrome's seventh 2026 zero-day. Most fleets can't say which hosts got it." — states the reader's actual gap (verification, not patching) as a direct, personal claim about their fleet.
- Runner-up: "Seven Chrome zero-days in 2026: the version number is the only proof of who's patched" — a stat-forward fragment that reads more like a headline than a challenge to the reader.
- Also considered: a CVE-led sentence, a contrastive "auto-update doesn't prove X, but Y does" construction, and a CVE-as-appositive construction. All rejected as either weaker hooks or too close in cadence to this pipeline's last few titles.

Deliberately avoided the "What Chrome's seventh zero-day means for confirming browser patch coverage" framing from the original pitch since it nearly duplicates the title structure and topic of the already-published Chrome 152 article ([chrome-152-critical-flaws-confirming-patch-coverage.md](https://github.com/fleetdm/fleet/blob/main/articles/chrome-152-critical-flaws-confirming-patch-coverage.md)).

### Article 2: macOS 27 drops Intel Mac support (`macos-27-drops-intel-mac-support-hardware-refresh.md`)

Drafted from an approved pitch in the same digest thread. Title candidates considered and why this one won:

- **Chosen:** "Every Intel Mac still in service loses macOS security updates the day macOS 27 ships" — plain, active-voice statement of the reader's actual stakes, no unfamiliar codename required to land the point.
- Runner-up: "macOS 27 Golden Gate: an Apple-silicon-only release that cuts off every Intel Mac's security updates" — leads with Apple's codename as a hook, but trades some immediate clarity for it.
- Also considered: a date-led sentence ("September 14 is the day..."), a direct question to the reader ("How many Intel Macs..."), and a participial/appositive construction. All rejected as weaker hooks or too close in structure to titles used earlier in this run/pipeline.

https://claude.ai/code/session_017h5YsyixvWicFfPsiA7Wrx