### PR TITLE
Harden install-fleetctl.sh: version pinning, checksum verification, and a working-binary check

### DIFF
--- a/website/assets/resources/install-fleetctl.sh
+++ b/website/assets/resources/install-fleetctl.sh
@@ -64,7 +64,13 @@ DOWNLOAD_URL="${GITHUB_RELEASES}/download/fleet-v${FLEETCTL_VERSION}/${ARCHIVE}.
 CHECKSUMS_URL="${GITHUB_RELEASES}/download/fleet-v${FLEETCTL_VERSION}/checksums.txt"
 
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+STAGED=""
+cleanup() {
+  rm -rf "$TMP_DIR"
+  [[ -n "$STAGED" ]] && rm -f "$STAGED"
+  return 0
+}
+trap cleanup EXIT
 
 echo "Downloading fleetctl ${FLEETCTL_VERSION} for ${OS_DISPLAY_NAME}..."
 curl -sSfL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE}.tar.gz" \
@@ -90,17 +96,18 @@ fi
 tar -xzf "${TMP_DIR}/${ARCHIVE}.tar.gz" -C "$TMP_DIR" --strip-components=1 "${ARCHIVE}/fleetctl"
 [[ -f "${TMP_DIR}/fleetctl" ]] || fail "fleetctl binary not found in ${ARCHIVE}.tar.gz."
 
-# Stage next to the destination so the final rename is atomic and never leaves a partial binary.
+# Stage next to the destination (created exclusively by mktemp, so the name can't be guessed)
+# and verify the new binary runs before the atomic rename replaces any existing fleetctl.
 mkdir -p "$FLEETCTL_INSTALL_DIR"
-STAGED="${FLEETCTL_INSTALL_DIR}/.fleetctl.tmp.$$"
+STAGED="$(mktemp "${FLEETCTL_INSTALL_DIR}/.fleetctl.XXXXXX")"
 cp "${TMP_DIR}/fleetctl" "$STAGED"
 chmod 0755 "$STAGED"
-mv -f "$STAGED" "${FLEETCTL_INSTALL_DIR}/fleetctl"
 
-INSTALLED_VERSION="$("${FLEETCTL_INSTALL_DIR}/fleetctl" --version 2>/dev/null | sed -n '1s/^fleetctl - version //p' || true)"
-if [[ "$INSTALLED_VERSION" != "$FLEETCTL_VERSION" ]]; then
-  fail "installed fleetctl at ${FLEETCTL_INSTALL_DIR}/fleetctl does not run or reports version \"${INSTALLED_VERSION}\" instead of ${FLEETCTL_VERSION}."
+STAGED_VERSION="$("$STAGED" --version 2>/dev/null | sed -n '1s/^fleetctl - version //p' || true)"
+if [[ "$STAGED_VERSION" != "$FLEETCTL_VERSION" ]]; then
+  fail "downloaded fleetctl does not run on this system or reports version \"${STAGED_VERSION}\" instead of ${FLEETCTL_VERSION}. Any existing fleetctl in ${FLEETCTL_INSTALL_DIR} was left unchanged."
 fi
+mv -f "$STAGED" "${FLEETCTL_INSTALL_DIR}/fleetctl"
 
 echo "fleetctl ${FLEETCTL_VERSION} installed successfully in ${FLEETCTL_INSTALL_DIR}"
 case ":${PATH}:" in

--- a/website/assets/resources/install-fleetctl.sh
+++ b/website/assets/resources/install-fleetctl.sh
@@ -1,61 +1,109 @@
 #!/bin/bash
+#
+# Installs fleetctl on macOS or Linux.
+#
+#   curl -sSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+#
+# Optional environment variables:
+#   FLEETCTL_VERSION      Version to install, e.g. 4.91.0 or v4.91.0. Defaults to the latest release.
+#                         Can also be passed as the first argument: ... | bash -s -- 4.91.0
+#   FLEETCTL_INSTALL_DIR  Directory to install the binary into. Defaults to $HOME/.fleetctl.
 
-set -e
+set -euo pipefail
 
