### PR TITLE
Update instructions for SCEP cert integration to match feature label in Fleet UI

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -35,7 +35,7 @@ We'll deploy a certificate with a dynamic SCEP challenge. To deploy certificates
   
 ### Step 2: Connect Fleet to Okta's CA
 
-1. In Fleet, head to **Settings > Integrations > Certificate enrollment**.
+1. In Fleet, head to **Settings > Integrations > Certificate authorities**.
 2. Select the **Add CA** button and select **Okta CA or Microsoft NDES** in the dropdown. Okta uses NDES under the hood.
 3. Enter your **SCEP URL**, **Admin URL**, and **Username** and **Password**.
 4. Select **Add CA**. Your Okta CA should appear in the list in Fleet.


### PR DESCRIPTION
The feature in the Fleet UI is now called Certificate authorities. cc @rachaelshaw 

<img width="634" height="153" alt="Screenshot 2026-09-11 at 6 03 53 PM" src="https://github.com/user-attachments/assets/79b387c3-9b02-45ef-ac72-c279e6ca93fd" />

<img width="927" height="644" alt="Screenshot 2026-09-11 at 6 03 14 PM" src="https://github.com/user-attachments/assets/1dc397af-2fa5-4612-bfd7-3a035aa0d78f" />


