### PR TITLE
Bump Linux Claude Desktop patch policy to 1.52386.0

### DIFF
--- a/it-and-security/lib/linux/policies/update-claude.yml
+++ b/it-and-security/lib/linux/policies/update-claude.yml
@@ -1,5 +1,5 @@
 - name: Claude up to date (Linux)
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM deb_packages WHERE name = 'claude-desktop' AND version_compare(version, '1.49585.0') < 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM deb_packages WHERE name = 'claude-desktop' AND version_compare(version, '1.52386.0') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Claude is managed by IT and is upgraded automatically from Anthropic's apt repository when this policy fails. You can also run `sudo apt update && sudo apt install claude-desktop`, or install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."


### PR DESCRIPTION
**Related issue:** NA

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] QA'd all new/changed functionality manually

## AI

**AI:** Claude Code (claude-sonnet-5)

## Summary

Automated bump of the dogfood Workstations "Claude up to date (Linux)" policy's pinned `claude-desktop` version.

- Old pinned version: `1.49585.0`
- New pinned version: `1.52386.0`

Newest published versions observed in Anthropic's apt repository:
- amd64: `1.52386.0` — https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages
- arm64: `1.52386.0` — https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-arm64/Packages

The new pinned version is the lower of the two architectures' newest versions (they matched here), so the policy never demands a version one architecture cannot install yet.

This is dogfood GitOps configuration, not a product change, so no changes file is needed.

https://claude.ai/code/session_01NM5yT6ZiNCUQrfiBTgGRdG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NM5yT6ZiNCUQrfiBTgGRdG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Raised the minimum accepted Claude Desktop version for the Linux policy to 1.52386.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->