### PR TITLE
Cleanup frontend test output

### DIFF
--- a/frontend/test/jest.config.js
+++ b/frontend/test/jest.config.js
@@ -71,6 +71,7 @@ const config = {
     "<rootDir>/frontend/utilities/osquery_sql_parser/osquery_sql_parser.generated.js",
   ],
   setupFilesAfterEnv: ["<rootDir>/frontend/test/test-setup.ts"],
+  reporters: ["<rootDir>/frontend/test/trimConsoleStackReporter.js", "default"],
   clearMocks: true,
   testEnvironmentOptions: {
     url: "http://fleettest.test:9876",

--- a/frontend/test/test-setup.ts
+++ b/frontend/test/test-setup.ts
@@ -34,18 +34,39 @@ beforeAll(() => mockServer.listen());
 afterEach(() => mockServer.resetHandlers());
 afterAll(() => mockServer.close());
 
-// suppress the opacity console warnings for react-tooltip. The code for assigning the
-// opacity is correct but there is still an unnecessary warning in the console when
-// the jest tests are run. This may be react-tooltip and JSdom not playing well together.
-beforeAll(() => {
-  const originalConsoleWarning = console.warn;
-  console.warn = (...args) => {
+// Known noisy warnings that don't indicate real bugs in Fleet code. Filtering
+// them keeps a genuine console.error/warn visible when a test actually fails,
+// instead of it being buried under thousands of unrelated lines.
+const SUPPRESSED_WARNINGS = [
+  // react-tooltip and jsdom disagree on a computed opacity; the app's usage is correct.
+  /\[react-tooltip\].*is not a valid `opacity`/,
+  // Async state updates inside third-party UI internals (react-select, Radix) and
+  // many existing components fire outside RTL's act() boundary. Enforcing
+  // act-wrapping across the whole app is a separate, larger cleanup effort.
+  /An update to .+ inside a test was not wrapped in act\(\.\.\.\)/,
+  // A dependency still calls the old, renamed React lifecycle methods internally.
+  /componentWill(Mount|ReceiveProps) has been renamed/,
+];
+
+// Trimming node_modules frames out of the stack these produce happens in
+// frontend/test/trimConsoleStackReporter.js (registered as a jest reporter) —
+// that runs in Jest's own process, unlike this file, which runs inside each
+// test file's sandboxed module registry and can't reach Jest's console output
+// pipeline directly.
+function suppressKnownWarnings(original: typeof console.warn) {
+  return (...args: Parameters<typeof console.warn>) => {
+    const [message] = args;
     if (
-      args[0]?.includes("[react-tooltip]") &&
-      args[0]?.includes("is not a valid `opacity`")
+      typeof message === "string" &&
+      SUPPRESSED_WARNINGS.some((pattern) => pattern.test(message))
     ) {
       return;
     }
-    originalConsoleWarning(...args);
+    original(...args);
   };
+}
+
+beforeAll(() => {
+  console.warn = suppressKnownWarnings(console.warn);
+  console.error = suppressKnownWarnings(console.error);
 });

--- a/frontend/test/trimConsoleStackReporter.js
+++ b/frontend/test/trimConsoleStackReporter.js
@@ -1,0 +1,30 @@
+// Jest captures the full JS call stack for every console.warn/error call in a
+// test, most of which is react-dom/react/testing-library internals rather than
+// our own code. Reporters run in Jest's main process (unlike setupFilesAfterEnv,
+// which runs in each test file's sandboxed module registry), so this is the one
+// place that can rewrite that stack before Jest's default reporter prints it,
+// while still going through Jest's normal color-coded console output.
+function withoutNodeModulesLines(text) {
+  return text
+    .split("\n")
+    .filter((line) => !line.includes("node_modules"))
+    .join("\n");
+}
+
+class TrimConsoleStackReporter {
+  // Jest instantiates reporters with `new`, so this must be an instance method
+  // even though it doesn't need `this`.
+  // eslint-disable-next-line class-methods-use-this
+  onTestResult(_test, testResult) {
+    testResult.console?.forEach((entry) => {
+      // `origin` is Jest's appended JS call stack; `message` is the warning
+      // text itself, which for React dev warnings includes its own component-
+      // stack listing (e.g. third-party wrapper components like
+      // QueryClientProvider) that can also point into node_modules.
+      entry.origin = withoutNodeModulesLines(entry.origin);
+      entry.message = withoutNodeModulesLines(entry.message);
+    });
+  }
+}
+
+module.exports = TrimConsoleStackReporter;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #53017

This significantly reduces the CI test output from 3.35M lines to 30-50k, so CI and locally it's way easier to read, plus locally it runs ~100% faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test output by suppressing known, non-actionable console warnings.
  * Simplified test failure logs by removing unnecessary dependency stack-trace details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->