### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/masscode/darwin.json
+++ b/ee/maintained-apps/outputs/masscode/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.10.0",
+      "version": "5.11.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.masscode.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.masscode.app' AND version_compare(bundle_short_version, '5.10.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.masscode.app' AND version_compare(bundle_short_version, '5.11.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'io.masscode.app' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/massCodeIO/massCode/releases/download/v5.10.0/massCode-5.10.0-arm64.dmg",
+      "installer_url": "https://github.com/massCodeIO/massCode/releases/download/v5.11.0/massCode-5.11.0-arm64.dmg",
       "install_script_ref": "d25eb03c",
       "uninstall_script_ref": "02f458b9",
-      "sha256": "533a0621491646c849268ff319907e4a6ef884a8b9c775413162fbf9b93f7d64",
+      "sha256": "f9be9b16273a9d9d75518dc62227ceae96fe706f13c762deb028669d2a2d417d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '135.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.operasoftware.Opera' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/135.0.5973.123/mac/Opera_135.0.5973.123_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/135.0.5973.133/mac/Opera_135.0.5973.133_Setup.dmg",
       "install_script_ref": "f2f3d814",
       "uninstall_script_ref": "bc37ca3d",
-      "sha256": "af1f7def65d025c3a8bd907d2632dc1f6cba25178af640c85e7e0c6e07219524",
+      "sha256": "bbe0e6a4b96bfe3e2e99a3a083292cbe0ea675694de3014192093f67318c8e20",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the macOS massCode package to version 5.11.0.
  - Updated the macOS Opera package to build 135.0.5973.133.
  - Refreshed installer verification details for both applications to support accurate downloads and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->