-FLEETCTL_INSTALL_DIR="${HOME}/.fleetctl/"
+FLEETCTL_INSTALL_DIR="${FLEETCTL_INSTALL_DIR:-${HOME}/.fleetctl}"
+FLEETCTL_VERSION="${FLEETCTL_VERSION:-${1:-}}"
+GITHUB_RELEASES="https://github.com/fleetdm/fleet/releases"
 
-
-# Check for necessary commands
-for cmd in curl tar grep sed; do
-    if ! command -v $cmd &> /dev/null; then
-        echo "Error: $cmd is not installed." >&2
-        exit 1
-    fi
-done
-
-echo "Fetching the latest version of fleetctl..."
-
-
-# Fetch the latest version number from NPM
-latest_strippedVersion=$(curl -s "https://registry.npmjs.org/fleetctl/latest" | grep -o '"version": *"[^"]*"' | cut -d'"' -f4)
-echo "Latest version available on NPM: $latest_strippedVersion"
-
-version_gt() {
-  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+fail() {
+  echo "Error: $*" >&2
+  exit 1
 }
 
-# Determine operating system (Linux or MacOS)
-OS="$(uname -s)"
+for cmd in curl tar grep sed mktemp; do
+  if ! command -v "$cmd" &> /dev/null; then
+    fail "$cmd is not installed."
+  fi
+done
 
-# Determine architecture (amd64 or arm64)
-if uname -m | grep -qE '^(arm|aarch64)';
-then
-  ARCH="arm64";
-else
-  ARCH="amd64";
+latest_version() {
+  # github.com/.../releases/latest redirects to the newest non-prerelease tag and, unlike the
+  # REST API, is not subject to the unauthenticated rate limit. Use the API only as a fallback.
+  local tag
+  tag="$(curl -sSfI "${GITHUB_RELEASES}/latest" 2>/dev/null | grep -i '^location:' | grep -o 'fleet-v[0-9][^[:space:]]*' || true)"
+  if [[ -z "$tag" ]]; then
+    tag="$(curl -sSfL "https://api.github.com/repos/fleetdm/fleet/releases/latest" 2>/dev/null | grep -o '"tag_name": *"fleet-v[^"]*"' | cut -d'"' -f4 || true)"
+  fi
+  echo "${tag#fleet-v}"
+}
+
+if [[ -z "$FLEETCTL_VERSION" || "$FLEETCTL_VERSION" == "latest" ]]; then
+  echo "Fetching the latest version of fleetctl..."
+  FLEETCTL_VERSION="$(latest_version)"
+  [[ -n "$FLEETCTL_VERSION" ]] || fail "could not determine the latest fleetctl version."
+fi
+FLEETCTL_VERSION="${FLEETCTL_VERSION#v}"
+if [[ ! "$FLEETCTL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+  fail "invalid fleetctl version \"${FLEETCTL_VERSION}\" (expected e.g. 4.91.0)."
 fi
 
-# Standardize OS name for file download
-case "${OS}" in
-    Linux*)     OS="linux_${ARCH}" OS_DISPLAY_NAME='Linux';;
-    Darwin*)    OS='macos' OS_DISPLAY_NAME='macOS';;
-    *)          echo "Unsupported operating system: ${OS}"; exit 1;;
+if uname -m | grep -qE '^(arm|aarch64)'; then
+  ARCH="arm64"
+else
+  ARCH="amd64"
+fi
+
+case "$(uname -s)" in
+  Linux*)  OS="linux_${ARCH}" OS_DISPLAY_NAME="Linux" ;;
+  Darwin*) OS="macos" OS_DISPLAY_NAME="macOS" ;;
+  *)       fail "unsupported operating system: $(uname -s)" ;;
 esac
 
-# Create the install directory if it does not exist.
-mkdir -p "${FLEETCTL_INSTALL_DIR}"
+ARCHIVE="fleetctl_v${FLEETCTL_VERSION}_${OS}"
+DOWNLOAD_URL="${GITHUB_RELEASES}/download/fleet-v${FLEETCTL_VERSION}/${ARCHIVE}.tar.gz"
+CHECKSUMS_URL="${GITHUB_RELEASES}/download/fleet-v${FLEETCTL_VERSION}/checksums.txt"
 
