### PR TITLE
Read in-house ipa metadata from the app bundle's own Info.plist

### DIFF
--- a/changes/ipa-metadata-from-main-app-plist.md
+++ b/changes/ipa-metadata-from-main-app-plist.md
@@ -1,0 +1,1 @@
+- Fixed in-house iOS/iPadOS `.ipa` uploads showing an embedded framework or CocoaPods resource bundle's name and version instead of the app's own, which also sent a mismatched bundle identifier to the host and prevented the app from installing. React Native and Expo apps were affected.

--- a/pkg/file/ipa.go
+++ b/pkg/file/ipa.go
@@ -12,6 +12,22 @@ import (
 	"howett.net/plist"
 )
 
+// bundleInfo is the subset of an Info.plist that Fleet reads.
+type bundleInfo struct {
+	BundleID         string `plist:"CFBundleIdentifier"`
+	Name             string `plist:"CFBundleName"`
+	Version          string `plist:"CFBundleShortVersionString"`
+	RequiresIPhoneOS bool   `plist:"LSRequiresIPhoneOS"`
+}
+
+// isMainAppInfoPlist reports whether name is the Info.plist of the .app bundle
+// at the root of an ipa payload, e.g. "Payload/Example.app/Info.plist".
+func isMainAppInfoPlist(name string) bool {
+	parts := strings.Split(name, "/")
+	return len(parts) == 3 && parts[0] == "Payload" &&
+		strings.HasSuffix(parts[1], ".app") && parts[2] == "Info.plist"
+}
+
 // ExtractZIPMetadata extracts the metadata from a zip file for an Apple app
 func ExtractZIPMetadata(tfr *fleet.TempFileReader) (*InstallerMetadata, error) {
 	h := sha256.New()
@@ -25,17 +41,14 @@ func ExtractZIPMetadata(tfr *fleet.TempFileReader) (*InstallerMetadata, error) {
 		return nil, err
 	}
 
-	var plistData struct {
-		BundleID         string `plist:"CFBundleIdentifier"`
-		Name             string `plist:"CFBundleName"`
-		Version          string `plist:"CFBundleShortVersionString"`
-		RequiresIPhoneOS bool   `plist:"LSRequiresIPhoneOS"`
-	}
-	var hasInfoPlist, isIPA bool
+	// Frameworks, app extensions, and CocoaPods resource bundles each ship an
+	// Info.plist describing themselves, so identity comes from the app bundle's
+	// own plist. Archives with no Payload/*.app/Info.plist keep the previous
+	// behavior of merging every plist in archive order.
+	var mainAppData, mergedData bundleInfo
+	var hasInfoPlist, isIPA, haveMainApp bool
 
 	for _, f := range r.File {
-		// Matches any Info.plist and the last wins, so a nested framework or
-		// extension plist can override the app's own plist.
 		if strings.Contains(f.Name, "Info.plist") {
 			// Get data from plist file
 			archiveFile, err := f.Open()
@@ -48,18 +61,28 @@ func ExtractZIPMetadata(tfr *fleet.TempFileReader) (*InstallerMetadata, error) {
 			if err != nil {
 				return nil, err
 			}
-			_, err = plist.Unmarshal(rawData, &plistData)
+			target := &mergedData
+			if isMainAppInfoPlist(f.Name) {
+				target, haveMainApp = &mainAppData, true
+			}
+			_, err = plist.Unmarshal(rawData, target)
 			if err != nil {
 				return nil, err
 			}
 
 			hasInfoPlist = true
 			// LSRequiresIPhoneOS is set on iOS/iPadOS apps and never on macOS
-			// apps, so it is probably an .ipa
-			if plistData.RequiresIPhoneOS {
+			// apps, so it is probably an .ipa. Every plist is still checked
+			// because only some bundles in the archive carry the key.
+			if target.RequiresIPhoneOS {
 				isIPA = true
 			}
 		}
+	}
+
+	plistData := mergedData
+	if haveMainApp {
+		plistData = mainAppData
 	}
 
 	if !hasInfoPlist || !isIPA {

--- a/pkg/file/ipa_test.go
+++ b/pkg/file/ipa_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func infoPlist(bundleID string, iOS bool) string {
+	return infoPlistNamed(bundleID, "Test", "1.0", iOS)
+}
+
+func infoPlistNamed(bundleID, name, version string, iOS bool) string {
 	requiresIPhoneOS := ""
 	if iOS {
 		requiresIPhoneOS = "<key>LSRequiresIPhoneOS</key><true/>"
@@ -19,8 +23,8 @@ func infoPlist(bundleID string, iOS bool) string {
 	return `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
 <key>CFBundleIdentifier</key><string>` + bundleID + `</string>
-<key>CFBundleName</key><string>Test</string>
-<key>CFBundleShortVersionString</key><string>1.0</string>
+<key>CFBundleName</key><string>` + name + `</string>
+<key>CFBundleShortVersionString</key><string>` + version + `</string>
 ` + requiresIPhoneOS + `
 </dict></plist>`
 }
@@ -100,4 +104,82 @@ func TestExtractZIPMetadata(t *testing.T) {
 	meta, err = file.ExtractZIPMetadata(latchTfr)
 	require.NoError(t, err)
 	require.NotNil(t, meta)
+	require.Equal(t, "com.example.ios", meta.BundleIdentifier)
+}
+
+// An Expo/React Native ipa embeds CocoaPods resource bundles whose Info.plist
+// carries the pod's name and version, so identity has to come from the app
+// bundle's own plist and not from whichever plist the zip happens to list last.
+func TestExtractZIPMetadataUsesMainAppInfoPlist(t *testing.T) {
+	app := infoPlistNamed("com.example.ios", "Example", "3.2.1", true)
+	privacy := infoPlistNamed("org.cocoapods.React-Core-privacy", "React-Core_privacy", "0.81.5", false)
+	framework := infoPlistNamed("org.cocoapods.hermes-engine", "hermes", "0.81.5", false)
+	appex := infoPlistNamed("com.example.ios.Widget", "Widget", "9.9.9", true)
+
+	requireAppMetadata := func(t *testing.T, entries [][2]string) {
+		t.Helper()
+		tfr, err := fleet.NewKeepFileReader(writeZip(t, entries))
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		meta, err := file.ExtractZIPMetadata(tfr)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		require.Equal(t, "com.example.ios", meta.BundleIdentifier)
+		require.Equal(t, []string{"com.example.ios"}, meta.PackageIDs)
+		require.Equal(t, "Example", meta.Name)
+		require.Equal(t, "3.2.1", meta.Version)
+	}
+
+	t.Run("nested plists listed after the app plist", func(t *testing.T) {
+		requireAppMetadata(t, [][2]string{
+			{"Payload/App.app/Info.plist", app},
+			{"Payload/App.app/Frameworks/hermes.framework/Info.plist", framework},
+			{"Payload/App.app/React-Core_privacy.bundle/Info.plist", privacy},
+			{"Payload/App.app/PlugIns/Widget.appex/Info.plist", appex},
+		})
+	})
+
+	t.Run("nested plists listed before the app plist", func(t *testing.T) {
+		requireAppMetadata(t, [][2]string{
+			{"Payload/App.app/React-Core_privacy.bundle/Info.plist", privacy},
+			{"Payload/App.app/PlugIns/Widget.appex/Info.plist", appex},
+			{"Payload/App.app/Info.plist", app},
+		})
+	})
+
+	t.Run("ipa still detected when only a nested plist sets LSRequiresIPhoneOS", func(t *testing.T) {
+		tfr, err := fleet.NewKeepFileReader(writeZip(t, [][2]string{
+			{"Payload/App.app/Info.plist", infoPlistNamed("com.example.ios", "Example", "3.2.1", false)},
+			{"Payload/App.app/PlugIns/Widget.appex/Info.plist", appex},
+		}))
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		meta, err := file.ExtractZIPMetadata(tfr)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		require.Equal(t, "com.example.ios", meta.BundleIdentifier)
+		require.Equal(t, "3.2.1", meta.Version)
+	})
+
+	t.Run("merges plists in order when there is no Payload app bundle", func(t *testing.T) {
+		// A plist carrying none of the keys, such as a compiled Core Data
+		// model, must not clear identity read from an earlier entry.
+		keyless := `<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict>
+<key>NSPersistenceFrameworkVersion</key><string>1234</string></dict></plist>`
+		tfr, err := fleet.NewKeepFileReader(writeZip(t, [][2]string{
+			{"Wrapped/Payload/App.app/Info.plist", infoPlistNamed("com.example.wrapped", "Wrapped", "1.2.3", true)},
+			{"Wrapped/Payload/App.app/Model.momd/VersionInfo.plist", keyless},
+		}))
+		require.NoError(t, err)
+		defer tfr.Close()
+
+		meta, err := file.ExtractZIPMetadata(tfr)
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+		require.Equal(t, "com.example.wrapped", meta.BundleIdentifier)
+		require.Equal(t, "Wrapped", meta.Name)
+		require.Equal(t, "1.2.3", meta.Version)
+	})
 }


### PR DESCRIPTION
**Related issue:** none filed. Details and a reproduction are below.

## Summary

`ExtractZIPMetadata` matches every zip entry whose path *contains* `Info.plist`, unmarshals each into one shared struct, and never breaks, so the last matching entry decides the app's name, version, and bundle identifier. The comment added in #48802 documented the hazard:

```go
// Matches any Info.plist and the last wins, so a nested framework or
// extension plist can override the app's own plist.
```

Every React Native and Expo `.ipa` trips it. CocoaPods emits a privacy manifest resource bundle per pod, each with its own `Info.plist` carrying `CFBundleName = <pod>_privacy`, the pod's version, and `CFBundleIdentifier = org.cocoapods.<pod>-privacy`. Those bundles sit beside the app binary in `Payload/<App>.app/`, so they are listed after the app's own plist and win.

On a React Native 0.81.5 iPad app that looks like this: the upload appears in the software library as `React-Core_privacy` version `0.81.5`, and because the stored bundle identifier is `org.cocoapods.React-Core-privacy`, the `bundle-identifier` in the `InstallApplication` manifest built in `ee/server/service/in_house_apps.go` does not match the payload, so the install never completes on the host. Which pod wins is down to zip entry order, so the name and version can differ between builds of the same app.

## Fix

Identity (`CFBundleIdentifier`, `CFBundleName`, `CFBundleShortVersionString`) comes from `Payload/*.app/Info.plist`, the only plist in the archive that describes the app itself. Three notes on scope:

- **Detection is unchanged.** Every plist is still checked for `LSRequiresIPhoneOS`, so an archive whose app plist omits the key is still recognized as an `.ipa` exactly as before.
- **The old merge is kept for archives without a payload-root app plist.** Those still accumulate identity across every plist in order, because `howett.net/plist` leaves absent keys untouched and some bundled plists (a compiled Core Data model, for instance) carry none of the four keys. Without that, such a plist would clear identity read from an earlier entry and the upload would be rejected with "couldn't find bundle identifier for in-house app" where it is accepted today.
- Entries written with a `./` prefix, or a lowercased `payload/`, do not match and so take that same merge path. Apple's packaging always writes `Payload/` at the root, so this only affects hand-rolled archives, and their behavior is unchanged from today.

This also removes the comment quoted above, since the behavior it described is what changed. It documented the hazard rather than a deliberate choice.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] Added/updated automated tests

`TestExtractZIPMetadataUsesMainAppInfoPlist` covers four cases: nested plists listed after the app plist, nested plists listed before it, an app plist that omits `LSRequiresIPhoneOS` while a nested one sets it, and the no-payload-root merge path with a keyless plist. Entries include a framework, an `.appex`, and a CocoaPods privacy bundle, each with a distinct name, version, and identifier.

The existing `TestExtractZIPMetadata` already built a nested-plist archive but never asserted whose identity survived, so it passed while the bug was live. It now asserts the bundle identifier. Reverting `pkg/file/ipa.go` alone turns it and two of the four new subtests red.

- [x] QA'd all new/changed functionality manually

Uploaded the signed Expo `.ipa` that produced the report above (React Native 0.81.5, 17 entries matching `Info.plist`, `React-Core_privacy.bundle/Info.plist` listed last) through `POST /api/latest/fleet/software/package` against MySQL, then read the library row, the `in_house_apps` row, and the generated `InstallApplication` manifest:

| | library name | `in_house_apps.version` | manifest `bundle-identifier` | manifest `bundle-version` |
|---|---|---|---|---|
| before | `React-Core_privacy` | `0.81.5` | `org.cocoapods.React-Core-privacy` | `0.81.5` |
| after | `FlowIssueReporter` | `0.4.0` | `com.hadrian-automation.flow-issue-reporter` | `0.4.0` |

The "before" row reproduces exactly what the software library displayed for that upload, and shows the manifest advertising a bundle identifier that cannot match the payload. Not verified against a physical device.

## AI

**AI:** Claude Code (claude-opus-5[1m])


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPA metadata now consistently comes from the main app bundle’s configuration, regardless of archive file order.
  * Bundle identifiers, package IDs, names, and versions are reported more accurately.
  * IPA detection remains compatible with archives containing nested app metadata or no main app bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->