### PR TITLE
Add CrowdStrike and SCCM client status reports to the standard query library

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -2064,6 +2064,44 @@ spec:
 apiVersion: v1
 kind: report
 spec:
+  name: Get CrowdStrike Falcon sensor status
+  platform: darwin, linux, windows
+  description: Reports whether the CrowdStrike Falcon sensor is running on each host by looking for its processes (com.crowdstrike.falcon.Agent or falcond on macOS, falcon-sensor on Linux, CSFalconService on Windows). Hosts that report "no" have no sensor running.
+  query: |
+    SELECT
+      CASE WHEN COUNT(*) > 0 THEN 'yes' ELSE 'no' END AS crowdstrike_running,
+      GROUP_CONCAT(DISTINCT name) AS sensor_processes
+    FROM processes
+    WHERE name IN ('com.crowdstrike.falcon.Agent', 'falcond', 'falcon-sensor', 'falcon-sensor-bpf', 'CSFalconService.exe', 'CSFalconContainer.exe');
+  purpose: Informational
+  tags: compliance, inventory, crowdstrike
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get SCCM client status
+  platform: windows
+  description: Reports whether the Microsoft Configuration Manager (SCCM) client is running on each host by checking the SMS Agent Host service (CcmExec). Returns "yes" when the service is running, "no" when it is installed but stopped, and "not installed" when the service is missing.
+  query: |
+    SELECT
+      CASE
+        WHEN s.status = 'RUNNING' THEN 'yes'
+        WHEN s.status IS NULL THEN 'not installed'
+        ELSE 'no'
+      END AS sccm_client_running,
+      s.display_name,
+      s.status AS service_status,
+      s.start_type,
+      s.path
+    FROM (SELECT 1) LEFT JOIN services s ON s.name = 'CcmExec';
+  purpose: Informational
+  tags: compliance, inventory, sccm
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: report
+spec:
   name: Get a list of Visual Studio Code extensions
   platform: darwin, linux, windows
   description: Get a list of installed VS Code extensions (requires osquery > 5.11.0).

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -2064,9 +2064,9 @@ spec:
 apiVersion: v1
 kind: report
 spec:
-  name: Get CrowdStrike Falcon sensor status
+  name: Get CrowdStrike sensor status
   platform: darwin, linux, windows
-  description: Reports whether the CrowdStrike Falcon sensor is running on each host by looking for its processes (com.crowdstrike.falcon.Agent or falcond on macOS, falcon-sensor on Linux, CSFalconService on Windows). Hosts that report "no" have no sensor running.
+  description: Reports whether the CrowdStrike sensor is running on each host by looking for its processes (com.crowdstrike.falcon.Agent or falcond on macOS, falcon-sensor on Linux, CSFalconService on Windows). Hosts that report "no" have no sensor running.
   query: |
     SELECT
       CASE WHEN COUNT(*) > 0 THEN 'yes' ELSE 'no' END AS crowdstrike_running,

--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -3038,9 +3038,9 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Get CrowdStrike Falcon sensor status
+  name: Get CrowdStrike sensor status
   platform: darwin, linux, windows
-  description: Reports whether the CrowdStrike Falcon sensor is running on each host by looking for its processes (com.crowdstrike.falcon.Agent or falcond on macOS, falcon-sensor on Linux, CSFalconService on Windows). Hosts that report "no" have no sensor running.
+  description: Reports whether the CrowdStrike sensor is running on each host by looking for its processes (com.crowdstrike.falcon.Agent or falcond on macOS, falcon-sensor on Linux, CSFalconService on Windows). Hosts that report "no" have no sensor running.
   query: |
     SELECT
       CASE WHEN COUNT(*) > 0 THEN 'yes' ELSE 'no' END AS crowdstrike_running,

--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -3038,6 +3038,44 @@ spec:
 apiVersion: v1
 kind: query
 spec:
