### PR TITLE
Add hover tooltips to configuration profile action buttons

### DIFF
--- a/changes/profile-action-button-tooltips
+++ b/changes/profile-action-button-tooltips
@@ -1,0 +1,1 @@
+- Added tooltips to the configuration profile action buttons (details, edit, download, delete) so hovering shows the button's action.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
@@ -189,42 +189,75 @@ const ProfileListItem = ({
       <div className={`${subClass}__actions-wrap`}>
         {renderLabelInfo()}
         <div className={`${subClass}__actions`}>
-          <Button
-            className={`${subClass}__action-button`}
-            variant="secondary"
-            onClick={() => onClickInfo(profile)}
-            icon="info"
-            ariaLabel={`View ${profile.name} details`}
-          />
-          {!isTechnician && (
-            // stays enabled in GitOps mode -- the modal is the only place to
-            // see a profile's label targeting; it blocks saving instead
+          <TooltipWrapper
+            tipContent="Details"
+            underline={false}
+            position="top"
+            showArrow
+            tipOffset={8}
+          >
             <Button
               className={`${subClass}__action-button`}
               variant="secondary"
-              onClick={() => onClickEdit(profile)}
-              ariaLabel={`Edit ${profile.name}`}
-              icon="pencil"
+              onClick={() => onClickInfo(profile)}
+              icon="info"
+              ariaLabel={`View ${profile.name} details`}
             />
+          </TooltipWrapper>
+          {!isTechnician && (
+            // stays enabled in GitOps mode -- the modal is the only place to
+            // see a profile's label targeting; it blocks saving instead
+            <TooltipWrapper
+              tipContent="Edit"
+              underline={false}
+              position="top"
+              showArrow
+              tipOffset={8}
+            >
+              <Button
+                className={`${subClass}__action-button`}
+                variant="secondary"
+                onClick={() => onClickEdit(profile)}
+                ariaLabel={`Edit ${profile.name}`}
+                icon="pencil"
+              />
+            </TooltipWrapper>
           )}
-          <Button
-            className={`${subClass}__action-button`}
-            variant="secondary"
-            onClick={onClickDownload}
-            icon="download"
-            ariaLabel={`Download ${profile.name}`}
-          />
+          <TooltipWrapper
+            tipContent="Download"
+            underline={false}
+            position="top"
+            showArrow
+            tipOffset={8}
+          >
+            <Button
+              className={`${subClass}__action-button`}
+              variant="secondary"
+              onClick={onClickDownload}
+              icon="download"
+              ariaLabel={`Download ${profile.name}`}
+            />
+          </TooltipWrapper>
           {!isTechnician && (
             <GitOpsModeTooltipWrapper
               renderChildren={(disableChildren) => (
-                <Button
-                  disabled={disableChildren}
-                  className={`${subClass}__action-button`}
-                  variant="secondary"
-                  onClick={() => onClickDelete(profile)}
-                  icon="trash"
-                  ariaLabel={`Delete ${profile.name}`}
-                />
+                <TooltipWrapper
+                  tipContent="Delete"
+                  underline={false}
+                  position="top"
+                  showArrow
+                  tipOffset={8}
+                  disableTooltip={disableChildren}
+                >
+                  <Button
+                    disabled={disableChildren}
+                    className={`${subClass}__action-button`}
+                    variant="secondary"
+                    onClick={() => onClickDelete(profile)}
+                    icon="trash"
+                    ariaLabel={`Delete ${profile.name}`}
+                  />
+                </TooltipWrapper>
               )}
             />
           )}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** https://github.com/fleetdm/confidential/issues/17545

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## AI

**AI:** Claude Code (claude-sonnet-5)

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

Before:
<img width="684" height="286" alt="Screenshot 2026-09-10 at 1 48 49 PM" src="https://github.com/user-attachments/assets/417e0b91-0f0a-49c5-87b2-d3af1f6dfe95" />

After:
<img width="1150" height="299" alt="Screenshot 2026-09-10 at 1 21 02 PM" src="https://github.com/user-attachments/assets/8bbd9157-de96-4f99-9264-a7981ee2b186" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Usability Improvements**
  * Added hover tooltips to configuration profile action buttons, clarifying the actions for viewing details, editing, downloading, and deleting profiles.
  * Delete button tooltips remain unavailable when deletion is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->