### PR TITLE
Install fleetctl with install-fleetctl.sh instead of npm in GitOps CI and workflows

### DIFF
--- a/.github/actions/gitops/action.yml
+++ b/.github/actions/gitops/action.yml
@@ -65,7 +65,10 @@ runs:
         fi
 
         echo "Installing fleetctl v$INSTALL_VERSION..."
-        npm install -g "fleetctl@$INSTALL_VERSION" || npm install -g fleetctl@latest
+        # Fall back to the latest release when no fleetctl release matches the server version.
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | FLEETCTL_VERSION="$INSTALL_VERSION" bash \
+          || curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+        echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
     - name: Configure fleetctl
       shell: bash

--- a/.github/actions/gitops/action.yml
+++ b/.github/actions/gitops/action.yml
@@ -29,7 +29,9 @@ runs:
     - name: Install fleetctl
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: |
+      # github-env: the GITHUB_PATH write below appends the runner-controlled constant
+      # $HOME/.fleetctl, not any user-supplied value, so it cannot inject a path.
+      run: | # zizmor: ignore[github-env]
         FLEET_URL="${FLEET_URL%/}"
 
         # Build optional custom request headers from FLEET_CUSTOM_HEADERS, a comma-separated

--- a/.github/workflows/build-fleetd-base-msi.yml
+++ b/.github/workflows/build-fleetd-base-msi.yml
@@ -50,7 +50,9 @@ jobs:
           egress-policy: audit
 
       - name: Install fleetctl
-        run: npm install -g fleetctl
+        run: |
+          curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+          echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
       - name: Build MSI
         id: build-msi

--- a/.github/workflows/build-fleetd-base-pkg.yml
+++ b/.github/workflows/build-fleetd-base-pkg.yml
@@ -64,7 +64,9 @@ jobs:
           rm certificate.p12
 
       - name: Install fleetctl
-        run: npm install -g fleetctl
+        run: |
+          curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+          echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
       - name: Build PKG, sign, and notarize
         id: build-sign-notarize

--- a/.github/workflows/e2e-agent.yml
+++ b/.github/workflows/e2e-agent.yml
@@ -104,7 +104,9 @@ jobs:
 
     - name: Run Fleet server
       run: |
-        npm install -g fleetctl
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+        export PATH="$HOME/.fleetctl:$PATH"
+        echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
         fleetctl preview --no-hosts --disable-open-browser
         fleetctl config set --address ${{ needs.gen.outputs.address }}
         fleetctl get enroll-secret
@@ -195,7 +197,9 @@ jobs:
     - id: login
       name: Attempt login
       run: |
-        npm install -g fleetctl
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+        export PATH="$HOME/.fleetctl:$PATH"
+        echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
         fleetctl config set --address ${{ needs.gen.outputs.address }}
 
         # Wait for DNS to propagate by querying Cloudflare's DoH endpoint over HTTPS.
@@ -244,7 +248,9 @@ jobs:
     steps:
     - name: Install fleetctl
       run: |
-        npm install -g fleetctl
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+        export PATH="$HOME/.fleetctl:$PATH"
+        echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
         fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }}
 
     - name: Set Cloudflare DNS
@@ -350,7 +356,9 @@ jobs:
 
     - name: Install fleetctl
       run: |
-        npm install -g fleetctl
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+        export PATH="$HOME/.fleetctl:$PATH"
+        echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
         fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }}
 
     - name: Set Cloudflare DNS
@@ -465,11 +473,31 @@ jobs:
         Clear-DnsClientCache
 
     - name: Install fleetctl
