### PR TITLE
Move declarations to the proper place to fix linter.

### DIFF
--- a/orbit/pkg/luks/luks.go
+++ b/orbit/pkg/luks/luks.go
@@ -285,15 +285,6 @@ const (
 	recoveryKeyServerTooOldText  = "Your Fleet server needs an update before it can back up your disk recovery key. Please contact your IT admin."
 )
 
-// promptOutcome is how the passphrase prompt ended.
-type promptOutcome int
-
-const (
-	promptEntered promptOutcome = iota
-	promptCanceled
-	promptTimedOut
-)
-
 type LuksRunner struct {
 	escrower KeyEscrower
 	notifier dialog.Dialog
@@ -333,21 +324,6 @@ type LuksResponse struct {
 func New(escrower KeyEscrower) *LuksRunner {
 	return &LuksRunner{
 		escrower: escrower,
-	}
-}
-
-func (lr *LuksRunner) reportsEscrowStatus() bool {
-	return lr.escrower.GetServerCapabilities().Has(fleet.CapabilityLinuxEscrowStatus)
-}
-
-// sendEscrowStatus is a no-op without the server capability. prompting (per re-prompt) and
-// escrowing (on acceptance) refresh the server's in-flight state through retries and key slot work.
-func (lr *LuksRunner) sendEscrowStatus(status string) {
-	if !lr.reportsEscrowStatus() {
-		return
-	}
-	if err := lr.escrower.SendLinuxKeyEscrowStatus(status); err != nil {
-		log.Debug().Err(err).Str("status", status).Msg("failed to report LUKS escrow status")
 	}
 }
 

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -40,6 +40,30 @@ const (
 
 var ErrKeySlotFull = regexp.MustCompile(`Key slot \d+ is full`)
 
+// promptOutcome is how the passphrase prompt ended.
+type promptOutcome int
+
+const (
+	promptEntered promptOutcome = iota
+	promptCanceled
+	promptTimedOut
+)
+
+func (lr *LuksRunner) reportsEscrowStatus() bool {
+	return lr.escrower.GetServerCapabilities().Has(fleet.CapabilityLinuxEscrowStatus)
+}
+
+// sendEscrowStatus is a no-op without the server capability. prompting (per re-prompt) and
+// escrowing (on acceptance) refresh the server's in-flight state through retries and key slot work.
+func (lr *LuksRunner) sendEscrowStatus(status string) {
+	if !lr.reportsEscrowStatus() {
+		return
+	}
+	if err := lr.escrower.SendLinuxKeyEscrowStatus(status); err != nil {
+		log.Debug().Err(err).Str("status", status).Msg("failed to report LUKS escrow status")
+	}
+}
+
 // luksDevice abstracts the subset of the go-blockdevice LUKS operations that
 // the escrow flow needs. *luksdevice.LUKS satisfies it; tests substitute a
 // fake so the prompt/validate logic can be exercised without cryptsetup or a

--- a/orbit/pkg/luks/luks_linux_test.go
+++ b/orbit/pkg/luks/luks_linux_test.go
@@ -323,3 +323,14 @@ func TestAddEscrowKeyAddKeyError(t *testing.T) {
 	// AddKey failed, so the escrow key was never validated.
 	assert.Empty(t, dev.checkedSlots)
 }
+
+func (f *fakeEscrower) sentStatuses() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.statuses...)
+}
+
+// newStatusEscrower returns a fake escrower whose server accepts escrow status reports.
+func newStatusEscrower() *fakeEscrower {
+	return &fakeEscrower{capabilities: fleet.CapabilityMap{fleet.CapabilityLinuxEscrowStatus: {}}}
+}

--- a/orbit/pkg/luks/luks_test.go
+++ b/orbit/pkg/luks/luks_test.go
@@ -418,17 +418,6 @@ func (f *fakeEscrower) SendLinuxKeyEscrowStatus(status string) error {
 	return f.err
 }
 
-func (f *fakeEscrower) sentStatuses() []string {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return append([]string(nil), f.statuses...)
-}
-
-// newStatusEscrower returns a fake escrower whose server accepts escrow status reports.
-func newStatusEscrower() *fakeEscrower {
-	return &fakeEscrower{capabilities: fleet.CapabilityMap{fleet.CapabilityLinuxEscrowStatus: {}}}
-}
-
 func (f *fakeEscrower) GetServerCapabilities() fleet.CapabilityMap {
 	if f.capabilities == nil {
 		return fleet.CapabilityMap{}


### PR DESCRIPTION
Introduced in #52717

The code is not actually dead, it's just that its only been referenced in "go:build linux"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery-key notifications when the connected server is outdated.
  - Linux systems now consistently report recovery-key escrow status when supported by the server.

- **Tests**
  - Expanded coverage for recovery-key escrow status reporting and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->