### PR TITLE
Cap the vulnerabilities tooltip in the software details modal

### DIFF
--- a/changes/52810-cap-truncated-text-list-tooltip
+++ b/changes/52810-cap-truncated-text-list-tooltip
@@ -1,0 +1,1 @@
+- Fixed the software details modal so that hovering the vulnerabilities list shows the first 10 CVEs and a count of the rest, instead of a tooltip that runs off the screen when software has many CVEs.

--- a/frontend/components/TruncatedTextList/TruncatedTextList.stories.tsx
+++ b/frontend/components/TruncatedTextList/TruncatedTextList.stories.tsx
@@ -37,3 +37,12 @@ export const AllFit: Story = {
   args: { items: ["Mac", "Linux"] },
   decorators: [withFrame(360)],
 };
+
+/** Hover "+N more" — the tooltip lists 10 items and counts the rest, rather
+ * than growing past the height of the window. */
+export const ManyItems: Story = {
+  args: {
+    items: Array.from({ length: 57 }, (_, i) => `CVE-2026-${1000 + i}`),
+  },
+  decorators: [withFrame(360)],
+};

--- a/frontend/components/TruncatedTextList/TruncatedTextList.tests.tsx
+++ b/frontend/components/TruncatedTextList/TruncatedTextList.tests.tsx
@@ -65,4 +65,19 @@ describe("TruncatedTextList — truncatedFirstContent edge cases", () => {
       expect.objectContaining({ tipContent: longName })
     );
   });
+
+  it("caps the hidden items listed in the tooltip and counts the rest", () => {
+    const items = Array.from({ length: 57 }, (_, i) => `CVE-2026-${i}`);
+    render(<TruncatedTextList items={items} />);
+
+    // The first item is short enough to skip its own tooltip, so the only
+    // wrapper here is the "+N more" pill's.
+    const { tipContent } = mockedTooltipWrapper.mock.calls[0][0];
+    const { container } = render(<div>{tipContent}</div>);
+
+    // 56 items are hidden: 10 listed, the remaining 46 rolled into a count.
+    expect(container).toHaveTextContent("CVE-2026-10");
+    expect(container).not.toHaveTextContent("CVE-2026-11");
+    expect(container).toHaveTextContent("+46 more");
+  });
 });

--- a/frontend/components/TruncatedTextList/TruncatedTextList.tsx
+++ b/frontend/components/TruncatedTextList/TruncatedTextList.tsx
@@ -25,16 +25,26 @@ interface ITruncatedTextListProps {
 const truncateString = (s: string, max: number) =>
   s.length > max ? `${s.slice(0, max).trimEnd()}...` : s;
 
-const renderItemsList = (list: string[]) => (
-  <>
-    {list.map((name, i) => (
-      <React.Fragment key={name}>
-        {name}
-        {i < list.length - 1 && <br />}
-      </React.Fragment>
-    ))}
-  </>
-);
+/** A hover tooltip can't scroll, so an uncapped list runs off the screen with
+ * no way to reach the rest of it. Same cap idea as `VulnerabilitiesCell`. */
+const MAX_ITEMS_IN_TOOLTIP = 10;
+
+const renderItemsList = (list: string[]) => {
+  const shown = list.slice(0, MAX_ITEMS_IN_TOOLTIP);
+  const remaining = list.length - shown.length;
+
+  return (
+    <>
+      {shown.map((name, i) => (
+        <React.Fragment key={name}>
+          {name}
+          {(i < shown.length - 1 || remaining > 0) && <br />}
+        </React.Fragment>
+      ))}
+      {remaining > 0 && `+${remaining} more`}
+    </>
+  );
+};
 
 interface IRenderVisibleRowParams {
   visibleCount: number;


### PR DESCRIPTION
**Related issue:** Fixes #52810

On My device, open a software title with a lot of CVEs and hover the "+53 more" next to Vulnerabilities. The tooltip lists every hidden CVE in one column. With 57 CVEs it was 887px tall in a 950px window, so it covered the modal it came from, and on a shorter window the bottom was unreachable. Hover tooltips do not scroll.

The list comes from `TruncatedTextList`, which hands every hidden item to the tooltip. I capped it at 10 with a "+N more" count for the rest. The cap lives in the component, not the call site, so host details, policy labels, and the software library accordion are covered too.

The table cell next to it already caps at 3 (`NUM_VULNERABILITIES_IN_TOOLTIP`). I used 10 because 3 is sized for an inline cell and would hide 54 of 57 CVEs in a modal. 10 keeps the tooltip near 200px. Say the word and I will match 3.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

New test in `TruncatedTextList.tests.tsx` renders 57 items and checks the tooltip lists 10 and counts the other 46. It fails without the fix.

Manual check in a local server: My device > Software > 1Password with 57 CVEs > hover "+52 more". Also in Storybook with a new `ManyItems` story, where the tooltip measures 936px before and 194px after.

## AI

**AI:** Claude Code (claude-opus-5[1m])

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

Before, 56 CVEs in one column at 936px, top and bottom off screen:

<img width="900" height="700" alt="before" src="https://github.com/user-attachments/assets/7f41ad11-41d3-4030-9bab-8a5a9a86ad8d" />


After, 10 CVEs and a "+46 more" count at 194px:

<img width="900" height="700" alt="after" src="https://github.com/user-attachments/assets/0424280d-5040-4824-b1ba-623e196a36e3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved truncated-list tooltips in the software details modal. They now show up to 10 vulnerability items followed by a count of additional items, preventing the tooltip from extending beyond the screen.

- **Tests**
  - Added coverage for long vulnerability lists to verify the displayed items and remaining-item count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->