### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/downie/darwin.json
+++ b/ee/maintained-apps/outputs/downie/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.12.15",
+      "version": "4.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.15') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.13') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.charliemonroe.Downie-4' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5256.dmg",
+      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5259.dmg",
       "install_script_ref": "4f6dd0e2",
       "uninstall_script_ref": "65dfe669",
-      "sha256": "a1e6e9347538d9e365db965d98231745bc3ce0b66402b6e1047d392386396d40",
+      "sha256": "b8c658fb865030fc7fa98d7b56ffb700b065fd2be83b76e7c36ef300cbc51bdb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/vivaldi/windows.json
+++ b/ee/maintained-apps/outputs/vivaldi/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.2.4133.47",
+      "version": "8.2.4133.52",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.2.4133.47') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.2.4133.52') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'vivaldi.exe');"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.2.4133.47.x64.exe",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.2.4133.52.x64.exe",
       "install_script_ref": "d5d49757",
       "uninstall_script_ref": "4e1acf1b",
-      "sha256": "65590b549db6d3300319a2fdb18cab3d774fed5ccb67e0442ab3b2ca55d06854",
+      "sha256": "68124557ae03a28e5669ad4c62eb2c8a1771740d8a7866385d2cf3a33b379614",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Downie macOS app definition to version 4.13, including its installer reference and verification data.
  - Updated the Vivaldi Windows app definition to version 8.2.4133.52, including its installer reference and verification data.
  - App installation and detection behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->