### PR TITLE
Deprecate managed_local_account_settings in docs

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -453,7 +453,8 @@ controls:
           - Engineering
         activation: ../lib/macos/activations/activation.json
     assets:
-      - path: ../lib/macos/assets/my-asset.json  
+      - path: ../lib/macos/assets/my-asset.json
+    enable_managed_local_account: true 
     end_user_local_account_type: "admin"
   windows_settings:
     configuration_profiles:
@@ -475,7 +476,6 @@ controls:
     apple_enable_release_device_manually: true
     apple_setup_assistant: ../lib/dep-profile.json
     macos_script: ../lib/macos-setup-script.sh
-    enable_managed_local_account: true
   macos_migration: # Available in Fleet Premium
     enable: true
     mode: voluntary
@@ -512,8 +512,8 @@ controls:
 
 ### apple_settings and windows_settings
 
-- `end_user_local_account_type` specifies the end user account type for macOS hosts. Requires `setup_experience.enable_managed_local_account` to be `true`. Only supported on macOS (`apple_settings`). Default: `"admin"`. To force a standard user account on Windows, use the [Autopilot profile](https://fleetdm.com/guides/windows-mdm-setup#force-a-standard-user-account).
-- `enable_managed_local_account` specifies whether to create the managed local account on that platform (default: `false`). Currently Windows only. macOS is [coming soon](https://github.com/fleetdm/fleet/issues/50084).
+- `enable_managed_local_account` specifies whether to create the managed local account on that platform (default: `false`).
+- `end_user_local_account_type` specifies the end user account type for macOS hosts. Requires `apple_settings.enable_managed_local_account` to be `true`. Only supported on macOS (`apple_settings`). Default: `"admin"`. To force a standard user account on Windows, use the [Autopilot profile](https://fleetdm.com/guides/windows-mdm-setup#force-a-standard-user-account).
 - `configuration_profiles` is a list of configuration profiles. Accepts .mobileconfig/.json (macOS/iOS/iPadOS) or .xml (Windows).
 
 Each entry can use either `path:` or `paths:`:
@@ -578,7 +578,7 @@ The `setup_experience` section lets you control the out-of-the-box [setup experi
 - `macos_script` is the path to a custom setup script to run after the host is first set up. Applies to macOS only.
 
 `enable_managed_local_account` and `end_user_local_account_type` at this level are deprecated. 
-Please use the platform-specific `apple_settings.managed_local_account_settings`, `apple_settings.end_user_local_account_type`, or `windows_settings.enable_managed_local_account` instead.
+Please use the platform-specific `apple_settings.enable_managed_local_account`, `apple_settings.end_user_local_account_type`, or `windows_settings.enable_managed_local_account` instead.
 
 #### Example
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1831,9 +1831,7 @@ None.
           "path": "path/to/assets/asset.json"
         }
       ],
-      "managed_local_account_settings": {
-        "enabled": true
-      },
+      "enable_managed_local_account": true,
       "end_user_local_account_type": "admin"
     },
     "windows_settings": {
@@ -1878,8 +1876,6 @@ None.
       "apple_setup_assistant": "path/to/config.json",
       "enable_release_device_manually": false,
       "manual_agent_install": false,
-      "enable_managed_local_account": false,
-      "end_user_local_account_type": "admin"
     },
     "client_url": "https://instance.fleet.com",
     "apple_account_provisioning": {
@@ -2231,9 +2227,7 @@ Modifies the Fleet's configuration with the supplied information.
           "path": "path/to/assets/asset.json"
         }
       ],
