### PR TITLE
Use the default fleethttp client timeout for APNs pushes

### DIFF
--- a/changes/50803-apns-push-timeout
+++ b/changes/50803-apns-push-timeout
@@ -1,0 +1,1 @@
+- Fixed APNs push requests potentially blocking MDM command delivery indefinitely when Apple's push service stalls a response.

--- a/cmd/fleet/mdm_apple.go
+++ b/cmd/fleet/mdm_apple.go
@@ -68,7 +68,7 @@ func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, apnsPushExpiratio
 		// keep the fleethttp client: it preserves proxy support and sane
 		// timeouts that nanopush's default bare transport does not have
 		nanopush.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
-			return fleethttp.NewClient(fleethttp.WithNoTimeout(), fleethttp.WithTLSClientConfig(&tls.Config{
+			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
 				Certificates: []tls.Certificate{*cert},
 				MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
 			})), nil

--- a/server/mdm/nanomdm/push/nanopush/provider_test.go
+++ b/server/mdm/nanomdm/push/nanopush/provider_test.go
@@ -12,9 +12,52 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
+
+// TestPushStalledErrorBody covers an APNs response whose headers arrive but
+// whose error body then stalls: transport-level timeouts don't bound the body
+// read, so only an overall client timeout (production sets one via fleethttp's
+// default) keeps Push from blocking its caller forever.
+func TestPushStalledErrorBody(t *testing.T) {
+	stall := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.(http.Flusher).Flush()
+		<-stall
+	}))
+	defer server.Close()
+	defer close(stall)
+
+	pushInfo := &mdm.Push{PushMagic: "magic", Topic: "com.example.topic"}
+	require.NoError(t, pushInfo.SetTokenString("00aa"))
+
+	prov := &Provider{
+		baseURL: server.URL,
+		client:  &http.Client{Timeout: 500 * time.Millisecond},
+		workers: 1,
+	}
+
+	done := make(chan struct{})
+	var responses map[string]*push.Response
+	var err error
+	go func() {
+		defer close(done)
+		responses, err = prov.Push(t.Context(), []*mdm.Push{pushInfo})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Push did not return: stalled error body read is unbounded")
+	}
+	require.NoError(t, err)
+	tokenResp := responses["00aa"]
+	require.NotNil(t, tokenResp)
+	require.ErrorContains(t, tokenResp.Err, "Client.Timeout")
+}
 
 func TestPush(t *testing.T) {
 	// our "raw" push info

--- a/server/mdm/nanomdm/push/nanopush/provider_test.go
+++ b/server/mdm/nanomdm/push/nanopush/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	"github.com/stretchr/testify/require"
@@ -36,7 +37,7 @@ func TestPushStalledErrorBody(t *testing.T) {
 
 	prov := &Provider{
 		baseURL: server.URL,
-		client:  &http.Client{Timeout: 500 * time.Millisecond},
+		client:  fleethttp.NewClient(fleethttp.WithTimeout(500 * time.Millisecond)),
 		workers: 1,
 	}
 


### PR DESCRIPTION
**Related issue:** Resolves #50803

APNs push requests now use fleethttp's default 60s client timeout instead of opting out. Transport-level timeouts only cover connect and response headers, so a stalled response body (e.g. the JSON error body nanopush decodes on non-200s) could previously block push callers — including the APNs cron, whose context has no deadline — until a server restart.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where Apple Push Notification Service requests could remain blocked indefinitely when Apple’s service stalled.
  - MDM command delivery now respects the configured client timeout and returns an error instead of waiting indefinitely.
  - Improved reliability when push responses are incomplete, delayed, or stall after response headers are received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->