### PR TITLE
Regenerate fleet-mcp osquery schema copy to unblock check-automated-doc

### DIFF
--- a/cmd/fleet-mcp/osquery_fleet_schema.json
+++ b/cmd/fleet-mcp/osquery_fleet_schema.json
@@ -18929,6 +18929,154 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/munki_installs.yml"
   },
   {
+    "name": "netskope",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
+    "description": "The local Netskope client's state, version, and steering configuration, as reported by `nsdiag -f`.\n\nNetskope can enter a silently degraded state where the STAgent process and its system extensions still look healthy but traffic is no longer steered. Checks against process state or system extension presence miss this; `client_status` and `tunnel_status` do not.",
+    "evented": false,
+    "columns": [
+      {
+        "name": "client_installed",
+        "description": "Whether a Netskope client install was found on this host (1=found, 0=not found). Always populated; when 0, the `error` column says why and the remaining columns are empty.",
+        "required": false,
+        "type": "integer"
+      },
+      {
+        "name": "error",
+        "description": "Why the client's state could not be read — `netskope client not installed`, an `nsdiag failed: ...` message (for example a permission failure), or `nsdiag reported no recognized fields`. Empty when the state was read successfully.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "install_path",
+        "description": "The directory the Netskope STAgent was found in. Empty when no install was found.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "orgname",
+        "description": "The Netskope tenant's organization name.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "tenant_url",
+        "description": "The tenant URL this client is enrolled with, for example `company.goskope.com`.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "addonhost",
+        "description": "The addon host endpoint the client connects to.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "addoncheckerhost",
+        "description": "The addon checker host endpoint the client connects to.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "gateway",
+        "description": "The hostname of the Netskope gateway traffic is steered through.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "gateway_ip",
+        "description": "The IP address of the Netskope gateway traffic is steered through.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "config",
+        "description": "The name of the client configuration currently applied.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "steering_config",
+        "description": "The name of the steering configuration currently applied.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "email",
+        "description": "The email address this client is enrolled with.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "peruser_config",
+        "description": "Whether a per-user configuration is in effect (`TRUE`/`FALSE`).",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "tunnel_status",
+        "description": "The state of the steering tunnel, for example `NSTUNNEL_CONNECTED`. A value other than connected on a host that should be steered is the degraded state to alert on.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "client_status",
+        "description": "The state of the client, for example `enable`.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "dynamic_steering",
+        "description": "Whether dynamic steering is enabled (`TRUE`/`FALSE`).",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "onpremdetection",
+        "description": "The on-premises detection setting, for example `Not Configured`.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "explicit_proxy",
+        "description": "Whether explicit proxy mode is enabled (`TRUE`/`FALSE`).",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "tunnel_protocol",
+        "description": "The protocol the steering tunnel uses, for example `TLS`.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "sni_enable",
+        "description": "Whether SNI-based steering is enabled (`TRUE`/`FALSE`).",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "traffic_mode",
+        "description": "The traffic steering mode, for example `All Traffic`.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "client_version",
+        "description": "The version of the installed Netskope client.",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "examples": "Find hosts where the Netskope client is installed but is no longer enabled and connected — the silently degraded state. `error = ''` keeps out clients whose state could not be read, which is a separate problem from a client that reported itself as degraded.\n```\nSELECT install_path, client_version, client_status, tunnel_status\nFROM netskope\nWHERE client_installed = 1\n  AND error = ''\n  AND NOT (client_status = 'enable' AND tunnel_status = 'NSTUNNEL_CONNECTED');\n```",
+    "notes": "This table is not a core osquery table. It is included as part of Fleet's agent\n([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).\n\nThe table always returns exactly one row, so that \"not installed\", \"installed but degraded\", and \"installed but state could not be read\" stay distinguishable. Check `client_installed` and `error` before treating the remaining columns as the client's real state.\n\nThe fields `nsdiag` reports change between Netskope releases. Fields this table does not recognize are ignored rather than failing the query, and a release that renames every field is reported through the `error` column.",
+    "url": "https://fleetdm.com/tables/netskope",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/netskope.yml"
+  },
+  {
     "name": "network_interfaces",
     "evented": false,
     "platforms": [


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA — follow-up to #52201 ([comment](https://github.com/fleetdm/fleet/pull/52201#issuecomment-5636527296))

`cmd/fleet-mcp/osquery_fleet_schema.json` is a generated copy of `schema/osquery_fleet_schema.json`. The copy is produced by the `//go:generate cp ../../schema/osquery_fleet_schema.json ./osquery_fleet_schema.json` directive in `cmd/fleet-mcp/schema.go`, which `make generate-doc` runs via its `generate-fleet-mcp` dependency.

#52201 added the netskope table to `schema/tables/netskope.yml` and to the top-level `schema/osquery_fleet_schema.json`, but the fleet-mcp copy was never regenerated. As a result `make generate-doc` re-adds the netskope block on every run, the `check-automated-doc` workflow's dirty-tree check trips, and the failure is inherited by `main` and by every PR that touches a `.go` file — not just the branch that introduced it.

This PR is the output of `make generate-fleet-mcp`: a single-file, additions-only diff of the netskope entry. No hand edits.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

Verified locally that `make generate-fleet-mcp` leaves a clean tree after this commit. Note that the failing CI run died at the `make generate-doc` step, so the subsequent `make vex-report` step never executed — if that step is also stale, it will surface on this PR's run.

## AI

**AI:** Claude Code (claude-opus-5)

## Frontend

NA — no user-visible change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `netskope` osquery table for macOS, Windows, and Linux.
  - Exposes Netskope installation, tenant, diagnostic, steering, tunnel, protocol, traffic mode, and client version details.
  - Includes guidance for degraded states, single-row results, and unrecognized diagnostic fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->