-# Construct download URL
-# ex: https://github.com/fleetdm/fleet/releases/download/fleet-v4.43.3/fleetctl_v4.43.3_macos.zip
-DOWNLOAD_URL="https://github.com/fleetdm/fleet/releases/download/fleet-v${latest_strippedVersion}/fleetctl_v${latest_strippedVersion}_${OS}.tar.gz"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
-# Download the latest version of fleetctl and extract it.
-echo "Downloading fleetctl ${latest_strippedVersion} for ${OS_DISPLAY_NAME}..."
-curl -sSL "$DOWNLOAD_URL" | tar -xz -C "$FLEETCTL_INSTALL_DIR" --strip-components=1 fleetctl_v"${latest_strippedVersion}"_${OS}/
-echo "fleetctl installed successfully in ${FLEETCTL_INSTALL_DIR}"
+echo "Downloading fleetctl ${FLEETCTL_VERSION} for ${OS_DISPLAY_NAME}..."
+curl -sSfL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE}.tar.gz" \
+  || fail "could not download ${DOWNLOAD_URL}. Check that fleetctl ${FLEETCTL_VERSION} exists at ${GITHUB_RELEASES}."
 
-# Verify if the binary is executable
-if [[ ! -x "${FLEETCTL_INSTALL_DIR}/fleetctl" ]]; then
-    echo "Failed to install or upgrade fleetctl. Please check your permissions and try running this script again."
-    exit 1
+# Verify the archive against the release's checksums when a SHA-256 tool is available.
+if command -v sha256sum &> /dev/null; then
+  SHA256="sha256sum"
+elif command -v shasum &> /dev/null; then
+  SHA256="shasum -a 256"
+else
+  SHA256=""
 fi
+if [[ -n "$SHA256" ]]; then
+  EXPECTED="$(curl -sSfL "$CHECKSUMS_URL" | grep " ${ARCHIVE}.tar.gz\$" | cut -d' ' -f1 || true)"
+  [[ -n "$EXPECTED" ]] || fail "could not find ${ARCHIVE}.tar.gz in ${CHECKSUMS_URL}."
+  ACTUAL="$($SHA256 "${TMP_DIR}/${ARCHIVE}.tar.gz" | cut -d' ' -f1)"
+  [[ "$EXPECTED" == "$ACTUAL" ]] || fail "checksum mismatch for ${ARCHIVE}.tar.gz (expected ${EXPECTED}, got ${ACTUAL})."
+else
+  echo "Warning: sha256sum or shasum not found, skipping checksum verification." >&2
+fi
+
+tar -xzf "${TMP_DIR}/${ARCHIVE}.tar.gz" -C "$TMP_DIR" --strip-components=1 "${ARCHIVE}/fleetctl"
+[[ -f "${TMP_DIR}/fleetctl" ]] || fail "fleetctl binary not found in ${ARCHIVE}.tar.gz."
+
+# Stage next to the destination so the final rename is atomic and never leaves a partial binary.
+mkdir -p "$FLEETCTL_INSTALL_DIR"
+STAGED="${FLEETCTL_INSTALL_DIR}/.fleetctl.tmp.$$"
+cp "${TMP_DIR}/fleetctl" "$STAGED"
+chmod 0755 "$STAGED"
+mv -f "$STAGED" "${FLEETCTL_INSTALL_DIR}/fleetctl"
+
+INSTALLED_VERSION="$("${FLEETCTL_INSTALL_DIR}/fleetctl" --version 2>/dev/null | sed -n '1s/^fleetctl - version //p' || true)"
+if [[ "$INSTALLED_VERSION" != "$FLEETCTL_VERSION" ]]; then
+  fail "installed fleetctl at ${FLEETCTL_INSTALL_DIR}/fleetctl does not run or reports version \"${INSTALLED_VERSION}\" instead of ${FLEETCTL_VERSION}."
+fi
+
+echo "fleetctl ${FLEETCTL_VERSION} installed successfully in ${FLEETCTL_INSTALL_DIR}"
+case ":${PATH}:" in
+  *":${FLEETCTL_INSTALL_DIR}:"*|*":${FLEETCTL_INSTALL_DIR}/:"*) ;;
+  *) echo "Add it to your PATH to run \"fleetctl\" directly: export PATH=\"${FLEETCTL_INSTALL_DIR}:\$PATH\"" ;;
+esac

