### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aptakube/windows.json
+++ b/ee/maintained-apps/outputs/aptakube/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.20.0",
+      "version": "1.20.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL' AND version_compare(version, '1.20.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Aptakube' AND publisher = 'Zandar Labs SL' AND version_compare(version, '1.20.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'aptakube.exe');"
       },
-      "installer_url": "https://releases.aptakube.com/Aptakube_1.20.0_x64_en-US.msi",
+      "installer_url": "https://releases.aptakube.com/Aptakube_1.20.1_x64_en-US.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "d2281ec5",
-      "sha256": "367912bae0a6b720b152fb41e13b867f3a9616ab53e3da2d4e18221044a676d2",
+      "sha256": "cae8e9bd05af80107ba5e5c76628bb8fba0186a8af766b1f1d3a1581b5edfb7d",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/azure-functions-core-tools/windows.json
+++ b/ee/maintained-apps/outputs/azure-functions-core-tools/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.13.0",
+      "version": "4.14.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Azure Functions Core Tools %' AND publisher = 'Microsoft';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Azure Functions Core Tools %' AND publisher = 'Microsoft' AND version_compare(version, '4.13.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Azure Functions Core Tools %' AND publisher = 'Microsoft' AND version_compare(version, '4.14.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'azure functions core tools.exe');"
       },
-      "installer_url": "https://github.com/Azure/azure-functions-core-tools/releases/download/4.13.0/func-cli-4.13.0-x64.msi",
+      "installer_url": "https://github.com/Azure/azure-functions-core-tools/releases/download/4.14.0/func-cli-4.14.0-x64.msi",
       "install_script_ref": "49fc2740",
       "uninstall_script_ref": "8d96b1b8",
-      "sha256": "60c4fe33df379d6099967e1af38be5d3db84b06cf381579e6149fbff6e4f4295",
+      "sha256": "36f3f291dc9761ae161114cb3bc0f6bef04423e18a3da0d5ae26981def44352f",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "152.1.94.121",
+      "version": "153.1.95.101",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '152.1.94.121') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '153.1.95.101') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.brave.Browser' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/194.121/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/195.101/Brave-Browser-arm64.dmg",
       "install_script_ref": "32bb30f2",
       "uninstall_script_ref": "9a376609",
-      "sha256": "fdb8af6099d91ec3813c93d9cc1bcb6e59ee1b9fde97e0a94283e4ed6c5db3b5",
+      "sha256": "2deaed060d24f0809bb87332a4d75c7dd140bd38d0915b9e63791917eee3898f",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.908.31748",
+      "version": "26.908.40401",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.908.31748') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.908.40401') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.openai.chat' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.908.31748.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.908.40401.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "81fe2b609c641ed1ba0d56ae8b985a9d5ee3fccc5d551d381616e3a5172204eb",
+      "sha256": "491670fc43c1f2c713961e18b6a0b5de19f114d41484ce2e264da1d9b7086fdf",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.52386.0",
+      "version": "1.52386.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.52386.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.52386.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.anthropic.claudefordesktop' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.52386.0/Claude-1003ca8d443708006c167ffbd0f9695343643af1.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.52386.1/Claude-e89233a543fc201223bf07b169e189d1c967bbeb.zip",
       "install_script_ref": "98321e4d",
       "uninstall_script_ref": "421baa98",
-      "sha256": "9a35677afdb02d4b0a53aa5d2c3b2ee4c96bfbfc46ee94a0faa06af21c69abc0",
+      "sha256": "b6e280a17345b1d1b9381d498d4552efc667810829df15ea99e86d246d32a272",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dayflow/darwin.json
+++ b/ee/maintained-apps/outputs/dayflow/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.4.4",
+      "version": "2.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.4.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'teleportlabs.com.Dayflow' AND version_compare(bundle_short_version, '2.5.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'teleportlabs.com.Dayflow' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.4.4/Dayflow.dmg",
+      "installer_url": "https://github.com/JerryZLiu/Dayflow/releases/download/v2.5.0/Dayflow.dmg",
       "install_script_ref": "9ec4db9b",
       "uninstall_script_ref": "8672edfc",
-      "sha256": "a3b3024eb0b91ce000aa27681f311b4f3fd1478d9185f86c15e644b29d087b40",
+      "sha256": "52f185b3adbd541d8fc1d3ef1b87ffb79852c2674a7488671f0a707f59d3c5e1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/devin-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/devin-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.9.19",
+      "version": "3.10.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '3.9.19') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '3.10.23') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.exafunction.windsurf' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/e2b252e21dd5cdfd88fce58f49477260e90294bc/Devin-darwin-arm64-3.9.19.dmg",
+      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/deb816008be02bf5f9da707b7def3ebdb53a51cd/Devin-darwin-arm64-3.10.23.dmg",
       "install_script_ref": "cea2287e",
       "uninstall_script_ref": "4fdaa2d1",
-      "sha256": "6d1b779fde24388b4e336f27b62439ed6784080cc0cc9464072e9425da7bdb4f",
+      "sha256": "74ec490cfe95d80d6d17efaad45eecedcba09043ffd7aa9219558f3f7ac26631",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "158.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15826.9.10') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15826.9.11') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.mozilla.nightly' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-10-21-41-18-mozilla-central/firefox-158.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/09/2026-09-11-09-29-15-mozilla-central/firefox-158.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "2da9357c4295fb4d472485c56587ae0c48ce8cf7343e114197141535cbb2b7bb",
+      "sha256": "3f9cfb866125ac0c1e0f9991227fcfbde2b9c773616fd75274a7135d7ad585e9",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/gdevelop/darwin.json
+++ b/ee/maintained-apps/outputs/gdevelop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.6.281",
+      "version": "5.6.282",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.gdevelop-app.ide';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.gdevelop-app.ide' AND version_compare(bundle_short_version, '5.6.281') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.gdevelop-app.ide' AND version_compare(bundle_short_version, '5.6.282') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.gdevelop-app.ide' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://github.com/4ian/GDevelop/releases/download/v5.6.281/GDevelop-5-5.6.281-universal.dmg",
+      "installer_url": "https://github.com/4ian/GDevelop/releases/download/v5.6.282/GDevelop-5-5.6.282-universal.dmg",
       "install_script_ref": "6eac5127",
       "uninstall_script_ref": "c1bae326",
