### PR TITLE
Bump Linux Claude Desktop patch policy to 1.52386.3

### DIFF
--- a/it-and-security/lib/linux/policies/update-claude.yml
+++ b/it-and-security/lib/linux/policies/update-claude.yml
@@ -1,5 +1,5 @@
 - name: Claude up to date (Linux)
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM deb_packages WHERE name = 'claude-desktop' AND version_compare(version, '1.52386.0') < 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM deb_packages WHERE name = 'claude-desktop' AND version_compare(version, '1.52386.3') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Claude is managed by IT and is upgraded automatically from Anthropic's apt repository when this policy fails. You can also run `sudo apt update && sudo apt install claude-desktop`, or install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."


### PR DESCRIPTION
**Related issue:** NA

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`. — not needed; this is dogfood GitOps configuration, not a product change.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

Updated the pinned version comparison in the osquery policy query from `1.52386.0` to `1.52386.3` to match the newest version published to Anthropic's apt repository for both architectures.

- Old pinned version: `1.52386.0`
- New pinned version: `1.52386.3`
- Newest published version, amd64: `1.52386.3` — https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages
- Newest published version, arm64: `1.52386.3` — https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-arm64/Packages

## AI

**AI:** Claude Code (claude-sonnet-5)

https://claude.ai/code/session_01D3y5RPuLx8LdW3TosumWRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3y5RPuLx8LdW3TosumWRu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Raised the minimum acceptable Claude Desktop version for Linux update policy checks to `1.52386.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->