### PR TITLE
Fix RealVNC Connect Viewer homebrew ingestion after upstream cask rename

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/vnc-viewer.json
+++ b/ee/maintained-apps/inputs/homebrew/vnc-viewer.json
@@ -1,7 +1,7 @@
 {
   "name": "RealVNC Connect Viewer",
   "unique_identifier": "com.realvnc.rvncconnect",
-  "token": "vnc-viewer",
+  "token": "realvnc-connect-viewer",
   "installer_format": "pkg",
   "slug": "vnc-viewer/darwin",
   "default_categories": ["Productivity"],


### PR DESCRIPTION
**Related issue:** N/A — fixes the failing scheduled workflow ([Ingest maintained apps](https://github.com/fleetdm/fleet/actions/workflows/ingest-maintained-apps.yml))

## What's happening

The `Ingest maintained apps` workflow panics on every run:

```
{"level":"INFO","msg":"ingesting homebrew app","name":"RealVNC Connect Viewer"}
panic: ingesting homebrew app: app not found in brew API
```

The homebrew ingester aborts on the first failing app, so no FMA update PR is generated at all.

## Root cause

On 2026-09-09 Homebrew renamed the cask from `vnc-viewer` to `realvnc-connect-viewer` ([Homebrew/homebrew-cask#286158](https://github.com/Homebrew/homebrew-cask/pull/286158), prompted by [Homebrew/homebrew-cask#285861](https://github.com/Homebrew/homebrew-cask/issues/285861): RealVNC moved its download URLs from `viewer.files/VNC-Viewer-*.dmg` to `realvnc-connect-viewer/RealVNC-Connect-Viewer-*.pkg`). The old token now 404s from `formulae.brew.sh`, which `fetchCask` correctly treats as non-transient and fatal.

The upstream cask records the rename itself:

```json
{
  "token": "realvnc-connect-viewer",
  "old_tokens": ["vnc-viewer"],
  "name": ["RealVNC Connect Viewer"],
  "version": "8.5.0"
}
```

`frozen: true` does not help here: the flag only gates the output write in `cmd/maintained-apps/main.go`; the ingester still fetches the cask for every input, so a frozen app with a dead token takes the whole run down.

## The fix

Point the input at the new token:

```diff
-  "token": "vnc-viewer",
+  "token": "realvnc-connect-viewer",
```

Deliberately unchanged, same as #51040 (Worksheet Crafter):

- **`slug` stays `vnc-viewer/darwin`.** It is the identifier Fleet customers already use (published in `apps.json`, referenced by the website route), and the validator derives the input file path from the slug, so the input file keeps its name too.
- **`name` stays `RealVNC Connect Viewer`.** It already matches the cask.
- **`frozen: true` stays.** The freeze predates this (#48255) and is a separate question; the output stays at 8.4.2 while upstream is at 8.5.0.

`vnc-server` (RealVNC Server) was checked as well: its cask is untouched upstream, still resolves, matches our output (7.17.0), and has no pending migration PR. The newer `realvnc-connect` cask is a separate combined client+server product, not a rename of `vnc-server`.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

No changes file: this is FMA manifest data, consistent with previous FMA data fixes (e.g. #51040).

## Testing

- [x] QA'd all new/changed functionality manually

The affected slug now ingests cleanly where it previously panicked, and writes nothing (it is frozen and its output already exists):

```
go run ./cmd/maintained-apps -slug vnc-viewer/darwin
```

Because the run aborts on the first failure, a fix for one app can just move the panic to the next one. Two checks against that:

1. Every homebrew input token was cross-checked against the full brew cask index (`https://formulae.brew.sh/api/cask.json`). `vnc-viewer` was the only token missing; the only other non-matches are custom-tap inputs (`cask_path`) that never hit the brew API.
2. The whole homebrew leg was run end to end (`-slug /darwin`, all 966 homebrew inputs). It completed with exit 0. `outputs/vnc-viewer/darwin.json` and `outputs/vnc-server/darwin.json` were untouched; the other output changes were ordinary upstream version bumps and were reverted rather than included here, since they belong to the automated update PR.

## AI

**AI:** Claude Code (claude-fable-5-1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Homebrew app token for the VNC Viewer app to `realvnc-connect-viewer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->