+      shell: powershell
+      env:
+        GH_TOKEN: ${{ github.token }} # authenticated requests avoid the 60/hour anonymous GitHub API limit
+      # install-fleetctl.sh does not support Windows, so install the fleetctl MSI from the latest release.
+      # The MSI installs to C:\Program Files\FleetDM\fleetctl and adds it to the system PATH.
+      run: |
+        $ProgressPreference = "SilentlyContinue"
+        $headers = @{ Authorization = "Bearer $env:GH_TOKEN"; Accept = "application/vnd.github+json" }
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/fleetdm/fleet/releases/latest" -Headers $headers
+        $arch = if ("${{ runner.arch }}" -eq "ARM64") { "arm64" } else { "amd64" }
+        $asset = $release.assets | Where-Object { $_.name -like "fleetctl_*_windows_$arch.msi" }
+        if (-not $asset) { throw "No fleetctl MSI for windows_$arch in release $($release.tag_name)" }
+        Write-Host "Installing $($asset.name)..."
+        $msi = Join-Path $env:RUNNER_TEMP $asset.name
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $msi
+        $proc = Start-Process msiexec.exe -ArgumentList "/i `"$msi`" /qn" -Wait -PassThru
+        if ($proc.ExitCode -ne 0) { throw "msiexec exited with code $($proc.ExitCode)" }
+        $installDir = "C:\Program Files\FleetDM\fleetctl"
+        $installDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        & "$installDir\fleetctl.exe" --version
+
+    - name: Configure fleetctl
       shell: bash
       # On Windows we need to set rootca or tls-skip verify. Since this is a test environment we can skip TLS verification.
-      run: |
-        npm install -g fleetctl
-        fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }} --tls-skip-verify
+      run: fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }} --tls-skip-verify
 
     - name: Wait until fleet address is reachable and fleet responds
       shell: bash

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -1,4 +1,8 @@
 # Tests the `fleetctl preview` command with latest npm released version of fleetctl.
+#
+# This workflow intentionally installs fleetctl with `npm install -g fleetctl` even though
+# other workflows use install-fleetctl.sh: it is the only CI coverage of the npm package
+# (tools/fleetctl-npm), so keep it on npm.
 name: Test fleetctl preview
 
 on:

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -68,3 +68,24 @@ jobs:
           fleet-logs.txt
           orbit.log
           osquery_result_status_logs
+
+    - name: Slack Notification
+      if: github.event_name == 'schedule' && failure()
+      uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+      with:
+        payload: |
+          {
+            "text": "${{ job.status }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "⚠️  Nightly `fleetctl preview` test with the npm-published fleetctl failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{ github.run_id }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Check for fleetd component updates
         id: check-for-fleetd-component-updates
+        env:
+          GH_TOKEN: ${{ github.token }} # authenticated requests avoid the 60/hour anonymous GitHub API limit
         run: |
           : # Always record a fresh date_dir for archive/ uploads.
           echo "date_dir=$(date -u +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
@@ -96,7 +98,7 @@ jobs:
             exit 0
           fi
 
-          : # 3. fleetctl-on-npm diff: rebuild if fleetctl was published after the current
+          : # 3. fleetctl release diff: rebuild if a Fleet release was published after the current
           : # stable base build. This catches packaging-code changes in fleetctl that ship
           : # with a Fleet release but don't bump any TUF component, e.g. new MSI properties.
           : # Compare RFC3339 timestamps as strings (lexicographic order matches chronological).
@@ -106,13 +108,13 @@ jobs:
           : # stable_build_dir format: YYYY-MM-DD_HH-MM-SS -> convert to YYYY-MM-DDTHH:MM:SSZ.
           : # Use -n + p so an unexpected format yields an empty string instead of passing garbage through to the comparison.
           stable_built_at=$(echo "$stable_build_dir" | sed -nE 's/^([0-9]{4}-[0-9]{2}-[0-9]{2})_([0-9]{2})-([0-9]{2})-([0-9]{2})$/\1T\2:\3:\4Z/p')
-          : # Skip npm metadata keys ("created","modified") and fall through to empty string
-          : # if there are no version entries (instead of jq's default "null").
-          fleetctl_published_at=$(npm view fleetctl time --json 2>/dev/null | jq -r '[to_entries[] | select(.key | test("^[0-9]"))] | sort_by(.value) | last.value // ""' 2>/dev/null)
+          : # Newest published fleet-v* release (patch releases of older minors count too, since they
+          : # also ship a fleetctl). Falls through to empty string if there are none (instead of jq's default "null").
+          fleetctl_published_at=$(curl -fsS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/fleetdm/fleet/releases?per_page=30" 2>/dev/null | jq -r '[.[] | select(.draft | not) | select(.tag_name | startswith("fleet-v")) | .published_at] | max // ""' 2>/dev/null)
           echo "stable built at:        $stable_built_at"
           echo "fleetctl published at:  $fleetctl_published_at"
           if [ -n "$stable_built_at" ] && [ -n "$fleetctl_published_at" ] && [[ "$fleetctl_published_at" > "$stable_built_at" ]]; then
-            echo "fleetctl on npm was published after the current stable base build; rebuilding to pick up packaging changes."
+            echo "A Fleet release was published after the current stable base build; rebuilding to pick up fleetctl packaging changes."
             echo "update_needed=true" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -151,7 +153,9 @@ jobs:
           persist-credentials: false
 
       - name: Install fleetctl
-        run: npm install -g fleetctl
+        run: |
+          curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+          echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
       - name: Import package signing keys
         env:
@@ -241,7 +245,9 @@ jobs:
           egress-policy: audit
 
       - name: Install fleetctl
-        run: npm install -g fleetctl
+        run: |
+          curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+          echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
       - name: Build MSI
         id: build

--- a/.github/workflows/update-old-tuf-timestamp-signature.yaml
+++ b/.github/workflows/update-old-tuf-timestamp-signature.yaml
@@ -36,7 +36,9 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Install fleetctl
-        run: npm install -g fleetctl
+        run: |
+          curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+          echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
       - name: Pull metadata files
         run: |

--- a/articles/fleetctl.md
+++ b/articles/fleetctl.md
@@ -51,9 +51,9 @@ sudo npm install -g fleetctl
 
 ### Upgrading fleetctl
 
-If you used npm to install fleetctl, fleetctl will update itself the next time you run it.
+To upgrade fleetctl, install it again from the [fleetdm.com/download page](https://fleetdm.com/download) or [GitHub](https://github.com/fleetdm/fleet/releases). Match the version of fleetctl to the version of your Fleet server.
 
-You can also install the latest version of the binary from [GitHub](https://github.com/fleetdm/fleet/releases).
+If you used npm to install fleetctl, it updates itself the next time you run it.
 
 ## Usage
 

--- a/articles/fleetctl.md
+++ b/articles/fleetctl.md
@@ -53,7 +53,7 @@ sudo npm install -g fleetctl
 
 To upgrade fleetctl, install it again from the [fleetdm.com/download page](https://fleetdm.com/download) or [GitHub](https://github.com/fleetdm/fleet/releases). Match the version of fleetctl to the version of your Fleet server.
 
-If you used npm to install fleetctl, it updates itself the next time you run it.
+If you installed fleetctl with npm, upgrade it with `npm update -g fleetctl`. The new binary is downloaded the next time you run a `fleetctl` command.
 
 ## Usage
 

--- a/cmd/fleetctl/fleetctl/templates/new/.github/fleet-gitops/action.template.yml
+++ b/cmd/fleetctl/fleetctl/templates/new/.github/fleet-gitops/action.template.yml
@@ -43,7 +43,10 @@ runs:
         fi
 
         echo "Installing fleetctl v$INSTALL_VERSION..."
-        npm install -g "fleetctl@$INSTALL_VERSION" || npm install -g fleetctl@latest
+        # Fall back to the latest release when no fleetctl release matches the server version.
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | FLEETCTL_VERSION="$INSTALL_VERSION" bash \
+          || curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
+        echo "$HOME/.fleetctl" >> "$GITHUB_PATH"
 
     - name: Configure fleetctl
       shell: bash

--- a/cmd/fleetctl/fleetctl/templates/new/.github/fleet-gitops/action.template.yml
+++ b/cmd/fleetctl/fleetctl/templates/new/.github/fleet-gitops/action.template.yml
@@ -18,7 +18,9 @@ runs:
     - name: Install fleetctl
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: |
+      # github-env: the GITHUB_PATH write below appends the runner-controlled constant
+      # $HOME/.fleetctl, not any user-supplied value, so it cannot inject a path.
+      run: | # zizmor: ignore[github-env]
         FLEET_URL="${FLEET_URL%/}"
         FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
         DEFAULT_FLEETCTL_VERSION="latest"

--- a/cmd/fleetctl/fleetctl/templates/new/.gitlab-ci.template.yml
+++ b/cmd/fleetctl/fleetctl/templates/new/.gitlab-ci.template.yml
@@ -1,5 +1,5 @@
 fleet-gitops:
-  image: node:22
+  image: debian:bookworm-slim
   variables:
     FLEET_DRY_RUN_ONLY: true
   rules:
@@ -12,16 +12,17 @@ fleet-gitops:
         FLEET_DRY_RUN_ONLY: false
   before_script:
     - apt-get -qq update
-    - apt-get install -y 'jq=1.6-2.1*'
+    - apt-get install -y curl 'jq=1.6-2.1*'
   script:
     - >
       FLEET_VERSION="$(curl "$FLEET_URL/api/v1/fleet/version" --header "Authorization: Bearer $FLEET_API_TOKEN" --fail --silent | jq --raw-output '.version')"
     - >
       if [[ -n "$FLEET_VERSION" ]] ; then
-        npm install -g "fleetctl@$FLEET_VERSION" || npm install -g fleetctl
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | FLEETCTL_VERSION="$FLEET_VERSION" bash || curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
       else
         echo "Failed to get Fleet version from $FLEET_URL, installing latest version of fleetctl"
-        npm install -g fleetctl
+        curl -fsSL https://fleetdm.com/resources/install-fleetctl.sh | bash
       fi
+    - export PATH="$HOME/.fleetctl:$PATH"
     - fleetctl config set --address $FLEET_URL --token $FLEET_API_TOKEN
     - ./.github/fleet-gitops/gitops.sh


### PR DESCRIPTION
Resolves #50853.

To be QAd and merged after https://github.com/fleetdm/fleet/pull/52969. Needs the new version of the script to be deployed on fleetdm.com first (hardened `install-fleetctl.sh`).

Switch the fleetctl new CI templates, the dogfood GitOps action, and internal workflows from `npm install -g fleetctl` to `install-fleetctl.sh` pinned to the server version. The Windows e2e job installs the fleetctl MSI from the latest release. fleetctl-preview.yml stays on npm since it is the only CI coverage of that package. release-fleetd-base.yml detects new fleetctl releases via the GitHub releases API instead of `npm`.

## Testing

- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated automated build and test environments to install `fleetctl` using Fleet’s official installer.
  * Added version pinning and fallback installation behavior for improved consistency.
  * Updated Windows automation to install `fleetctl` through the released MSI.
  * Improved release checks by using authenticated GitHub release information.
  * Added failure notifications for scheduled preview runs.
  * Updated GitLab templates with a slimmer base image and local `fleetctl` installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->