### PR TITLE
Fix fleetctl npm wrapper exiting 0 when the download or binary fails

### DIFF
--- a/changes/50853-fleetctl-npm-silent-failure
+++ b/changes/50853-fleetctl-npm-silent-failure
@@ -1,0 +1,1 @@
+- Fixed `fleetctl` installed with `npm install -g fleetctl` exiting successfully without running when the binary download was interrupted or the binary was killed by a signal. The wrapper now reports the error and exits non-zero, and no longer re-downloads the binary on every run on Windows.

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -2,15 +2,26 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const { spawnSync } = require("child_process");
-const { existsSync, mkdirSync } = require("fs");
-const { type } = require("os");
+const {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+} = require("fs");
+const { constants: osConstants, type } = require("os");
 const { join } = require("path");
 const { arch } = require("process");
+const { pipeline } = require("stream/promises");
 
 const axios = require("axios");
 const { rimrafSync } = require("rimraf");
 const { extract } = require("tar");
 const { version } = require("./package.json");
+
+// Fail closed: if anything below leaves a promise pending (e.g. a download stream that stops
+// without an error event), the event loop drains and Node would otherwise exit 0 silently.
+process.exitCode = 1;
 
 // Strip any v4.0.0-1 style suffix (but not -rc1) so that the correct package is
 // downloaded if there is a mistake in the NPM publish and we need to release a
@@ -34,36 +45,43 @@ const platform = (() => {
     case "Darwin":
       return "macos";
     default:
-      throw new Error(`platform ${type} unrecognized`);
+      throw new Error(`platform ${type()} unrecognized`);
   }
 })();
 
-const binName = platform === "windows" ? "fleetctl.exe" : "fleetctl";
+const binName = platform.startsWith("windows") ? "fleetctl.exe" : "fleetctl";
 const binPath = join(installDir, binName);
 
 const install = async () => {
   const url = `https://github.com/fleetdm/fleet/releases/download/fleet-${strippedVersion}/fleetctl_${strippedVersion}_${platform}.tar.gz`;
 
-  mkdirSync(installDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  // Extract into a temporary directory and rename it into place, so an interrupted
+  // download never leaves a partial binary where the next run would find it.
+  const tmpDir = mkdtempSync(join(binDir, "tmp-"));
 
   try {
-    const response = await axios({ url, responseType: "stream" });
-
-    // Strip the outer directory when extracting. Just get the binary.
-    const tarWriter = extract({ strip: 1, cwd: installDir });
-    response.data.pipe(tarWriter);
-
-    // Need to return a promise with the writer to ensure we can await for it to complete.
-    return new Promise((resolve, reject) => {
-      tarWriter.on("finish", resolve);
-      tarWriter.on("error", reject);
-    });
-  } catch (err) {
-    if (axios.isAxiosError(err)) {
-      throw new Error(`download archive ${url}: ${err.message}`);
-    } else {
+    let response;
+    try {
+      response = await axios({ url, responseType: "stream" });
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        throw new Error(`download archive ${url}: ${err.message}`);
+      }
       throw err;
     }
+
+    // Unlike stream.pipe(), pipeline() rejects on errors and premature close from either side.
+    // Strip the outer directory when extracting. Just get the binary.
+    await pipeline(response.data, extract({ strip: 1, cwd: tmpDir }));
+
+    if (!existsSync(join(tmpDir, binName))) {
+      throw new Error(`archive ${url} does not contain ${binName}`);
+    }
+    renameSync(tmpDir, installDir);
+  } catch (err) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    throw err;
   }
 };
 
