### PR TITLE
Fix vulnerability exposure chart tooltip claiming a critical default

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
@@ -85,6 +85,9 @@ describe("ChartCard", () => {
 
   beforeAll(() => {
     global.ResizeObserver = (MockResizeObserver as unknown) as typeof ResizeObserver;
+  });
+
+  beforeEach(() => {
     Element.prototype.getBoundingClientRect = function mockBCR() {
       return {
         width: MOCK_WIDTH,
@@ -268,6 +271,18 @@ describe("ChartCard", () => {
       await user.click(option);
     };
 
+    const hoverChartDescription = async (
+      user: ReturnType<typeof renderPremium>["user"]
+    ) => {
+      Element.prototype.getBoundingClientRect = origGetBCR;
+      await user.hover(screen.getByTestId("info-outline-icon"));
+      await waitFor(
+        () => expect(screen.getByRole("tooltip")).toBeInTheDocument(),
+        { timeout: 3000 }
+      );
+      return screen.getByRole("tooltip");
+    };
+
     // Which bounds a selection resolves to is severityFilters' contract. What
     // only a real request shows is the wiring either side: that they land on
     // severity_min / severity_max, and that buildQueryStringFromParams keeps an
@@ -384,6 +399,46 @@ describe("ChartCard", () => {
         screen.queryByText("Probability of exploit")
       ).not.toBeInTheDocument();
     });
+
+    const descriptionCases: {
+      label: string;
+      filterDefaults: React.ComponentProps<typeof ChartCard>["filterDefaults"];
+      sentence: string | null;
+    }[] = [
+      {
+        label: "the built-in critical default",
+        filterDefaults: undefined,
+        sentence: "Severity is filtered to critical by default.",
+      },
+      {
+        label: "a seeded high default",
+        filterDefaults: { cvss_min: 7, cvss_max: 8.9 },
+        sentence: "Severity is filtered to high by default.",
+      },
+      {
+        label: "a default that narrows nothing",
+        filterDefaults: { cvss_min: 0, cvss_max: 10 },
+        sentence: null,
+      },
+    ];
+
+    it.each(descriptionCases)(
+      "describes $label in the info tooltip",
+      async ({ filterDefaults, sentence }) => {
+        useCveHandler();
+        const { user } = renderPremium({ filterDefaults });
+
+        await selectDataset(user, "Vulnerability exposure");
+        const tip = await hoverChartDescription(user);
+
+        expect(tip).toHaveTextContent("at least one vulnerability matching");
+        if (sentence) {
+          expect(tip).toHaveTextContent(sentence);
+        } else {
+          expect(tip).not.toHaveTextContent(/Severity is filtered/);
+        }
+      }
+    );
 
     it("no longer advertises the severity filter as coming soon", async () => {
       useCveHandler();

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -41,6 +41,7 @@ import {
   hasActiveHostFilters,
   hasActiveSoftwareFilters,
   hostFilterLines,
+  severityDefaultSentence,
   severitySelection,
   softwareFilterLines,
 } from "./helpers";
@@ -147,6 +148,7 @@ const ChartCard = ({
     DATASETS.find((ds) => ds.name === name) || DATASETS[0];
 
   if (isPremiumTier) {
+    const severityDefault = severityDefaultSentence(initialChartFilters);
     DATASETS.push({
       name: "cve",
       label: "Vulnerability exposure",
@@ -155,9 +157,13 @@ const ChartCard = ({
         <>
           The number of hosts with at least one vulnerability matching the
           chart&apos;s filters.
-          <br />
-          <br />
-          Severity is filtered to critical by default.
+          {severityDefault && (
+            <>
+              <br />
+              <br />
+              {severityDefault}
+            </>
+          )}
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>

--- a/frontend/pages/DashboardPage/cards/ChartCard/helpers.tests.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/helpers.tests.ts
@@ -4,6 +4,7 @@ import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
 import {
   buildInitialChartFilters,
   hostFilterLines,
+  severityDefaultSentence,
   softwareFilterLines,
 } from "./helpers";
 
@@ -45,6 +46,11 @@ describe("buildInitialChartFilters", () => {
       cvssMin: "7",
       cvssMax: "10",
     });
+    expect(buildInitialChartFilters({ cvss_max: 6 })).toMatchObject({
+      severity: "custom",
+      cvssMin: "0",
+      cvssMax: "6",
+    });
   });
 
   it("seeds present fields and falls back per-field for absent ones", () => {
@@ -75,6 +81,39 @@ describe("buildInitialChartFilters", () => {
       exclude_vulnerabilities: ["CVE-2025-50897"],
     });
     expect(filters.excludeCVEs).toEqual(["CVE-2025-50897"]);
+  });
+});
+
+describe("severityDefaultSentence", () => {
+  const cases: {
+    label: string;
+    filters: ReturnType<typeof buildInitialChartFilters>;
+    expected: string | null;
+  }[] = [
+    {
+      label: "the built-in critical default",
+      filters: buildInitialChartFilters(),
+      expected: "Severity is filtered to critical by default.",
+    },
+    {
+      label: "a seeded band",
+      filters: buildInitialChartFilters({ cvss_min: 7, cvss_max: 8.9 }),
+      expected: "Severity is filtered to high by default.",
+    },
+    {
+      label: "a seeded custom range",
+      filters: buildInitialChartFilters({ cvss_min: 0, cvss_max: 6.5 }),
+      expected: "Severity is filtered to a CVSS score of 0 to 6.5 by default.",
+    },
+    {
+      label: "a default that narrows nothing",
+      filters: buildInitialChartFilters({ cvss_min: 0, cvss_max: 10 }),
+      expected: null,
+    },
+  ];
+
+  it.each(cases)("describes $label", ({ filters, expected }) => {
+    expect(severityDefaultSentence(filters)).toBe(expected);
   });
 });
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/helpers.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/helpers.ts
@@ -102,6 +102,16 @@ export const severitySelection = (
   maxScore: filters.cvssMax,
 });
 
+export const severityDefaultSentence = (
+  filters: IChartFilterState
+): string | null => {
+  if (isEmpty(severityFilters(severitySelection(filters)))) return null;
+  const filteredTo = getSeverityBand(filters.severity)
+    ? filters.severity
+    : `a CVSS score of ${filters.cvssMin || 0} to ${filters.cvssMax || 10}`;
+  return `Severity is filtered to ${filteredTo} by default.`;
+};
+
 export const hasActiveHostFilters = (filters: IChartFilterState): boolean => {
   const hasHostFilter =
     filters.hostFilterMode !== "none" && filters.selectedHosts.length > 0;


### PR DESCRIPTION
<img width="1848" height="645" alt="Screenshot 2026-09-10 at 11 21 58 AM" src="https://github.com/user-attachments/assets/5e7b3df8-d0d7-44d7-b0c7-a3994f5a3dba" />

Resolves #52867

The info tooltip's "Severity is filtered to critical by default" was a fixed string, contradicting any org that seeds a different severity through features.vulnerability_exposure_historical_reporting.

Derive it from the chart's seeded baseline instead: name the band for a preset, spell out the bounds for a custom range, and drop the sentence when the baseline narrows nothing. It reads the baseline rather than the live filter state because "by default" is how the chart loads, and the Filtered pill already reports later edits.

No changelog entry: the severity filter it contradicts is unreleased and its entry already covers the chart.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

## Frontend

- [X] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart cards now display accurate severity-filter descriptions based on the selected default.
  * Descriptions support severity bands and custom CVSS score ranges.
  * Severity text is omitted when no narrowing filter is applied.

* **Tests**
  * Added coverage for built-in defaults, custom ranges, persisted score limits, and unrestricted filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->