### PR TITLE
Edit enroll secret activity is used for add/delete...pluralize to make it less confusing

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2293,7 +2293,7 @@ const TAGGED_TEMPLATES = {
     ) : (
       <></>
     );
-    return <>edited enroll secret{postFix}.</>;
+    return <>edited enroll secrets{postFix}.</>;
   },
   addedMicrosoftEntraTenant: (activity: IActivity) => {
     const tenantId = activity.details?.tenant_id;


### PR DESCRIPTION
- @noahtalerman: Today, this activity is used for adding and deleting secrets:
<img width="476" height="153" alt="Screenshot 2026-09-10 at 4 12 17 PM" src="https://github.com/user-attachments/assets/f48bed90-5c8e-4b6c-aa89-783afd2fffd6" />


That's confusing...but at least making it plural means that this encompasses adding a secret, editing one, or deleting one.
- Follow up story for add/edit activities: https://github.com/fleetdm/fleet/issues/52984