### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/3df-zephyr-free/windows.json
+++ b/ee/maintained-apps/outputs/3df-zephyr-free/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "9.011",
+      "version": "9.013",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE '3DF Zephyr Free %' AND publisher = '3Dflow srl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE '3DF Zephyr Free %' AND publisher = '3Dflow srl' AND version_compare(version, '9.011') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE '3DF Zephyr Free %' AND publisher = '3Dflow srl' AND version_compare(version, '9.013') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = '3df zephyr free.exe');"
       },
-      "installer_url": "https://3df-eu.fra1.digitaloceanspaces.com/9.011/3DF%20Zephyr%20Free%20v9.011%20(x64).exe",
+      "installer_url": "https://3df-eu.fra1.digitaloceanspaces.com/9.013/3DF%20Zephyr%20Free%20v9.013%20(x64).exe",
       "install_script_ref": "df7f059c",
       "uninstall_script_ref": "740ec2ac",
-      "sha256": "f9601419bc9958193d7c19d1460f19952898d5385ce699bd9afa9a560cefced7",
+      "sha256": "2c6402cbe8e9f170437d9894cc4445257571fab603960af3b71144eef8c256ce",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/adlock/darwin.json
+++ b/ee/maintained-apps/outputs/adlock/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.1.9.3",
+      "version": "2.1.9.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankuper.adlock.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankuper.adlock.desktop' AND version_compare(bundle_short_version, '2.1.9.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankuper.adlock.desktop' AND version_compare(bundle_short_version, '2.1.9.7') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.hankuper.adlock.desktop' AND a.bundle_executable != '');"
       },
       "installer_url": "https://downloads.adlock.com/mac/AdLock_Installer.dmg",

--- a/ee/maintained-apps/outputs/adobe-creative-cloud/windows.json
+++ b/ee/maintained-apps/outputs/adobe-creative-cloud/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "6.10.0.252.3",
+      "version": "6.10.0.252.41",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Adobe Creative Cloud' AND publisher = 'Adobe Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Creative Cloud' AND publisher = 'Adobe Inc.' AND version_compare(version, '6.10.0.252.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Creative Cloud' AND publisher = 'Adobe Inc.' AND version_compare(version, '6.10.0.252.41') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'adobe creative cloud.exe');"
       },
       "installer_url": "https://prod-rel-ffc-ccm.oobesaas.adobe.com/adobe-ffc-external/core/v1/wam/download?sapCode=KCCC&wamFeature=nuj-live",

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.3.104",
+      "version": "4.3.113",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.104') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.113') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.automattic.beeper.desktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.104-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.113-arm64-mac.zip",
       "install_script_ref": "403ed251",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "ef228b69962689d7e25bf87d991597383781c746d8bda2b9b8fa8c62cb97388c",
+      "sha256": "ca8323a011af071c4517d6c3aee9c954a20a2808c7b841538559f5e004e4917d",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/unity-hub/darwin.json
+++ b/ee/maintained-apps/outputs/unity-hub/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.21.1",
+      "version": "3.21.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.21.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.21.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.unity3d.unityhub' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/3.21.1/UnityHubSetup-3.21.1-arm64.dmg",
+      "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/3.21.2/UnityHubSetup-3.21.2-arm64.dmg",
       "install_script_ref": "f7867145",
       "uninstall_script_ref": "5b95ff58",
-      "sha256": "8aa37701d42db5acecf5fe89c34ff8a0ef2851582024755e7d47ab82cbeeb2e5",
+      "sha256": "1f8881fd1b985a2b945387feb4be89dac95e5d754a58e7f72c0612dcf9552ecf",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated 3DF Zephyr Free for Windows to version 9.013.
  - Updated AdLock for macOS to version 2.1.9.7.
  - Updated Adobe Creative Cloud for Windows to version 6.10.0.252.41.
  - Updated Beeper for macOS to version 4.3.113.
  - Updated Unity Hub for macOS to version 3.21.2.
  - Installer links and verification data were refreshed where applicable to support the latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->