### PR TITLE
Add `--cpu-quota` flag to set systemd's `CPUQuota` for fleetd on Linux

### DIFF
--- a/changes/fleetctl-package-cpu-quota
+++ b/changes/fleetctl-package-cpu-quota
@@ -1,0 +1,1 @@
+- Added `--cpu-quota` flag to `fleetctl package` to set the systemd `CPUQuota` enforced on fleetd in Linux packages (deb, rpm, pkg.tar.zst). Default remains 20%.

--- a/cmd/fleetctl/fleetctl/package.go
+++ b/cmd/fleetctl/fleetctl/package.go
@@ -259,6 +259,13 @@ func packageCommand() *cli.Command {
 				EnvVars:     []string{"FLEETCTL_OSQUERY_DB"},
 				Destination: &opt.OsqueryDB,
 			},
+			&cli.UintFlag{
+				Name:        "cpu-quota",
+				Usage:       "CPU quota, as a percentage of one CPU core, that systemd enforces on fleetd (only available with '--type' deb, rpm, or pkg.tar.zst)",
+				Value:       20,
+				EnvVars:     []string{"FLEETCTL_CPU_QUOTA"},
+				Destination: &opt.CPUQuota,
+			},
 			&cli.StringFlag{
 				Name:        "outfile",
 				Usage:       "Output file for the generated package",
@@ -322,6 +329,17 @@ func packageCommand() *cli.Command {
 
 			if opt.OsqueryDB != "" && !isAbsolutePath(opt.OsqueryDB, c.String("type")) {
 				return fmt.Errorf("--osquery-db must be an absolute path: %q", opt.OsqueryDB)
+			}
+
+			if c.IsSet("cpu-quota") {
+				switch c.String("type") {
+				case "deb", "rpm", "pkg.tar.zst":
+				default:
+					return errors.New("--cpu-quota is only supported for deb/rpm/pkg.tar.zst packages")
+				}
+				if opt.CPUQuota == 0 {
+					return errors.New("--cpu-quota must be greater than 0")
+				}
 			}
 
 			if runtime.GOOS == "windows" && c.String("type") != "msi" {

--- a/cmd/fleetctl/integrationtest/package/package_test.go
+++ b/cmd/fleetctl/integrationtest/package/package_test.go
@@ -63,6 +63,17 @@ func TestPackage(t *testing.T) {
 		}
 	})
 
+	t.Run("--cpu-quota is only available for Linux packages", func(t *testing.T) {
+		for _, p := range []string{"pkg", "msi"} {
+			fleetctltest.RunAppCheckErr(
+				t,
+				[]string{"package", fmt.Sprintf("--type=%s", p), "--cpu-quota=1"},
+				"--cpu-quota is only supported for deb/rpm/pkg.tar.zst packages",
+			)
+		}
+		fleetctltest.RunAppCheckErr(t, []string{"package", "--type=deb", "--cpu-quota=0"}, "--cpu-quota must be greater than 0")
+	})
+
 	// fleet-osquery.msi
 	// runAppForTest(t, []string{"package", "--type=msi", "--insecure"}) TODO: this is currently failing on Github runners due to permission issues
 	// info, err = os.Stat("orbit-osquery_0.0.3.msi")

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -334,14 +334,11 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 	return filename, nil
 }
 
-func writeSystemdUnit(opt Options, rootPath string) error {
-	systemdRoot := filepath.Join(rootPath, "usr", "lib", "systemd", "system")
-	if err := secure.MkdirAll(systemdRoot, constant.DefaultDirMode); err != nil {
-		return fmt.Errorf("create systemd dir: %w", err)
-	}
-	if err := os.WriteFile(
-		filepath.Join(systemdRoot, "orbit.service"),
-		[]byte(`
+// defaultCPUQuota is the systemd CPUQuota percentage applied to the orbit
+// service when none is specified.
+const defaultCPUQuota uint = 20
+
+var systemdUnitTemplate = template.Must(template.New("systemd").Parse(`
 [Unit]
 Description=Orbit osquery
 After=network.service syslog.service
@@ -355,11 +352,30 @@ Restart=always
 RestartSec=1
 KillMode=control-group
 KillSignal=SIGTERM
-CPUQuota=20%
+CPUQuota={{ .CPUQuota }}%
 
 [Install]
 WantedBy=multi-user.target
-`),
+`))
+
+func writeSystemdUnit(opt Options, rootPath string) error {
+	systemdRoot := filepath.Join(rootPath, "usr", "lib", "systemd", "system")
+	if err := secure.MkdirAll(systemdRoot, constant.DefaultDirMode); err != nil {
+		return fmt.Errorf("create systemd dir: %w", err)
+	}
+
+	cpuQuota := opt.CPUQuota
+	if cpuQuota == 0 {
+		cpuQuota = defaultCPUQuota
+	}
+	var contents bytes.Buffer
+	if err := systemdUnitTemplate.Execute(&contents, struct{ CPUQuota uint }{CPUQuota: cpuQuota}); err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(systemdRoot, "orbit.service"),
+		contents.Bytes(),
 		constant.DefaultSystemdUnitMode,
 	); err != nil {
 		return fmt.Errorf("write file: %w", err)

--- a/orbit/pkg/packaging/linux_shared_test.go
+++ b/orbit/pkg/packaging/linux_shared_test.go
@@ -1,6 +1,8 @@
 package packaging
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,6 +82,27 @@ func TestStripRPMRelease(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, stripRPMRelease(tc.in, tc.arch))
+		})
+	}
+}
+
+func TestWriteSystemdUnit(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		quota uint
+		want  string
+	}{
+		{name: "default", quota: 0, want: "CPUQuota=20%"},
+		{name: "custom", quota: 1, want: "CPUQuota=1%"},
+		{name: "above one core", quota: 150, want: "CPUQuota=150%"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, writeSystemdUnit(Options{CPUQuota: tc.quota}, root))
+			b, err := os.ReadFile(filepath.Join(root, "usr", "lib", "systemd", "system", "orbit.service"))
+			require.NoError(t, err)
+			require.Contains(t, string(b), "\n"+tc.want+"\n")
+			require.Contains(t, string(b), "ExecStart=/opt/orbit/bin/orbit/orbit")
 		})
 	}
 }

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -138,6 +138,9 @@ type Options struct {
 	// OsqueryDB is the directory to use for the osquery database.
 	// If not set, then the default is `$ORBIT_ROOT_DIR/osquery.db`.
 	OsqueryDB string
+	// CPUQuota is the systemd CPUQuota percentage applied to the orbit service
+	// (Linux only). Zero means the default of 20%.
+	CPUQuota uint
 	// Architecture that the package is being built for. (amd64, arm64)
 	Architecture string
 	// TUF platform name. windows, windows-arm64, linux, linux-arm64, darwin


### PR DESCRIPTION
Resolves #49925.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

Tested on arm64 (Ubuntu 25.04) and amd64 (Omarchy Quattro) without Fleet Desktop (feature planned to run on servers)

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--cpu-quota` option to `fleetctl package` for configuring the CPU limit applied to the Linux service.
  - Supports Debian, RPM, and Arch Linux package formats.
  - Defaults to a 20% CPU quota and can be configured through the environment.

- **Bug Fixes**
  - Added validation to reject unsupported package types and non-positive quota values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->