### PR TITLE
Disable agent options Save while the YAML is invalid

### DIFF
--- a/changes/52677-agent-options-save-spinner
+++ b/changes/52677-agent-options-save-spinner
@@ -1,0 +1,1 @@
+- Fixed the Save button on a fleet's agent options page spinning forever when the YAML has a syntax error.

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tests.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tests.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import mockServer from "test/mock-server";
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+  createMockLocation,
+} from "test/test-utils";
+import { createGetConfigHandler } from "test/handlers/config-handlers";
+import createMockUser from "__mocks__/userMock";
+import { createMockTeamSummary } from "__mocks__/teamMock";
+import osqueryOptionsAPI from "services/entities/osquery_options";
+import { EMPTY_AGENT_OPTIONS } from "utilities/constants";
+
+import AgentOptionsPage from "./AgentOptionsPage";
+
+// react-ace doesn't render an editable field under jsdom, so stand in a plain
+// textarea that calls the same onChange.
+jest.mock("components/YamlAce", () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+    error,
+  }: {
+    value?: string;
+    onChange: (value: string) => void;
+    error?: string;
+  }) => (
+    <>
+      <textarea
+        aria-label="YAML"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {error && <span>{error}</span>}
+    </>
+  ),
+}));
+
+const renderAgentOptionsPage = () => {
+  mockServer.use(
+    createGetConfigHandler(),
+    http.get(baseUrl("/fleets/:id"), () =>
+      HttpResponse.json({
+        team: {
+          id: 1,
+          name: "Team 1",
+          agent_options: { config: { options: { pack_delimiter: "/" } } },
+        },
+      })
+    )
+  );
+
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        isPremiumTier: true,
+        isGlobalAdmin: true,
+        isOnGlobalTeam: true,
+        currentUser: createMockUser({ global_role: "admin" }),
+        availableTeams: [createMockTeamSummary({ id: 1, name: "Team 1" })],
+        setCurrentTeam: jest.fn(),
+      },
+    },
+  });
+
+  return render(
+    <AgentOptionsPage
+      location={createMockLocation({
+        pathname: "/settings/teams/agent-options",
+        search: "?fleet_id=1",
+        query: { fleet_id: "1" },
+      })}
+      router={createMockRouter()}
+    />
+  );
+};
+
+describe("AgentOptionsPage", () => {
+  // Regression (#52677): submitting invalid YAML threw out of yaml.load before
+  // the request promise, leaving the Save button spinning forever.
+  it("blocks submit while the YAML has a syntax error", async () => {
+    const updateSpy = jest
+      .spyOn(osqueryOptionsAPI, "updateTeam")
+      .mockResolvedValue({} as never);
+    const { user } = renderAgentOptionsPage();
+
+    const editor = await screen.findByLabelText("YAML");
+    await user.clear(editor);
+    await user.type(editor, "config: 1\n  bad: 2");
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+  });
+
+  it("submits once the YAML is valid", async () => {
+    const updateSpy = jest
+      .spyOn(osqueryOptionsAPI, "updateTeam")
+      .mockResolvedValue({} as never);
+    const { user } = renderAgentOptionsPage();
+
+    const editor = await screen.findByLabelText("YAML");
+    await user.clear(editor);
+    await user.type(editor, "config: null");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it("shows the syntax error on the editor label", async () => {
+    const { user } = renderAgentOptionsPage();
+
+    const editor = await screen.findByLabelText("YAML");
+    await user.clear(editor);
+    await user.type(editor, "config: 1\n  bad: 2");
+
+    expect(await screen.findByText(/Syntax Error:/)).toBeInTheDocument();
+  });
+
+  it("re-enables Save once the syntax error is fixed", async () => {
+    const updateSpy = jest
+      .spyOn(osqueryOptionsAPI, "updateTeam")
+      .mockResolvedValue({} as never);
+    const { user } = renderAgentOptionsPage();
+
+    const editor = await screen.findByLabelText("YAML");
+    await user.clear(editor);
+    await user.type(editor, "config: 1\n  bad: 2");
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    await user.clear(editor);
+    await user.type(editor, "config: null");
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    expect(saveButton).toBeEnabled();
+    await user.click(saveButton);
+    expect(updateSpy).toHaveBeenCalled();
+  });
+
+  it("submits empty agent options as an empty config", async () => {
+    const updateSpy = jest
+      .spyOn(osqueryOptionsAPI, "updateTeam")
+      .mockResolvedValue({} as never);
+    const { user } = renderAgentOptionsPage();
+
+    const editor = await screen.findByLabelText("YAML");
+    await user.clear(editor);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(updateSpy).toHaveBeenCalledWith(1, EMPTY_AGENT_OPTIONS);
+  });
+});

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -184,7 +184,7 @@ const AgentOptionsPage = ({
             renderChildren={(disableChildren) => (
               <Button
                 type="submit"
-                disabled={disableChildren}
+                disabled={Object.keys(formErrors).length > 0 || disableChildren}
                 className="save-loading"
                 isLoading={isUpdatingAgentOptions}
               >


### PR DESCRIPTION
**Related issue:** Resolves #52677

Save on a fleet's Agent options page spun forever when the YAML had a syntax error, and no request was sent.

`onFormSubmit` turns on the loading state, then calls `yaml.load()`, which throws on bad YAML before the request promise exists. The `.finally` that turns the spinner off never runs.

The page already validates the YAML on change and shows the error on the editor label. It just didn't disable Save. Now it does, the same way the global Agent options page does (`OrgSettingsPage/cards/Agents.tsx:133`), along with Team settings, SMTP, and the host status webhook cards.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Five new tests: bad YAML disables Save and sends no request, the syntax error shows on the label, fixing the YAML re-enables Save, valid YAML saves, and empty YAML still submits empty agent options. Revert the one-line fix and two of them fail. `YamlAce` is stubbed with a textarea because react-ace isn't editable under jsdom.

Manual QA on a local dev server: made a fleet, opened Agent options, changed the YAML to `config: {`. The label turns red and Save goes grey. Fixing the YAML re-enables Save and it saves.

## AI

**AI:** Claude Code (claude-opus-5[1m])

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

Before: video on #52677. After: recording below.

https://github.com/user-attachments/assets/34c29707-967e-4b12-b2de-18d6c7807828

## Note for product

Expected behavior on the issue is still TODO, so I matched the global Agent options page. If you'd rather keep Save enabled and show an error toast, I can switch it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The Save button on the fleet agent options page is now disabled when the YAML contains syntax errors, preventing it from spinning indefinitely.
  - Correcting invalid YAML re-enables saving, while valid and empty configurations continue to submit successfully.

- **Tests**
  - Added coverage for YAML validation, error display, save-button behavior, and successful submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->