### PR TITLE
Show "Last restarted" tooltip below the value & fix "Hardware model" missing ellipses

### DIFF
--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -337,43 +337,6 @@ describe("Vitals Card component", () => {
   });
 });
 
-describe("Hardware model vital", () => {
-  it("truncates a long marketing name instead of letting it overflow with no ellipsis", () => {
-    const mockHost = createMockHost({
-      platform: "darwin",
-      hardware_model: "MacBookPro18,1",
-      hardware_marketing_name: "MacBook Pro (16-inch, 2021)",
-    });
-
-    const { container } = render(
-      <Vitals vitalsData={mockHost} mdm={mockHost.mdm} />
-    );
-
-    expect(
-      container.querySelector(".vitals-card__hardware-model-text")
-    ).toBeInTheDocument();
-  });
-
-  it("truncates a long raw model instead of letting it overflow with no ellipsis", () => {
-    const mockHost = createMockHost({
-      platform: "darwin",
-      hardware_model: "MacBook Pro (16-inch, 2021)",
-      hardware_marketing_name: "",
-    });
-
-    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
-
-    // Scoped to the Hardware model row specifically — Serial number/UUID on
-    // the same card also render via TooltipTruncatedText and share this class.
-    const hardwareModelDataSet = screen
-      .getByText("Hardware model")
-      .closest(".data-set");
-    expect(
-      hardwareModelDataSet?.querySelector(".tooltip-truncated-text__text-value")
-    ).toBeInTheDocument();
-  });
-});
-
 describe("Location vital", () => {
   // ADE = iOS/iPadOS host with mdm.enrollment_status === "On (automatic)";
   // matches the definition in Vitals.tsx.

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -337,6 +337,43 @@ describe("Vitals Card component", () => {
   });
 });
 
