### PR TITLE
Revert "[Activity] Document end user agreement audit log activities" from docs-v4.92.0

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3694,35 +3694,6 @@ This activity contains the following fields:
 }
 ```
 
-## added_end_user_agreement
-
-Generated when a user uploads a custom end user agreement file (EULA for macOS, terms and conditions for Windows).
-
-This activity contains the following fields:
-- "platform": the platform of the agreement ("macos" or "windows").
-
-#### Example
-
-```json
-{
-  "platform": "windows"
-}
-```
-
-## deleted_end_user_agreement
-
-Generated when a user deletes a custom end user agreement file (EULA for macOS, terms and conditions for Windows).
-
-This activity contains the following fields:
-- "platform": the platform of the agreement ("macos" or "windows").
-
-#### Example
-
-```json
-{
-  "platform": "macos"
-}
-
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">
 <meta name="description" value="Learn how Fleet logs administrative actions in JSON format.">


### PR DESCRIPTION
Reverts #51965 from `docs-v4.92.0`. Feature is moving to `docs-v4.94.0`.

**Related:** #51965