-      "sha256": "aef3fb9ae7b81ee1cb31bec50e29aca8194a672bc608f9081a1694496907bd2d",
+      "sha256": "f6e078e14d576412e173b322860229ba0b5de8213805d74710d41fb682c782ab",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gdevelop/windows.json
+++ b/ee/maintained-apps/outputs/gdevelop/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.6.281",
+      "version": "5.6.282",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GDevelop' AND publisher = 'GDevelop Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GDevelop' AND publisher = 'GDevelop Team' AND version_compare(version, '5.6.281') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GDevelop' AND publisher = 'GDevelop Team' AND version_compare(version, '5.6.282') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'gdevelop.exe');"
       },
-      "installer_url": "https://github.com/4ian/GDevelop/releases/download/v5.6.281/GDevelop-5-Setup-5.6.281.exe",
+      "installer_url": "https://github.com/4ian/GDevelop/releases/download/v5.6.282/GDevelop-5-Setup-5.6.282.exe",
       "install_script_ref": "01cf10cc",
       "uninstall_script_ref": "7ab32cde",
-      "sha256": "5430c52eb074882db406f829689ccb28424e70e51c63026000cecfb8dcb591f2",
+      "sha256": "2e43682c9782fd8d598e2d4d0ffdb69dcaab5685e2f49330082a22105b475d5a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gimp/windows.json
+++ b/ee/maintained-apps/outputs/gimp/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.2.4.0",
+      "version": "3.2.6.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team' AND version_compare(version, '3.2.4.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team' AND version_compare(version, '3.2.6.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'gimp.exe');"
       },
-      "installer_url": "https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe",
+      "installer_url": "https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.6-setup.exe",
       "install_script_ref": "7e5269bc",
       "uninstall_script_ref": "79fb181d",
-      "sha256": "ec31d757dd82831d201ffcf47ffeac4175df739e0c02d5122e89aeeadfb988cc",
+      "sha256": "9337cccbc01d4098ee7a3dab215b3afbe6ece99c5287c92441d6f12cf541ebca",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/kdenlive/darwin.json
+++ b/ee/maintained-apps/outputs/kdenlive/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.08.0",
+      "version": "26.08.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.Kdenlive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.Kdenlive' AND version_compare(bundle_short_version, '26.08.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.Kdenlive' AND version_compare(bundle_short_version, '26.08.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'org.kde.Kdenlive' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://cdn.download.kde.org/stable/kdenlive/26.08/macOS/kdenlive-26.08.0-arm64.dmg",
+      "installer_url": "https://cdn.download.kde.org/stable/kdenlive/26.08/macOS/kdenlive-26.08.1-arm64.dmg",
       "install_script_ref": "7b5dd185",
       "uninstall_script_ref": "a2f49d83",
-      "sha256": "a49e253d40bb63bb0f23e0335b484ff4b27e5533e178efb4d5ac44398edd401e",
+      "sha256": "b606beaf42c0482a07c052bd2da384587b3aedcc948e7c885f954e195ff10bda",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.3.0.0",
+      "version": "2.3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '2.3.0.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '2.3.1.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.raycast.macos' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://x.raycast-releases.com/download?platform=macos&architecture=arm64&version=2.3.0.0",
+      "installer_url": "https://x.raycast-releases.com/download?platform=macos&architecture=arm64&version=2.3.1.0",
       "install_script_ref": "f52a81be",
       "uninstall_script_ref": "cb893329",
-      "sha256": "997b9e1d5026496df83fe7c06bba5fb19a8afd4b217066831ee1c8a34ed522c0",
+      "sha256": "9af903aee95af55e5f844b7b47c77740cfc30fe50ce9e37bab2f7946584a0ec8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ticktick/darwin.json
+++ b/ee/maintained-apps/outputs/ticktick/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.2.02",
+      "version": "8.2.03",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.TickTick.task.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.TickTick.task.mac' AND version_compare(bundle_short_version, '8.2.02') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.TickTick.task.mac' AND version_compare(bundle_short_version, '8.2.03') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path = concat(a.path, '/Contents/MacOS/', a.bundle_executable) WHERE a.bundle_identifier = 'com.TickTick.task.mac' AND a.bundle_executable != '');"
       },
-      "installer_url": "https://download.ticktick.app/download/mac/TickTick_8.2.02_919.dmg",
+      "installer_url": "https://download.ticktick.app/download/mac/TickTick_8.2.03_920.dmg",
       "install_script_ref": "541567ee",
       "uninstall_script_ref": "364f718f",
-      "sha256": "7406c434c760566c649584ae996ce3246dc07273e61fb49998dc3d9ea4c36407",
+      "sha256": "a722f5777666afd088d02117acd1ba4285aae4c14261010a40b6e4447013f3ef",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated maintained app definitions and installers for Aptakube, Azure Functions Core Tools, Brave Browser, ChatGPT, Claude, Dayflow, Devin Desktop, Firefox Nightly, GDevelop, GIMP, Kdenlive, Raycast, and TickTick.
  * Version checks, download links, and installer checksums now align with the latest available releases.
  * GDevelop definitions were updated for both macOS and Windows; all other updates apply to their specified platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->