@@ -110,14 +128,26 @@ const run = async () => {
 
   const [, , ...args] = process.argv;
   const options = { cwd: process.cwd(), stdio: "inherit" };
-  const { status, error } = spawnSync(binPath, args, options);
+  const { status, signal, error } = spawnSync(binPath, args, options);
 
   if (error) {
     console.error(error);
     process.exit(1);
   }
+  if (status === null) {
+    // Killed by a signal: status is null and process.exit(null) would report success.
+    // Mirror the shell convention (128 + signal number) and stay quiet on SIGPIPE, which is
+    // routine when the output is piped to a command that exits early (e.g. `| head`).
+    if (signal !== "SIGPIPE") {
+      console.error(`Error: fleetctl was terminated by signal ${signal}`);
+    }
+    process.exit(128 + (osConstants.signals[signal] || 0));
+  }
 
   process.exit(status);
 };
 
-run();
+run().catch((err) => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -4,6 +4,7 @@
 const { spawnSync } = require("child_process");
 const {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   renameSync,
@@ -75,8 +76,14 @@ const install = async () => {
     // Strip the outer directory when extracting. Just get the binary.
     await pipeline(response.data, extract({ strip: 1, cwd: tmpDir }));
 
-    if (!existsSync(join(tmpDir, binName))) {
-      throw new Error(`archive ${url} does not contain ${binName}`);
+    // Validate before caching: a bad entry here would otherwise be reused on every later run.
+    const extracted = join(tmpDir, binName);
+    const stat = existsSync(extracted) ? lstatSync(extracted) : null;
+    if (!stat || !stat.isFile()) {
+      throw new Error(`archive ${url} does not contain a ${binName} file`);
+    }
+    if (!platform.startsWith("windows") && !(stat.mode & 0o111)) {
+      throw new Error(`${binName} in archive ${url} is not executable`);
     }
     renameSync(tmpDir, installDir);
   } catch (err) {

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -3,6 +3,7 @@
 
 const { spawnSync } = require("child_process");
 const {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -85,6 +86,9 @@ const install = async () => {
     if (!platform.startsWith("windows") && !(stat.mode & 0o111)) {
       throw new Error(`${binName} in archive ${url} is not executable`);
     }
+    // mkdtempSync creates the directory as 0700; keep it traversable for other users when
+    // installed as root (sudo npm install -g fleetctl), like the plain mkdirSync it replaced.
+    chmodSync(tmpDir, 0o755);
     renameSync(tmpDir, installDir);
   } catch (err) {
     rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
**Related issue:** #50853 (fixes the silent-success part; see below)

Separate PRs to stop relying on npm for installing fleetctl on our scripts/automations: https://github.com/fleetdm/fleet/pull/52969, https://github.com/fleetdm/fleet/pull/52971

## Summary

The `fleetctl` npm package is a Node wrapper that downloads the Go binary from GitHub releases the first time `fleetctl` runs. Two paths let that first run exit 0 while doing nothing, which is what the customer saw in #50853: `fleetctl config set` printed nothing, exited 0, and the GitOps run silently applied nothing.

- The download stream was piped into `tar` with `stream.pipe()` and `run()` was never awaited. If the connection dropped without an `error` event, the tar writer never finished, the event loop drained, and Node exited 0 after printing only `Installing fleetctl vX...`. This matches the missing `Install completed.` line in the customer's logs.
- A child killed by a signal has `status === null`, and `process.exit(null)` exits 0.

Changes to `tools/fleetctl-npm/run.js`:

- Use `stream.pipeline` so errors and premature close from either side reject.
- Set `process.exitCode = 1` up front and only exit 0 through the explicit path, so a drained event loop can never report success.
- Extract into a temp dir and rename it into place, and verify the binary is present, so an interrupted download never leaves a partial binary where the next run would find it.
- Exit `128 + signal` when the child is killed by a signal (quiet on `SIGPIPE`, e.g. `fleetctl get hosts | head`).
- Look for `fleetctl.exe` on Windows. `platform === "windows"` was never true, so Windows re-downloaded the binary on every invocation.

This does not change the lazy-install design: `npm install -g fleetctl` still returns before the binary exists (postinstall was removed in #308 because npm skips lifecycle scripts as root). The issue's "install should not return until the binary is ready" expectation is addressed separately by moving GitOps CI to `install-fleetctl.sh`, which pins a version, verifies checksums, and runs the binary before exiting 0.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

Tested from a copy of the package with deps installed (`node run.js`), on macOS (arm64), in a Linux (arm64) VM, and in a Windows 11 VM. Failure paths use a copy of `run.js` with the release URL pointed at a local HTTP server that serves a tarball or misbehaves on demand.

macOS:

- Real install then `--version`: install lines printed once, exit 0. Second run uses the cached binary, no install lines. Child exit codes pass through (`fleetctl bogus` exits 1).
- Server sends a few bytes with a large `Content-Length`, then destroys the socket: `Error: Failed to install: aborted`, exit 1, `install/` left empty. On `main` this prints only `Installing fleetctl v4.91.0...`, exits 0, and leaves an empty `install/v4.91.0/` behind.
- Archive without a `fleetctl` member: `does not contain a fleetctl file`, exit 1, `install/` empty.
- Archive with a non-executable `fleetctl`: `is not executable`, exit 1, `install/` empty.
- 404 from the server: `Request failed with status code 404`, exit 1.
- Cached binary replaced with a script that `kill -9`s itself: `terminated by signal SIGKILL`, exit 137. On `main` this exits 0.
- Cached binary replaced with `exec yes`, run as `fleetctl | head -1`: no error message, wrapper exits 141.
- Cached binary replaced with a non-executable file: spawn error printed, exit 1.
- `npm pack` then `npm install -g --prefix <tmp> <tarball>`: bin symlink resolves to `run.js`, first run installs and prints the version.
- With `os.type()` stubbed to `Windows_NT`: requests `fleetctl_v4.91.0_windows_arm64.tar.gz`, installs `fleetctl.exe`, cached on the second run, rejects an archive whose member is `fleetctl` rather than `fleetctl.exe`. The same stub against `main` downloads the archive on every run.
- Confirmed both Windows release tarballs contain `<dir>/fleetctl.exe`, so `strip: 1` yields the expected name.

Linux VM (arm64):

- Real install then `--version`: install lines printed once, exit 0. Second run cached, no install lines. Child exit codes pass through.
- Truncated download, archive without `fleetctl`, non-executable `fleetctl`, and 404: clear error, exit 1, `install/` empty.
- Cached binary replaced with a `kill -9` script: exit 137 with the signal message. Replaced with `exec yes` and piped to `head -1`: exit 141, no error text.
- Root install: `npm pack` then `sudo npm install -g <tarball>`. Running `fleetctl --version` as a non-root user before any binary exists prints the "installed as root, re-run with sudo" message and exits 1. `sudo fleetctl --version` installs and exits 0. `fleetctl --version` as the non-root user then runs the cached binary and exits 0, and `install/v4.91.0` is `drwxr-xr-x`, so the temp-dir rename keeps the directory traversable.

Windows 11 VM:

- Real install then `--version`: install lines printed once, exit 0, `install4.91.0leetctl.exe` present. Second run does not re-download. On `main` every run prints `Installing fleetctl v4.91.0...` and downloads again, because it looked for `fleetctl` without the `.exe` extension.
- Truncated download, archive without `fleetctl.exe`, and 404: clear error, exit 1, `install\` empty.
- `npm pack` then `npm install -g` of the tarball: `fleetctl --version` works from a fresh terminal.

Not tested: the "installed as administrator" (`EACCES`) message on Windows, and signal handling on Windows (not applicable: a force-killed child reports status 1 there, not a null status).

## AI

**AI:** Claude Code (claude-fable-5-1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- `fleetctl` npm installations now report interrupted, failed, or signal-terminated downloads instead of completing silently.
- Installation failures now exit with an appropriate non-zero status.
- Failed installations are cleaned up to prevent incomplete binaries from being used.
- Downloads are validated before installation completes, reducing the risk of using incomplete or invalid binaries.
- Windows installations correctly select the platform-specific executable and avoid unnecessary repeated downloads.
- Routine broken-pipe signals no longer produce unnecessary error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