-      "managed_local_account_settings": {
-        "enabled": true
-      },
+      "enable_managed_local_account": true,
       "end_user_local_account_type": "admin"
     },
     "windows_settings": {
@@ -2273,8 +2267,6 @@ Modifies the Fleet's configuration with the supplied information.
     "setup_experience": {
       "bootstrap_package": "",
       "enable_end_user_authentication": false,
-      "enable_managed_local_account": false,
-      "end_user_local_account_type": "admin",
       "lock_end_user_info": true,
       "apple_setup_assistant": "path/to/config.json"
     },
@@ -2948,9 +2940,9 @@ _Available in Fleet Premium._
 | Name                                 | Type    | Description   |
 | ---------------------                | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enable_end_user_authentication       | boolean | If set to true, end user authentication will be required during automatic MDM enrollment of new macOS devices. Settings for your IdP provider must also be [configured](https://fleetdm.com/guides/setup-experience#end-user-authentication). |
-| enable_managed_local_account         | boolean | _Available in Fleet Premium._ During Setup experience, a managed local account will be created on eligible hosts if set to true. |
-| end_user_local_account_type          | string  | _Available in Fleet Premium._ Specifies the type of local end user account created. (Default: `"admin"`) `enable_managed_local_account` must be true. |
 | lock_end_user_info                   | boolean | If set to true, end user can't edit the local account's Account Name and Full Name in macOS Setup Assistant. These fields will be locked to values from your IdP. (Default: `true`) |
+
+> `enable_managed_local_account` and `end_user_local_account_type` are deprecated as of Fleet 4.94. It is maintained for backwards compatibility. Please use the platform based `enable_managed_local_account` and `apple_settings.end_user_local_account_type` instead.
 
 <br/>
 
@@ -2971,9 +2963,10 @@ _Available in Fleet Premium._
 | Name                                   | Type    | Description   |
 | -------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | custom_settings                        | array   | Only intended to be used by [Fleet's YAML](https://fleetdm.com/docs/configuration/yaml-files). To add macOS configuration profiles using Fleet's API, use the [Create configuration profile](#create-configuration-profile) endpoint instead. |
-| managed_local_account_settings         | object  | Settings for the managed local account. |
-| managed_local_account_settings.enabled | boolean | Whether to create the managed local account (default: `false`). |
-| end_user_local_account_type            | string  | The end user account type. Requires `managed_local_account_settings.enabled` to be `true`. Options: `"admin"`, `"standard"`, `"none"` (default: `"admin"`). |
+| enable_managed_local_account           | boolean | Whether to create the managed local account (default: `false`). |
+| end_user_local_account_type            | string  | The end user account type. Requires `enable_managed_local_account` to be `true`. Options: `"admin"`, `"standard"`, `"none"` (default: `"admin"`). |
+
+> `managed_local_account_settings` and `managed_local_account_settings.enabled` are deprecated as of Fleet 4.94. It is maintained for backwards compatibility. Please use `enable_managed_local_account` instead.
 
 <br/>
 
@@ -3047,10 +3040,7 @@ _Available in Fleet Premium._
           "path": "path/to/assets/asset.json"
         }
       ],
-      "managed_local_account_settings": {
-        "enabled": true
-      }
-    },
+      "enable_managed_local_account": true
     "windows_settings": {
       "configuration_profiles": [
         {
@@ -9290,8 +9280,6 @@ _Available in Fleet Premium_
 | require_all_software_windows | boolean | body | If set to `true`, setup will be canceled on Windows hosts if any software installs fail (the host is blocked at the Windows Enrollment Status Page until the device is reset). If `false`, the Enrollment Status Page lists the failed software and the end user can continue to the desktop and install it later via self-service. |
 | enable_release_device_manually | boolean | body  | When enabled, you're responsible for sending the [`DeviceConfigured` command](https://developer.apple.com/documentation/devicemanagement/device-configured-command). End users will be stuck in Setup Assistant until this command is sent. |
 | manual_agent_install | boolean | body  | If set to `true` Fleet's agent (fleetd) won't be installed as part of automatic enrollment (ADE) on macOS hosts. (Default: `false`) |
-| enable_managed_local_account     | boolean | body | _Available in Fleet Premium._ During the Setup experience, a managed local account will be created on macOS hosts if set to true. |
-| end_user_local_account_type     | string | body | Specifies the type of local end user account created. (Default: `"admin"`) `enable_managed_local_account` must be true. |
 
 #### Example
 
@@ -16084,9 +16072,7 @@ _Available in Fleet Premium_
             "path": "path/to/assets/asset.json"
           }
         ],
-        "managed_local_account_settings": {
-          "enabled": true
-        }
+        "enable_managed_local_account": true
       },
       "windows_settings": {
         "custom_settings": [
@@ -16113,8 +16099,6 @@ _Available in Fleet Premium_
       "setup_experience": {
         "bootstrap_package": "",
         "enable_end_user_authentication": false,
-        "enable_managed_local_account": false,
-        "end_user_local_account_type": "admin",
         "apple_setup_assistant": "path/to/config.json",
         "enable_release_device_manually": false,
         "manual_agent_install": false
@@ -16534,9 +16518,10 @@ Omitting `host_activities_webhook` from a `webhook_settings` update leaves the s
 | Name                                   | Type    | Description   |
 | -------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | custom_settings                        | array   | Only intended to be used by [Fleet's YAML](https://fleetdm.com/docs/configuration/yaml-files). To add macOS configuration profiles using Fleet's API, use the [Create configuration profile](#create-configuration-profile) endpoint instead. |
-| managed_local_account_settings         | object  | Settings for the managed local account. |
-| managed_local_account_settings.enabled | boolean | Whether to create the managed local account (default: `false`). |
-| end_user_local_account_type            | string  | The end user account type. Requires `managed_local_account_settings.enabled` to be `true`. Options: `"admin"`, `"standard"`, `"none"` (default: `"admin"`). |
+| enable_managed_local_account           | boolean | Whether to create the managed local account (default: `false`). |
+| end_user_local_account_type            | string  | The end user account type. Requires `enable_managed_local_account` to be `true`. Options: `"admin"`, `"standard"`, `"none"` (default: `"admin"`). |
+
+> `managed_local_account_settings` and `managed_local_account_settings.enabled` are deprecated as of Fleet 4.94. It is maintained for backwards compatibility. Please use `enable_managed_local_account` instead.
 
 <br/>
 
@@ -16562,9 +16547,8 @@ Omitting `host_activities_webhook` from a `webhook_settings` update leaves the s
 | ------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enable_end_user_authentication        | boolean | If set to true, IdP authentication will be required during automatic MDM enrollment of new macOS hosts. Settings for your IdP provider must also be [configured](https://fleetdm.com/guides/setup-experience#require-idp-authentication).
 | lock_end_user_info                    | boolean | If set to true, end user can't edit the local account's Account Name and Full Name in macOS Setup Assistant. These fields will be locked to values from your IdP. (Default: `true`) |
-| enable_managed_local_account          | boolean | _Available in Fleet Premium._ During Setup experience, a managed local account will be created on eligible hosts if set to true. |
-| end_user_local_account_type          | string  | body  | Specifies the type of local end user account created. (Default: `"admin"`) `enable_managed_local_account` must be true. |
 
+> `enable_managed_local_account` and `end_user_local_account_type` are deprecated as of Fleet 4.94. It is maintained for backwards compatibility. Please use the platform based `enable_managed_local_account` and `apple_settings.end_user_local_account_type` instead.
 
 ##### Example request body
 
@@ -16605,9 +16589,7 @@ Omitting `host_activities_webhook` from a `webhook_settings` update leaves the s
           "path": "path/to/assets/asset.json"
         }
       ],
-      "managed_local_account_settings": {
-        "enabled": true
-      }
+      "enable_managed_local_account": true
     },
     "windows_settings": {
       "custom_settings": [
@@ -16812,9 +16794,7 @@ _Available in Fleet Premium_
             "path": "path/to/assets/asset.json"
           }
         ],
-        "managed_local_account_settings": {
-          "enabled": true
-        }
+        "enable_managed_local_account": true
       },
       "windows_settings": {
         "custom_settings": [


### PR DESCRIPTION
Updated the documentation to reflect the deprecation of 'managed_local_account_settings' in favor of 'enable_managed_local_account'. Adjusted examples and descriptions accordingly.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50084