### PR TITLE
use 60s default timeout on DEP client

### DIFF
--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -718,7 +718,8 @@ func (d *DEPService) processDeviceResponse(
 			deadline = device.MDMMigrationDeadline.String()
 		}
 		// FIXME: Move this log back to debug level after we've added/improved functionality for accessing DEP status.
-		d.logger.InfoContext(ctx, "process device response",
+		d.logger.InfoContext(
+			ctx, "process device response",
 			"serial_number", device.SerialNumber,
 			"device_assigned_by", device.DeviceAssignedBy,
 			"device_assigned_date", device.DeviceAssignedDate,
@@ -742,7 +743,8 @@ func (d *DEPService) processDeviceResponse(
 		case "deleted":
 			keepRecent(device, deletedDevices)
 		default:
-			d.logger.WarnContext(ctx, "unrecognized op_type",
+			d.logger.WarnContext(
+				ctx, "unrecognized op_type",
 				"op_type", device.OpType,
 				"serial_number", device.SerialNumber,
 			)
@@ -845,7 +847,8 @@ func (d *DEPService) processDeviceResponse(
 		d.logger.DebugContext(ctx, "no DEP hosts to add")
 	}
 
-	d.logger.InfoContext(ctx, "devices to assign DEP profiles",
+	d.logger.InfoContext(
+		ctx, "devices to assign DEP profiles",
 		"to_add", strings.Join(addedSerials, ", "),
 		"to_remove", strings.Join(deletedSerials, ", "),
 		"to_modify", strings.Join(modifiedSerials, ", "),
@@ -990,7 +993,8 @@ func (d *DEPService) processDeviceResponse(
 				// only log the error so the failure can be recorded
 				// below in UpdateHostDEPAssignProfileResponses and
 				// the proper cooldowns are applied
-				logger.ErrorContext(ctx, "assign profile",
+				logger.ErrorContext(
+					ctx, "assign profile",
 					"devices", len(serials),
 					"err", err,
 				)
@@ -1011,7 +1015,8 @@ func (d *DEPService) processDeviceResponse(
 			}
 			// We don't expect to see this but log here just in case
 			if err != nil && implicitlyFailedAssignments > 0 {
-				logger.ErrorContext(ctx,
+				logger.ErrorContext(
+					ctx,
 					"assign profile: no error was returned but some devices were not assigned a status in the response",
 					"devices", implicitlyFailedAssignments,
 				)
@@ -1086,7 +1091,7 @@ func logCountsForResults(deviceResults map[string]string) (out []interface{}) {
 // changes, and flag the ABM token's token_invalid field whenever Apple
 // rejects the token or reports its signature as invalid.
 func NewDEPClient(storage godep.ClientStorage, updater fleet.ABMTermsUpdater, logger *slog.Logger) *godep.Client {
-	httpClient := fleethttp.NewClient(fleethttp.WithNoTimeout())
+	httpClient := fleethttp.NewClient()
 	return godep.NewClient(storage, httpClient, godep.WithAfterHook(func(ctx context.Context, reqErr error) error {
 		// to check for ABM terms expired, we must have an ABM token organization
 		// name and NOT a raw ABM token in the context (as the presence of a raw
@@ -2166,7 +2171,8 @@ func sendSetRecoveryLockCommands(
 
 		err := send(ctx, hostUUIDs, cmdUUID)
 		if err == nil {
-			logger.InfoContext(ctx, "sent SetRecoveryLock commands",
+			logger.InfoContext(
+				ctx, "sent SetRecoveryLock commands",
 				"host_count", len(hostUUIDs),
 				"command_uuid", cmdUUID,
 			)
@@ -2177,7 +2183,8 @@ func sendSetRecoveryLockCommands(
 		// In this case, the command is already queued and will be delivered when the device
 		// checks in, so we should NOT clear the pending status (which would cause duplicates).
 		if apnsErr, ok := errors.AsType[*APNSDeliveryError](err); ok {
-			logger.WarnContext(ctx, "SetRecoveryLock commands enqueued but APNs push failed",
+			logger.WarnContext(
+				ctx, "SetRecoveryLock commands enqueued but APNs push failed",
 				"host_count", len(hostUUIDs),
 				"command_uuid", cmdUUID,
 				"error", apnsErr,
@@ -2187,12 +2194,14 @@ func sendSetRecoveryLockCommands(
 
 		// Persistence failed - reset status to NULL so hosts will be picked up again on next cron run.
 		// The password is already stored, but a new one will be generated on retry (overwrites old).
-		logger.ErrorContext(ctx, "failed to enqueue SetRecoveryLock commands",
+		logger.ErrorContext(
+			ctx, "failed to enqueue SetRecoveryLock commands",
 			"host_count", len(hostUUIDs),
 			"error", err,
 		)
 		if clearErr := ds.ClearRecoveryLockPendingStatus(ctx, hostUUIDs); clearErr != nil {
-			logger.ErrorContext(ctx, "failed to clear recovery lock pending status after enqueue failure",
+			logger.ErrorContext(
+				ctx, "failed to clear recovery lock pending status after enqueue failure",
 				"host_count", len(hostUUIDs),
 				"error", clearErr,
 			)
@@ -2202,7 +2211,8 @@ func sendSetRecoveryLockCommands(
 	}
 
 	var result *multierror.Error
-	result = multierror.Append(result,
+	result = multierror.Append(
+		result,
 		enqueue(commander.SetRecoveryLock, freshSetHostUUIDs, setCmdUUID),
 		enqueue(commander.RotateRecoveryLock, rotateHostUUIDs, rotateCmdUUID),
 	)
@@ -2237,7 +2247,8 @@ func sendClearRecoveryLockCommands(
 		var apnsErr *APNSDeliveryError
 		if errors.As(err, &apnsErr) {
 			// Command was persisted but push notification failed - log warning but don't fail.
-			logger.WarnContext(ctx, "ClearRecoveryLock commands enqueued but APNs push failed",
+			logger.WarnContext(
+				ctx, "ClearRecoveryLock commands enqueued but APNs push failed",
 				"host_count", len(hosts),
 				"command_uuid", cmdUUID,
 				"error", err,
@@ -2246,12 +2257,14 @@ func sendClearRecoveryLockCommands(
 		}
 
 		// Persistence failed - reset status to NULL so hosts will be picked up again.
-		logger.ErrorContext(ctx, "failed to enqueue ClearRecoveryLock commands",
+		logger.ErrorContext(
+			ctx, "failed to enqueue ClearRecoveryLock commands",
 			"host_count", len(hosts),
 			"error", err,
 		)
 		if clearErr := ds.ClearRecoveryLockPendingStatus(ctx, hosts); clearErr != nil {
-			logger.ErrorContext(ctx, "failed to clear recovery lock pending status after enqueue failure",
+			logger.ErrorContext(
+				ctx, "failed to clear recovery lock pending status after enqueue failure",
 				"host_count", len(hosts),
 				"error", clearErr,
 			)
@@ -2260,7 +2273,8 @@ func sendClearRecoveryLockCommands(
 		return ctxerr.Wrap(ctx, err, "enqueue ClearRecoveryLock commands")
 	}
 
-	logger.InfoContext(ctx, "sent ClearRecoveryLock commands",
+	logger.InfoContext(
+		ctx, "sent ClearRecoveryLock commands",
 		"host_count", len(hosts),
 		"command_uuid", cmdUUID,
 	)
@@ -2300,14 +2314,16 @@ func sendAutoRotationCommands(
 			if fleet.IsNotFound(err) ||
 				errors.Is(err, fleet.ErrRecoveryLockRotationPending) ||
 				errors.Is(err, fleet.ErrRecoveryLockNotEligible) {
-				logger.DebugContext(ctx, "host lost eligibility for auto-rotation",
+				logger.DebugContext(
+					ctx, "host lost eligibility for auto-rotation",
 					"host_uuid", host.HostUUID,
 					"error", err,
 				)
 				continue
 			}
 
-			logger.ErrorContext(ctx, "failed to initiate auto-rotation",
+			logger.ErrorContext(
+				ctx, "failed to initiate auto-rotation",
 				"host_uuid", host.HostUUID,
 				"error", err,
 			)
@@ -2321,7 +2337,8 @@ func sendAutoRotationCommands(
 				// Command was persisted but push notification failed - log activity and continue.
 				// The command will be retried when the device checks in.
 				logAutoRotationActivity(ctx, logger, newActivityFn, host)
-				logger.WarnContext(ctx, "auto-rotation command enqueued but APNs push failed",
+				logger.WarnContext(
+					ctx, "auto-rotation command enqueued but APNs push failed",
 					"host_uuid", host.HostUUID,
 					"command_uuid", setCmdUUID,
 					"error", apnsErr,
@@ -2330,12 +2347,14 @@ func sendAutoRotationCommands(
 			}
 
 			// Persistence failed - clear pending rotation so host can be retried
-			logger.ErrorContext(ctx, "failed to enqueue auto-rotation command",
+			logger.ErrorContext(
+				ctx, "failed to enqueue auto-rotation command",
 				"host_uuid", host.HostUUID,
 				"error", err,
 			)
 			if clearErr := ds.ClearRecoveryLockRotation(ctx, host.HostUUID); clearErr != nil {
-				logger.ErrorContext(ctx, "failed to clear pending rotation after enqueue failure",
+				logger.ErrorContext(
+					ctx, "failed to clear pending rotation after enqueue failure",
 					"host_uuid", host.HostUUID,
 					"error", clearErr,
 				)
@@ -2348,7 +2367,8 @@ func sendAutoRotationCommands(
 		// Log activity for auto-rotation (Fleet-initiated)
 		logAutoRotationActivity(ctx, logger, newActivityFn, host)
 
-		logger.DebugContext(ctx, "sent auto-rotation command",
+		logger.DebugContext(
+			ctx, "sent auto-rotation command",
 			"host_uuid", host.HostUUID,
 			"command_uuid", setCmdUUID,
 		)
@@ -2374,7 +2394,8 @@ func logAutoRotationActivity(
 		HostDisplayName: host.DisplayName,
 		FleetInitiated:  true,
 	}); err != nil {
-		logger.WarnContext(ctx, "auto-rotation: failed to create activity",
+		logger.WarnContext(
+			ctx, "auto-rotation: failed to create activity",
 			"host_uuid", host.HostUUID,
 			"err", err,
 		)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50802 

Seems like it bundled a couple of formatting changes 🤷‍♂️

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Timeouts are implemented and retries are limited to avoid infinite loops


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Apple device enrollment and management requests now use standard HTTP timeout behavior, helping prevent requests from remaining open indefinitely.

- **Refactor**
  - Improved consistency in internal diagnostic logging without changing log messages, severity levels, or recorded details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->