### PR TITLE
Unfreeze Whispering (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/whispering.json
+++ b/ee/maintained-apps/inputs/homebrew/whispering.json
@@ -6,6 +6,5 @@
   "slug": "whispering/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/whispering/darwin.json
+++ b/ee/maintained-apps/outputs/whispering/darwin.json
@@ -10,7 +10,7 @@
       "installer_url": "https://github.com/epicenter-os/epicenter/releases/download/v7.11.0/Whispering_7.11.0_aarch64.dmg",
       "install_script_ref": "97e6a9b5",
       "uninstall_script_ref": "2a39a669",
-      "sha256": "7c15883a5562e594633e2636db5abbc8197b8ae93c4714711bf802b531eaf2d0",
+      "sha256": "52b79ad24f14907fad55673761935ba90ce70c6d3248f804a7d302b62bfef828",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
test-fma-darwin-pr-only can validate `whispering/darwin` at its current upstream version.

Frozen since: 2026-08-31
Version: 7.11.0 -> 7.11.0

Note: the version string did not move. The only output change is the installer `sha256`
(`7c15883a...` -> `52b79ad2...`), i.e. upstream republished the same version with a different
binary. The manifest still changes, so the validate shard does run for this slug — but merging
this would not bump the pinned version.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

https://claude.ai/code/session_01XiqxN7o7nP8FHZSpm4uUZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiqxN7o7nP8FHZSpm4uUZF)_