### PR TITLE
Cap GET /software/versions page size when unpaginated

### DIFF
--- a/changes/47755-software-versions-default-page-size
+++ b/changes/47755-software-versions-default-page-size
@@ -1,0 +1,1 @@
+* Limited `GET /software/versions` to 10,000 results per page when no pagination parameters are specified, so the request no longer times out on large software inventories. Use `page` and `per_page` (or `after`) to retrieve the rest.

--- a/cmd/fleetctl/fleetctl/get.go
+++ b/cmd/fleetctl/fleetctl/get.go
@@ -1462,7 +1462,7 @@ func getSoftwareCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "versions",
-				Usage: "List all software versions",
+				Usage: "List software versions (up to 10,000)",
 			},
 			jsonFlag(),
 			yamlFlag(),
@@ -1497,6 +1497,8 @@ func getSoftwareCommand() *cli.Command {
 }
 
 func printSoftwareVersions(c *cli.Context, client *service.Client, query url.Values) error {
+	// The request carries no pagination, so the server returns at most its
+	// maximum page size. An inventory larger than that is truncated here.
 	software, err := client.ListSoftwareVersions(query.Encode())
 	if err != nil {
 		return fmt.Errorf("could not list software versions: %w", err)

--- a/server/activity/internal/service/endpoint_utils.go
+++ b/server/activity/internal/service/endpoint_utils.go
@@ -23,7 +23,7 @@ const (
 	defaultPerPage = 20
 
 	// maxPerPage is the maximum allowed value for per_page.
-	maxPerPage = 10000
+	maxPerPage = platform_http.MaxPerPage
 )
 
 // encodeResponse encodes the response as JSON.

--- a/server/platform/http/request.go
+++ b/server/platform/http/request.go
@@ -13,4 +13,7 @@ const (
 	// MaxMultipartFormSize represents how big the in memory elements is when parsing a multipart form data set,
 	// anything above that limit (primarily files) will be written to temp disk files
 	MaxMultipartFormSize int64 = 1 * units.MiB
+
+	// MaxPerPage is the largest page a list endpoint should return.
+	MaxPerPage = 10000
 )

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
@@ -71,6 +72,13 @@ func listSoftwareVersionsEndpoint(ctx context.Context, request interface{}, svc 
 	// always include pagination for new software versions endpoint (not included by default in
 	// legacy endpoint for backwards compatibility)
 	req.SoftwareListOptions.ListOptions.IncludeMetadata = true
+
+	// fleet.DefaultPerPage is effectively unbounded, and returning a whole large
+	// inventory in one response takes long enough to trip a load balancer's idle
+	// timeout, so fall back to the bounded page size instead.
+	if req.SoftwareListOptions.ListOptions.PerPage == 0 {
+		req.SoftwareListOptions.ListOptions.PerPage = platform_http.MaxPerPage
+	}
 
 	resp, meta, err := svc.ListSoftware(ctx, req.SoftwareListOptions)
 	if err != nil {

--- a/tools/nvd/nvdvuln/README.md
+++ b/tools/nvd/nvdvuln/README.md
@@ -4,7 +4,7 @@ This tool can be used to reproduce false positive/negative vulnerabilities found
 
 The tool has two modes of operation:
 1. Run vulnerability processing using the NVD dataset on a specific software item. Such software item should be specified to the tool with the fields as stored in Fleet's `software` MySQL table.
-2. Fetch software from a Fleet instance (and their found vulnerabilities), then, run vulnerability processing on such software and report any differences in CVEs against the Fleet instance. This mode of operation is useful to test new changes to the vulnerability processing.
+2. Fetch software from a Fleet instance (and their found vulnerabilities), then, run vulnerability processing on such software and report any differences in CVEs against the Fleet instance. This mode of operation is useful to test new changes to the vulnerability processing. Note that this mode fetches a single unpaginated page of software versions, so it covers at most 10,000 versions; on a larger instance the comparison silently runs against a subset.
 
 PS: This tool is only useful on systems and software where the NVD dataset is used to detect vulnerabilities. For instance, this tool should not be used with Microsoft Office applications for macOS because Fleet uses a different dataset to detect vulnerabilities on such applications.
 


### PR DESCRIPTION
Fixes #47755

A request without per_page fell back to fleet.DefaultPerPage (1,000,000), so
on a large inventory the endpoint tried to serialize the whole software table
and exceeded the load balancer's idle timeout, surfacing as a 502. The
placeholder fix in https://github.com/fleetdm/fleet/issues/43030 unmasked this. Fall back to 10,000 instead.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Software version listings now return up to 10,000 results by default, improving reliability for large inventories.
  - Use pagination options to retrieve additional results beyond the default limit.

- **Documentation**
  - Updated command-line help to clarify that software version listings include up to 10,000 results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->