### PR TITLE
Software inventory guide: per-category coverage tables and data depth

### DIFF
--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -2,15 +2,13 @@
 
 Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. Vulnerability processing runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
 
-To see what software is covered, check out the [Coverage section](#coverage). To see which of that software Fleet checks for vulnerabilities, see [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
+Fleet collects software inventory for the software types below. ✅ means collected, ❌ means not collected, ✅\* means collected with a caveat described under the table, and ❔ means not verified yet.
 
-## Coverage
+Each section says whether Fleet matches that software to vulnerabilities (CVEs). To see exactly which software Fleet checks, see [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
 
-Fleet collects software inventory for these software types. ✅ means collected, ❌ means not collected, ✅\* means collected with a caveat described under the table, and ❔ means not verified yet.
+> If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
 
-Each section also says whether Fleet matches that software to vulnerabilities (CVEs). Learn more in [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
-
-### Apps
+## Apps
 
 | Type | macOS | Windows | Linux | ChromeOS | Android | iOS/iPadOS |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -28,7 +26,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - Alternative app store and sideloaded apps: these should appear in the same MDM app lists on fully-managed hosts. Fleet hasn't verified this yet.
 - Personal-side apps on BYOD hosts: Apple User Enrollment and Android work profiles don't expose them.
 
-### Operating systems
+## Operating systems
 
 | Platform | Collected |
 | --- | --- |
@@ -39,7 +37,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 | iOS and iPadOS | ✅ |
 | Linux | ✅ On recognized distributions. See the table below. |
 
-#### Linux distributions
+### Linux distributions
 
 | Distribution | Collected |
 | --- | --- |
@@ -101,7 +99,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - SteamOS, Bazzite, Bluefin, and Aurora: these use immutable root filesystems. Installing Fleet's agent is unsupported, and their platform values aren't in Fleet's list.
 - Ubuntu Core runs snaps only. Fleet's agent isn't packaged as a snap, so Ubuntu Core hosts can't enroll.
 
-### Browser extensions
+## Browser extensions
 
 | Browser | macOS | Windows | Linux | ChromeOS |
 | --- | --- | --- | --- | --- |
@@ -131,7 +129,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - Fleet doesn't hash browser extensions on any platform.
 - Safari on iOS and Firefox, Edge, and Yandex on Android support extensions, but no MDM API exposes them.
 
-### Packages
+## Packages
 
 | Type | macOS | Windows | Linux |
 | --- | --- | --- | --- |
@@ -163,7 +161,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - npm: Fleet collects globally installed packages, including nvm, fnm, asdf, mise, and Volta locations. Scoped (`@org/name`) and nested packages require osquery 5.23 or later. On Windows, osquery supports npm packages but Fleet doesn't query them yet. Project-level `node_modules` directories aren't collected.
 - Atom packages were removed from inventory in December 2023 after the editor was sunset.
 
-### IDE extensions
+## IDE extensions
 
 | Type | macOS | Windows | Linux |
 | --- | --- | --- | --- |
@@ -179,7 +177,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - JetBrains: osquery enumerates 13 products installed under the `JetBrains` directory. Learn more in the [jetbrains_plugins](https://fleetdm.com/tables/jetbrains_plugins) table. Android Studio installs under a `Google` directory and isn't collected. DataSpell, Aqua, and Writerside aren't in osquery's list.
 - Zed, Sublime Text, Neovim/Vim, and Emacs: no osquery or fleetd table reads them.
 
-### Plugins
+## Plugins
 
 | Category | Type | macOS | Windows | Linux |
 | --- | --- | --- | --- | --- |
@@ -221,7 +219,7 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - Sketch, Affinity, GIMP, Inkscape, Krita, Blender, darktable, OFX, FxPlug, audio plug-ins, 3D suites, game engines, AutoCAD, SolidWorks, Microsoft Office add-ins, Obsidian, LibreOffice, OpenOffice, Notepad++, Android SDK, and Arduino SDK: no osquery or fleetd table reads them. Affinity loads Photoshop-compatible plug-ins from a folder the user chooses. Unity and Godot plugins are installed per project, not per host. Notepad++ has no native macOS or Linux build.
 - Xcode source editor extensions ship inside apps that already appear under Apps. Xcode has no separate plugin system.
 
-### Binaries, AI tools, and other
+## Binaries, AI tools, and other
 
 | Category | Type | macOS | Windows | Linux | Android | iOS/iPadOS |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -238,7 +236,6 @@ Each section also says whether Fleet matches that software to vulnerabilities (C
 - macOS widgets are WidgetKit extensions that ship inside apps that already appear under Apps.
 - Shortcuts and Android ringtones: no MDM API exposes them.
 
-> If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
 
 ## Data collected
 
@@ -253,7 +250,7 @@ Fleet stores a name and a version for every item in inventory. What else it stor
 | File hashes | ✅ macOS apps only. fleetd collects the code directory hash (cdhash) and the SHA-256 hash of the app's executable. Not collected on Windows or Linux, or for packages, extensions, and plugins. |
 | Last opened | ✅ macOS apps. No other software type reports usage. |
 | Install count | ✅ The number of hosts in your Fleet running each title and each version. |
-| Vulnerabilities (CVEs) | ✅ For the software types marked in [Coverage](#coverage). Fleet Premium adds the CVE publish date, CVSS score, EPSS probability, and CISA KEV status. |
+| Vulnerabilities (CVEs) | ✅ For the software types marked above. Fleet Premium adds the CVE publish date, CVSS score, EPSS probability, and CISA KEV status. |
 | Title and version release dates | ❌ Not collected. Fleet reports the version a host is running, not when that version shipped. |
 | Popularity outside your Fleet | ❌ Not collected. Install counts cover your hosts only. |
 | Publisher reputation | ❌ Not collected. Fleet reports the publisher name, and the Team ID on macOS, but not a publisher's first release date or install totals across their other titles. |

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -23,18 +23,18 @@ Fleet collects software inventory for the software types below. Each table says 
 
 ## Operating systems
 
-| Platform | Collected |
-| --- | --- |
-| macOS | ✅ |
-| Windows 10, 11, and Server | ✅ |
-| ChromeOS | ✅ |
-| Android | ✅ |
-| iOS and iPadOS | ✅ |
-| Linux | ✅ On recognized distributions. See the table below. |
+| Platform | Collected | Data collected | Vulnerabilities |
+| --- | --- | --- | --- |
+| macOS | ✅ | Name, version, architecture, and kernel version. | ✅ |
+| Windows 10, 11, and Server | ✅ | Name, version, display version (such as 23H2), architecture, and installation type. | ✅ Matched against Microsoft security bulletins. |
+| ChromeOS | ✅ | Name, version, and architecture. | ❌ |
+| Android | ✅ | Name and version. | ✅ Matched against the Android security patch level. |
+| iOS and iPadOS | ✅ | Name and version. | ❌ |
+| Linux | ✅ On recognized distributions. See the table below. | Name, version, architecture, and kernel version. | ✅ Kernel vulnerabilities, on supported distributions. |
 
 ### Linux distributions
 
-✅\* means Fleet collects software on the distribution, with a caveat in the notes below the table.
+✅\* means Fleet collects software on the distribution, with a caveat in the notes below the table. Kernel vulnerability coverage varies by distribution. See [Linux coverage](https://fleetdm.com/guides/vulnerability-processing#linux-coverage).
 
 | Distribution | Collected |
 | --- | --- |
@@ -86,8 +86,6 @@ Fleet collects software inventory for the software types below. Each table says 
 | Bazzite, Bluefin, and Aurora | ❌ |
 | Ubuntu Core | ❌ |
 | Any other distribution | ❌ |
-
-**Vulnerabilities:** Fleet detects OS vulnerabilities on macOS, Windows, Android, and supported Linux kernels. ChromeOS, iOS, and iPadOS aren't matched. Linux coverage varies by distribution. See [Linux coverage](https://fleetdm.com/guides/vulnerability-processing#linux-coverage).
 
 - Fedora, Rocky Linux, AlmaLinux, and Oracle Linux report as RHEL because they ship `/etc/redhat-release`. Fleet shows them under RHEL on the **Software** > **OS** page.
 - NVIDIA DGX OS reports as Ubuntu (DGX OS 7 as Ubuntu 24.04, DGX OS 6 as Ubuntu 22.04) because its `/etc/os-release` is Ubuntu's. Fleet doesn't read `/etc/dgx-release`, so the host appears as Ubuntu on the **Software** > **OS** page and the DGX OS version isn't reported. DGX Spark is arm64; use the `arm64` fleetd package.

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -3,7 +3,6 @@
 Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. [Vulnerability (CVE) processing](https://fleetdm.com/guides/vulnerability-processing#coverage) runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
 
 
-> If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
 
 ## Apps
 

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -1,6 +1,6 @@
 # Software inventory
 
-Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. Vulnerability processing runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
+Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. [Vulnerability (CVE) processing](https://fleetdm.com/guides/vulnerability-processing#coverage) runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
 
 Fleet collects software inventory for the software types below. Each table says where Fleet collects that software, what it stores beyond a name and a version, and whether it matches that software to vulnerabilities (CVEs). To see exactly which software Fleet checks, see [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
 

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -19,7 +19,7 @@ Software inventory in Fleet collects the apps, operating systems, browser extens
 
 ## Operating systems
 
-| Type | Data collected | Vulnerabilities | Caveats |
+| OS | Data collected | Vulnerabilities | Caveats |
 | --- | --- | --- | --- |
 | macOS | Name, version, architecture, and kernel version. | ✅ | — |
 | Windows 10, 11, and Server | Name, version, display version (such as 23H2), architecture, and installation type. | ✅ Matched against Microsoft security bulletins. | — |

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -2,28 +2,23 @@
 
 Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. Vulnerability processing runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
 
-Fleet collects software inventory for the software types below. ✅ means collected, ❌ means not collected, ✅\* means collected with a caveat described under the table, and ❔ means not verified yet.
-
-Each section says whether Fleet matches that software to vulnerabilities (CVEs). To see exactly which software Fleet checks, see [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
+Fleet collects software inventory for the software types below. Each table says where Fleet collects that software, what it stores beyond a name and a version, and whether it matches that software to vulnerabilities (CVEs). To see exactly which software Fleet checks, see [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
 
 > If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
 
 ## Apps
 
-| Type | macOS | Windows | Linux | ChromeOS | Android | iOS/iPadOS |
-| --- | --- | --- | --- | --- | --- | --- |
-| Native apps | ✅ | ✅ | Apps are installed as [packages](#packages). | ❌ | ✅\* | ✅\* |
-| Microsoft Store (MSIX/Appx) apps | N/A | ✅\* | N/A | N/A | N/A | N/A |
-| Alternative app store and sideloaded apps | N/A | N/A | N/A | N/A | ❔ | ❔ |
-| Personal-side apps on BYOD hosts | N/A | N/A | N/A | N/A | ❌ | ❌ |
-
-**Vulnerabilities:** Fleet detects vulnerabilities in apps on macOS and Windows, and in Linux packages. Apps reported over MDM on Android, iOS, and iPadOS aren't matched to CVEs.
+| Type | Collected on | Data collected | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- |
+| Native apps | macOS, Windows, Android, iOS, iPadOS | Name and version everywhere. Bundle ID on Apple platforms, application ID on Android. macOS adds the install path, the Apple Developer Team ID, file hashes, and last opened. Windows adds the publisher, install path, upgrade code, and last opened. | ✅ macOS and Windows. ❌ Android, iOS, and iPadOS. | On Linux, apps install as [packages](#packages). Not collected on ChromeOS. |
+| Microsoft Store (MSIX/Appx) apps | Windows | Name, version, publisher, install path, upgrade code, and last opened. | ✅ | Per-user and machine-wide provisioned packages need a recent version of Fleet's agent. |
+| Alternative app store and sideloaded apps | Android, iOS, iPadOS | Expected to match native apps on the same platform. | ❌ | Fleet hasn't verified that these appear in MDM app lists. |
+| Personal-side apps on BYOD hosts | ❌ Not collected | — | ❌ | Apple User Enrollment and Android work profiles don't expose them. |
 
 - Native apps on ChromeOS: Fleet's ChromeOS agent runs as a browser extension. It has no API for installed Android apps or progressive web apps (PWAs).
 - Native apps on Android: personally-owned (BYOD) hosts report apps in the work profile only. Fully-managed hosts report all installed apps.
 - Native apps on iOS and iPadOS: personally-owned (BYOD) hosts report only the apps Fleet installed. Built-in and user-installed apps aren't included. Learn more in [Enrolling BYOD iPad/iOS devices](https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts).
-- Microsoft Store apps: requires osquery 5.17 or later for per-user packages and 5.22.1 or later for machine-wide provisioned packages. Hosts on fleetd's `stable` channel receive osquery updates automatically.
-- Alternative app store and sideloaded apps: these should appear in the same MDM app lists on fully-managed hosts. Fleet hasn't verified this yet.
+- Microsoft Store apps: hosts on fleetd's `stable` channel update automatically and pick up support for these as it ships.
 - Personal-side apps on BYOD hosts: Apple User Enrollment and Android work profiles don't expose them.
 
 ## Operating systems
@@ -38,6 +33,8 @@ Each section says whether Fleet matches that software to vulnerabilities (CVEs).
 | Linux | ✅ On recognized distributions. See the table below. |
 
 ### Linux distributions
+
+✅\* means Fleet collects software on the distribution, with a caveat in the notes below the table.
 
 | Distribution | Collected |
 | --- | --- |
@@ -95,147 +92,75 @@ Each section says whether Fleet matches that software to vulnerabilities (CVEs).
 - Fedora, Rocky Linux, AlmaLinux, and Oracle Linux report as RHEL because they ship `/etc/redhat-release`. Fleet shows them under RHEL on the **Software** > **OS** page.
 - NVIDIA DGX OS reports as Ubuntu (DGX OS 7 as Ubuntu 24.04, DGX OS 6 as Ubuntu 22.04) because its `/etc/os-release` is Ubuntu's. Fleet doesn't read `/etc/dgx-release`, so the host appears as Ubuntu on the **Software** > **OS** page and the DGX OS version isn't reported. DGX Spark is arm64; use the `arm64` fleetd package.
 - Raspberry Pi OS 64-bit reports as Debian and is covered. Raspberry Pi OS 32-bit reports as `raspbian`, which Fleet doesn't recognize.
-- Alpine, elementary OS, Deepin, Garuda, Clear Linux, Photon OS, Solus, Parrot OS, Vanilla OS, openSUSE MicroOS, Aeon, and any distribution not listed above: Fleet recognizes Linux by matching the platform value osquery reads from `/etc/os-release` against a [fixed list](https://github.com/fleetdm/fleet/blob/main/server/fleet/hosts.go). Hosts with any other value enroll, but Fleet doesn't collect an OS entry or software inventory for them.
+- Alpine, elementary OS, Deepin, Garuda, Clear Linux, Photon OS, Solus, Parrot OS, Vanilla OS, openSUSE MicroOS, Aeon, and any distribution not listed above: Fleet recognizes Linux by matching the platform value Fleet reads from `/etc/os-release` against a [fixed list](https://github.com/fleetdm/fleet/blob/main/server/fleet/hosts.go). Hosts with any other value enroll, but Fleet doesn't collect an OS entry or software inventory for them.
 - SteamOS, Bazzite, Bluefin, and Aurora: these use immutable root filesystems. Installing Fleet's agent is unsupported, and their platform values aren't in Fleet's list.
 - Ubuntu Core runs snaps only. Fleet's agent isn't packaged as a snap, so Ubuntu Core hosts can't enroll.
 
 ## Browser extensions
 
-| Browser | macOS | Windows | Linux | ChromeOS |
+| Browser | Collected on | Data collected | Vulnerabilities | Caveats |
 | --- | --- | --- | --- | --- |
-| Chrome | ✅ | ✅ | ✅ | ✅ |
-| Chrome Beta, Dev, and Canary | ✅\* | ✅\* | ✅\* | N/A |
-| Chromium | ✅ | ✅ | ✅ | N/A |
-| Brave | ✅ | ✅ | ✅ | N/A |
-| Brave Beta and Nightly | ✅\* | ✅\* | ✅\* | N/A |
-| Edge | ✅ | ✅ | ✅ | N/A |
-| Edge Beta | ✅ | ✅ | ✅ | N/A |
-| Edge Dev and Canary | ✅\* | ✅\* | ✅\* | N/A |
-| Opera | ✅ | ✅ | ✅ | N/A |
-| Yandex | ✅ | ✅ | ✅ | N/A |
-| Vivaldi | ✅\* | ✅\* | ✅\* | N/A |
-| Arc | ✅\* | ❌ | N/A | N/A |
-| Perplexity Comet and Dia | ❌ | ❌ | N/A | N/A |
-| Firefox | ✅ | ✅ | ✅\* | N/A |
-| Safari | ✅\* | N/A | N/A | N/A |
-| Internet Explorer | N/A | ✅\* | N/A | N/A |
+| Chrome | macOS, Windows, Linux, ChromeOS | Name, version, extension ID, browser, and install path. | ✅ | ChromeOS reports no install path. |
+| Chromium, Brave, Edge, Edge Beta, Opera, and Yandex | macOS, Windows, Linux | Name, version, extension ID, browser, and install path. | ✅ | — |
+| Chrome Beta, Dev, and Canary, Brave Beta and Nightly, Edge Dev and Canary, and Vivaldi | macOS, Windows, Linux | Name, version, extension ID, browser, and install path. | ✅ | The **Type** column shows the raw browser value, such as "Chrome Beta". |
+| Arc | macOS | Name, version, extension ID, browser, and install path. | ✅ | Not collected on Windows. Shows the raw browser value. |
+| Firefox | macOS, Windows, Linux | Name, version, extension ID, and install path. | ✅ | On Linux, the snap profile is collected and the Flatpak profile isn't. |
+| Safari | macOS | Name and version only. | ✅ When the NVD has a matching entry. | Fleet doesn't store the extension identifier yet. |
+| Internet Explorer | Windows | Name and version only. | ✅ When the NVD has a matching entry. | Fleet doesn't store the extension identifier yet. |
+| Perplexity Comet and Dia | ❌ Not collected | — | ❌ | Support ships in an upcoming version of Fleet's agent. |
 
-**Vulnerabilities:** Fleet detects vulnerabilities in Chrome and Firefox extensions on macOS, Windows, and Linux. Extensions in other browsers aren't matched.
-
-- Chrome Beta, Dev, and Canary, Brave Beta and Nightly, Edge Dev and Canary, Vivaldi, and Arc: osquery 5.15 or later collects these and Fleet stores them, but the **Type** column shows the raw browser value (for example, "Chrome Beta" or "Vivaldi") because Fleet doesn't have a display name for them yet. Arc on Windows isn't collected.
-- Perplexity Comet and Dia: support was added to osquery after 5.23.1. Fleet will collect them once the next osquery release ships in fleetd.
-- Firefox on Linux: the snap profile location is collected. The Flatpak profile location isn't.
-- Safari and Internet Explorer: osquery reports an identifier for each extension, but Fleet doesn't store it yet. Only the name and version are collected.
 - Fleet doesn't hash browser extensions on any platform.
 - Safari on iOS and Firefox, Edge, and Yandex on Android support extensions, but no MDM API exposes them.
 
 ## Packages
 
-| Type | macOS | Windows | Linux |
-| --- | --- | --- | --- |
-| Homebrew | ✅\* | N/A | ❌ |
-| Chocolatey | N/A | ✅ | N/A |
-| Scoop | N/A | ❌ | N/A |
-| winget portable packages | N/A | ❌ | N/A |
-| deb | N/A | N/A | ✅ |
-| rpm | N/A | N/A | ✅ |
-| pacman | N/A | N/A | ✅ |
-| Portage | N/A | N/A | ✅ |
-| snap | N/A | N/A | ❌ |
-| Flatpak | N/A | N/A | ❌ |
-| AppImage | N/A | N/A | ❌ |
-| Nix | ❌ | N/A | ❌ |
-| Python | ✅\* | ✅\* | ✅\* |
-| npm | ✅\* | ❌ | ✅\* |
-| pnpm, Yarn, and Bun (global) | ❌ | ❌ | ❌ |
-| RubyGems | ❌ | ❌ | ❌ |
-| Rust (cargo) | ❌ | ❌ | ❌ |
-| Nim | ❌ | ❌ | ❌ |
-| Atom | ❌ | ❌ | ❌ |
+| Type | Collected on | Data collected | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- |
+| Homebrew | macOS | Name, version, and install path. | ✅ | Formulae, plus casks that don't install a `.app` bundle. Those appear under Apps. Homebrew on Linux isn't collected. |
+| Chocolatey | Windows | Name, version, and install path. | ✅ | — |
+| deb | Linux | Name, version, and last opened. | ✅ Ubuntu. Debian covers the kernel only. | No install path, architecture, or publisher. |
+| rpm | Linux | Name, version, publisher, architecture, release, and last opened. | ✅ RHEL, CentOS, Fedora, and Amazon Linux. | No install path. |
+| pacman | Linux | Name, version, and architecture. | ✅ Matched against the NVD by version, which can produce false positives. | Needs Fleet's agent. |
+| Portage | Linux | Name and version. | ✅ When the NVD has a matching entry. | — |
+| Python | macOS, Windows, Linux | Name, version, and install path. | ✅ | System and per-user site-packages, plus pipx, uv tools, conda, pipenv, pyenv, and mise. Project-level `.venv` directories aren't collected. |
+| npm | macOS, Linux | Name, version, and install path. | ✅ | Global packages only, including nvm, fnm, asdf, mise, and Volta locations. Windows isn't queried yet. Project-level `node_modules` directories aren't collected. |
+| Scoop, winget portable packages, snap, Flatpak, AppImage, Nix, pnpm, Yarn, Bun, RubyGems, cargo, and Nim | ❌ Not collected | — | ❌ | Fleet doesn't read them. |
+| Atom | ❌ Not collected | — | ❌ | Removed from inventory in December 2023 after the editor was sunset. |
 
-**Vulnerabilities:** Fleet detects vulnerabilities in Python and npm packages on all three platforms, Homebrew on macOS, Chocolatey and Atom on Windows, and deb, rpm, and pacman packages on Linux. Coverage varies by distribution.
-
-- Homebrew on macOS: Fleet collects formulae, plus casks that don't install a `.app` bundle (those appear under Apps). Homebrew on Linux isn't collected because osquery's `homebrew_packages` table only runs on macOS.
-- Scoop, winget portable packages, snap, Flatpak, AppImage, Nix, pnpm, Yarn, Bun, RubyGems, cargo, and Nim: no osquery or fleetd table reads them. On Ubuntu desktop, Firefox and Chromium are installed as snaps by default, so those browsers are missing from inventory even though their extensions are collected. Follow the snap request in [#22658](https://github.com/fleetdm/fleet/issues/22658).
-- Python: with osquery 5.23 or later, Fleet collects system and per-user site-packages, plus packages installed with pipx, uv tools, conda, pipenv, pyenv, and mise. Packages inside project-level `.venv` directories aren't collected.
-- npm: Fleet collects globally installed packages, including nvm, fnm, asdf, mise, and Volta locations. Scoped (`@org/name`) and nested packages require osquery 5.23 or later. On Windows, osquery supports npm packages but Fleet doesn't query them yet. Project-level `node_modules` directories aren't collected.
-- Atom packages were removed from inventory in December 2023 after the editor was sunset.
+- On Ubuntu desktop, Firefox and Chromium install as snaps by default, so those browsers are missing from inventory even though their extensions are collected. Follow the snap request in [#22658](https://github.com/fleetdm/fleet/issues/22658).
 
 ## IDE extensions
 
-| Type | macOS | Windows | Linux |
-| --- | --- | --- | --- |
-| VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (Devin), and Trae | ✅ | ✅ | ✅ |
-| Google Antigravity, Kiro, and code-server | ❌ | ❌ | ❌ |
-| JetBrains: CLion, DataGrip, GoLand, IntelliJ IDEA (and Community Edition), PhpStorm, PyCharm (and Community Edition), ReSharper, Rider, RubyMine, RustRover, and WebStorm | ✅ | ✅ | ✅ |
-| JetBrains: Android Studio, DataSpell, Aqua, and Writerside | ❌ | ❌ | ❌ |
-| Zed, Sublime Text, Neovim/Vim, and Emacs | ❌ | ❌ | ❌ |
-
-**Vulnerabilities:** Fleet detects vulnerabilities in VS Code, VS Code fork, and JetBrains extensions on macOS, Windows, and Linux.
-
-- VS Code and its forks: osquery reads the extension directories for VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (including its Devin rename), and Trae, plus their remote-server variants. Learn more in the [vscode_extensions](https://fleetdm.com/tables/vscode_extensions) table. Google Antigravity, Kiro, and code-server use the same format but aren't in osquery's list yet.
-- JetBrains: osquery enumerates 13 products installed under the `JetBrains` directory. Learn more in the [jetbrains_plugins](https://fleetdm.com/tables/jetbrains_plugins) table. Android Studio installs under a `Google` directory and isn't collected. DataSpell, Aqua, and Writerside aren't in osquery's list.
-- Zed, Sublime Text, Neovim/Vim, and Emacs: no osquery or fleetd table reads them.
+| Type | Collected on | Data collected | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- |
+| VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (Devin), and Trae | macOS, Windows, Linux | Name, version, publisher, extension ID, edition, and install path. | ✅ | Remote-server variants are collected too. Learn more in the [vscode_extensions](https://fleetdm.com/tables/vscode_extensions) reference. |
+| JetBrains: CLion, DataGrip, GoLand, IntelliJ IDEA (and Community Edition), PhpStorm, PyCharm (and Community Edition), ReSharper, Rider, RubyMine, RustRover, and WebStorm | macOS, Windows, Linux | Name, version, publisher, product, and install path. | ✅ | Fleet reads 13 products installed under the `JetBrains` directory. Learn more in the [jetbrains_plugins](https://fleetdm.com/tables/jetbrains_plugins) reference. |
+| Google Antigravity, Kiro, and code-server | ❌ Not collected | — | ❌ | These use the VS Code extension format, but Fleet doesn't read their directories yet. |
+| JetBrains: Android Studio, DataSpell, Aqua, and Writerside | ❌ Not collected | — | ❌ | Android Studio installs under a `Google` directory. The rest aren't in Fleet's list. |
+| Zed, Sublime Text, Neovim/Vim, and Emacs | ❌ Not collected | — | ❌ | Fleet doesn't read them. |
 
 ## Plugins
 
-| Category | Type | macOS | Windows | Linux |
+| Type | Collected on | Data collected | Vulnerabilities | Caveats |
 | --- | --- | --- | --- | --- |
-| Adobe plugins | CEP extensions for Photoshop, Illustrator, Premiere Pro, After Effects, InDesign, InCopy, Animate, Dreamweaver, Audition, Bridge, Lightroom, Lightroom Classic, XD, and Prelude | ✅\* | ✅\* | N/A |
-| | UXP plugins for Photoshop, XD, InDesign, InCopy, and Premiere Pro | ✅\* | ✅\* | N/A |
-| | Native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator | ❌ | ❌ | N/A |
-| | Native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D | ❌ | ❌ | N/A |
-| | MediaCore shared plug-ins (third-party effects for Premiere Pro, After Effects, and Audition) | ❌ | ❌ | N/A |
-| Design and creative plugins | Sketch | ❌ | N/A | N/A |
-| | Figma | N/A | N/A | N/A |
-| | Affinity Photo, Designer, and Publisher | ❌ | ❌ | N/A |
-| | GIMP | ❌ | ❌ | ❌ |
-| | Inkscape | ❌ | ❌ | ❌ |
-| | Krita | ❌ | ❌ | ❌ |
-| | Blender | ❌ | ❌ | ❌ |
-| | darktable | ❌ | ❌ | ❌ |
-| | OFX plug-ins for DaVinci Resolve, Nuke, and Natron | ❌ | ❌ | ❌ |
-| | Final Cut Pro and Motion (FxPlug and Motion templates) | ❌ | N/A | N/A |
-| | Audio plug-ins (AU, VST/VST3, AAX, and LV2) for Logic Pro, Ableton Live, Pro Tools, and Reaper | ❌ | ❌ | ❌ |
-| | Autodesk Maya, 3ds Max, Cinema 4D, and Houdini | ❌ | ❌ | ❌ |
-| | Unity, Unreal Engine, and Godot | ❌ | ❌ | ❌ |
-| | AutoCAD | ❌ | ❌ | N/A |
-| | SolidWorks | N/A | ❌ | N/A |
-| Productivity and other plugins | Microsoft Office add-ins (Excel, Word, Outlook, and PowerPoint) | ❌ | ❌ | N/A |
-| | Xcode | ✅\* | N/A | N/A |
-| | Obsidian | ❌ | ❌ | ❌ |
-| | LibreOffice and OpenOffice | ❌ | ❌ | ❌ |
-| | Notepad++ (Windows only) | N/A | ❌ | N/A |
-| | Android SDK and Arduino SDK | ❌ | ❌ | ❌ |
+| Adobe CEP extensions for Photoshop, Illustrator, Premiere Pro, After Effects, InDesign, InCopy, Animate, Dreamweaver, Audition, Bridge, Lightroom, Lightroom Classic, XD, and Prelude | macOS, Windows | Name, version, vendor, plugin ID, and install path. | ❌ Adobe files CVEs against the host application, which Fleet detects under Apps. | Adobe ships no Linux applications. The **Type** column shows "Plugin (Adobe)" for every host application, because the host application is read from the manifest but not stored. |
+| Adobe UXP plugins for Photoshop, XD, InDesign, InCopy, and Premiere Pro | macOS, Windows | Name, version, vendor, plugin ID, and install path. | ❌ | Fleet scans the shared `Adobe/UXP/extensions` directory. Plugins that Creative Cloud installs under `Adobe/UXP/PluginsStorage` haven't been verified. |
+| Adobe native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator | ❌ Not collected | — | ❌ | Reported only by a deep-scan mode Fleet doesn't ingest. Native plug-ins have no manifest, so they have no version. |
+| Adobe native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D, and MediaCore shared plug-ins | ❌ Not collected | — | ❌ | Fleet doesn't scan these locations. MediaCore is where third-party effects such as Boris FX, Red Giant, Sapphire, and Neat Video install. |
+| Xcode | macOS, as an app | Collected under Apps, with everything a macOS app reports. | ✅ As an app. | Xcode source editor extensions ship inside apps that already appear under Apps. Xcode has no separate plugin system. |
+| Figma | ❌ Not collected | — | ❌ | Plugins are tied to the user's Figma account and run from Figma's servers. Nothing is installed on the device. |
+| Sketch, Affinity Photo, Designer, and Publisher, GIMP, Inkscape, Krita, Blender, darktable, OFX plug-ins for DaVinci Resolve, Nuke, and Natron, Final Cut Pro and Motion (FxPlug and Motion templates), audio plug-ins (AU, VST/VST3, AAX, and LV2), Autodesk Maya, 3ds Max, Cinema 4D, and Houdini, Unity, Unreal Engine, and Godot, AutoCAD, SolidWorks, Microsoft Office add-ins, Obsidian, LibreOffice and OpenOffice, Notepad++, Android SDK, and Arduino SDK | ❌ Not collected | — | ❌ | Fleet doesn't read them. Affinity loads Photoshop-compatible plug-ins from a folder the user chooses. Unity and Godot plugins are installed per project, not per host. Notepad++ has no native macOS or Linux build. |
 
-**Vulnerabilities:** Fleet doesn't scan plugins for vulnerabilities. Adobe files CVEs against the host application, such as Photoshop or Acrobat, which Fleet detects under Apps.
-
-- Adobe applications (Photoshop, Acrobat, Substance 3D, and others) appear under Apps. That's also where Fleet matches Adobe vulnerabilities. Adobe doesn't ship applications for Linux.
-- Adobe CEP extensions: Fleet collects the name, version, and vendor. The host application is read from the manifest but not stored, so the **Type** column shows "Plugin (Adobe)" for every host application. Learn more in the [adobe_plugins](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/adobe_plugins) table.
-- Adobe UXP plugins: Fleet scans the shared `Adobe/UXP/extensions` directory. Plugins that Creative Cloud installs under `Adobe/UXP/PluginsStorage` haven't been verified.
-- Adobe native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator: the `adobe_plugins` table can report these in its deep-scan mode, but Fleet doesn't ingest that mode. Native plug-ins don't have a manifest, so they have no version.
-- Adobe native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D, and MediaCore shared plug-ins: the `adobe_plugins` table doesn't scan these locations. MediaCore is where third-party effects such as Boris FX, Red Giant, Sapphire, and Neat Video install.
-- Figma plugins are tied to the user's Figma account and run from Figma's servers. Nothing is installed on the device to collect.
-- Sketch, Affinity, GIMP, Inkscape, Krita, Blender, darktable, OFX, FxPlug, audio plug-ins, 3D suites, game engines, AutoCAD, SolidWorks, Microsoft Office add-ins, Obsidian, LibreOffice, OpenOffice, Notepad++, Android SDK, and Arduino SDK: no osquery or fleetd table reads them. Affinity loads Photoshop-compatible plug-ins from a folder the user chooses. Unity and Godot plugins are installed per project, not per host. Notepad++ has no native macOS or Linux build.
-- Xcode source editor extensions ship inside apps that already appear under Apps. Xcode has no separate plugin system.
+- Adobe applications (Photoshop, Acrobat, Substance 3D, and others) appear under Apps. That's also where Fleet matches Adobe vulnerabilities. Learn more in the [adobe_plugins](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/adobe_plugins) reference.
 
 ## Binaries, AI tools, and other
 
-| Category | Type | macOS | Windows | Linux | Android | iOS/iPadOS |
-| --- | --- | --- | --- | --- | --- | --- |
-| Binaries | Go | ✅\* | ✅\* | ✅\* | N/A | N/A |
-| AI tools | AI desktop apps, agent CLIs, MCP servers, and agent instruction files | ❌ | ❌ | ❌ | N/A | N/A |
-| Other | macOS widgets | ✅\* | N/A | N/A | N/A | N/A |
-| | Shortcuts | ❌ | N/A | N/A | N/A | ❌ |
-| | Ringtones | N/A | N/A | N/A | ❌ | N/A |
-
-**Vulnerabilities:** Fleet doesn't match Go binaries, macOS widgets, or the other items in this table to CVEs.
-
-- Go binaries: Fleet collects binaries in each user's `~/go/bin` directory. Learn more in the [go_binaries](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/go_binaries) table.
-- AI tools: fleetd includes an [ai_tools](https://github.com/fleetdm/fleet/blob/main/orbit/pkg/table/ai_tools/README.md) table that you can query, but Fleet doesn't add its results to software inventory yet.
-- macOS widgets are WidgetKit extensions that ship inside apps that already appear under Apps.
-- Shortcuts and Android ringtones: no MDM API exposes them.
-
+| Type | Collected on | Data collected | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- |
+| Go binaries | macOS, Windows, Linux | Name, version, and install path. | ✅ When the NVD has a matching entry. | Collected from each user's `~/go/bin` directory. Needs Fleet's agent. Learn more in the [go_binaries](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/go_binaries) reference. |
+| AI desktop apps, agent CLIs, MCP servers, and agent instruction files | ❌ Not in inventory | — | ❌ | Fleet's agent includes an [ai_tools](https://github.com/fleetdm/fleet/blob/main/orbit/pkg/table/ai_tools/README.md) table you can report on, but its results don't feed software inventory yet. |
+| macOS widgets | macOS, as part of their app | Collected under Apps, with everything a macOS app reports. | ✅ As an app. | Widgets are WidgetKit extensions that ship inside apps that already appear under Apps. |
+| Shortcuts and Android ringtones | ❌ Not collected | — | ❌ | No MDM API exposes them. |
 
 ## Data collected
 
@@ -244,11 +169,12 @@ Fleet stores a name and a version for every item in inventory. What else it stor
 | Data | Collected |
 | --- | --- |
 | Name (title) and version | ✅ Every software type. |
-| Publisher (vendor) | ✅ Where the source reports it, including Windows programs, deb and rpm packages, and Adobe plugins. macOS apps also report the Apple Developer Team ID from the app's code signature. |
-| Unique identifier | ✅ Bundle ID (macOS, iOS, and iPadOS), application ID (Android), upgrade code (Windows), and extension ID (browser and IDE extensions). |
-| Install path | ✅ Apps, browser extensions, IDE extensions, plugins, and Go binaries. Linux system packages (deb, rpm, pacman, and Portage) don't report a path. |
+| Publisher (vendor) | ✅ Windows programs, rpm packages, IDE extensions, and Adobe plugins. macOS apps report the Apple Developer Team ID from the app's code signature instead. deb packages report no publisher. |
+| Unique identifier | ✅ Bundle ID (macOS, iOS, and iPadOS), application ID (Android), upgrade code (Windows apps only), and extension ID (browser extensions, VS Code extensions, and Adobe plugins). |
+| Install path | ✅ Apps, browser extensions, IDE extensions, plugins, Go binaries, and Homebrew, Chocolatey, Python, and npm packages. Linux system packages (deb, rpm, pacman, and Portage) and ChromeOS extensions don't report a path. |
 | File hashes | ✅ macOS apps only. fleetd collects the code directory hash (cdhash) and the SHA-256 hash of the app's executable. Not collected on Windows or Linux, or for packages, extensions, and plugins. |
-| Last opened | ✅ macOS apps. No other software type reports usage. |
+| Last opened | ✅ macOS apps, Windows programs, and deb and rpm packages. No other software type reports usage. |
+| Architecture and release | ✅ rpm packages report both. pacman packages report architecture. No other software type reports either. |
 | Install count | ✅ The number of hosts in your Fleet running each title and each version. |
 | Vulnerabilities (CVEs) | ✅ For the software types marked above. Fleet Premium adds the CVE publish date, CVSS score, EPSS probability, and CISA KEV status. |
 | Title and version release dates | ❌ Not collected. Fleet reports the version a host is running, not when that version shipped. |

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -2,8 +2,6 @@
 
 Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. [Vulnerability (CVE) processing](https://fleetdm.com/guides/vulnerability-processing#coverage) runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
 
-
-
 ## Apps
 
 | Type | Collected on | Data collected | Vulnerabilities | Caveats |
@@ -21,14 +19,14 @@ Software inventory in Fleet collects the apps, operating systems, browser extens
 
 ## Operating systems
 
-| Platform | Collected | Data collected | Vulnerabilities |
+| Type | Data collected | Vulnerabilities | Caveats |
 | --- | --- | --- | --- |
-| macOS | ✅ | Name, version, architecture, and kernel version. | ✅ |
-| Windows 10, 11, and Server | ✅ | Name, version, display version (such as 23H2), architecture, and installation type. | ✅ Matched against Microsoft security bulletins. |
-| ChromeOS | ✅ | Name, version, and architecture. | ❌ |
-| Android | ✅ | Name and version. | ✅ Matched against the Android security patch level. |
-| iOS and iPadOS | ✅ | Name and version. | ❌ |
-| Linux | ✅ On recognized distributions. See the table below. | Name, version, architecture, and kernel version. | ✅ Kernel vulnerabilities, on supported distributions. |
+| macOS | Name, version, architecture, and kernel version. | ✅ | — |
+| Windows 10, 11, and Server | Name, version, display version (such as 23H2), architecture, and installation type. | ✅ Matched against Microsoft security bulletins. | — |
+| ChromeOS | Name, version, and architecture. | ❌ | — |
+| Android | Name and version. | ✅ Matched against the Android security patch level. | — |
+| iOS and iPadOS | Name and version. | ❌ | — |
+| Linux | Name, version, architecture, and kernel version. | ✅ Kernel vulnerabilities, on supported distributions. | Collected on recognized distributions only. See the table below. |
 
 ### Linux distributions
 

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -4,29 +4,29 @@ Software inventory in Fleet collects the apps, operating systems, browser extens
 
 ## Apps
 
-| Type | Collected on | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- | --- |
-| Native apps | macOS, Windows, Android, iOS, iPadOS | Name and version everywhere. Bundle ID on Apple platforms, application ID on Android. macOS adds the install path, the Apple Developer Team ID, file hashes, and last opened. Windows adds the publisher, install path, upgrade code, and last opened. | ✅ macOS and Windows. ❌ Android, iOS, and iPadOS. | On Linux, apps install as [packages](#packages). Not collected on ChromeOS. |
-| Microsoft Store (MSIX/Appx) apps | Windows | Name, version, publisher, install path, upgrade code, and last opened. | ✅ | Per-user and machine-wide provisioned packages need a recent version of Fleet's agent. |
-| Alternative app store and sideloaded apps | Android, iOS, iPadOS | Expected to match native apps on the same platform. | ❌ | Fleet hasn't verified that these appear in MDM app lists. |
-| Personal-side apps on BYOD hosts | ❌ Not collected | — | ❌ | Apple User Enrollment and Android work profiles don't expose them. |
+| Type | Name | Version | Publisher | Identifier | Install path | File hashes | Last opened | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| macOS apps | ✅ | ✅ | ✅ Apple Developer Team ID | ✅ Bundle ID | ✅ | ✅ cdhash and executable SHA-256 | ✅ | ✅ | — |
+| Windows apps | ✅ | ✅ | ✅ | ✅ Upgrade code | ✅ | ❌ | ✅ | ✅ | Includes Microsoft Store (MSIX/Appx) apps on recent versions of Fleet's agent. |
+| Linux apps | ✅ | ✅ | ✅ rpm only | ❌ | ❌ | ❌ | ✅ deb and rpm | ✅ | Apps install as [packages](#packages) on Linux. |
+| Android apps | ✅ | ✅ | ❌ | ✅ Application ID | ❌ | ❌ | ❌ | ❌ | BYOD hosts report work profile apps only. Fully-managed hosts report all apps. |
+| iOS and iPadOS apps | ✅ | ✅ | ❌ | ✅ Bundle ID | ❌ | ❌ | ❌ | ❌ | BYOD hosts report only the apps Fleet installed. |
+| ChromeOS apps | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Fleet's ChromeOS agent runs as a browser extension, with no API for installed Android apps or progressive web apps (PWAs). |
+| Personal-side apps on BYOD hosts | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Apple User Enrollment and Android work profiles don't expose them. |
 
-- Native apps on ChromeOS: Fleet's ChromeOS agent runs as a browser extension. It has no API for installed Android apps or progressive web apps (PWAs).
-- Native apps on Android: personally-owned (BYOD) hosts report apps in the work profile only. Fully-managed hosts report all installed apps.
-- Native apps on iOS and iPadOS: personally-owned (BYOD) hosts report only the apps Fleet installed. Built-in and user-installed apps aren't included. Learn more in [Enrolling BYOD iPad/iOS devices](https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts).
-- Microsoft Store apps: hosts on fleetd's `stable` channel update automatically and pick up support for these as it ships.
-- Personal-side apps on BYOD hosts: Apple User Enrollment and Android work profiles don't expose them.
+- Alternative app store and sideloaded apps should appear in the same MDM app lists on fully-managed hosts. Fleet hasn't verified this yet.
+- Native apps on iOS and iPadOS: built-in and user-installed apps aren't included on BYOD hosts. Learn more in [Enrolling BYOD iPad/iOS devices](https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts).
 
 ## Operating systems
 
-| OS | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- |
-| macOS | Name, version, architecture, and kernel version. | ✅ | — |
-| Windows 10, 11, and Server | Name, version, display version (such as 23H2), architecture, and installation type. | ✅ Matched against Microsoft security bulletins. | — |
-| ChromeOS | Name, version, and architecture. | ❌ | — |
-| Android | Name and version. | ✅ Matched against the Android security patch level. | — |
-| iOS and iPadOS | Name and version. | ❌ | — |
-| Linux | Name, version, architecture, and kernel version. | ✅ Kernel vulnerabilities, on supported distributions. | Collected on recognized distributions only. See the table below. |
+| OS | Name | Version | Architecture | Kernel version | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- |
+| macOS | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Windows 10, 11, and Server | ✅ | ✅ | ✅ | ✅ | ✅ Matched against Microsoft security bulletins. | Also reports display version, such as 23H2, and installation type. |
+| Linux | ✅ | ✅ | ✅ | ✅ | ✅ Kernel vulnerabilities, on supported distributions. | Collected on recognized distributions only. See the table below. |
+| ChromeOS | ✅ | ✅ | ✅ | ✅ | ❌ | The kernel version repeats the OS version. |
+| Android | ✅ | ✅ | ❌ | ❌ | ✅ Matched against the Android security patch level. | — |
+| iOS and iPadOS | ✅ | ✅ | ❌ | ❌ | ❌ | — |
 
 ### Linux distributions
 
@@ -92,88 +92,82 @@ Software inventory in Fleet collects the apps, operating systems, browser extens
 
 ## Browser extensions
 
-| Browser | Collected on | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- | --- |
-| Chrome | macOS, Windows, Linux, ChromeOS | Name, version, extension ID, browser, and install path. | ✅ | ChromeOS reports no install path. |
-| Chromium, Brave, Edge, Edge Beta, Opera, and Yandex | macOS, Windows, Linux | Name, version, extension ID, browser, and install path. | ✅ | — |
-| Chrome Beta, Dev, and Canary, Brave Beta and Nightly, Edge Dev and Canary, and Vivaldi | macOS, Windows, Linux | Name, version, extension ID, browser, and install path. | ✅ | The **Type** column shows the raw browser value, such as "Chrome Beta". |
-| Arc | macOS | Name, version, extension ID, browser, and install path. | ✅ | Not collected on Windows. Shows the raw browser value. |
-| Firefox | macOS, Windows, Linux | Name, version, extension ID, and install path. | ✅ | On Linux, the snap profile is collected and the Flatpak profile isn't. |
-| Safari | macOS | Name and version only. | ✅ When the NVD has a matching entry. | Fleet doesn't store the extension identifier yet. |
-| Internet Explorer | Windows | Name and version only. | ✅ When the NVD has a matching entry. | Fleet doesn't store the extension identifier yet. |
-| Perplexity Comet and Dia | ❌ Not collected | — | ❌ | Support ships in an upcoming version of Fleet's agent. |
+| Browser | Collected on | Name | Version | Publisher | Extension ID | Install path | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Chrome | macOS, Windows, Linux, ChromeOS | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ChromeOS reports no install path. |
+| Chromium, Brave, Edge, Edge Beta, Opera, and Yandex | macOS, Windows, Linux | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | — |
+| Chrome Beta, Dev, and Canary, Brave Beta and Nightly, Edge Dev and Canary, and Vivaldi | macOS, Windows, Linux | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | The **Type** column shows the raw browser value, such as "Chrome Beta". |
+| Arc | macOS | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | Not collected on Windows. Shows the raw browser value. |
+| Firefox | macOS, Windows, Linux | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | On Linux, the snap profile is collected and the Flatpak profile isn't. |
+| Safari | macOS | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ When the NVD has a matching entry. | Fleet doesn't store the extension identifier yet. |
+| Internet Explorer | Windows | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ When the NVD has a matching entry. | Fleet doesn't store the extension identifier yet. |
+| Perplexity Comet and Dia | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Support ships in an upcoming version of Fleet's agent. |
 
-- Fleet doesn't hash browser extensions on any platform.
+- Fleet doesn't hash browser extensions on any platform, and none of them report a last opened time.
 - Safari on iOS and Firefox, Edge, and Yandex on Android support extensions, but no MDM API exposes them.
 
 ## Packages
 
-| Type | Collected on | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- | --- |
-| Homebrew | macOS | Name, version, and install path. | ✅ | Formulae, plus casks that don't install a `.app` bundle. Those appear under Apps. Homebrew on Linux isn't collected. |
-| Chocolatey | Windows | Name, version, and install path. | ✅ | — |
-| deb | Linux | Name, version, and last opened. | ✅ Ubuntu. Debian covers the kernel only. | No install path, architecture, or publisher. |
-| rpm | Linux | Name, version, publisher, architecture, release, and last opened. | ✅ RHEL, CentOS, Fedora, and Amazon Linux. | No install path. |
-| pacman | Linux | Name, version, and architecture. | ✅ Matched against the NVD by version, which can produce false positives. | Needs Fleet's agent. |
-| Portage | Linux | Name and version. | ✅ When the NVD has a matching entry. | — |
-| Python | macOS, Windows, Linux | Name, version, and install path. | ✅ | System and per-user site-packages, plus pipx, uv tools, conda, pipenv, pyenv, and mise. Project-level `.venv` directories aren't collected. |
-| npm | macOS, Linux | Name, version, and install path. | ✅ | Global packages only, including nvm, fnm, asdf, mise, and Volta locations. Windows isn't queried yet. Project-level `node_modules` directories aren't collected. |
-| Scoop, winget portable packages, snap, Flatpak, AppImage, Nix, pnpm, Yarn, Bun, RubyGems, cargo, and Nim | ❌ Not collected | — | ❌ | Fleet doesn't read them. |
-| Atom | ❌ Not collected | — | ❌ | Removed from inventory in December 2023 after the editor was sunset. |
+| Type | Collected on | Name | Version | Publisher | Install path | Last opened | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Homebrew | macOS | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | Formulae, plus casks that don't install a `.app` bundle. Those appear under Apps. Homebrew on Linux isn't collected. |
+| Chocolatey | Windows | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | — |
+| deb | Linux | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ Ubuntu. Debian covers the kernel only. | — |
+| rpm | Linux | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ RHEL, CentOS, Fedora, and Amazon Linux. | Also reports architecture and release. |
+| pacman | Linux | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ Matched against the NVD by version, which can produce false positives. | Needs Fleet's agent. Also reports architecture. |
+| Portage | Linux | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ When the NVD has a matching entry. | — |
+| Python | macOS, Windows, Linux | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | System and per-user site-packages, plus pipx, uv tools, conda, pipenv, pyenv, and mise. Project-level `.venv` directories aren't collected. |
+| npm | macOS, Linux | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | Global packages only, including nvm, fnm, asdf, mise, and Volta locations. Windows isn't queried yet. Project-level `node_modules` directories aren't collected. |
+| Scoop, winget portable packages, snap, Flatpak, AppImage, Nix, pnpm, Yarn, Bun, RubyGems, cargo, and Nim | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Fleet doesn't read them. |
+| Atom | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Removed from inventory in December 2023 after the editor was sunset. |
 
 - On Ubuntu desktop, Firefox and Chromium install as snaps by default, so those browsers are missing from inventory even though their extensions are collected. Follow the snap request in [#22658](https://github.com/fleetdm/fleet/issues/22658).
 
 ## IDE extensions
 
-| Type | Collected on | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- | --- |
-| VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (Devin), and Trae | macOS, Windows, Linux | Name, version, publisher, extension ID, edition, and install path. | ✅ | Remote-server variants are collected too. Learn more in the [vscode_extensions](https://fleetdm.com/tables/vscode_extensions) reference. |
-| JetBrains: CLion, DataGrip, GoLand, IntelliJ IDEA (and Community Edition), PhpStorm, PyCharm (and Community Edition), ReSharper, Rider, RubyMine, RustRover, and WebStorm | macOS, Windows, Linux | Name, version, publisher, product, and install path. | ✅ | Fleet reads 13 products installed under the `JetBrains` directory. Learn more in the [jetbrains_plugins](https://fleetdm.com/tables/jetbrains_plugins) reference. |
-| Google Antigravity, Kiro, and code-server | ❌ Not collected | — | ❌ | These use the VS Code extension format, but Fleet doesn't read their directories yet. |
-| JetBrains: Android Studio, DataSpell, Aqua, and Writerside | ❌ Not collected | — | ❌ | Android Studio installs under a `Google` directory. The rest aren't in Fleet's list. |
-| Zed, Sublime Text, Neovim/Vim, and Emacs | ❌ Not collected | — | ❌ | Fleet doesn't read them. |
+| Type | Collected on | Name | Version | Publisher | Extension ID | Install path | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (Devin), and Trae | macOS, Windows, Linux | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Remote-server variants are collected too. Learn more in the [vscode_extensions](https://fleetdm.com/tables/vscode_extensions) reference. |
+| JetBrains: CLion, DataGrip, GoLand, IntelliJ IDEA (and Community Edition), PhpStorm, PyCharm (and Community Edition), ReSharper, Rider, RubyMine, RustRover, and WebStorm | macOS, Windows, Linux | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | Fleet reads 13 products installed under the `JetBrains` directory. Learn more in the [jetbrains_plugins](https://fleetdm.com/tables/jetbrains_plugins) reference. |
+| Google Antigravity, Kiro, and code-server | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | These use the VS Code extension format, but Fleet doesn't read their directories yet. |
+| JetBrains: Android Studio, DataSpell, Aqua, and Writerside | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Android Studio installs under a `Google` directory. The rest aren't in Fleet's list. |
+| Zed, Sublime Text, Neovim/Vim, and Emacs | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Fleet doesn't read them. |
 
 ## Plugins
 
-| Type | Collected on | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- | --- |
-| Adobe CEP extensions for Photoshop, Illustrator, Premiere Pro, After Effects, InDesign, InCopy, Animate, Dreamweaver, Audition, Bridge, Lightroom, Lightroom Classic, XD, and Prelude | macOS, Windows | Name, version, vendor, plugin ID, and install path. | ❌ Adobe files CVEs against the host application, which Fleet detects under Apps. | Adobe ships no Linux applications. The **Type** column shows "Plugin (Adobe)" for every host application, because the host application is read from the manifest but not stored. |
-| Adobe UXP plugins for Photoshop, XD, InDesign, InCopy, and Premiere Pro | macOS, Windows | Name, version, vendor, plugin ID, and install path. | ❌ | Fleet scans the shared `Adobe/UXP/extensions` directory. Plugins that Creative Cloud installs under `Adobe/UXP/PluginsStorage` haven't been verified. |
-| Adobe native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator | ❌ Not collected | — | ❌ | Reported only by a deep-scan mode Fleet doesn't ingest. Native plug-ins have no manifest, so they have no version. |
-| Adobe native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D, and MediaCore shared plug-ins | ❌ Not collected | — | ❌ | Fleet doesn't scan these locations. MediaCore is where third-party effects such as Boris FX, Red Giant, Sapphire, and Neat Video install. |
-| Xcode | macOS, as an app | Collected under Apps, with everything a macOS app reports. | ✅ As an app. | Xcode source editor extensions ship inside apps that already appear under Apps. Xcode has no separate plugin system. |
-| Figma | ❌ Not collected | — | ❌ | Plugins are tied to the user's Figma account and run from Figma's servers. Nothing is installed on the device. |
-| Sketch, Affinity Photo, Designer, and Publisher, GIMP, Inkscape, Krita, Blender, darktable, OFX plug-ins for DaVinci Resolve, Nuke, and Natron, Final Cut Pro and Motion (FxPlug and Motion templates), audio plug-ins (AU, VST/VST3, AAX, and LV2), Autodesk Maya, 3ds Max, Cinema 4D, and Houdini, Unity, Unreal Engine, and Godot, AutoCAD, SolidWorks, Microsoft Office add-ins, Obsidian, LibreOffice and OpenOffice, Notepad++, Android SDK, and Arduino SDK | ❌ Not collected | — | ❌ | Fleet doesn't read them. Affinity loads Photoshop-compatible plug-ins from a folder the user chooses. Unity and Godot plugins are installed per project, not per host. Notepad++ has no native macOS or Linux build. |
+| Type | Collected on | Name | Version | Publisher | Plugin ID | Install path | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Adobe CEP extensions for Photoshop, Illustrator, Premiere Pro, After Effects, InDesign, InCopy, Animate, Dreamweaver, Audition, Bridge, Lightroom, Lightroom Classic, XD, and Prelude | macOS, Windows | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ Adobe files CVEs against the host application, which Fleet detects under Apps. | Adobe ships no Linux applications. The **Type** column shows "Plugin (Adobe)" for every host application, because the host application is read from the manifest but not stored. |
+| Adobe UXP plugins for Photoshop, XD, InDesign, InCopy, and Premiere Pro | macOS, Windows | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | Fleet scans the shared `Adobe/UXP/extensions` directory. Plugins that Creative Cloud installs under `Adobe/UXP/PluginsStorage` haven't been verified. |
+| Adobe native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Reported only by a deep-scan mode Fleet doesn't ingest. Native plug-ins have no manifest, so they have no version. |
+| Adobe native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D, and MediaCore shared plug-ins | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Fleet doesn't scan these locations. MediaCore is where third-party effects such as Boris FX, Red Giant, Sapphire, and Neat Video install. |
+| Xcode | macOS, as an app | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Collected under Apps, with everything a macOS app reports. Xcode source editor extensions ship inside apps that already appear under Apps, and Xcode has no separate plugin system. |
+| Figma | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Plugins are tied to the user's Figma account and run from Figma's servers. Nothing is installed on the device. |
+| Sketch, Affinity Photo, Designer, and Publisher, GIMP, Inkscape, Krita, Blender, darktable, OFX plug-ins for DaVinci Resolve, Nuke, and Natron, Final Cut Pro and Motion (FxPlug and Motion templates), audio plug-ins (AU, VST/VST3, AAX, and LV2), Autodesk Maya, 3ds Max, Cinema 4D, and Houdini, Unity, Unreal Engine, and Godot, AutoCAD, SolidWorks, Microsoft Office add-ins, Obsidian, LibreOffice and OpenOffice, Notepad++, Android SDK, and Arduino SDK | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Fleet doesn't read them. Affinity loads Photoshop-compatible plug-ins from a folder the user chooses. Unity and Godot plugins are installed per project, not per host. Notepad++ has no native macOS or Linux build. |
 
 - Adobe applications (Photoshop, Acrobat, Substance 3D, and others) appear under Apps. That's also where Fleet matches Adobe vulnerabilities. Learn more in the [adobe_plugins](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/adobe_plugins) reference.
 
 ## Binaries, AI tools, and other
 
-| Type | Collected on | Data collected | Vulnerabilities | Caveats |
-| --- | --- | --- | --- | --- |
-| Go binaries | macOS, Windows, Linux | Name, version, and install path. | ✅ When the NVD has a matching entry. | Collected from each user's `~/go/bin` directory. Needs Fleet's agent. Learn more in the [go_binaries](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/go_binaries) reference. |
-| AI desktop apps, agent CLIs, MCP servers, and agent instruction files | ❌ Not in inventory | — | ❌ | Fleet's agent includes an [ai_tools](https://github.com/fleetdm/fleet/blob/main/orbit/pkg/table/ai_tools/README.md) table you can report on, but its results don't feed software inventory yet. |
-| macOS widgets | macOS, as part of their app | Collected under Apps, with everything a macOS app reports. | ✅ As an app. | Widgets are WidgetKit extensions that ship inside apps that already appear under Apps. |
-| Shortcuts and Android ringtones | ❌ Not collected | — | ❌ | No MDM API exposes them. |
+| Type | Collected on | Name | Version | Publisher | Install path | Vulnerabilities | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Go binaries | macOS, Windows, Linux | ✅ | ✅ | ❌ | ✅ | ✅ When the NVD has a matching entry. | Collected from each user's `~/go/bin` directory. Needs Fleet's agent. Learn more in the [go_binaries](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/go_binaries) reference. |
+| AI desktop apps, agent CLIs, MCP servers, and agent instruction files | ❌ Not in inventory | ❌ | ❌ | ❌ | ❌ | ❌ | Fleet's agent includes an [ai_tools](https://github.com/fleetdm/fleet/blob/main/orbit/pkg/table/ai_tools/README.md) table you can report on, but its results don't feed software inventory yet. |
+| macOS widgets | macOS, as part of their app | ✅ | ✅ | ✅ | ✅ | ✅ | Collected under Apps. Widgets are WidgetKit extensions that ship inside apps that already appear there. |
+| Shortcuts and Android ringtones | ❌ Not collected | ❌ | ❌ | ❌ | ❌ | ❌ | No MDM API exposes them. |
 
 ## Data collected
 
-Fleet stores a name and a version for every item in inventory. What else it stores depends on the software type and the platform.
+The tables above list what Fleet stores for each software type. Two things apply to every type:
 
-| Data | Collected |
-| --- | --- |
-| Name (title) and version | ✅ Every software type. |
-| Publisher (vendor) | ✅ Windows programs, rpm packages, IDE extensions, and Adobe plugins. macOS apps report the Apple Developer Team ID from the app's code signature instead. deb packages report no publisher. |
-| Unique identifier | ✅ Bundle ID (macOS, iOS, and iPadOS), application ID (Android), upgrade code (Windows apps only), and extension ID (browser extensions, VS Code extensions, and Adobe plugins). |
-| Install path | ✅ Apps, browser extensions, IDE extensions, plugins, Go binaries, and Homebrew, Chocolatey, Python, and npm packages. Linux system packages (deb, rpm, pacman, and Portage) and ChromeOS extensions don't report a path. |
-| File hashes | ✅ macOS apps only. fleetd collects the code directory hash (cdhash) and the SHA-256 hash of the app's executable. Not collected on Windows or Linux, or for packages, extensions, and plugins. |
-| Last opened | ✅ macOS apps, Windows programs, and deb and rpm packages. No other software type reports usage. |
-| Architecture and release | ✅ rpm packages report both. pacman packages report architecture. No other software type reports either. |
-| Install count | ✅ The number of hosts in your Fleet running each title and each version. |
-| Vulnerabilities (CVEs) | ✅ For the software types marked above. Fleet Premium adds the CVE publish date, CVSS score, EPSS probability, and CISA KEV status. |
-| Title and version release dates | ❌ Not collected. Fleet reports the version a host is running, not when that version shipped. |
-| Popularity outside your Fleet | ❌ Not collected. Install counts cover your hosts only. |
-| Publisher reputation | ❌ Not collected. Fleet reports the publisher name, and the Team ID on macOS, but not a publisher's first release date or install totals across their other titles. |
+- **Install count:** Fleet counts how many hosts in your Fleet run each title and each version.
+- **Vulnerability details:** Fleet Premium adds the CVE publish date, CVSS score, EPSS probability, and CISA KEV status.
+
+Fleet doesn't collect these for any software type:
+
+- **Title and version release dates.** Fleet reports the version a host is running, not when that version shipped.
+- **Popularity outside your Fleet.** Install counts cover your hosts only.
+- **Publisher reputation.** Fleet reports the publisher name, and the Apple Developer Team ID on macOS, but not a publisher's first release date or install totals across their other titles.
 
 ## How Fleet collects software
 
@@ -185,7 +179,7 @@ Fleet stores a name and a version for every item in inventory. What else it stor
 
 Fleet collects software from known package databases and install locations. Software installed outside of those, such as tarballs extracted to `/opt`, portable Windows executables, and AppImage files, isn't collected.
 
-Fleet collects a name and version for each item. What else it collects varies by software type. See [Data collected](#data-collected).
+Fleet collects a name and version for each item. What else it collects varies by software type, as the tables above show.
 
 On personally-owned (BYOD) iOS, iPadOS, and Android hosts, the platform limits what MDM can see. Fleet reports only Fleet-installed apps (Apple) or work-profile apps (Android). This is a platform restriction, not a Fleet setting.
 

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -2,7 +2,6 @@
 
 Software inventory in Fleet collects the apps, operating systems, browser extensions, packages, IDE extensions, plugins, and binaries installed on your hosts. [Vulnerability (CVE) processing](https://fleetdm.com/guides/vulnerability-processing#coverage) runs against this inventory, so software that isn't collected here can't be checked for vulnerabilities.
 
-Fleet collects software inventory for the software types below. Each table says where Fleet collects that software, what it stores beyond a name and a version, and whether it matches that software to vulnerabilities (CVEs). To see exactly which software Fleet checks, see [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
 
 > If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
 

--- a/articles/software-inventory.md
+++ b/articles/software-inventory.md
@@ -6,152 +6,20 @@ To see what software is covered, check out the [Coverage section](#coverage). To
 
 ## Coverage
 
-Fleet collects software inventory for these software types.
+Fleet collects software inventory for these software types. ✅ means collected, ❌ means not collected, ✅\* means collected with a caveat described under the table, and ❔ means not verified yet.
 
-| Category | Type | macOS | Windows | Linux | ChromeOS | Android | iOS/iPadOS |
-| -------- | ---- | ----- | ------- | ----- | -------- | ------- | ---------- |
-| Apps | Native apps | ✅ | ✅ | On Linux, apps are installed as "Packages". | ❌ | ✅\* | ✅\* |
-| | Microsoft Store (MSIX/Appx) apps | N/A | ✅\* | N/A | N/A | N/A | N/A |
-| | Alternative app store and sideloaded apps | N/A | N/A | N/A | N/A | ❔ | ❔ |
-| | Personal-side apps on BYOD hosts | N/A | N/A | N/A | N/A | ❌ | ❌ |
-| Operating system | macOS | ✅ | N/A | N/A | N/A | N/A | N/A |
-| | Windows 10, 11, and Server | N/A | ✅ | N/A | N/A | N/A | N/A |
-| | ChromeOS | N/A | N/A | N/A | ✅ | N/A | N/A |
-| | Android | N/A | N/A | N/A | N/A | ✅ | N/A |
-| | iOS and iPadOS | N/A | N/A | N/A | N/A | N/A | ✅ |
-| | Ubuntu | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Debian | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Red Hat Enterprise Linux (RHEL) | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | CentOS and CentOS Stream | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Fedora | N/A | N/A | ✅\* | N/A | N/A | N/A |
-| | Rocky Linux | N/A | N/A | ✅\* | N/A | N/A | N/A |
-| | AlmaLinux | N/A | N/A | ✅\* | N/A | N/A | N/A |
-| | Oracle Linux | N/A | N/A | ✅\* | N/A | N/A | N/A |
-| | Amazon Linux | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | SLES | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | openSUSE Leap | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | openSUSE Tumbleweed | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Arch Linux | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Arch Linux ARM | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Omarchy | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | CachyOS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | EndeavourOS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Manjaro | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Manjaro ARM | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Gentoo | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Kali | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Pop!_OS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Linux Mint | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Zorin OS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Void | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | NixOS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Tuxedo OS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | KDE neon | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Flatcar | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | CoreOS | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | AMD Ryzen AI Developer Platform | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | NVIDIA DGX OS (DGX Spark, DGX Station, and DGX servers) | N/A | N/A | ✅\* | N/A | N/A | N/A |
-| | Raspberry Pi OS 64-bit | N/A | N/A | ✅\* | N/A | N/A | N/A |
-| | Raspberry Pi OS 32-bit | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Alpine | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | elementary OS | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Deepin | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Garuda | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Clear Linux | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Photon OS | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Solus | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Parrot OS | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Vanilla OS | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | openSUSE MicroOS and Aeon | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | SteamOS | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Bazzite, Bluefin, and Aurora | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Ubuntu Core | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Any other distribution | N/A | N/A | ❌ | N/A | N/A | N/A |
-| Browser extensions | Chrome | ✅ | ✅ | ✅ | ✅ | N/A | N/A |
-| | Chrome Beta, Dev, and Canary | ✅\* | ✅\* | ✅\* | N/A | N/A | N/A |
-| | Chromium | ✅ | ✅ | ✅ | N/A | N/A | N/A |
-| | Brave | ✅ | ✅ | ✅ | N/A | N/A | N/A |
-| | Brave Beta and Nightly | ✅\* | ✅\* | ✅\* | N/A | N/A | N/A |
-| | Edge | ✅ | ✅ | ✅ | N/A | ❌ | N/A |
-| | Edge Beta | ✅ | ✅ | ✅ | N/A | N/A | N/A |
-| | Edge Dev and Canary | ✅\* | ✅\* | ✅\* | N/A | N/A | N/A |
-| | Opera | ✅ | ✅ | ✅ | N/A | N/A | N/A |
-| | Yandex | ✅ | ✅ | ✅ | N/A | ❌ | N/A |
-| | Vivaldi | ✅\* | ✅\* | ✅\* | N/A | N/A | N/A |
-| | Arc | ✅\* | ❌ | N/A | N/A | N/A | N/A |
-| | Perplexity Comet and Dia | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| | Firefox | ✅ | ✅ | ✅\* | N/A | ❌ | N/A |
-| | Safari | ✅\* | N/A | N/A | N/A | N/A | ❌ |
-| | Internet Explorer | N/A | ✅\* | N/A | N/A | N/A | N/A |
-| Packages | Homebrew | ✅\* | N/A | ❌ | N/A | N/A | N/A |
-| | Chocolatey | N/A | ✅ | N/A | N/A | N/A | N/A |
-| | Scoop | N/A | ❌ | N/A | N/A | N/A | N/A |
-| | winget portable packages | N/A | ❌ | N/A | N/A | N/A | N/A |
-| | deb | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | rpm | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | pacman | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | Portage | N/A | N/A | ✅ | N/A | N/A | N/A |
-| | snap | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Flatpak | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | AppImage | N/A | N/A | ❌ | N/A | N/A | N/A |
-| | Nix | ❌ | N/A | ❌ | N/A | N/A | N/A |
-| | Python | ✅\* | ✅\* | ✅\* | N/A | N/A | N/A |
-| | npm | ✅\* | ❌ | ✅\* | N/A | N/A | N/A |
-| | pnpm, Yarn, and Bun (global) | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | RubyGems | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Rust (cargo) | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Nim | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Atom | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| IDE extensions | VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (Devin), and Trae | ✅ | ✅ | ✅ | N/A | N/A | N/A |
-| | Google Antigravity, Kiro, and code-server | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | JetBrains: CLion, DataGrip, GoLand, IntelliJ IDEA (and Community Edition), PhpStorm, PyCharm (and Community Edition), ReSharper, Rider, RubyMine, RustRover, and WebStorm | ✅ | ✅ | ✅ | N/A | N/A | N/A |
-| | JetBrains: Android Studio, DataSpell, Aqua, and Writerside | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Zed, Sublime Text, Neovim/Vim, and Emacs | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| Adobe plugins | CEP extensions for Photoshop, Illustrator, Premiere Pro, After Effects, InDesign, InCopy, Animate, Dreamweaver, Audition, Bridge, Lightroom, Lightroom Classic, XD, and Prelude | ✅\* | ✅\* | N/A | N/A | N/A | N/A |
-| | UXP plugins for Photoshop, XD, InDesign, InCopy, and Premiere Pro | ✅\* | ✅\* | N/A | N/A | N/A | N/A |
-| | Native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| | Native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| | MediaCore shared plug-ins (third-party effects for Premiere Pro, After Effects, and Audition) | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| Design and creative plugins | Sketch | ❌ | N/A | N/A | N/A | N/A | N/A |
-| | Figma | N/A | N/A | N/A | N/A | N/A | N/A |
-| | Affinity Photo, Designer, and Publisher | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| | GIMP | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Inkscape | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Krita | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Blender | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | darktable | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | OFX plug-ins for DaVinci Resolve, Nuke, and Natron | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Final Cut Pro and Motion (FxPlug and Motion templates) | ❌ | N/A | N/A | N/A | N/A | N/A |
-| | Audio plug-ins (AU, VST/VST3, AAX, and LV2) for Logic Pro, Ableton Live, Pro Tools, and Reaper | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Autodesk Maya, 3ds Max, Cinema 4D, and Houdini | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Unity, Unreal Engine, and Godot | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | AutoCAD | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| | SolidWorks | N/A | ❌ | N/A | N/A | N/A | N/A |
-| Productivity and other plugins | Microsoft Office add-ins (Excel, Word, Outlook, and PowerPoint) | ❌ | ❌ | N/A | N/A | N/A | N/A |
-| | Xcode | ✅\* | N/A | N/A | N/A | N/A | N/A |
-| | Obsidian | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | LibreOffice and OpenOffice | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| | Notepad++ (Windows only) | N/A | ❌ | N/A | N/A | N/A | N/A |
-| | Android SDK and Arduino SDK | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| Binaries | Go | ✅\* | ✅\* | ✅\* | N/A | N/A | N/A |
-| AI tools | AI desktop apps, agent CLIs, MCP servers, and agent instruction files | ❌ | ❌ | ❌ | N/A | N/A | N/A |
-| Other | macOS widgets | ✅\* | N/A | N/A | N/A | N/A | N/A |
-| | Shortcuts | ❌ | N/A | N/A | N/A | N/A | ❌ |
-| | Ringtones | N/A | N/A | N/A | N/A | ❌ | N/A |
+Each section also says whether Fleet matches that software to vulnerabilities (CVEs). Learn more in [Vulnerability processing](https://fleetdm.com/guides/vulnerability-processing#coverage).
 
-| Symbol | Meaning |
-| ------ | ------- |
-| ✅ | Collected |
-| ✅\* | Collected, with a caveat (see Details) |
-| ❌ | Not collected (see Details) |
-| ❔ | Not yet verified |
-| N/A | Not applicable on this platform |
+### Apps
 
-> If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
+| Type | macOS | Windows | Linux | ChromeOS | Android | iOS/iPadOS |
+| --- | --- | --- | --- | --- | --- | --- |
+| Native apps | ✅ | ✅ | Apps are installed as [packages](#packages). | ❌ | ✅\* | ✅\* |
+| Microsoft Store (MSIX/Appx) apps | N/A | ✅\* | N/A | N/A | N/A | N/A |
+| Alternative app store and sideloaded apps | N/A | N/A | N/A | N/A | ❔ | ❔ |
+| Personal-side apps on BYOD hosts | N/A | N/A | N/A | N/A | ❌ | ❌ |
 
-### Details
-
-#### Apps
+**Vulnerabilities:** Fleet detects vulnerabilities in apps on macOS and Windows, and in Linux packages. Apps reported over MDM on Android, iOS, and iPadOS aren't matched to CVEs.
 
 - Native apps on ChromeOS: Fleet's ChromeOS agent runs as a browser extension. It has no API for installed Android apps or progressive web apps (PWAs).
 - Native apps on Android: personally-owned (BYOD) hosts report apps in the work profile only. Fully-managed hosts report all installed apps.
@@ -160,7 +28,71 @@ Fleet collects software inventory for these software types.
 - Alternative app store and sideloaded apps: these should appear in the same MDM app lists on fully-managed hosts. Fleet hasn't verified this yet.
 - Personal-side apps on BYOD hosts: Apple User Enrollment and Android work profiles don't expose them.
 
-#### Operating system
+### Operating systems
+
+| Platform | Collected |
+| --- | --- |
+| macOS | ✅ |
+| Windows 10, 11, and Server | ✅ |
+| ChromeOS | ✅ |
+| Android | ✅ |
+| iOS and iPadOS | ✅ |
+| Linux | ✅ On recognized distributions. See the table below. |
+
+#### Linux distributions
+
+| Distribution | Collected |
+| --- | --- |
+| Ubuntu | ✅ |
+| Debian | ✅ |
+| Red Hat Enterprise Linux (RHEL) | ✅ |
+| CentOS and CentOS Stream | ✅ |
+| Fedora | ✅\* |
+| Rocky Linux | ✅\* |
+| AlmaLinux | ✅\* |
+| Oracle Linux | ✅\* |
+| Amazon Linux | ✅ |
+| SLES | ✅ |
+| openSUSE Leap | ✅ |
+| openSUSE Tumbleweed | ✅ |
+| Arch Linux | ✅ |
+| Arch Linux ARM | ✅ |
+| Omarchy | ✅ |
+| CachyOS | ✅ |
+| EndeavourOS | ✅ |
+| Manjaro | ✅ |
+| Manjaro ARM | ✅ |
+| Gentoo | ✅ |
+| Kali | ✅ |
+| Pop!_OS | ✅ |
+| Linux Mint | ✅ |
+| Zorin OS | ✅ |
+| Void | ✅ |
+| NixOS | ✅ |
+| Tuxedo OS | ✅ |
+| KDE neon | ✅ |
+| Flatcar | ✅ |
+| CoreOS | ✅ |
+| AMD Ryzen AI Developer Platform | ✅ |
+| NVIDIA DGX OS (DGX Spark, DGX Station, and DGX servers) | ✅\* |
+| Raspberry Pi OS 64-bit | ✅\* |
+| Raspberry Pi OS 32-bit | ❌ |
+| Alpine | ❌ |
+| elementary OS | ❌ |
+| Deepin | ❌ |
+| Garuda | ❌ |
+| Clear Linux | ❌ |
+| Photon OS | ❌ |
+| Solus | ❌ |
+| Parrot OS | ❌ |
+| Vanilla OS | ❌ |
+| openSUSE MicroOS and Aeon | ❌ |
+| SteamOS | ❌ |
+| Bazzite, Bluefin, and Aurora | ❌ |
+| Ubuntu Core | ❌ |
+| Any other distribution | ❌ |
+
+**Vulnerabilities:** Fleet detects OS vulnerabilities on macOS, Windows, Android, and supported Linux kernels. ChromeOS, iOS, and iPadOS aren't matched. Linux coverage varies by distribution. See [Linux coverage](https://fleetdm.com/guides/vulnerability-processing#linux-coverage).
 
 - Fedora, Rocky Linux, AlmaLinux, and Oracle Linux report as RHEL because they ship `/etc/redhat-release`. Fleet shows them under RHEL on the **Software** > **OS** page.
 - NVIDIA DGX OS reports as Ubuntu (DGX OS 7 as Ubuntu 24.04, DGX OS 6 as Ubuntu 22.04) because its `/etc/os-release` is Ubuntu's. Fleet doesn't read `/etc/dgx-release`, so the host appears as Ubuntu on the **Software** > **OS** page and the DGX OS version isn't reported. DGX Spark is arm64; use the `arm64` fleetd package.
@@ -169,7 +101,28 @@ Fleet collects software inventory for these software types.
 - SteamOS, Bazzite, Bluefin, and Aurora: these use immutable root filesystems. Installing Fleet's agent is unsupported, and their platform values aren't in Fleet's list.
 - Ubuntu Core runs snaps only. Fleet's agent isn't packaged as a snap, so Ubuntu Core hosts can't enroll.
 
-#### Browser extensions
+### Browser extensions
+
+| Browser | macOS | Windows | Linux | ChromeOS |
+| --- | --- | --- | --- | --- |
+| Chrome | ✅ | ✅ | ✅ | ✅ |
+| Chrome Beta, Dev, and Canary | ✅\* | ✅\* | ✅\* | N/A |
+| Chromium | ✅ | ✅ | ✅ | N/A |
+| Brave | ✅ | ✅ | ✅ | N/A |
+| Brave Beta and Nightly | ✅\* | ✅\* | ✅\* | N/A |
+| Edge | ✅ | ✅ | ✅ | N/A |
+| Edge Beta | ✅ | ✅ | ✅ | N/A |
+| Edge Dev and Canary | ✅\* | ✅\* | ✅\* | N/A |
+| Opera | ✅ | ✅ | ✅ | N/A |
+| Yandex | ✅ | ✅ | ✅ | N/A |
+| Vivaldi | ✅\* | ✅\* | ✅\* | N/A |
+| Arc | ✅\* | ❌ | N/A | N/A |
+| Perplexity Comet and Dia | ❌ | ❌ | N/A | N/A |
+| Firefox | ✅ | ✅ | ✅\* | N/A |
+| Safari | ✅\* | N/A | N/A | N/A |
+| Internet Explorer | N/A | ✅\* | N/A | N/A |
+
+**Vulnerabilities:** Fleet detects vulnerabilities in Chrome and Firefox extensions on macOS, Windows, and Linux. Extensions in other browsers aren't matched.
 
 - Chrome Beta, Dev, and Canary, Brave Beta and Nightly, Edge Dev and Canary, Vivaldi, and Arc: osquery 5.15 or later collects these and Fleet stores them, but the **Type** column shows the raw browser value (for example, "Chrome Beta" or "Vivaldi") because Fleet doesn't have a display name for them yet. Arc on Windows isn't collected.
 - Perplexity Comet and Dia: support was added to osquery after 5.23.1. Fleet will collect them once the next osquery release ships in fleetd.
@@ -178,7 +131,31 @@ Fleet collects software inventory for these software types.
 - Fleet doesn't hash browser extensions on any platform.
 - Safari on iOS and Firefox, Edge, and Yandex on Android support extensions, but no MDM API exposes them.
 
-#### Packages
+### Packages
+
+| Type | macOS | Windows | Linux |
+| --- | --- | --- | --- |
+| Homebrew | ✅\* | N/A | ❌ |
+| Chocolatey | N/A | ✅ | N/A |
+| Scoop | N/A | ❌ | N/A |
+| winget portable packages | N/A | ❌ | N/A |
+| deb | N/A | N/A | ✅ |
+| rpm | N/A | N/A | ✅ |
+| pacman | N/A | N/A | ✅ |
+| Portage | N/A | N/A | ✅ |
+| snap | N/A | N/A | ❌ |
+| Flatpak | N/A | N/A | ❌ |
+| AppImage | N/A | N/A | ❌ |
+| Nix | ❌ | N/A | ❌ |
+| Python | ✅\* | ✅\* | ✅\* |
+| npm | ✅\* | ❌ | ✅\* |
+| pnpm, Yarn, and Bun (global) | ❌ | ❌ | ❌ |
+| RubyGems | ❌ | ❌ | ❌ |
+| Rust (cargo) | ❌ | ❌ | ❌ |
+| Nim | ❌ | ❌ | ❌ |
+| Atom | ❌ | ❌ | ❌ |
+
+**Vulnerabilities:** Fleet detects vulnerabilities in Python and npm packages on all three platforms, Homebrew on macOS, Chocolatey and Atom on Windows, and deb, rpm, and pacman packages on Linux. Coverage varies by distribution.
 
 - Homebrew on macOS: Fleet collects formulae, plus casks that don't install a `.app` bundle (those appear under Apps). Homebrew on Linux isn't collected because osquery's `homebrew_packages` table only runs on macOS.
 - Scoop, winget portable packages, snap, Flatpak, AppImage, Nix, pnpm, Yarn, Bun, RubyGems, cargo, and Nim: no osquery or fleetd table reads them. On Ubuntu desktop, Firefox and Chromium are installed as snaps by default, so those browsers are missing from inventory even though their extensions are collected. Follow the snap request in [#22658](https://github.com/fleetdm/fleet/issues/22658).
@@ -186,13 +163,54 @@ Fleet collects software inventory for these software types.
 - npm: Fleet collects globally installed packages, including nvm, fnm, asdf, mise, and Volta locations. Scoped (`@org/name`) and nested packages require osquery 5.23 or later. On Windows, osquery supports npm packages but Fleet doesn't query them yet. Project-level `node_modules` directories aren't collected.
 - Atom packages were removed from inventory in December 2023 after the editor was sunset.
 
-#### IDE extensions
+### IDE extensions
+
+| Type | macOS | Windows | Linux |
+| --- | --- | --- | --- |
+| VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (Devin), and Trae | ✅ | ✅ | ✅ |
+| Google Antigravity, Kiro, and code-server | ❌ | ❌ | ❌ |
+| JetBrains: CLion, DataGrip, GoLand, IntelliJ IDEA (and Community Edition), PhpStorm, PyCharm (and Community Edition), ReSharper, Rider, RubyMine, RustRover, and WebStorm | ✅ | ✅ | ✅ |
+| JetBrains: Android Studio, DataSpell, Aqua, and Writerside | ❌ | ❌ | ❌ |
+| Zed, Sublime Text, Neovim/Vim, and Emacs | ❌ | ❌ | ❌ |
+
+**Vulnerabilities:** Fleet detects vulnerabilities in VS Code, VS Code fork, and JetBrains extensions on macOS, Windows, and Linux.
 
 - VS Code and its forks: osquery reads the extension directories for VS Code, VS Code Insiders, VSCodium, VSCodium Insiders, Cursor, Windsurf (including its Devin rename), and Trae, plus their remote-server variants. Learn more in the [vscode_extensions](https://fleetdm.com/tables/vscode_extensions) table. Google Antigravity, Kiro, and code-server use the same format but aren't in osquery's list yet.
 - JetBrains: osquery enumerates 13 products installed under the `JetBrains` directory. Learn more in the [jetbrains_plugins](https://fleetdm.com/tables/jetbrains_plugins) table. Android Studio installs under a `Google` directory and isn't collected. DataSpell, Aqua, and Writerside aren't in osquery's list.
 - Zed, Sublime Text, Neovim/Vim, and Emacs: no osquery or fleetd table reads them.
 
-#### Plugins
+### Plugins
+
+| Category | Type | macOS | Windows | Linux |
+| --- | --- | --- | --- | --- |
+| Adobe plugins | CEP extensions for Photoshop, Illustrator, Premiere Pro, After Effects, InDesign, InCopy, Animate, Dreamweaver, Audition, Bridge, Lightroom, Lightroom Classic, XD, and Prelude | ✅\* | ✅\* | N/A |
+| | UXP plugins for Photoshop, XD, InDesign, InCopy, and Premiere Pro | ✅\* | ✅\* | N/A |
+| | Native plug-ins for Photoshop, Premiere Pro, After Effects, and Illustrator | ❌ | ❌ | N/A |
+| | Native plug-ins for Acrobat, InDesign, Lightroom Classic, and Substance 3D | ❌ | ❌ | N/A |
+| | MediaCore shared plug-ins (third-party effects for Premiere Pro, After Effects, and Audition) | ❌ | ❌ | N/A |
+| Design and creative plugins | Sketch | ❌ | N/A | N/A |
+| | Figma | N/A | N/A | N/A |
+| | Affinity Photo, Designer, and Publisher | ❌ | ❌ | N/A |
+| | GIMP | ❌ | ❌ | ❌ |
+| | Inkscape | ❌ | ❌ | ❌ |
+| | Krita | ❌ | ❌ | ❌ |
+| | Blender | ❌ | ❌ | ❌ |
+| | darktable | ❌ | ❌ | ❌ |
+| | OFX plug-ins for DaVinci Resolve, Nuke, and Natron | ❌ | ❌ | ❌ |
+| | Final Cut Pro and Motion (FxPlug and Motion templates) | ❌ | N/A | N/A |
+| | Audio plug-ins (AU, VST/VST3, AAX, and LV2) for Logic Pro, Ableton Live, Pro Tools, and Reaper | ❌ | ❌ | ❌ |
+| | Autodesk Maya, 3ds Max, Cinema 4D, and Houdini | ❌ | ❌ | ❌ |
+| | Unity, Unreal Engine, and Godot | ❌ | ❌ | ❌ |
+| | AutoCAD | ❌ | ❌ | N/A |
+| | SolidWorks | N/A | ❌ | N/A |
+| Productivity and other plugins | Microsoft Office add-ins (Excel, Word, Outlook, and PowerPoint) | ❌ | ❌ | N/A |
+| | Xcode | ✅\* | N/A | N/A |
+| | Obsidian | ❌ | ❌ | ❌ |
+| | LibreOffice and OpenOffice | ❌ | ❌ | ❌ |
+| | Notepad++ (Windows only) | N/A | ❌ | N/A |
+| | Android SDK and Arduino SDK | ❌ | ❌ | ❌ |
+
+**Vulnerabilities:** Fleet doesn't scan plugins for vulnerabilities. Adobe files CVEs against the host application, such as Photoshop or Acrobat, which Fleet detects under Apps.
 
 - Adobe applications (Photoshop, Acrobat, Substance 3D, and others) appear under Apps. That's also where Fleet matches Adobe vulnerabilities. Adobe doesn't ship applications for Linux.
 - Adobe CEP extensions: Fleet collects the name, version, and vendor. The host application is read from the manifest but not stored, so the **Type** column shows "Plugin (Adobe)" for every host application. Learn more in the [adobe_plugins](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/adobe_plugins) table.
@@ -203,12 +221,42 @@ Fleet collects software inventory for these software types.
 - Sketch, Affinity, GIMP, Inkscape, Krita, Blender, darktable, OFX, FxPlug, audio plug-ins, 3D suites, game engines, AutoCAD, SolidWorks, Microsoft Office add-ins, Obsidian, LibreOffice, OpenOffice, Notepad++, Android SDK, and Arduino SDK: no osquery or fleetd table reads them. Affinity loads Photoshop-compatible plug-ins from a folder the user chooses. Unity and Godot plugins are installed per project, not per host. Notepad++ has no native macOS or Linux build.
 - Xcode source editor extensions ship inside apps that already appear under Apps. Xcode has no separate plugin system.
 
-#### Binaries, AI tools, and other
+### Binaries, AI tools, and other
+
+| Category | Type | macOS | Windows | Linux | Android | iOS/iPadOS |
+| --- | --- | --- | --- | --- | --- | --- |
+| Binaries | Go | ✅\* | ✅\* | ✅\* | N/A | N/A |
+| AI tools | AI desktop apps, agent CLIs, MCP servers, and agent instruction files | ❌ | ❌ | ❌ | N/A | N/A |
+| Other | macOS widgets | ✅\* | N/A | N/A | N/A | N/A |
+| | Shortcuts | ❌ | N/A | N/A | N/A | ❌ |
+| | Ringtones | N/A | N/A | N/A | ❌ | N/A |
+
+**Vulnerabilities:** Fleet doesn't match Go binaries, macOS widgets, or the other items in this table to CVEs.
 
 - Go binaries: Fleet collects binaries in each user's `~/go/bin` directory. Learn more in the [go_binaries](https://github.com/fleetdm/fleet/tree/main/orbit/pkg/table/go_binaries) table.
 - AI tools: fleetd includes an [ai_tools](https://github.com/fleetdm/fleet/blob/main/orbit/pkg/table/ai_tools/README.md) table that you can query, but Fleet doesn't add its results to software inventory yet.
 - macOS widgets are WidgetKit extensions that ship inside apps that already appear under Apps.
 - Shortcuts and Android ringtones: no MDM API exposes them.
+
+> If Fleet isn't collecting software that's installed on your hosts, please file a [feature request](https://github.com/fleetdm/fleet/issues/new?template=feature-request.md). If Fleet is collecting software incorrectly (wrong name, version, or type), please file a [bug](https://github.com/fleetdm/fleet/issues/new?template=bug-report.md).
+
+## Data collected
+
+Fleet stores a name and a version for every item in inventory. What else it stores depends on the software type and the platform.
+
+| Data | Collected |
+| --- | --- |
+| Name (title) and version | ✅ Every software type. |
+| Publisher (vendor) | ✅ Where the source reports it, including Windows programs, deb and rpm packages, and Adobe plugins. macOS apps also report the Apple Developer Team ID from the app's code signature. |
+| Unique identifier | ✅ Bundle ID (macOS, iOS, and iPadOS), application ID (Android), upgrade code (Windows), and extension ID (browser and IDE extensions). |
+| Install path | ✅ Apps, browser extensions, IDE extensions, plugins, and Go binaries. Linux system packages (deb, rpm, pacman, and Portage) don't report a path. |
+| File hashes | ✅ macOS apps only. fleetd collects the code directory hash (cdhash) and the SHA-256 hash of the app's executable. Not collected on Windows or Linux, or for packages, extensions, and plugins. |
+| Last opened | ✅ macOS apps. No other software type reports usage. |
+| Install count | ✅ The number of hosts in your Fleet running each title and each version. |
+| Vulnerabilities (CVEs) | ✅ For the software types marked in [Coverage](#coverage). Fleet Premium adds the CVE publish date, CVSS score, EPSS probability, and CISA KEV status. |
+| Title and version release dates | ❌ Not collected. Fleet reports the version a host is running, not when that version shipped. |
+| Popularity outside your Fleet | ❌ Not collected. Install counts cover your hosts only. |
+| Publisher reputation | ❌ Not collected. Fleet reports the publisher name, and the Team ID on macOS, but not a publisher's first release date or install totals across their other titles. |
 
 ## How Fleet collects software
 
@@ -220,11 +268,11 @@ Fleet collects software inventory for these software types.
 
 Fleet collects software from known package databases and install locations. Software installed outside of those, such as tarballs extracted to `/opt`, portable Windows executables, and AppImage files, isn't collected.
 
-Fleet collects a name and version for each item. It doesn't collect file hashes for apps, packages, or extensions.
+Fleet collects a name and version for each item. What else it collects varies by software type. See [Data collected](#data-collected).
 
 On personally-owned (BYOD) iOS, iPadOS, and Android hosts, the platform limits what MDM can see. Fleet reports only Fleet-installed apps (Apple) or work-profile apps (Android). This is a platform restriction, not a Fleet setting.
 
-On Linux, Fleet only collects software from distributions it recognizes. See the [Operating system](#operating-system) details above.
+On Linux, Fleet only collects software from distributions it recognizes. See [Linux distributions](#linux-distributions) above.
 
 ## Configuration
 


### PR DESCRIPTION
**Related issue:** Follow-up to #12782 / #53057

Follow-up to the software inventory guide, addressing two pieces of review feedback:

> we could list out every inventory type, and the columns can describe the depth of data, or any caveats. (E.g. Adobe plugins, not supported on linux). Then we can clarify the extent to which we support not just the feed of titles and versions, but also vulnerabilities, and credibility (i.e. title publish date, version publish date, title popularity [install count], version popularity [install count], and publisher reputation [first publish date, and total installs across all published software titles])

> Also if it were in reference docs, could use h3s for sub-nav for the different categories and breaking up the table into multiple tables.

## What changed

**Coverage is now one H3 per category**, each with its own table, so the page has real sub-nav instead of a single 128-row table: Apps, Operating systems (with an H4 Linux distributions table), Browser extensions, Packages, IDE extensions, Plugins, and Binaries, AI tools, and other.

- Each table drops the platform columns that were `N/A` for every row in that category, so caveats sit in the cell that needs them rather than in a wall of `N/A`.
- The former "Details" section is gone. Its caveats now sit directly under the table they belong to.
- Each category gained a **Vulnerabilities:** line stating whether Fleet matches that software type to CVEs, with the per-distribution detail delegated to the vulnerability processing guide rather than duplicated here.

**New "Data collected" section** answers the depth-of-data question per item, including the credibility signals that were asked about. Every row is verified against the server code rather than asserted:

| Claim | Source |
| --- | --- |
| Name, version, publisher, unique identifiers | `software` and `software_titles` tables in `server/datastore/mysql/schema.sql` |
| Apple Developer Team ID, cdhash, executable SHA-256, macOS only | `macos_codesign` and `macos_executable_sha256` queries in `server/service/osquery_utils/queries.go`; `host_software_installed_paths` |
| Install path not reported for deb, rpm, pacman, Portage | `''  AS installed_path` in those queries |
| Last opened, macOS apps only | `last_opened_time AS last_opened_at` on the `apps` query; every other source reports `0`/`''` |
| Install count is hosts in your Fleet | `software_host_counts.hosts_count` |
| CVE publish date, CVSS, EPSS, KEV are Premium | `cve_meta` table; "Fleet Premium only" annotations in `docs/REST API/rest-api.md` |
| Release dates, outside popularity, publisher reputation not collected | No such columns exist |

**Correction:** the Limitations section said Fleet doesn't collect file hashes. That's wrong for macOS apps, which report a cdhash and an executable SHA-256 through fleetd. The line now points at the Data collected table instead.

## Testing

- [x] QA'd all new/changed functionality manually:
  - Every in-page anchor resolves against the new heading set, including the renamed `#linux-distributions` target used from Limitations.
  - No table has an inconsistent column count (158 table rows checked).
  - `description` meta is unchanged at 92 characters; `articleTitle` still matches the H1.
  - No new external links were introduced in this commit.

## AI

**AI:** Claude Code (claude-opus-5[1m])