+  name: Get CrowdStrike Falcon sensor status
+  platform: darwin, linux, windows
+  description: Reports whether the CrowdStrike Falcon sensor is running on each host by looking for its processes (com.crowdstrike.falcon.Agent or falcond on macOS, falcon-sensor on Linux, CSFalconService on Windows). Hosts that report "no" have no sensor running.
+  query: |
+    SELECT
+      CASE WHEN COUNT(*) > 0 THEN 'yes' ELSE 'no' END AS crowdstrike_running,
+      GROUP_CONCAT(DISTINCT name) AS sensor_processes
+    FROM processes
+    WHERE name IN ('com.crowdstrike.falcon.Agent', 'falcond', 'falcon-sensor', 'falcon-sensor-bpf', 'CSFalconService.exe', 'CSFalconContainer.exe');
+  purpose: Informational
+  tags: compliance, inventory, crowdstrike
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get SCCM client status
+  platform: windows
+  description: Reports whether the Microsoft Configuration Manager (SCCM) client is running on each host by checking the SMS Agent Host service (CcmExec). Returns "yes" when the service is running, "no" when it is installed but stopped, and "not installed" when the service is missing.
+  query: |
+    SELECT
+      CASE
+        WHEN s.status = 'RUNNING' THEN 'yes'
+        WHEN s.status IS NULL THEN 'not installed'
+        ELSE 'no'
+      END AS sccm_client_running,
+      s.display_name,
+      s.status AS service_status,
+      s.start_type,
+      s.path
+    FROM (SELECT 1) LEFT JOIN services s ON s.name = 'CcmExec';
+  purpose: Informational
+  tags: compliance, inventory, sccm
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: query
+spec:
   name: Get a list of Visual Studio Code extensions
   platform: darwin, linux, windows
   description: Get a list of installed VS Code extensions (requires osquery > 5.11.0).


### PR DESCRIPTION
**Related issue:** Resolves #33818

Adds two reports to the standard query library (and to `docs/queries.yml`, which fleetdm.com/queries is built from) answering the two "SCCM compliance" questions from the issue: is CrowdStrike running, and is SCCM running?

- **Get CrowdStrike sensor status** (macOS, Linux, Windows). One row per host with `crowdstrike_running` = `yes`/`no` plus the matched sensor process names. Matches the CrowdStrike sensor processes by name: `com.crowdstrike.falcon.Agent`/`falcond` (macOS), `falcon-sensor`/`falcon-sensor-bpf` (Linux), `CSFalconService.exe`/`CSFalconContainer.exe` (Windows).
- **Get SCCM client status** (Windows). Checks the SMS Agent Host service (`CcmExec`) and returns `sccm_client_running` = `yes`, `no` (installed but stopped), or `not installed`, plus service status, start type, and path. Uses `FROM (SELECT 1) LEFT JOIN services` so hosts without the service still return a row.

Reviewer notes:
- Both queries were executed under osqueryd on macOS and pass the frontend osquery SQL parser (`astify`). `go test ./pkg/spec/` (which loads the library) passes. Not runtime-tested on Windows/Linux hosts; process/service names follow CrowdStrike's and Microsoft's naming.
- `docs/queries.yml` has seven pre-existing YAML warnings on `main` (duplicate `bash` key, `\w` escapes, etc.) that the website's lenient `yaml` parser tolerates. None are on the new lines.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually (osqueryd on macOS, frontend SQL parser, `go test ./pkg/spec/`, YAML parse of both files)

## AI

**AI:** Claude Code (claude-fable-5-1)

## Frontend

- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standard queries to check CrowdStrike sensor status on macOS, Linux, and Windows. Results indicate whether the sensor is running and include matching process names.
  * Added a Windows query to report Microsoft Configuration Manager (SCCM) client status, distinguishing between running, installed but stopped, and not installed.
  * Added both queries to the standard query library for easier access in system reporting and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
