### PR TITLE
Docs: Note last_mdm_checked_in_at semantics on host listing responses

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4036,6 +4036,7 @@ Returns the information of the specified host.
 
 > If you're hitting this endpoint often (e.g. every hour) for a large number of hosts (e.g. 1k+) the best practice is to set the `exclude_software` to `true` to prevent overloading the Fleet server.
 
+For iOS and iPadOS hosts, `last_mdm_checked_in_at` is populated from the active Apple MDM enrollment (`nano_enrollments.last_seen_at`, `enabled = 1` only), so the timestamp stops advancing after MDM checkout. The same field is populated on [List hosts](#list-hosts), [Search targets](#search-targets), and [List label's hosts](#list-labels-hosts) responses.
 
 #### Parameters
 


### PR DESCRIPTION
## Issue

Follow-up to #52572. Raised by @cdcme in review of #52486's mobile status branch: on `main`, `last_mdm_checked_in_at` was null on List hosts, Search targets, and List label's hosts. #52486 now populates it from `nano_enrollments.last_seen_at` (filtered to `enabled = 1`), so callers reading the raw field on those listings inherit new semantics (stops advancing after MDM checkout).

## Description

- Adds a one-paragraph note under **Get host** in `docs/REST API/rest-api.md`: for iOS/iPadOS, `last_mdm_checked_in_at` is populated from the active Apple MDM enrollment (`nano_enrollments.last_seen_at`, `enabled = 1` only) and stops advancing after MDM checkout.
- The paragraph lists the sibling endpoints where the same field is populated (List hosts, Search targets, List label's hosts) so a single note covers all four surfaces without duplicating text.
- Docs-only. Behavior itself ships in #52486. Targets `docs-v4.93.0` so the note ships alongside #52572 in the 4.93 reference-docs cut.

## Screenrecording

Not applicable. Docs-only.

## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
- No code paths touched; nothing to automate. QA renders the docs from `docs-v4.93.0` after merge and confirms the paragraph appears under **Get host**.

## AI

**AI:** Claude Code (claude-opus-4-7[1m])