+describe("Hardware model vital", () => {
+  it("truncates a long marketing name instead of letting it overflow with no ellipsis", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      hardware_model: "MacBookPro18,1",
+      hardware_marketing_name: "MacBook Pro (16-inch, 2021)",
+    });
+
+    const { container } = render(
+      <Vitals vitalsData={mockHost} mdm={mockHost.mdm} />
+    );
+
+    expect(
+      container.querySelector(".vitals-card__hardware-model-text")
+    ).toBeInTheDocument();
+  });
+
+  it("truncates a long raw model instead of letting it overflow with no ellipsis", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      hardware_model: "MacBook Pro (16-inch, 2021)",
+      hardware_marketing_name: "",
+    });
+
+    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
+
+    // Scoped to the Hardware model row specifically — Serial number/UUID on
+    // the same card also render via TooltipTruncatedText and share this class.
+    const hardwareModelDataSet = screen
+      .getByText("Hardware model")
+      .closest(".data-set");
+    expect(
+      hardwareModelDataSet?.querySelector(".tooltip-truncated-text__text-value")
+    ).toBeInTheDocument();
+  });
+});
+
 describe("Location vital", () => {
   // ADE = iOS/iPadOS host with mdm.enrollment_status === "On (automatic)";
   // matches the definition in Vitals.tsx.

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -417,10 +417,10 @@ export const buildHostVitals = ({
         value={
           hardwareModelDisplay.tooltip ? (
             <TooltipWrapper
-              className={`${baseClass}__hardware-model-tooltip`}
+              className={`${baseClass}__ellipsis-tooltip`}
               tipContent={hardwareModelDisplay.tooltip}
             >
-              <span className={`${baseClass}__hardware-model-text`}>
+              <span className={`${baseClass}__ellipsis-tooltip-text`}>
                 {hardwareModelDisplay.value}
               </span>
             </TooltipWrapper>
@@ -645,7 +645,7 @@ export const buildHostVitals = ({
                 <Icon name="error-outline" color="ui-fleet-black-75" />
               )}
               <TooltipWrapper
-                className={`${baseClass}__os-version-tooltip`}
+                className={`${baseClass}__ellipsis-tooltip`}
                 tipContent={
                   <>
                     Minimum version required: <b>{osUpdateMinimumVersion}</b>
@@ -654,7 +654,7 @@ export const buildHostVitals = ({
                   </>
                 }
               >
-                <span className={`${baseClass}__os-version-text`}>
+                <span className={`${baseClass}__ellipsis-tooltip-text`}>
                   {vitalsData.os_version}
                 </span>
               </TooltipWrapper>

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -416,11 +416,16 @@ export const buildHostVitals = ({
         title="Hardware model"
         value={
           hardwareModelDisplay.tooltip ? (
-            <TooltipWrapper tipContent={hardwareModelDisplay.tooltip}>
-              {hardwareModelDisplay.value}
+            <TooltipWrapper
+              className={`${baseClass}__hardware-model-tooltip`}
+              tipContent={hardwareModelDisplay.tooltip}
+            >
+              <span className={`${baseClass}__hardware-model-text`}>
+                {hardwareModelDisplay.value}
+              </span>
             </TooltipWrapper>
           ) : (
-            hardwareModelDisplay.value
+            <TooltipTruncatedText value={hardwareModelDisplay.value} />
           )
         }
       />

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -438,6 +438,7 @@ export const buildHostVitals = ({
           value={
             <HumanTimeDiffWithFleetLaunchCutoff
               timeString={vitalsData.last_restarted_at}
+              tooltipPosition="bottom"
             />
           }
         />

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -85,7 +85,13 @@
     margin-bottom: 0;
   }
 
-  &__hardware-model-tooltip {
+  // Shared by any TooltipWrapper-based vital value (rather than
+  // TooltipTruncatedText) that still needs to truncate with an ellipsis —
+  // e.g. Operating system, Hardware model. TooltipWrapper's own element has
+  // no overflow handling, so this class chain overrides the flex item's
+  // default min-width so it can shrink, and the inner text span does the
+  // actual ellipsis truncation.
+  &__ellipsis-tooltip {
     min-width: 0;
 
     > .component__tooltip-wrapper__element {
@@ -93,22 +99,7 @@
     }
   }
 
-  &__hardware-model-text {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__os-version-tooltip {
-    min-width: 0;
-
-    > .component__tooltip-wrapper__element {
-      overflow: hidden;
-    }
-  }
-
-  &__os-version-text {
+  &__ellipsis-tooltip-text {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -85,6 +85,21 @@
     margin-bottom: 0;
   }
 
+  &__hardware-model-tooltip {
+    min-width: 0;
+
+    > .component__tooltip-wrapper__element {
+      overflow: hidden;
+    }
+  }
+
+  &__hardware-model-text {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   &__os-version-tooltip {
     min-width: 0;
 


### PR DESCRIPTION
- [x] QA'd all new/changed functionality manually

Before:

<img width="810" height="419" alt="Screenshot 2026-09-12 at 9 53 02 AM" src="https://github.com/user-attachments/assets/45bb00e6-4201-4095-858f-43daf49dccda" />

<img width="205" height="91" alt="Screenshot 2026-09-12 at 10 04 17 AM" src="https://github.com/user-attachments/assets/ff19ccc2-f259-4912-ab58-c889f7e007ab" />

After:

<img width="233" height="157" alt="Screenshot 2026-09-12 at 10 04 02 AM" src="https://github.com/user-attachments/assets/3afe8b06-85c3-4b0b-bf9b-731981fce19c" />

So that it doesn't cover the "Last restarted" label

<img width="216" height="102" alt="Screenshot 2026-09-12 at 10 14 30 AM" src="https://github.com/user-attachments/assets/b5dc456b-8992-4a55-86e7-904bfbe6d3d9" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip positioning for the “Last restarted” host vital.
  * Improved truncation and tooltip behavior for hardware and OS version details, making long values easier to view without disrupting the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->