### PR TITLE
Allow clearing AAP form via the UI

### DIFF
--- a/changes/52888-allow-clearing-aap
+++ b/changes/52888-allow-clearing-aap
@@ -1,0 +1,1 @@
+- Fixed an issue where it was not possible to clear the Apple Account Provisioning in the UI once configured.

--- a/frontend/hooks/useFormValidation.tests.ts
+++ b/frontend/hooks/useFormValidation.tests.ts
@@ -283,6 +283,22 @@ describe("useFormValidation", () => {
     });
   });
 
+  describe("setFieldError", () => {
+    it("shows an error immediately, even on a pristine field", () => {
+      const { result } = setup();
+
+      act(() =>
+        result.current.setFieldError("password", "Re-enter your password")
+      );
+
+      expect(result.current.getError("password")).toBe(
+        "Re-enter your password"
+      );
+      expect(result.current.getError("name")).toBeUndefined();
+      expect(result.current.getError("email")).toBeUndefined();
+    });
+  });
+
   describe("handleSubmit", () => {
     const validData = {
       name: "  Alice  ",

--- a/frontend/hooks/useFormValidation.ts
+++ b/frontend/hooks/useFormValidation.ts
@@ -68,6 +68,7 @@ interface IUseFormValidationReturn<TFormData> {
   getError: (name: string) => string | undefined;
   /** Wire to a field's `onFocus`. Clears that field's error, client or server. */
   clearFieldError: (name: string) => void;
+  setFieldError: (name: string, message: string) => void;
   /**
    * Wire to a field's `onBlur`. Validates that one field, and only once it is
    * dirty, so a pristine required field stays silent until submit.
@@ -283,6 +284,10 @@ const useFormValidation = <TFormData extends object>({
     });
   }, []);
 
+  const setFieldError = useCallback((name: string, message: string) => {
+    setErrors((prev) => ({ ...prev, [name]: message }));
+  }, []);
+
   const validateField = useCallback((name: string) => {
     if (!dirtyFieldsRef.current.has(name)) {
       return;
@@ -371,6 +376,7 @@ const useFormValidation = <TFormData extends object>({
     errors,
     getError,
     clearFieldError,
+    setFieldError,
     validateField,
     clearErrors,
     handleSubmit,

--- a/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tests.tsx
@@ -106,8 +106,8 @@ describe("AccountProvisioning", () => {
 
   describe("Token URL validation", () => {
     it("shows a required error on blur when empty", async () => {
-      const { user } = render(<AccountProvisioning {...defaultProps} />);
-      await user.click(screen.getByLabelText(/token url/i));
+      const { user } = render(<AccountProvisioning {...savedConfigProps} />);
+      await user.clear(screen.getByLabelText(/token url/i));
       await user.tab();
       await waitFor(() => {
         expect(screen.getByText(/token url is required/i)).toBeInTheDocument();
@@ -168,8 +168,8 @@ describe("AccountProvisioning", () => {
 
   describe("Client ID validation", () => {
     it("shows a required error on blur when empty", async () => {
-      const { user } = render(<AccountProvisioning {...defaultProps} />);
-      await user.click(screen.getByLabelText(/client id/i));
+      const { user } = render(<AccountProvisioning {...savedConfigProps} />);
+      await user.clear(screen.getByLabelText(/client id/i));
       await user.tab();
       await waitFor(() => {
         expect(screen.getByText(/client id is required/i)).toBeInTheDocument();
@@ -179,8 +179,8 @@ describe("AccountProvisioning", () => {
 
   describe("Client secret validation", () => {
     it("shows a required error on blur when empty", async () => {
-      const { user } = render(<AccountProvisioning {...defaultProps} />);
-      await user.click(screen.getByLabelText(/client secret/i));
+      const { user } = render(<AccountProvisioning {...savedConfigProps} />);
+      await user.clear(screen.getByLabelText(/client secret/i));
       await user.tab();
       await waitFor(() => {
         expect(
@@ -191,16 +191,44 @@ describe("AccountProvisioning", () => {
   });
 
   describe("Form submission", () => {
-    it("shows all errors on submit when all fields are empty", async () => {
+    it("submits successfully as a no-op when the form is already empty", async () => {
       const { user } = render(<AccountProvisioning {...defaultProps} />);
       await user.click(screen.getByRole("button", { name: /save/i }));
+
       await waitFor(() => {
-        expect(screen.getByText(/token url is required/i)).toBeInTheDocument();
-        expect(screen.getByText(/client id is required/i)).toBeInTheDocument();
-        expect(
-          screen.getByText(/client secret is required/i)
-        ).toBeInTheDocument();
+        expect(configAPI.update).toHaveBeenCalledWith({
+          mdm: {
+            apple_account_provisioning: {
+              oauth_idp_token_url: "",
+              oauth_idp_client_id: "",
+              oauth_idp_client_secret: "",
+            },
+          },
+        });
       });
+      expect(screen.queryByText(/is required/i)).not.toBeInTheDocument();
+    });
+
+    it("clears a saved configuration when every field is emptied before submit", async () => {
+      const { user } = render(<AccountProvisioning {...savedConfigProps} />);
+      await user.clear(screen.getByLabelText(/token url/i));
+      await user.clear(screen.getByLabelText(/client id/i));
+      await user.clear(screen.getByLabelText(/client secret/i));
+
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      await waitFor(() => {
+        expect(configAPI.update).toHaveBeenCalledWith({
+          mdm: {
+            apple_account_provisioning: {
+              oauth_idp_token_url: "",
+              oauth_idp_client_id: "",
+              oauth_idp_client_secret: "",
+            },
+          },
+        });
+      });
+      expect(screen.queryByText(/is required/i)).not.toBeInTheDocument();
     });
 
     it("does not submit when token URL is invalid", async () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tsx
@@ -35,11 +35,14 @@ const isEmptyFormData = (data: IFormData) => {
   return !data.tokenUrl && !data.clientId && !data.clientSecret;
 };
 
-const validate = (formData: IFormData): IFormErrors => {
+const validate = (rawFormData: IFormData): IFormErrors => {
   const errors: IFormErrors = {};
 
-  // Trim all values
-  Object.values(formData).map((val) => val?.trim() || "");
+  const formData: IFormData = {
+    tokenUrl: rawFormData.tokenUrl.trim(),
+    clientId: rawFormData.clientId.trim(),
+    clientSecret: rawFormData.clientSecret.trim(),
+  };
 
   if (isEmptyFormData(formData)) {
     // Clearing a form is a valid state.

--- a/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { useQueryClient } from "react-query";
 
@@ -15,13 +15,13 @@ import SettingsSection from "pages/admin/components/SettingsSection";
 import PageDescription from "components/PageDescription";
 import CustomLink from "components/CustomLink";
 import InputField from "components/forms/fields/InputField";
-import { IInputFieldParseTarget } from "interfaces/form_field";
 import Button from "components/buttons/Button";
 import validUrl from "components/forms/validators/valid_url";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import useGitOpsMode from "hooks/useGitOpsMode";
 import { isPremiumTier } from "utilities/permissions/permissions";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
+import useFormValidation, { IFormErrors } from "hooks/useFormValidation";
 
 const baseClass = "account-provisioning";
 
@@ -31,14 +31,20 @@ interface IFormData {
   clientSecret: string;
 }
 
-interface IFormErrors {
-  tokenUrl?: string | null;
-  clientId?: string | null;
-  clientSecret?: string | null;
-}
+const isEmptyFormData = (data: IFormData) => {
+  return !data.tokenUrl && !data.clientId && !data.clientSecret;
+};
 
 const validate = (formData: IFormData): IFormErrors => {
   const errors: IFormErrors = {};
+
+  // Trim all values
+  Object.values(formData).map((val) => val?.trim() || "");
+
+  if (isEmptyFormData(formData)) {
+    // Clearing a form is a valid state.
+    return errors;
+  }
 
   if (!formData.tokenUrl) {
     errors.tokenUrl = "Token URL is required.";
@@ -81,80 +87,71 @@ const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
   const { gitOpsModeEnabled } = useGitOpsMode();
   const queryClient = useQueryClient();
   const [isUpdating, setIsUpdating] = useState(false);
-  const [formData, setFormData] = useState<IFormData>({
-    tokenUrl: "",
-    clientId: "",
-    clientSecret: "",
+  const [serverFormErrors, setServerFormErrors] = useState<IFormErrors>({});
+
+  const {
+    formData,
+    setField,
+    validateField,
+    getError,
+    setFieldError,
+    clearFieldError,
+    clearErrors,
+    handleSubmit,
+    isSubmitting,
+  } = useFormValidation<IFormData>({
+    validate,
+    initialFormData: {
+      clientId:
+        appConfig.mdm.apple_account_provisioning?.oauth_idp_client_id || "",
+      clientSecret:
+        appConfig.mdm.apple_account_provisioning?.oauth_idp_client_secret || "",
+      tokenUrl:
+        appConfig.mdm.apple_account_provisioning?.oauth_idp_token_url || "",
+    },
+    serverErrors: serverFormErrors,
+    isSubmitting: isUpdating,
   });
-  const [formErrors, setFormErrors] = useState<IFormErrors>({});
 
-  useEffect(() => {
-    const provisioning = appConfig.mdm.apple_account_provisioning;
-    if (provisioning) {
-      setFormData({
-        tokenUrl: provisioning.oauth_idp_token_url,
-        clientId: provisioning.oauth_idp_client_id,
-        clientSecret: provisioning.oauth_idp_client_secret,
-      });
-    }
-  }, [appConfig]);
+  const onFieldChange = (name: keyof IFormData, value: string) => {
+    setField(name, value);
 
-  const onInputChange = ({ name, value }: IInputFieldParseTarget) => {
-    const newFormData = { ...formData, [name]: value };
-
-    // The server rejects a token URL change that reuses the stored secret
-    // (the secret would be sent to the new, possibly hostile, URL), so clear
-    // the masked secret and have the user re-enter it. Same pattern as
-    // editing a certificate authority.
-    const secretCleared =
-      name === "tokenUrl" &&
-      formData.clientSecret === UNCHANGED_PASSWORD_API_RESPONSE;
-    if (secretCleared) {
-      newFormData.clientSecret = "";
-    }
-
-    setFormData(newFormData);
-    setFormErrors((prev) => {
-      const next = { ...prev };
-      if (secretCleared) {
-        next.clientSecret =
-          "Client secret must be re-entered when changing the token URL.";
-      }
-      // only update errors for fields that already have an error
-      if (prev[name as keyof IFormErrors]) {
-        next[name as keyof IFormErrors] = validate(newFormData)[
-          name as keyof IFormErrors
-        ];
-      }
-      return next;
-    });
-  };
-
-  const onInputBlur = (field: keyof IFormData) => () => {
-    const newErrors = validate(formData);
-    setFormErrors((prev) => ({ ...prev, [field]: newErrors[field] }));
-  };
-
-  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const errors = validate(formData);
-    if (Object.keys(errors).length > 0) {
-      setFormErrors(errors);
+    // Emptying the last field is how the configuration gets cleared, and an
+    // empty form is valid, so every required-field error stops applying.
+    if (isEmptyFormData({ ...formData, [name]: value })) {
+      clearErrors();
       return;
     }
 
-    const secretToSubmit =
+    if (
+      name === "tokenUrl" &&
       formData.clientSecret === UNCHANGED_PASSWORD_API_RESPONSE
+    ) {
+      // The server rejects a token URL change that reuses the stored secret
+      // (the secret would be sent to the new, possibly hostile, URL), so clear
+      // the masked secret and have the user re-enter it. Same pattern as
+      // editing a certificate authority.
+      setField("clientSecret", "");
+      setFieldError(
+        "clientSecret",
+        "Client secret must be re-entered when changing the token URL."
+      );
+    }
+  };
+
+  const onSubmit = async (data: IFormData) => {
+    const secretToSubmit =
+      data.clientSecret === UNCHANGED_PASSWORD_API_RESPONSE
         ? undefined
-        : formData.clientSecret;
+        : data.clientSecret;
 
     setIsUpdating(true);
     try {
       await configAPI.update({
         mdm: {
           apple_account_provisioning: {
-            oauth_idp_token_url: formData.tokenUrl,
-            oauth_idp_client_id: formData.clientId,
+            oauth_idp_token_url: data.tokenUrl,
+            oauth_idp_client_id: data.clientId,
             ...(secretToSubmit !== undefined && {
               oauth_idp_client_secret: secretToSubmit,
             }),
@@ -164,7 +161,7 @@ const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
       await queryClient.invalidateQueries(["config"]);
       notify.success("Successfully updated settings.");
     } catch (err) {
-      setFormErrors((prev) => ({ ...prev, ...getServerFieldErrors(err) }));
+      setServerFormErrors(getServerFieldErrors(err));
       const reason = getErrorReason(err);
       notify.error(
         reason
@@ -198,7 +195,7 @@ const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
             </>
           }
         />
-        <form onSubmit={onSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <div
             className={`form ${
               gitOpsModeEnabled ? "disabled-by-gitops-mode" : ""
@@ -208,41 +205,44 @@ const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
               label="Token URL"
               name="tokenUrl"
               value={formData.tokenUrl}
-              onChange={onInputChange}
-              onBlur={onInputBlur("tokenUrl")}
-              parseTarget
+              onChange={(val) => onFieldChange("tokenUrl", val)}
+              onBlur={() => validateField("tokenUrl")}
+              onFocus={() => clearFieldError("tokenUrl")}
+              error={getError("tokenUrl")}
+              disabled={isSubmitting}
               placeholder="https://yourdomain.okta.com/oauth2/v1/token"
-              error={formErrors.tokenUrl}
               helpText="Your IdP URL for verifying login credentials. For Okta, this is typically https://yourdomain.okta.com/oauth2/v1/token."
             />
             <InputField
               label="Client ID"
               name="clientId"
               value={formData.clientId}
-              onChange={onInputChange}
-              onBlur={onInputBlur("clientId")}
-              parseTarget
-              error={formErrors.clientId}
+              onChange={(val) => onFieldChange("clientId", val)}
+              onBlur={() => validateField("clientId")}
+              onFocus={() => clearFieldError("clientId")}
+              error={getError("clientId")}
               helpText="In Okta, this will be in the Client Credentials section."
+              disabled={isSubmitting}
             />
             <InputField
               type="password"
               label="Client secret"
               name="clientSecret"
               value={formData.clientSecret}
-              onChange={onInputChange}
-              onBlur={onInputBlur("clientSecret")}
-              parseTarget
-              error={formErrors.clientSecret}
+              onChange={(val) => onFieldChange("clientSecret", val)}
+              onBlur={() => validateField("clientSecret")}
+              onFocus={() => clearFieldError("clientSecret")}
+              error={getError("clientSecret")}
               helpText="In Okta, this will be in the Client Credentials section."
+              disabled={isSubmitting}
             />
           </div>
           <GitOpsModeTooltipWrapper
             renderChildren={(disableChildren) => (
               <Button
                 type="submit"
-                disabled={disableChildren}
-                isLoading={isUpdating}
+                disabled={disableChildren || isSubmitting}
+                isLoading={isSubmitting}
               >
                 Save
               </Button>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #52888 

_It also moves the Apple account provisioning form to the new form validation hook_

https://github.com/user-attachments/assets/18fcb0d9-a6ef-4588-85ba-cb661c507498

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apple Account Provisioning can now be cleared from the interface after it has been configured.
  * Saving an entirely empty provisioning form is accepted without unnecessary required-field errors.
  * Validation now provides clearer feedback when the token URL changes while a saved secret remains masked.
  * Form errors are cleared appropriately as fields are corrected or the configuration is emptied.
  * Validation messages now appear immediately when an error is set, without affecting other fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->