### PR TITLE
Cherry-pick #52308: Exponential backoff for android certificate retries

### DIFF
--- a/changes/51313-android-cert-retry-backoff
+++ b/changes/51313-android-cert-retry-backoff
@@ -1,0 +1,1 @@
+- Made Android certificate delivery retry logic more robust by increasing automatic retries from 3 to 7 and adding exponential backoff between attempts.

--- a/server/datastore/mysql/certificate_templates.go
+++ b/server/datastore/mysql/certificate_templates.go
@@ -516,7 +516,7 @@ func (ds *Datastore) ResendHostCertificateTemplate(ctx context.Context, hostID u
 		WHERE
 			h.id = ? AND
 			hct.certificate_template_id = ?
-		`, fleet.MaxCertificateInstallRetries)
+		`, fleet.MaxCertificateInstallRetries+1)
 
 	const deleteChallenge = `
 		DELETE c FROM

--- a/server/datastore/mysql/host_certificate_templates.go
+++ b/server/datastore/mysql/host_certificate_templates.go
@@ -450,9 +450,10 @@ func (ds *Datastore) ListAndroidHostUUIDsWithPendingCertificateTemplates(
 		SELECT DISTINCT host_uuid
 		FROM host_certificate_templates
 		WHERE status = '%s'
+		  AND (retry_count = 0 OR retry_count > %d OR updated_at <= NOW() - INTERVAL CAST(POW(2, retry_count - 1) * 30 AS UNSIGNED) SECOND)
 		ORDER BY host_uuid
 		LIMIT ? OFFSET ?
-	`, fleet.CertificateTemplatePending)
+	`, fleet.CertificateTemplatePending, fleet.MaxCertificateInstallRetries)
 	var hostUUIDs []string
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, stmt, limit, offset); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list host uuids with pending certificate templates")
@@ -831,7 +832,6 @@ func (ds *Datastore) GetOrCreateFleetChallengeForCertificateTemplate(
 		challenge = newChal
 		return nil
 	})
-
 	if err != nil {
 		return "", err
 	}

--- a/server/fleet/host_certificate_template.go
+++ b/server/fleet/host_certificate_template.go
@@ -12,7 +12,19 @@ const ONCProfileWithheldDetailPrefix = "Waiting for certificate"
 // MaxCertificateInstallRetries is the maximum number of automatic retries after the initial attempt
 // when the Android agent reports a certificate install failure. Manual resend via the UI sets
 // retry_count to this value so the resend gets exactly one attempt with no automatic retry.
-const MaxCertificateInstallRetries uint = 3
+//
+// Retries use exponential backoff, the approximate schedule (AMAPI delivery latency may extend these intervals):
+// updated_at + 2^(retry_count-1) * 30 seconds
+//
+//	Initial delivery: picked up on next cron cycle 0 - 30s
+//	Retry 1: backoff  30s,  cumulative ~1 min
+//	Retry 2: backoff  1min, cumulative ~2 min
+//	Retry 3: backoff  2min, cumulative ~4 min
+//	Retry 4: backoff  4min, cumulative ~8 min
+//	Retry 5: backoff  8min, cumulative ~16 min
+//	Retry 6: backoff 16min, cumulative ~32 min
+//	Retry 7: backoff 32min, cumulative ~64 min (terminal failure)
+const MaxCertificateInstallRetries uint = 7
 
 type HostCertificateTemplate struct {
 	ID                    uint                      `db:"id"`

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -1740,6 +1740,17 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateResend() {
 				fleet.CertificateTemplateDelivered, "")
 		}
 
+		// backdateRetry sets updated_at far enough in the past for the exponential backoff
+		// in ListAndroidHostUUIDsWithPendingCertificateTemplates to consider the row eligible.
+		backdateRetry := func() {
+			mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+				_, err := q.ExecContext(ctx,
+					`UPDATE host_certificate_templates SET updated_at = DATE_SUB(NOW(), INTERVAL 1 HOUR) WHERE host_uuid = ? AND certificate_template_id = ?`,
+					host.UUID, certTemplateID)
+				return err
+			})
+		}
+
 		// Fail MaxCertificateInstallRetries times -- each should auto-retry (status resets to pending)
 		for i := range fleet.MaxCertificateInstallRetries {
 			deliverCert()
@@ -1750,6 +1761,9 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateResend() {
 			require.NoError(t, err)
 			require.Equal(t, fleet.CertificateTemplatePending, record.Status, "retry %d should auto-retry", i+1)
 			require.Equal(t, i+1, record.RetryCount)
+
+			// Backdate updated_at so the cron picks up the retried row despite exponential backoff.
+			backdateRetry()
 		}
 
 		// One more failure with retry_count at max -- should be terminal
@@ -1784,7 +1798,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateResend() {
 			nil, http.StatusOK, &struct{}{})
 		record, err = s.ds.GetHostCertificateTemplateRecord(ctx, host.UUID, certTemplateID)
 		require.NoError(t, err)
-		require.Equal(t, fleet.MaxCertificateInstallRetries, record.RetryCount, "resend should set retry_count to max")
+		require.Equal(t, fleet.MaxCertificateInstallRetries+1, record.RetryCount, "resend should set retry_count above max to bypass backoff")
 
 		// Deliver and fail once more -- terminal immediately (no auto-retry after resend)
 		deliverCert()
@@ -1806,6 +1820,8 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateResend() {
 		require.NoError(t, err)
 		require.Equal(t, fleet.CertificateTemplatePending, record.Status)
 
+		// Backdate so the cron picks up the retried row despite exponential backoff.
+		backdateRetry()
 		deliverCert()
 		reportCertStatus(string(fleet.MDMDeliveryVerified), nil)
 		record, err = s.ds.GetHostCertificateTemplateRecord(ctx, host.UUID, certTemplateID)


### PR DESCRIPTION
Cherry-pick of #52308 into the RC branch.