### PR TITLE
Fix missing underline indicator on Hosts table Agent column tooltip

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -386,6 +386,12 @@ $shadow-transition-width: 16px;
             }
           }
         }
+
+        // fixes the Agent column tooltip's dashed underline getting clipped
+        // by .text-cell's overflow: hidden
+        .agent-cell-tooltip-wrapper {
+          overflow: visible;
+        }
         .w400 {
           max-width: 352px; // 400px - 48px padding
           min-width: 100%;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -386,7 +386,6 @@ $shadow-transition-width: 16px;
             }
           }
         }
-
         .w400 {
           max-width: 352px; // 400px - 48px padding
           min-width: 100%;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -387,11 +387,6 @@ $shadow-transition-width: 16px;
           }
         }
 
-        // fixes the Agent column tooltip's dashed underline getting clipped
-        // by .text-cell's overflow: hidden
-        .agent-cell-tooltip-wrapper {
-          overflow: visible;
-        }
         .w400 {
           max-width: 352px; // 400px - 48px padding
           min-width: 100%;

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -691,6 +691,7 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
         <TextCell
           value={
             <TooltipWrapper
+              className="agent-cell-tooltip-wrapper"
               tipContent={
                 <>
                   osquery: {osquery_version}

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -688,29 +688,24 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
       }
 
       return (
-        <TextCell
-          value={
-            <TooltipWrapper
-              className="agent-cell-tooltip-wrapper"
-              tipContent={
-                <>
-                  osquery: {osquery_version}
-                  <br />
-                  Orbit: {orbit_version}
-                  {fleet_desktop_version &&
-                    fleet_desktop_version !== DEFAULT_EMPTY_CELL_VALUE && (
-                      <>
-                        <br />
-                        Fleet Desktop: {fleet_desktop_version}
-                      </>
-                    )}
-                </>
-              }
-            >
-              {orbit_version}
-            </TooltipWrapper>
+        <TooltipWrapper
+          tipContent={
+            <>
+              osquery: {osquery_version}
+              <br />
+              Orbit: {orbit_version}
+              {fleet_desktop_version &&
+                fleet_desktop_version !== DEFAULT_EMPTY_CELL_VALUE && (
+                  <>
+                    <br />
+                    Fleet Desktop: {fleet_desktop_version}
+                  </>
+                )}
+            </>
           }
-        />
+        >
+          {orbit_version}
+        </TooltipWrapper>
       );
     },
   },


### PR DESCRIPTION
- [ ] QA'd all new/changed functionality manually

For the following bug:
- #52959

Before:

<img width="143" height="95" alt="Image" src="https://github.com/user-attachments/assets/1726981a-667f-4eb1-9461-a22a28202b17" />

After:

<img width="151" height="105" alt="Screenshot 2026-09-11 at 11 41 58 AM" src="https://github.com/user-attachments/assets/9e6f1014-2132-40e7-af1a-3e89867833cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Agent column’s tooltip behavior in the Hosts table.
  * Agent version details for osquery, Orbit, and Fleet Desktop continue to display as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->