### PR TITLE
Clarify Platform SSO (PSSO) is Mac-only on software management page

### DIFF
--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -340,7 +340,7 @@
             <div purpose="feature-title">
               <img alt="Platform single sign-on" purpose="feature-icon" src="/images/icon-psso-20x20@2x.png">
               <h5>
-                Platform Single Sign-On (PSSO) for Mac
+                macOS Platform Single Sign-On (PSSO)
               </h5>
             </div>
             <div purpose="feature-text">

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -340,7 +340,7 @@
             <div purpose="feature-title">
               <img alt="Platform single sign-on" purpose="feature-icon" src="/images/icon-psso-20x20@2x.png">
               <h5>
-                Platform single sign-on (PSSO) for Mac
+                Apple Platform Single Sign-On (PSSO)
               </h5>
             </div>
             <div purpose="feature-text">

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -345,7 +345,7 @@
             </div>
             <div purpose="feature-text">
               <p>
-                Simplify onboarding and let Mac users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO. Windows devices get the same experience through Windows Autopilot.
+                Simplify onboarding and let users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO. Windows devices get the same experience through Windows Autopilot.
               </p>
             </div>
           </div>

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -340,7 +340,7 @@
             <div purpose="feature-title">
               <img alt="Platform single sign-on" purpose="feature-icon" src="/images/icon-psso-20x20@2x.png">
               <h5>
-                Apple Platform Single Sign-On (PSSO)
+                Platform Single Sign-On (PSSO) for Mac
               </h5>
             </div>
             <div purpose="feature-text">

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -340,12 +340,12 @@
             <div purpose="feature-title">
               <img alt="Platform single sign-on" purpose="feature-icon" src="/images/icon-psso-20x20@2x.png">
               <h5>
-                Platform single sign-on (PSSO)
+                Platform single sign-on (PSSO) for Mac
               </h5>
             </div>
             <div purpose="feature-text">
               <p>
-                Simplify onboarding and let users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO.
+                Simplify onboarding and let Mac users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO.
               </p>
             </div>
           </div>

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -345,7 +345,7 @@
             </div>
             <div purpose="feature-text">
               <p>
-                Simplify onboarding and let Mac users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO.
+                Simplify onboarding and let Mac users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO. Windows devices get the same experience through Windows Autopilot.
               </p>
             </div>
           </div>


### PR DESCRIPTION
**Related issue:** N/A — copy fix from Slack feedback

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

## AI

**AI:** Claude Code (claude-sonnet-5)

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

Mike McNeil flagged in Slack that the "Platform single sign-on (PSSO)" section on the [software management page](https://fleetdm.com/software-management) reads like there's no Windows equivalent to PSSO. There is: Windows Autopilot gives Windows devices the same sign-on-with-everyday-credentials onboarding experience.

This is a copy-only fix, in two parts:
1. Scoped the PSSO heading to "for Mac" (PSSO is a macOS 13+ feature per docs/Contributing/research/mdm/psso.md, not available on iOS/iPadOS).
2. Added a closing line to the PSSO card body pointing to Windows Autopilot (already introduced in the card right above it) as the Windows equivalent.

**Before:**
> Platform single sign-on (PSSO)
> Simplify onboarding and let users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO.

**After:**
> Platform single sign-on (PSSO) for Mac
> Simplify onboarding and let Mac users sign in to their computer with credentials they use for everything else. Migrate from Jamf Connect or Iru Liftoff to Apple's native platform SSO. Windows devices get the same experience through Windows Autopilot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Platform single sign-on feature card heading to “macOS Platform Single Sign-On (PSSO).”
  * Clarified that Windows devices receive the same experience through Windows Autopilot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->