### PR TITLE
Website: Test replacing docsearch on documentation and article pages

### DIFF
--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -73,26 +73,26 @@ parasails.registerComponent('docsNavAndSearch', {
     //…
   },
   mounted: async function() {
-    let filterForSearch = {};
-    if(this.searchFilter){
-      let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'controls'];
-      let buttonTextBySearchFilter = {
-        docs: 'Search the docs',
-        software: 'Search software',
-        queries: 'Search reports',
-        vitals: 'Search vitals',
-        policies: 'Search policies',
-        tables: 'Search data tables',
-        controls: 'Search controls'
-      };
-      if(!searchIndexesThatExist.includes(this.searchFilter)){
-        throw new Error(`Invalid 'searchFilter' value provided to <docs-nav-and-search> component. Please change the searchFilter value to one of: ${searchIndexesThatExist.join(', ')}`);
-      }
-      filterForSearch = {
-        'facetFilters': [`section:${this.searchFilter}`]
-      };
-      this.searchBoxLabel = buttonTextBySearchFilter[this.searchFilter];
-    }
+    // let filterForSearch = {};
+    // if(this.searchFilter){
+    //   let searchIndexesThatExist = ['docs', 'software', 'queries', 'vitals', 'policies', 'tables', 'controls'];
+    //   let buttonTextBySearchFilter = {
+    //     docs: 'Search the docs',
+    //     software: 'Search software',
+    //     queries: 'Search reports',
+    //     vitals: 'Search vitals',
+    //     policies: 'Search policies',
+    //     tables: 'Search data tables',
+    //     controls: 'Search controls'
+    //   };
+    //   if(!searchIndexesThatExist.includes(this.searchFilter)){
+    //     throw new Error(`Invalid 'searchFilter' value provided to <docs-nav-and-search> component. Please change the searchFilter value to one of: ${searchIndexesThatExist.join(', ')}`);
+    //   }
+    //   filterForSearch = {
+    //     'facetFilters': [`section:${this.searchFilter}`]
+    //   };
+    //   this.searchBoxLabel = buttonTextBySearchFilter[this.searchFilter];
+    // }
     // Note: algolia docsearch is disabled while we test sending search queries to google.
     // if(this.algoliaPublicKey) {
     //   docsearch({

--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -53,11 +53,11 @@ parasails.registerComponent('docsNavAndSearch', {
                   <img style="height: 16px; width: 16px;" class="search" alt="search" src="/images/icon-search-16x16@2x.png">
                 </span>
               </div>
-              <div class="form-control border-0 ">
-              <input class="docsearch-input pr-1"
-                placeholder="Search" aria-label="Search"
-                />
-              </div>
+              <form purpose="google-search">
+                <div class="form-control border-0">
+                  <input class="docsearch-input pr-1" placeholder="Search" aria-label="Search"/>
+                </div>
+              </form>
             </div>
           </div>
         </div>
@@ -93,23 +93,24 @@ parasails.registerComponent('docsNavAndSearch', {
       };
       this.searchBoxLabel = buttonTextBySearchFilter[this.searchFilter];
     }
-    if(this.algoliaPublicKey) {
-      docsearch({
-        appId: 'NZXAYZXDGH',
-        apiKey: this.algoliaPublicKey,
-        indexName: 'fleetdm',
-        container: '#docsearch-query',
-        placeholder: this.searchBoxLabel,
-        debug: false,
-        searchParameters: filterForSearch,
-        translations: {
-          button: {
-            buttonText: this.searchBoxLabel,
-            buttonAriaLabel: this.searchBoxLabel,
-          },
-        },
-      });
-    }
+    // Note: algolia docsearch is disabled while we test sending search queries to google.
+    // if(this.algoliaPublicKey) {
+    //   docsearch({
+    //     appId: 'NZXAYZXDGH',
+    //     apiKey: this.algoliaPublicKey,
+    //     indexName: 'fleetdm',
+    //     container: '#docsearch-query',
+    //     placeholder: this.searchBoxLabel,
+    //     debug: false,
+    //     searchParameters: filterForSearch,
+    //     translations: {
+    //       button: {
+    //         buttonText: this.searchBoxLabel,
+    //         buttonAriaLabel: this.searchBoxLabel,
+    //       },
+    //     },
+    //   });
+    // }
   },
   beforeDestroy: function() {
     //…

--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -70,28 +70,29 @@ parasails.registerPage('articles', {
   },
 
   mounted: async function() {
-    if(['Blog', 'News', 'Guides', 'Releases'].includes(this.articleCategory)) {
-      if(this.algoliaPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the handbook search will be disabled.
-        docsearch({
-          appId: 'NZXAYZXDGH',
-          apiKey: this.algoliaPublicKey,
-          indexName: 'fleetdm',
-          container: '#docsearch-query',
-          placeholder: 'Search articles',
-          debug: false,
-          clickAnalytics: true,
-          searchParameters: {
-            facetFilters: ['section:articles']
-          },
-          translations: {
-            button: {
-              buttonText: 'Search articles',
-              buttonAriaLabel: 'Search articles',
-            },
-          },
-        });
-      }
-    }
+    // Note: algolia docsearch is disabled while we test sending users to google.
+    // if(['Blog', 'News', 'Guides', 'Releases'].includes(this.articleCategory)) {
+    //   if(this.algoliaPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the handbook search will be disabled.
+    //     docsearch({
+    //       appId: 'NZXAYZXDGH',
+    //       apiKey: this.algoliaPublicKey,
+    //       indexName: 'fleetdm',
+    //       container: '#docsearch-query',
+    //       placeholder: 'Search articles',
+    //       debug: false,
+    //       clickAnalytics: true,
+    //       searchParameters: {
+    //         facetFilters: ['section:articles']
+    //       },
+    //       translations: {
+    //         button: {
+    //           buttonText: 'Search articles',
+    //           buttonAriaLabel: 'Search articles',
+    //         },
+    //       },
+    //     });
+    //   }
+    // }
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗

--- a/website/assets/js/pages/articles/basic-article.page.js
+++ b/website/assets/js/pages/articles/basic-article.page.js
@@ -98,43 +98,44 @@ parasails.registerPage('basic-article', {
     window.addEventListener('scroll', this.handleScrollingInArticle);
 
     if(this.algoliaPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the handbook search will be disabled.
-      docsearch({
-        appId: 'NZXAYZXDGH',
-        apiKey: this.algoliaPublicKey,
-        indexName: 'fleetdm',
-        container: '#docsearch-query',
-        placeholder: 'Search articles',
-        debug: false,
-        clickAnalytics: true,
-        searchParameters: {
-          facetFilters: ['section:articles']
-        },
-        translations: {
-          button: {
-            buttonText: 'Search articles',
-            buttonAriaLabel: 'Search articles',
-          },
-        },
-      });
+      // Note: algolia docsearch is disabled while we test sending users to google.
+      // docsearch({
+      //   appId: 'NZXAYZXDGH',
+      //   apiKey: this.algoliaPublicKey,
+      //   indexName: 'fleetdm',
+      //   container: '#docsearch-query',
+      //   placeholder: 'Search articles',
+      //   debug: false,
+      //   clickAnalytics: true,
+      //   searchParameters: {
+      //     facetFilters: ['section:articles']
+      //   },
+      //   translations: {
+      //     button: {
+      //       buttonText: 'Search articles',
+      //       buttonAriaLabel: 'Search articles',
+      //     },
+      //   },
+      // });
       // For mobile search
-      docsearch({
-        appId: 'NZXAYZXDGH',
-        apiKey: this.algoliaPublicKey,
-        indexName: 'fleetdm',
-        container: '#mobile-docsearch',
-        placeholder: 'Search articles',
-        debug: false,
-        clickAnalytics: true,
-        searchParameters: {
-          facetFilters: ['section:articles']
-        },
-        translations: {
-          button: {
-            buttonText: 'Search articles',
-            buttonAriaLabel: 'Search articles',
-          },
-        },
-      });
+      // docsearch({
+      //   appId: 'NZXAYZXDGH',
+      //   apiKey: this.algoliaPublicKey,
+      //   indexName: 'fleetdm',
+      //   container: '#mobile-docsearch',
+      //   placeholder: 'Search articles',
+      //   debug: false,
+      //   clickAnalytics: true,
+      //   searchParameters: {
+      //     facetFilters: ['section:articles']
+      //   },
+      //   translations: {
+      //     button: {
+      //       buttonText: 'Search articles',
+      //       buttonAriaLabel: 'Search articles',
+      //     },
+      //   },
+      // });
     }
   },
 

--- a/website/assets/styles/components/docs-nav-and-search.component.less
+++ b/website/assets/styles/components/docs-nav-and-search.component.less
@@ -93,12 +93,15 @@
         padding-top: 6px;
         padding-bottom: 6px;
         border: none;
+        &:focus-visible {
+          outline-color: @core-vibrant-green;
         }
         &::placeholder {
           font-size: 16px;
           line-height: 24px;
           color: #8B8FA2;
         }
+      }
       .input-group {
         border-top-left-radius: 6px;
         border-bottom-left-radius: 6px;
@@ -108,14 +111,17 @@
         background: #FFF;
       }
       .input-group:focus-within {
-        border: 1px solid @core-vibrant-blue;
+        border: 1px solid @core-vibrant-green;
       }
       .form-control {
         border-radius: 6px;
         padding: 6px;
         height: 36px;
         margin: 0;
-        width: 212px;
+        width: 171px;
+        .docsearch-input {
+          width: 165px;
+        }
       }
       .docsearch-input:focus-visible {
         outline: none;
@@ -184,7 +190,7 @@
         display: none;
       }
       .input-group:focus-within {
-        border: 1px solid @core-vibrant-blue;
+        border: 1px solid @core-vibrant-green;
       }
       .DocSearch-Button-Placeholder {
         font-size: 16px;
@@ -213,14 +219,17 @@
           background: #FFF;
         }
         .input-group:focus-within {
-          border: 1px solid @core-vibrant-blue;
+          border: 1px solid @core-vibrant-green;
         }
         .form-control {
           border-radius: 6px;
           padding: 6px;
           height: 36px;
           margin: 0;
-          width: 212px;
+          width: 100px;
+          .docsearch-input {
+            width: 65px;
+          }
         }
         .docsearch-input:focus-visible {
           outline: none;

--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -270,7 +270,7 @@ html, body {
       align-items: flex-start;
       gap: 10px;
       align-self: stretch;
-      .DocSearch-Button {
+      input {
         border-radius: 8px;
         border: 1px solid @core-fleet-black-25;
         background-color: #FFF;
@@ -282,6 +282,9 @@ html, body {
         justify-content: space-between;
         align-items: center;
         align-self: stretch;
+        &:focus-visible {
+          outline-color: @core-vibrant-green;
+        }
       }
       .DocSearch-Button:hover {
         box-shadow: none;
@@ -304,7 +307,7 @@ html, body {
         display: none;
       }
       .input-group:focus-within {
-        border: 1px solid @core-vibrant-blue;
+        border: 1px solid @core-vibrant-green;
       }
       .DocSearch-Button-Placeholder {
         font-size: 16px;

--- a/website/assets/styles/pages/articles/articles.less
+++ b/website/assets/styles/pages/articles/articles.less
@@ -164,10 +164,11 @@
         padding-top: 6px;
         padding-bottom: 6px;
         border: none;
-        } &::placeholder {
+        &::placeholder {
           font-size: 16px;
           line-height: 24px;
         }
+      }
       .input-group {
         border-top-left-radius: 6px;
         border-bottom-left-radius: 6px;
@@ -177,7 +178,7 @@
         background: #FFF;
       }
       .input-group:focus-within {
-        border: 1px solid @core-vibrant-blue;
+        border: 1px solid @core-vibrant-green;
       }
       .docsearch-input {
         height: 100%;

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -104,11 +104,12 @@
           padding-top: 6px;
           padding-bottom: 6px;
           border: none;
-          } &::placeholder {
+          &::placeholder {
             font-size: 16px;
             line-height: 24px;
             color: #8B8FA2;
           }
+        }
         .input-group {
           border-top-left-radius: 6px;
           border-bottom-left-radius: 6px;
@@ -118,7 +119,7 @@
           background: #FFF;
         }
         .input-group:focus-within {
-          border: 1px solid @core-vibrant-blue;
+          border: 1px solid @core-vibrant-green;
         }
         .form-control {
           border-radius: 6px;

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -1154,7 +1154,7 @@
         var input = form.querySelector('input');
         var searchQuery = (input ? input.value : '').trim();
         if (!searchQuery) { return; }
-        window.open('https://www.google.com/search?q=' + encodeURIComponent('site:fleetdm.com ' + searchQuery), '_blank', 'noopener');
+        window.open('https://www.google.com/search?q=' + encodeURIComponent('site:fleetdm.com ' + searchQuery) + '&udm=50', '_blank', 'noopener');
       });
     </script>
     <% if (sails.config.environment === 'production') { %>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -208,8 +208,11 @@
                 </div>
                 <div purpose="mobile-nav-container" id="mobileDropdowns">
                   <div purpose="mobile-dropdown-menus">
-                    <div purpose="mobile-search" id="mobile-docsearch" class="<%- showSearchInMobileMenu ? 'd-flex' : 'd-none'%>">
-                    </div>
+                    <form purpose="google-search" >
+                      <div purpose="mobile-search" class="<%- showSearchInMobileMenu ? 'd-flex' : 'd-none'%>">
+                        <input class="docsearch-input pr-1" placeholder="Search" aria-label="Search"/>
+                      </div>
+                    </form>
                     <div purpose="mobile-dropdown-toggle" class="d-flex flex-row justify-content-between align-items-center collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleUseCases" aria-haspopup="true" aria-expanded="false">
                       <div><p>Solutions</p></div>
                       <div><img src="/images/icon-chevron-fleet-black-50-12x12@2x.png" alt="a small chevron"></div>
@@ -1140,6 +1143,18 @@
             });
           }
         }
+      });
+    </script>
+    <script>
+      // Sends search queries to a scoped Google search.
+      document.addEventListener('submit', function(event) {
+        var form = event.target.closest('form[purpose="google-search"]');
+        if (!form) { return; }
+        event.preventDefault();
+        var input = form.querySelector('input');
+        var searchQuery = (input ? input.value : '').trim();
+        if (!searchQuery) { return; }
+        window.open('https://www.google.com/search?q=' + encodeURIComponent('site:fleetdm.com ' + searchQuery) + '&udm=50', '_blank', 'noopener');
       });
     </script>
     <% if (sails.config.environment === 'production') { %>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -1154,7 +1154,7 @@
         var input = form.querySelector('input');
         var searchQuery = (input ? input.value : '').trim();
         if (!searchQuery) { return; }
-        window.open('https://www.google.com/search?q=' + encodeURIComponent('site:fleetdm.com ' + searchQuery) + '&udm=50', '_blank', 'noopener');
+        window.open('https://www.google.com/search?q=' + encodeURIComponent('site:fleetdm.com ' + searchQuery), '_blank', 'noopener');
       });
     </script>
     <% if (sails.config.environment === 'production') { %>

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -18,11 +18,11 @@
                       <img style="height: 16px; width: 16px;" class="search" alt="search" src="/images/icon-search-16x16@2x.png">
                     </span>
                   </div>
-                  <div class="form-control border-0 ">
-                  <input class="docsearch-input pr-1"
-                    placeholder="Search" aria-label="Search"
-                    />
-                  </div>
+                  <form purpose="google-search">
+                    <div class="form-control border-0">
+                      <input class="docsearch-input pr-1" placeholder="Search" aria-label="Search"/>
+                    </div>
+                  </form>
                 </div>
               </div>
             </div>

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -17,11 +17,11 @@
                 <img style="height: 16px; width: 16px;" class="search" alt="search" src="/images/icon-search-16x16@2x.png">
               </span>
             </div>
-            <div class="form-control border-0 ">
-            <input class="docsearch-input pr-1"
-              placeholder="Search" aria-label="Search"
-              />
-            </div>
+            <form purpose="google-search">
+              <div class="form-control border-0">
+                <input class="docsearch-input pr-1" placeholder="Search" aria-label="Search"/>
+              </div>
+            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changes:
- Disabled Algolia DocSearch on documentation and article pages, and replaced it with a search bar that opens a scoped Google search in a new tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Google-powered site search to desktop and mobile navigation.
  - Search results open in a new tab and are limited to the Fleet device management website.
  - Empty search submissions are ignored.

- **Changes**
  - Disabled the previous documentation search on article and documentation pages.
  - Updated search field sizing for desktop and mobile layouts.
  - Improved focus styling with green accent colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->