--- a/website/views/pages/download.ejs
+++ b/website/views/pages/download.ejs
@@ -39,8 +39,12 @@
               </p>
               <div purpose="accordion-answer" id="accordion__body-faq-2" class="collapse" aria-labelledby="accordion__header-faq-2">
                 <p>
-                Yes. Match the version of fleetctl to the version of your Fleet server.
+                Yes. Match the version of fleetctl to the version of your Fleet server. To install a specific version on macOS or Linux, set <code>FLEETCTL_VERSION</code> when you run the install script:
                 </p>
+                <div purpose="codeblock">
+                  <button type="button" purpose="copy-button" aria-label="Copy command"></button>
+                  <pre><code>curl -sSL https://fleetdm.com/resources/install-fleetctl.sh | FLEETCTL_VERSION=4.91.0 bash</code></pre>
+                </div>
               </div>
             </div>
             <div purpose="accordion-item">


### PR DESCRIPTION
**Related issue:** #50853 (first of two PRs; a follow-up moves GitOps CI templates and workflows from `npm install -g fleetctl` to this script)

## Summary

Hardens `website/assets/resources/install-fleetctl.sh`, served at `https://fleetdm.com/resources/install-fleetctl.sh`, so it can replace `npm install -g fleetctl` in CI pipelines. This needs to land and deploy before the CI changes, because the current script silently ignores `FLEETCTL_VERSION` and installs latest.

- `FLEETCTL_VERSION` (env var or first argument) pins a version, e.g. `curl -sSL .../install-fleetctl.sh | FLEETCTL_VERSION=4.91.0 bash`. `v` prefix and `latest` are accepted. Defaults to the latest release.
- `FLEETCTL_INSTALL_DIR` overrides the install directory (default unchanged: `$HOME/.fleetctl`).
- Verifies the archive against the release's `checksums.txt` with `sha256sum` or `shasum`, and warns if neither is available.
- Downloads and extracts into a temp dir, then renames into place, so an interrupted run never leaves a partial `fleetctl`.
- Runs the installed binary and fails unless `--version` reports the requested version. This is the "binary is ready when the command returns" guarantee the npm wrapper never gave.
- Resolves the latest version from the GitHub releases "latest" redirect (no API rate limit) with the REST API as fallback, instead of the npm registry.
- `set -euo pipefail`, `curl --fail`, clear errors for a missing release or invalid version, a PATH hint when the install dir isn't on `PATH`. Passes shellcheck.

Also documents `FLEETCTL_VERSION` in the fleetdm.com/download FAQ entry about matching the Fleet server version.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters. (`FLEETCTL_VERSION` is validated against a semver regex before it is used in URLs or paths.)

## Testing

- [x] QA'd all new/changed functionality manually

macOS (arm64): latest, pinned via env (`v4.90.2`) and via argument, custom install dir, invalid version, nonexistent release, and the pin-then-fallback-to-latest sequence the CI templates use. Linux (arm64, `debian:bookworm-slim` in Docker, mirroring the GitLab template): pinned install, `fleetctl --version`, forced checksum mismatch, forced redirect failure falling back to the API, and both lookups failing. Each failure path exits 1 with a clear message; each success path leaves a `0755` binary that reports the requested version.

## AI

**AI:** Claude Code (claude-fable-5-1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a more reliable `fleetctl` installer for macOS and Linux.
  - Install a specific version using `FLEETCTL_VERSION` or a command-line argument, or install the latest release by default.
  - Customize the installation location with `FLEETCTL_INSTALL_DIR`.
  - Added archive checksum and installed-binary verification when supported.
  - Added a post-installation PATH guidance message.

- **Documentation**
  - Updated the download FAQ with instructions and an example for installing a specific `fleetctl` version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->